### PR TITLE
Setup Typescript typechecking CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,10 +71,10 @@ jobs:
             marimo/pnpm-lock.yaml
             marimo-lsp/extension/pnpm-lock.yaml
 
-      - name: Build marimo
+      - name: Build marimo packages
         run: |
           cd marimo
-          pnpm build
+          pnpm --recursive --filter "./packages/*" build
 
       - name: Install and typecheck extension
         run: |


### PR DESCRIPTION
This is a little hacky, but until we move this repo into `@marimo-team/marimo` we need to clone the peer repo in CI. We could use submodules, but because the plan is to merge in the future this is just a bit more simple just to make sure we have type checking in CI until that point.