### PR TITLE
Add interrupt handler for notebook execution

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -98,6 +98,17 @@ Updates UI element values from frontend interactions.
 }
 ```
 
+<a name="marimo.interrupt" href="#marimo.interrupt">#</a>
+**marimo.interrupt** · [Source](src/marimo_lsp/server.py#L184)
+
+Interrupts kernel execution for the specified notebook, stopping all running cells.
+
+```typescript
+{
+  notebookUri: string;
+}
+```
+
 <a name="marimo.dap" href="#marimo.dap">#</a> **marimo.dap** ·
 [Source](src/marimo_lsp/server.py#L149)
 
@@ -207,6 +218,7 @@ Cell execution follows this lifecycle:
 1. **Queued**: `NotebookCellExecution` created when cell is submitted
 2. **Running**: Execution started with timestamp, outputs begin streaming
 3. **Idle**: Execution completed, final outputs rendered, execution disposed
+4. **Interrupted**: Execution can be stopped via VS Code's interrupt button, which sends a SIGINT signal to the kernel
 
 ### Frontend Integration
 

--- a/extension/package.json
+++ b/extension/package.json
@@ -98,7 +98,8 @@
     "build": "pnpm run build:renderer && pnpm run build:extension",
     "build:extension": "esbuild --format=cjs --define:import.meta.env.DEV=false --platform=node --minify --external:vscode --bundle --sourcemap src/extension.ts --outdir=dist",
     "build:renderer": "vite build",
-    "fix": "biome check --write"
+    "fix": "biome check --write",
+    "typecheck": "tsgo"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.2.2",

--- a/extension/src/notebookSerializer.ts
+++ b/extension/src/notebookSerializer.ts
@@ -1,151 +1,87 @@
-import { Effect, type Layer, ParseResult, Schema } from "effect";
+import { Effect, type Layer } from "effect";
 import * as vscode from "vscode";
-import { Logger } from "./logging.ts";
-import { NotebookSerializationSchema } from "./schemas.ts";
-import { MarimoLanguageClient } from "./services.ts";
+import { MarimoLanguageClient, runPromise } from "./services.ts";
 import { notebookType } from "./types.ts";
 
 export function notebookSerializer(
   layer: Layer.Layer<MarimoLanguageClient>,
   options: { signal: AbortSignal },
 ) {
-  const disposer = vscode.workspace.registerNotebookSerializer(
-    notebookType,
-    new MarimoNotebookSerializer(layer),
-  );
+  const disposer = vscode.workspace.registerNotebookSerializer(notebookType, {
+    async serializeNotebook(
+      notebook: vscode.NotebookData,
+      token: vscode.CancellationToken,
+    ): Promise<Uint8Array> {
+      return run(
+        Effect.gen(function* () {
+          const client = yield* MarimoLanguageClient;
+          yield* Effect.logDebug("Serializing notebook").pipe(
+            Effect.annotateLogs({ cellCount: notebook.cells.length }),
+          );
+          const bytes = yield* client.serialize(notebook);
+          yield* Effect.logDebug("Serialization complete").pipe(
+            Effect.annotateLogs({ bytes: bytes.length }),
+          );
+          return bytes;
+        }),
+        {
+          layer,
+          token,
+          kind: "serialization",
+        },
+      );
+    },
+    async deserializeNotebook(
+      bytes: Uint8Array,
+      token: vscode.CancellationToken,
+    ): Promise<vscode.NotebookData> {
+      return run(
+        Effect.gen(function* () {
+          const client = yield* MarimoLanguageClient;
+          yield* Effect.logDebug("Deserializing notebook").pipe(
+            Effect.annotateLogs({ bytes: bytes.length }),
+          );
+          const notebook = yield* client.deserialize(bytes);
+          yield* Effect.logDebug("Deserialization complete").pipe(
+            Effect.annotateLogs({ cellCount: notebook.cells.length }),
+          );
+          return notebook;
+        }),
+        {
+          kind: "deserialization",
+          layer,
+          token,
+        },
+      );
+    },
+  });
   options.signal.addEventListener("aborted", () => {
     disposer.dispose();
   });
 }
 
-export class MarimoNotebookSerializer implements vscode.NotebookSerializer {
-  private layer: Layer.Layer<MarimoLanguageClient>;
-
-  constructor(layer: Layer.Layer<MarimoLanguageClient>) {
-    this.layer = layer;
-  }
-
-  async serializeNotebook(
-    notebook: vscode.NotebookData,
-    token: vscode.CancellationToken,
-  ): Promise<Uint8Array> {
-    const startTime = Date.now();
-    Logger.debug("Serializer", "Serializing notebook", {
-      cellCount: notebook.cells.length,
-    });
-    Logger.trace("Serializer.Data", "Notebook data", notebook);
-    const { cells, metadata = {} } = notebook;
-
-    const program = Effect.gen(function* () {
-      const client = yield* MarimoLanguageClient;
-      const notebookData = yield* Schema.decodeUnknown(
-        NotebookSerializationSchema,
-      )({
-        app: metadata.app ?? { options: {} },
-        header: metadata.header ?? null,
-        version: metadata.version ?? null,
-        violations: metadata.violations ?? [],
-        valid: metadata.valid ?? true,
-        cells: cells.map((cell) => ({
-          code: cell.value,
-          name: cell.metadata?.name ?? "_",
-          options: cell.metadata?.options ?? {},
-        })),
-      }).pipe(
-        Effect.tapErrorTag("ParseError", (error) => {
-          Logger.error(
-            "Serializer.Parse",
-            "Failed to parse notebook data",
-            ParseResult.TreeFormatter.formatErrorSync(error),
-          );
-          return Effect.void;
-        }),
-      );
-
-      const { source } = yield* client
-        .serialize({ notebook: notebookData })
-        .pipe(
-          Effect.andThen(
-            Schema.decodeUnknown(Schema.Struct({ source: Schema.String })),
-          ),
-          Effect.tapError((error) => {
-            Logger.error(
-              "Serializer.Command",
-              "marimo.serialize command failed",
-              error,
-            );
-            return Effect.void;
-          }),
-        );
-
-      const result = new TextEncoder().encode(source);
-      Logger.debug("Serializer", "Serialization complete", {
-        duration: Date.now() - startTime,
-        bytes: result.length,
-      });
-      return result;
-    });
-
-    return this.runProgram(program, token);
-  }
-
-  async deserializeNotebook(
-    data: Uint8Array,
-    token: vscode.CancellationToken,
-  ): Promise<vscode.NotebookData> {
-    const source = new TextDecoder().decode(data);
-    const startTime = Date.now();
-    Logger.debug("Serializer", "Deserializing notebook", {
-      bytes: data.length,
-    });
-    Logger.trace("Serializer.Data", "Source content", source);
-
-    const program = Effect.gen(function* () {
-      const client = yield* MarimoLanguageClient;
-      const notebookData = yield* client.deserialize({ source }).pipe(
-        Effect.andThen(Schema.decodeUnknown(NotebookSerializationSchema)),
-        Effect.tapError((error) => {
-          Logger.error(
-            "Serializer.Command",
-            "marimo.deserialize command failed",
-            error,
-          );
-          return Effect.void;
-        }),
-      );
-      const { cells, ...metadata } = notebookData;
-      const result = {
-        metadata: metadata,
-        cells: cells.map((cell) => ({
-          kind: vscode.NotebookCellKind.Code,
-          value: cell.code,
-          languageId: "python",
-          metadata: {
-            name: cell.name,
-            options: cell.options,
-          },
-        })),
-      };
-      Logger.debug("Serializer", "Deserialization complete", {
-        duration: Date.now() - startTime,
-        cellCount: result.cells.length,
-      });
-      return result;
-    });
-
-    const result = this.runProgram(program, token);
-    return result;
-  }
-
-  private runProgram<T, E>(
-    program: Effect.Effect<T, E, MarimoLanguageClient>,
-    token: vscode.CancellationToken,
-  ): Promise<T> {
-    const controller = new AbortController();
-    token.onCancellationRequested(() => {
-      controller.abort();
-    });
-    const runnable = Effect.provide(program, this.layer);
-    return Effect.runPromise(runnable, { signal: controller.signal });
-  }
+function run<T, E>(
+  program: Effect.Effect<T, E, MarimoLanguageClient>,
+  options: {
+    layer: Layer.Layer<MarimoLanguageClient>;
+    token: vscode.CancellationToken;
+    kind: "deserialization" | "serialization";
+  },
+): Promise<T> {
+  const { token, kind, layer } = options;
+  const controller = new AbortController();
+  token.onCancellationRequested(() => {
+    controller.abort();
+  });
+  const runnable = program.pipe(
+    Effect.tapError((error) =>
+      Effect.logError(`Notebook ${kind} failed.`, error),
+    ),
+    Effect.mapError(
+      // show logs
+      () => new Error(`Notebook ${kind} failed. See logs for details.`),
+    ),
+    Effect.provide(layer),
+  );
+  return runPromise(runnable, { signal: controller.signal });
 }

--- a/extension/src/operations.ts
+++ b/extension/src/operations.ts
@@ -28,8 +28,13 @@ export function routeOperation(
       case "send-ui-element-message": {
         return yield* renderer.postMessage(operation);
       }
+      case "interrupted":
       case "completed-run": {
-        // TODO: Do something to clear out existing context?
+        // Clear all pending executions when run is completed/interrupted
+        for (const [_cellId, execution] of context.executions) {
+          execution.end(false, Date.now());
+        }
+        context.executions.clear();
         return yield* Effect.void;
       }
       default:

--- a/extension/src/services.ts
+++ b/extension/src/services.ts
@@ -4,14 +4,16 @@ import {
   Effect,
   Layer,
   Logger,
-  type LogLevel,
+  LogLevel,
+  type ParseResult,
+  Schema,
   Stream,
 } from "effect";
 import * as vscode from "vscode";
 import type * as lsp from "vscode-languageclient";
 import { executeCommand } from "./commands.ts";
 import { Logger as VsCodeLogger } from "./logging.ts";
-
+import { NotebookSerializationSchema } from "./schemas.ts";
 import type {
   MarimoCommand,
   MarimoNotification,
@@ -45,10 +47,24 @@ export class MarimoLanguageClient extends Effect.Service<MarimoLanguageClient>()
       const client = yield* RawLanguageClient;
 
       function exec(command: MarimoCommand) {
-        return Effect.tryPromise({
-          try: () => executeCommand(client, command),
-          catch: (error) => new ExecuteCommandError({ command, error }),
-        });
+        return Effect.withSpan(command.command)(
+          Effect.tryPromise({
+            try: (signal) => {
+              const source = new vscode.CancellationTokenSource();
+              if (signal.aborted) source.cancel();
+              signal.addEventListener("abort", () => {
+                source.cancel();
+              });
+              return executeCommand(client, {
+                ...command,
+                token: source.token,
+              }).finally(() => {
+                source.dispose();
+              });
+            },
+            catch: (error) => new ExecuteCommandError({ command, error }),
+          }),
+        );
       }
 
       return {
@@ -59,11 +75,68 @@ export class MarimoLanguageClient extends Effect.Service<MarimoLanguageClient>()
         setUiElementValue(params: ParamsFor<"marimo.set_ui_element_value">) {
           return exec({ command: "marimo.set_ui_element_value", params });
         },
-        serialize(params: ParamsFor<"marimo.serialize">) {
-          return exec({ command: "marimo.serialize", params });
+        interrupt(params: ParamsFor<"marimo.interrupt">) {
+          return exec({ command: "marimo.interrupt", params });
         },
-        deserialize(params: ParamsFor<"marimo.deserialize">) {
-          return exec({ command: "marimo.deserialize", params });
+        serialize(
+          params: vscode.NotebookData,
+        ): Effect.Effect<
+          Uint8Array,
+          ExecuteCommandError | ParseResult.ParseError,
+          never
+        > {
+          const { cells, metadata = {} } = params;
+          return Effect.gen(function* () {
+            const notebook = yield* Schema.decodeUnknown(
+              NotebookSerializationSchema,
+            )({
+              app: metadata.app ?? { options: {} },
+              header: metadata.header ?? null,
+              version: metadata.version ?? null,
+              violations: metadata.violations ?? [],
+              valid: metadata.valid ?? true,
+              cells: cells.map((cell) => ({
+                code: cell.value,
+                name: cell.metadata?.name ?? "_",
+                options: cell.metadata?.options ?? {},
+              })),
+            });
+            return yield* exec({
+              command: "marimo.serialize",
+              params: { notebook },
+            }).pipe(
+              Effect.andThen(
+                Schema.decodeUnknown(Schema.Struct({ source: Schema.String })),
+              ),
+              Effect.andThen(({ source }) => new TextEncoder().encode(source)),
+            );
+          });
+        },
+        deserialize(
+          buf: Uint8Array,
+        ): Effect.Effect<
+          vscode.NotebookData,
+          ExecuteCommandError | ParseResult.ParseError,
+          never
+        > {
+          return exec({
+            command: "marimo.deserialize",
+            params: { source: new TextDecoder().decode(buf) },
+          }).pipe(
+            Effect.andThen(Schema.decodeUnknown(NotebookSerializationSchema)),
+            Effect.andThen(({ cells, ...metadata }) => ({
+              metadata: metadata,
+              cells: cells.map((cell) => ({
+                kind: vscode.NotebookCellKind.Code,
+                value: cell.code,
+                languageId: "python",
+                metadata: {
+                  name: cell.name,
+                  options: cell.options,
+                },
+              })),
+            })),
+          );
         },
         streamOf<Notification extends MarimoNotification>(
           notification: Notification,
@@ -141,3 +214,14 @@ export const LoggerLive = Logger.replace(
     log(message);
   }),
 );
+
+export function runPromise<A, E>(
+  e: Effect.Effect<A, E>,
+  options: { readonly signal?: AbortSignal } = {},
+): Promise<A> {
+  // We just forward everything since the VsCodeLogger automatically filters
+  return Effect.runPromise(
+    e.pipe(Logger.withMinimumLogLevel(LogLevel.All)),
+    options,
+  );
+}

--- a/extension/src/types.ts
+++ b/extension/src/types.ts
@@ -33,12 +33,15 @@ interface DebugAdapterRequest {
   sessionId: string;
   message: vscode.DebugProtocolMessage;
 }
+// biome-ignore lint/complexity/noBannedTypes: We need this for over the wire
+type InterruptRequest = {};
 
 // client -> language server
 type MarimoCommandMap = {
   "marimo.run": SessionScoped<RunRequest>;
   "marimo.set_ui_element_value": NotebookScoped<SetUIElementValueRequest>;
   "marimo.dap": NotebookScoped<DebugAdapterRequest>;
+  "marimo.interrupt": NotebookScoped<InterruptRequest>;
   "marimo.serialize": SerializeRequest;
   "marimo.deserialize": DeserializeRequest;
 };

--- a/src/marimo_lsp/models.py
+++ b/src/marimo_lsp/models.py
@@ -72,5 +72,9 @@ class DebugAdapterRequest(msgspec.Struct, rename="camel"):
     """They DAP message."""
 
 
+class InterruptRequest(msgspec.Struct, rename="camel"):
+    """A request to interrupt the kernel execution."""
+
+
 RunRequest = core.RunRequest
 SetUIElementValueRequest = requests.SetUIElementValueRequest

--- a/src/marimo_lsp/server.py
+++ b/src/marimo_lsp/server.py
@@ -24,6 +24,7 @@ from marimo_lsp.models import (
     ConvertRequest,
     DebugAdapterRequest,
     DeserializeRequest,
+    InterruptRequest,
     NotebookCommand,
     RunRequest,
     SerializeRequest,
@@ -179,6 +180,19 @@ def create_server() -> LanguageServer:  # noqa: C901, PLR0915
         session = manager.get_session(args.notebook_uri)
         assert session, f"No session in workspace for {args.notebook_uri}"
         session.put_control_request(args.inner, from_consumer_id=None)
+
+    @command(server, "marimo.interrupt", NotebookCommand[InterruptRequest])
+    async def interrupt(
+        ls: LanguageServer,  # noqa: ARG001
+        args: NotebookCommand[InterruptRequest],
+    ):
+        logger.info(f"marimo.interrupt for {args.notebook_uri}")
+        session = manager.get_session(args.notebook_uri)
+        if session:
+            session.try_interrupt()
+            logger.info(f"Interrupt request sent for {args.notebook_uri}")
+        else:
+            logger.warning(f"No session found for {args.notebook_uri}")
 
     @command(server, "marimo.serialize", SerializeRequest)
     async def serialize(ls: LanguageServer, args: SerializeRequest):  # noqa: ARG001


### PR DESCRIPTION
This adds a new `marimo.interrupt` command that flows from the VS Code notebook controller through the language server to the marimo kernel, properly handling SIGINT signals to stop execution. The implementation follows the existing command pattern and integrates with VS Code's `interruptHandler` API for REPL-style interruption similar to Ctrl+C in terminals.