### PR TITLE
Avoid install/building `@marimo-team/frontend` in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,11 +71,6 @@ jobs:
             marimo/pnpm-lock.yaml
             marimo-lsp/extension/pnpm-lock.yaml
 
-      - name: Build marimo packages
-        run: |
-          cd marimo
-          pnpm --recursive --filter "./packages/*" build
-
       - name: Install and typecheck extension
         run: |
           cd marimo-lsp/extension

--- a/extension/tsconfig.json
+++ b/extension/tsconfig.json
@@ -11,6 +11,9 @@
     "allowImportingTsExtensions": true,
     "jsx": "react-jsx",
     "exactOptionalPropertyTypes": true,
-    "erasableSyntaxOnly": true
+    "erasableSyntaxOnly": true,
+    "paths": {
+      "@marimo-team/marimo-api": ["./node_modules/@marimo-team/openapi"]
+    }
   }
 }


### PR DESCRIPTION
Adds an alias for `@marimo-team/marimo-api` to `tsconfig.json`, which allows us to avoid install/build of marimo monorepo in CI. Should speed up typechecking in CI.