### PR TITLE
Refactor message passing between frontend and backend for type safety

### DIFF
--- a/extension/src/commands.ts
+++ b/extension/src/commands.ts
@@ -3,7 +3,7 @@ import type * as lsp from "vscode-languageclient";
 
 import { AssertionError } from "./assert.ts";
 import { Logger } from "./logging.ts";
-import type { RequestMap } from "./types.ts";
+import type { MarimoCommand } from "./types.ts";
 
 export function registerCommand(command: string, callback: () => unknown) {
   return vscode.commands.registerCommand(command, () => {
@@ -21,11 +21,9 @@ export function registerCommand(command: string, callback: () => unknown) {
   });
 }
 
-export function executeCommand<K extends keyof RequestMap>(
+export function executeCommand(
   client: lsp.BaseLanguageClient,
-  options: {
-    command: K;
-    params: RequestMap[K];
+  options: MarimoCommand & {
     token?: vscode.CancellationToken;
   },
 ): Promise<unknown> {

--- a/extension/src/debugAdapter.ts
+++ b/extension/src/debugAdapter.ts
@@ -91,9 +91,11 @@ function createDebugAdapterDescriptor(
       executeCommand(client, {
         command: "marimo.dap",
         params: {
-          sessionId: session.id,
           notebookUri: session.configuration.notebookUri,
-          message,
+          inner: {
+            sessionId: session.id,
+            message,
+          },
         },
       });
     },

--- a/extension/src/notifications.ts
+++ b/extension/src/notifications.ts
@@ -1,0 +1,50 @@
+import type * as lsp from "vscode-languageclient";
+
+import { Logger } from "./logging.ts";
+import type { MarimoNotification, MarimoNotificationOf } from "./types.ts";
+
+export function registerNotificationHandler<K extends MarimoNotification>(
+  client: lsp.BaseLanguageClient,
+  options: {
+    method: K;
+    callback: (message: MarimoNotificationOf<K>) => void;
+    signal: AbortSignal;
+  },
+): void {
+  const disposer = client.onNotification(
+    options.method,
+    (message: MarimoNotificationOf<K>) => {
+      Logger.debug(
+        "Notification.Received",
+        `Received notification: ${options.method}`,
+      );
+      Logger.trace(
+        "Notification.Received",
+        `Message for ${options.method}`,
+        message,
+      );
+      return Promise.resolve(options.callback(message))
+        .then(() => {
+          Logger.trace(
+            "Notification.Handled",
+            `Successfully handled: ${options.method}`,
+          );
+        })
+        .catch((error) => {
+          Logger.error(
+            "Notification.Handler",
+            `Handler failed for: ${options.method}`,
+            error,
+          );
+          throw error;
+        });
+    },
+  );
+  options.signal.addEventListener("abort", () => {
+    Logger.debug(
+      "Notification.Unregister",
+      `Unregistering handler for: ${options.method}`,
+    );
+    disposer.dispose();
+  });
+}

--- a/extension/src/operations.ts
+++ b/extension/src/operations.ts
@@ -2,18 +2,7 @@ import * as vscode from "vscode";
 import { assert } from "./assert.ts";
 import { Logger } from "./logging.ts";
 import { type CellRuntimeState, CellStateManager } from "./shared/cells.ts";
-import type {
-  MessageOperation,
-  MessageOperationData,
-  MessageOperationType,
-} from "./types.ts";
-
-export type OperationMessage = {
-  [Type in MessageOperationType]: {
-    op: Type;
-    data: Omit<Extract<MessageOperation, { name: Type }>, "name">;
-  };
-}[MessageOperationType];
+import type { CellMessage, MessageOperation } from "./types.ts";
 
 export interface OperationContext {
   notebookUri: string;
@@ -23,12 +12,12 @@ export interface OperationContext {
 
 export async function route(
   context: OperationContext,
-  operation: OperationMessage,
+  operation: MessageOperation,
 ): Promise<void> {
-  Logger.trace("Operation.Router", `Received: ${operation.op}`, operation.data);
+  Logger.trace("Operation.Router", `Received: ${operation.op}`, operation);
   switch (operation.op) {
     case "cell-op": {
-      handleCellOperation(context, operation.data);
+      handleCellOperation(context, operation);
       break;
     }
 
@@ -45,9 +34,9 @@ const cellStateManager = new CellStateManager();
 
 async function handleCellOperation(
   context: OperationContext,
-  data: MessageOperationData<"cell-op">,
+  data: CellMessage,
 ): Promise<void> {
-  const { cell_id: cellId, status, timestamp } = data;
+  const { cell_id: cellId, status, timestamp = 0 } = data;
   const state = cellStateManager.handleCellOp(data);
 
   switch (status) {

--- a/extension/src/renderer/marimo-frontend.ts
+++ b/extension/src/renderer/marimo-frontend.ts
@@ -31,8 +31,6 @@ import { initializePlugins } from "@marimo-team/frontend/unstable_internal/plugi
 // @ts-expect-error
 import { useTheme as untypedUseTheme } from "@marimo-team/frontend/unstable_internal/theme/useTheme.ts?nocheck";
 
-import type { MessageOperationData } from "../types.ts";
-
 import "@marimo-team/frontend/unstable_internal/css/common.css";
 import "@marimo-team/frontend/unstable_internal/css/globals.css";
 import "@marimo-team/frontend/unstable_internal/css/codehilite.css";
@@ -44,7 +42,6 @@ import "@marimo-team/frontend/unstable_internal/css/table.css";
 
 import type { CellRuntimeState } from "../shared/cells.ts";
 export type RequestClient = EditRequests & RunRequests;
-export type CellMessage = MessageOperationData<"cell-op">;
 export type { CellRuntimeState, CellId };
 
 /**

--- a/extension/src/renderer/utils.ts
+++ b/extension/src/renderer/utils.ts
@@ -1,17 +1,14 @@
 import type * as vscode from "vscode-notebook-renderer";
 
 import { assert } from "../assert.ts";
-import type { RequestMap } from "../types.ts";
+import type { RendererCommand } from "../types.ts";
 import type { RequestClient } from "./marimo-frontend.ts";
 
 type TypedRequestContext = Omit<
   vscode.RendererContext<unknown>,
   "postMessage" | "onDidReceiveMessage"
 > & {
-  postMessage<K extends keyof RequestMap>(options: {
-    command: K;
-    params: Omit<RequestMap[K], "notebookUri">;
-  }): void;
+  postMessage(options: RendererCommand): void;
   onDidReceiveMessage(listener: (e: unknown) => unknown): { dispose(): void };
 };
 

--- a/extension/src/shared/cells.ts
+++ b/extension/src/shared/cells.ts
@@ -2,9 +2,8 @@
 import { transitionCell as untypedTransitionCell } from "@marimo-team/frontend/unstable_internal/core/cells/cell.ts?nocheck";
 import type { CellRuntimeState } from "@marimo-team/frontend/unstable_internal/core/cells/types.ts";
 import { createCellRuntimeState } from "@marimo-team/frontend/unstable_internal/core/cells/types.ts";
-import type { MessageOperationData } from "../types.ts";
+import type { CellMessage } from "../types.ts";
 
-export type CellMessage = MessageOperationData<"cell-op">;
 export type { CellRuntimeState };
 
 /* Type-safe wrapper around marimo's `transitionCell` we import above */

--- a/src/marimo_lsp/session_consumer.py
+++ b/src/marimo_lsp/session_consumer.py
@@ -48,9 +48,7 @@ class LspSessionConsumer(SessionConsumer):
                     "marimo/operation",
                     {
                         "notebookUri": self.notebook_uri,
-                        "op": op_name,
-                        # TODO: Just send bytes directly
-                        "data": json.loads(msg_bytes),
+                        "operation": json.loads(msg_bytes),
                     },
                 )
 
@@ -71,8 +69,7 @@ class LspSessionConsumer(SessionConsumer):
             "marimo/operation",
             {
                 "notebookUri": self.notebook_uri,
-                "op": op.name,
-                "data": asdict(op),
+                "operation": asdict(op),
             },
         )
         logger.debug(f"Sent {op.name} operation to {self.notebook_uri}")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -358,7 +358,7 @@ x = 42\
         # pygls dynamically makes an `Object` named tuple which makes snapshotting hard
         # we just convert to a regular dict here for snapshotting
         messages.append(asdict(params))
-        if params.op == "completed-run":
+        if params.operation.op == "completed-run":
             # FIXME: stdin/stdout are flushed every 10ms, so wait 100ms to ensure
             # all related events. The frontend uses the same workaround.
             await asyncio.sleep(0.1)
@@ -384,8 +384,7 @@ x = 42\
         [
             {
                 "notebookUri": "file:///exec_test.py",
-                "op": "update-cell-codes",
-                "data": {
+                "operation": {
                     "op": "update-cell-codes",
                     "cell_ids": ["cell1"],
                     "codes": [
@@ -402,13 +401,11 @@ x = 42\
             },
             {
                 "notebookUri": "file:///exec_test.py",
-                "op": "focus-cell",
-                "data": {"op": "focus-cell", "cell_id": "cell1"},
+                "operation": {"op": "focus-cell", "cell_id": "cell1"},
             },
             {
                 "notebookUri": "file:///exec_test.py",
-                "op": "variables",
-                "data": {
+                "operation": {
                     "op": "variables",
                     "variables": IsList(
                         {"name": "sys", "declared_by": ["cell1"], "used_by": []},
@@ -419,8 +416,7 @@ x = 42\
             },
             {
                 "notebookUri": "file:///exec_test.py",
-                "op": "cell-op",
-                "data": {
+                "operation": {
                     "op": "cell-op",
                     "cell_id": "cell1",
                     "output": None,
@@ -434,13 +430,11 @@ x = 42\
             },
             {
                 "notebookUri": "file:///exec_test.py",
-                "op": "remove-ui-elements",
-                "data": {"op": "remove-ui-elements", "cell_id": "cell1"},
+                "operation": {"op": "remove-ui-elements", "cell_id": "cell1"},
             },
             {
                 "notebookUri": "file:///exec_test.py",
-                "op": "cell-op",
-                "data": {
+                "operation": {
                     "op": "cell-op",
                     "cell_id": "cell1",
                     "output": None,
@@ -454,8 +448,7 @@ x = 42\
             },
             {
                 "notebookUri": "file:///exec_test.py",
-                "op": "variable-values",
-                "data": {
+                "operation": {
                     "op": "variable-values",
                     "variables": IsList(
                         {"name": "sys", "value": "sys", "datatype": "module"},
@@ -466,8 +459,7 @@ x = 42\
             },
             {
                 "notebookUri": "file:///exec_test.py",
-                "op": "cell-op",
-                "data": {
+                "operation": {
                     "op": "cell-op",
                     "cell_id": "cell1",
                     "output": {
@@ -486,8 +478,7 @@ x = 42\
             },
             {
                 "notebookUri": "file:///exec_test.py",
-                "op": "cell-op",
-                "data": {
+                "operation": {
                     "op": "cell-op",
                     "cell_id": "cell1",
                     "output": None,
@@ -501,13 +492,11 @@ x = 42\
             },
             {
                 "notebookUri": "file:///exec_test.py",
-                "op": "completed-run",
-                "data": {"op": "completed-run"},
+                "operation": {"op": "completed-run"},
             },
             {
                 "notebookUri": "file:///exec_test.py",
-                "op": "cell-op",
-                "data": {
+                "operation": {
                     "op": "cell-op",
                     "cell_id": "cell1",
                     "output": None,
@@ -526,8 +515,7 @@ x = 42\
             },
             {
                 "notebookUri": "file:///exec_test.py",
-                "op": "cell-op",
-                "data": {
+                "operation": {
                     "op": "cell-op",
                     "cell_id": "cell1",
                     "output": None,


### PR DESCRIPTION
Consolidate the typed boundary for client-server communication by introducing structured message types and notification handlers. The changes ensure type-safe message passing between the VSCode extension frontend and the marimo language server backend.

Key improvements include wrapping all command parameters in a `NotebookScoped` container to consistently associate operations with their notebook context, creating dedicated TypeScript types for commands and notifications to replace loosely typed maps, and simplifying the Python backend to send operations as unified objects rather than split op/data fields.