### PR TITLE
Capture stdout/stderr in server test and align completion timing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,4 +54,5 @@ ignore = [
   "SLF001",
   "PLC",
   "PLR",
+  "FIX",
 ]


### PR DESCRIPTION
Update the language server test cell code to use stdout/stderr. Inserts
a 100ms delay before setting the completion event to ensure we
capture the stdout/stderr, which are buffered and flushed every 10ms.

Ideally, we could flush prior to the "idle" cell-op for each cell run,
but that requires more complicated upstream change so this works for
now. We will do the same thing (maybe 50ms) in the extension front end.