### PR TITLE
Use `msgspec` for ops/requests

### DIFF
--- a/src/marimo_lsp/models.py
+++ b/src/marimo_lsp/models.py
@@ -2,89 +2,42 @@
 
 from __future__ import annotations
 
-import re
-from typing import TYPE_CHECKING, Any
+import typing
 
-import attrs
 import marimo._server.models.models as core
+import msgspec
 from marimo._runtime import requests
-from pygls.protocol import default_converter
 
-if TYPE_CHECKING:
-    import cattrs
+T = typing.TypeVar("T", bound=msgspec.Struct)
 
 
-@attrs.define
-class BaseRequest:
-    """Base class for marimo's custom LSP commands."""
+class NotebookCommand(msgspec.Struct, typing.Generic[T], rename="camel"):
+    """Wraps a marimo command with its target notebook context.
 
-
-@attrs.define
-class RunRequest(BaseRequest):
-    """
-    A request to execute specific cells in a marimo notebook.
-
-    Wraps `marimo._server.models.RunRequest` with notebook context.
+    Associates any marimo command/request with the specific notebook
+    it should operate on, enabling proper routing in multi-notebook
+    environments.
     """
 
     notebook_uri: str
     """The URI of the notebook."""
 
-    cell_ids: list[core.CellId_t]
-    """The IDs of the cells to run."""
-
-    codes: list[str]
-    """Code to register or run for each cell."""
-
-    def into_marimo(self) -> core.RunRequest:
-        """Convert to the marimo core RunRequest."""
-        return core.RunRequest(
-            cell_ids=self.cell_ids,
-            codes=self.codes,
-        )
+    inner: T
+    """The wrapped marimo command to execute."""
 
 
-@attrs.define
-class SetUIElementValueRequest(BaseRequest):
-    """
-    A request to update ui elements in a marimo notebook.
-
-    Wraps `marimo._runtime.requests.SetUIElementValueRequest` with notebook context.
-    """
-
-    notebook_uri: str
-    """The URI of the notebook."""
-
-    object_ids: list[core.UIElementId]
-    """Identifiers for the UI elements"""
-
-    values: list[Any]
-    """Corresponding values for the UI elements"""
-
-    token: str
-    """Dummy token that is technically required"""
-
-    def into_marimo(self) -> requests.SetUIElementValueRequest:
-        """Convert to the marimo SetUIElementValueRequest."""
-        return requests.SetUIElementValueRequest(
-            object_ids=self.object_ids, values=self.values
-        )
-
-
-@attrs.define
-class SerializeRequest(BaseRequest):
+class SerializeRequest(msgspec.Struct, rename="camel"):
     """
     A request to serialize a notebook to Python source.
 
     Contains the notebook data to be serialized.
     """
 
-    notebook: dict[str, Any]
+    notebook: dict[str, typing.Any]
     """The notebook data in marimo's internal format."""
 
 
-@attrs.define
-class DeserializeRequest(BaseRequest):
+class DeserializeRequest(msgspec.Struct, rename="camel"):
     """
     A request to deserialize Python source to notebook format.
 
@@ -95,46 +48,22 @@ class DeserializeRequest(BaseRequest):
     """The Python source code to deserialize."""
 
 
-@attrs.define
-class ConvertRequest(BaseRequest):
+class ConvertRequest(msgspec.Struct, rename="camel"):
     """A request to convert a file source a marimo notebook."""
 
     uri: str
     """The identifier for the text document to convert"""
 
 
-@attrs.define
-class DebugAdapterRequest(BaseRequest):
+class DebugAdapterRequest(msgspec.Struct, rename="camel"):
     """A forwarded DAP request."""
 
     session_id: str
     """A UUID for the debug session."""
 
-    notebook_uri: str
-    """The URI of the notebook."""
-
     message: dict
     """They DAP message."""
 
 
-def _camel_to_snake(name: str) -> str:
-    s1 = re.sub(r"(.)([A-Z][a-z]+)", r"\1_\2", name)
-    return re.sub(r"([A-Z]+)([A-Z][a-z]*)", r"\1_\2", s1).lower()
-
-
-def _structure_base_request(data: object, cls: type[BaseRequest]) -> BaseRequest:
-    """Structure hook that converts camelCase keys to snake_case."""
-    if isinstance(data, dict):
-        converted = {}
-        for key, value in data.items():
-            snake_key = _camel_to_snake(key)
-            converted[snake_key] = value
-        return cls(**converted)
-    return data  # type: ignore[return-value]
-
-
-def converter_factory() -> cattrs.Converter:
-    """Extend `pygls` attrs converter with `BaseRequest` camelCase support."""
-    converter = default_converter()
-    converter.register_structure_hook(BaseRequest, _structure_base_request)
-    return converter
+RunRequest = core.RunRequest
+SetUIElementValueRequest = requests.SetUIElementValueRequest

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -369,9 +369,11 @@ x = 42\
             command="marimo.run",
             arguments=[
                 {
-                    "notebook_uri": "file:///exec_test.py",
-                    "cell_ids": ["cell1"],
-                    "codes": [code],
+                    "notebookUri": "file:///exec_test.py",
+                    "inner": {
+                        "cellIds": ["cell1"],
+                        "codes": [code],
+                    },
                 }
             ],
         )


### PR DESCRIPTION
Replaces `attrs` (modeling from `pygls`) with `msgspec`. This allows us to reuse more of marimo's internal types and avoid going between multiple serialization libraries.