### PR TITLE
Fix cell execution lifecycle and output rendering

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -96,7 +96,7 @@
   },
   "scripts": {
     "build": "pnpm run build:renderer && pnpm run build:extension",
-    "build:extension": "esbuild --format=cjs --platform=node --minify --external:vscode --bundle --sourcemap src/extension.ts --outdir=dist",
+    "build:extension": "esbuild --format=cjs --define:import.meta.env.DEV=false --platform=node --minify --external:vscode --bundle --sourcemap src/extension.ts --outdir=dist",
     "build:renderer": "vite build",
     "fix": "biome check --write"
   },

--- a/extension/src/renderer/CellOutput.tsx
+++ b/extension/src/renderer/CellOutput.tsx
@@ -3,6 +3,7 @@ import {
   type CellRuntimeState,
   ConsoleOutput,
   OutputRenderer,
+  TooltipProvider,
   useTheme,
 } from "./marimo-frontend.ts";
 
@@ -18,17 +19,19 @@ export function CellOutput({ cellId, state }: CellOutputProps) {
   const { theme } = useTheme();
   return (
     <div className={`marimo-cell-output p-4 ${theme}`}>
-      <ConsoleOutput
-        cellId={cellId}
-        cellName={"_"}
-        consoleOutputs={state.consoleOutputs}
-        stale={false}
-        debuggerActive={false}
-        onSubmitDebugger={(_text: string, _index: number) => {}}
-      />
-      {state.output && (
-        <OutputRenderer cellId={cellId} message={state.output} />
-      )}
+      <TooltipProvider>
+        <ConsoleOutput
+          cellId={cellId}
+          cellName={"_"}
+          consoleOutputs={state.consoleOutputs}
+          stale={false}
+          debuggerActive={false}
+          onSubmitDebugger={(_text: string, _index: number) => {}}
+        />
+        {state.output && (
+          <OutputRenderer cellId={cellId} message={state.output} />
+        )}
+      </TooltipProvider>
     </div>
   );
 }

--- a/extension/src/renderer/marimo-frontend.ts
+++ b/extension/src/renderer/marimo-frontend.ts
@@ -17,6 +17,8 @@
 import { OutputRenderer as UntypedOutputRenderer } from "@marimo-team/frontend/unstable_internal/components/editor/Output.tsx?nocheck";
 // @ts-expect-error
 import { ConsoleOutput as UntypedConsoleOutput } from "@marimo-team/frontend/unstable_internal/components/editor/output/ConsoleOutput.tsx?nocheck";
+// @ts-expect-error
+import { TooltipProvider as UntypedTooltipProvider } from "@marimo-team/frontend/unstable_internal/components/ui/tooltip.tsx?nocheck";
 import type { CellId } from "@marimo-team/frontend/unstable_internal/core/cells/ids.ts";
 // @ts-expect-error
 import { RuntimeState } from "@marimo-team/frontend/unstable_internal/core/kernel/RuntimeState.ts?nocheck";
@@ -28,6 +30,7 @@ import { store } from "@marimo-team/frontend/unstable_internal/core/state/jotai.
 import { initializePlugins } from "@marimo-team/frontend/unstable_internal/plugins/plugins.ts?nocheck";
 // @ts-expect-error
 import { useTheme as untypedUseTheme } from "@marimo-team/frontend/unstable_internal/theme/useTheme.ts?nocheck";
+
 import type { MessageOperationData } from "../types.ts";
 
 import "@marimo-team/frontend/unstable_internal/css/common.css";
@@ -76,6 +79,9 @@ export const ConsoleOutput: React.FC<{
   debuggerActive: boolean;
   onSubmitDebugger: (text: string, index: number) => void;
 }> = UntypedConsoleOutput;
+
+export const TooltipProvider: React.FC<React.PropsWithChildren> =
+  UntypedTooltipProvider;
 
 /**
  * Type imports from @marimo-team/frontend

--- a/extension/src/shared/cells.ts
+++ b/extension/src/shared/cells.ts
@@ -2,7 +2,6 @@
 import { transitionCell as untypedTransitionCell } from "@marimo-team/frontend/unstable_internal/core/cells/cell.ts?nocheck";
 import type { CellRuntimeState } from "@marimo-team/frontend/unstable_internal/core/cells/types.ts";
 import { createCellRuntimeState } from "@marimo-team/frontend/unstable_internal/core/cells/types.ts";
-
 import type { MessageOperationData } from "../types.ts";
 
 export type CellMessage = MessageOperationData<"cell-op">;


### PR DESCRIPTION
Cell outputs couldn't render until execution started, preventing queued cells from showing their state. This decouples output updates from execution state and enforces VS Code's timing requirements: outputs must be modified after start() but before end(). Cells now properly display their runtime state at all lifecycle stages.