### PR TITLE
Embed `sdist` within VS Code extension instead of `.whl`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,8 +105,7 @@ jobs:
         run: |
           pnpm install
           pnpm build
-          # Include a built Python wheel for marimo-lsp inside the dist/
-          uv build --directory=.. --out-dir=extension/dist --wheel
+          pnpm embed-sdist
 
       - name: vitest
         run: pnpm test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,8 +57,7 @@ jobs:
         run: |
           pnpm install
           pnpm build
-          # Include a built Python wheel for marimo-lsp inside the dist/
-          uv build --directory=.. --out-dir=extension/dist --wheel
+          pnpm embed-sdist
 
       - name: Package the extension
         working-directory: marimo-lsp/extension

--- a/extension/.vscodeignore
+++ b/extension/.vscodeignore
@@ -10,3 +10,5 @@ turbo.json
 vite.config.mjs
 .tsbuildinfo
 .vscode-test
+.claude
+tests

--- a/extension/package.json
+++ b/extension/package.json
@@ -112,7 +112,8 @@
     "fix": "biome check --write",
     "typecheck": "tsgo && tsc",
     "test": "vitest",
-    "test:extension": "vscode-test"
+    "test:extension": "vscode-test",
+    "embed-sdist": "uv build --directory=.. --out-dir=extension/dist --sdist && cd dist/ && tar xzf marimo_lsp-*.tar.gz && rm marimo_lsp-*.tar.gz"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.2.4",

--- a/extension/src/languageClient.ts
+++ b/extension/src/languageClient.ts
@@ -16,17 +16,17 @@ async function getLspExecutable(): Promise<lsp.Executable> {
     };
   }
 
-  // Look for bundled wheel matching marimo_lsp*.whl pattern
+  // Look for bundled wheel matching marimo_lsp-* pattern
   // The wheel is built during the vscode:prepublish step and copied to the dist directory
-  const wheelFile = fs
+  const sdistDir = fs
     .readdirSync(__dirname)
-    .find((f) => f.startsWith("marimo_lsp") && f.endsWith(".whl"));
-  if (wheelFile) {
-    const wheelPath = path.join(__dirname, wheelFile);
-    Logger.info("LSP", `Using bundled wheel: ${wheelFile}`);
+    .find((f) => f.startsWith("marimo_lsp-"));
+  if (sdistDir) {
+    const sdist = path.join(__dirname, sdistDir);
+    Logger.info("LSP", `Using bundled marimo-lsp: ${sdist}`);
     return {
       command: "uvx",
-      args: ["--from", wheelPath, "marimo-lsp"],
+      args: ["--from", sdist, "marimo-lsp"],
       transport: lsp.TransportKind.stdio,
     };
   }


### PR DESCRIPTION
Our previous pre-release failed virus checks I'm guessing because we uploaded a wheel (zip file) in the distribution. These changes now embed the untarred `sdist` of `marimo-lsp`.