### PR TITLE
Add strict linting rule for `vscode` imports

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -5,6 +5,7 @@
     "clientKind": "git",
     "useIgnoreFile": true
   },
+  "plugins": ["./extension/lint/vscode-type-only.grit"],
   "files": {
     "ignoreUnknown": false
   },
@@ -18,6 +19,9 @@
       "recommended": true,
       "correctness": {
         "useHookAtTopLevel": "off"
+      },
+      "style": {
+        "useImportType": "error"
       }
     }
   },

--- a/extension/lint/vscode-type-only.grit
+++ b/extension/lint/vscode-type-only.grit
@@ -1,0 +1,13 @@
+language js
+
+or {
+  `import * as $n from "vscode"` where {
+    register_diagnostic(span=$n, message="Use type-only imports for vscode module. Change to: import type * as ... from 'vscode'", severity="error")
+  },
+  `import { $names } from "vscode"` where {
+    register_diagnostic(span=$names, message="Use type-only imports for vscode module. Change to: import type { ... } from 'vscode'", severity="error")
+  },
+  `import $name from "vscode"` where {
+    register_diagnostic(span=$name, message="Use type-only imports for vscode module. Change to: import type ... from 'vscode'", severity="error")
+  }
+}

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -1,5 +1,5 @@
 import { Effect, Exit, Layer, Logger, LogLevel, pipe, Scope } from "effect";
-import * as vscode from "vscode";
+import type * as vscode from "vscode";
 
 import { MainLive } from "./layers/Main.ts";
 
@@ -9,10 +9,7 @@ export async function activate(
   return pipe(
     Effect.gen(function* () {
       yield* Effect.logInfo("Activating marimo extension").pipe(
-        Effect.annotateLogs({
-          extensionPath: context.extensionPath,
-          workspaceFolder: vscode.workspace.workspaceFolders?.[0]?.uri.fsPath,
-        }),
+        Effect.annotateLogs({ extensionPath: context.extensionPath }),
       );
       // Create a scope and build layers with it. Layer.buildWithScope completes
       // once all layer initialization finishes (commands registered, serializer

--- a/extension/src/layers/RegisterCommands.ts
+++ b/extension/src/layers/RegisterCommands.ts
@@ -15,8 +15,17 @@ export const RegisterCommandsLive = Layer.scopedDiscard(
     yield* code.commands.registerCommand(
       "marimo.newMarimoNotebook",
       Effect.gen(function* () {
-        const doc = yield* code.workspace.createEmptyPythonNotebook(
-          serializer.notebookType,
+        const doc = yield* code.workspace.use((api) =>
+          api.openNotebookDocument(
+            serializer.notebookType,
+            new code.NotebookData([
+              new code.NotebookCellData(
+                code.NotebookCellKind.Code,
+                "",
+                "python",
+              ),
+            ]),
+          ),
         );
         yield* code.window.use((api) => api.showNotebookDocument(doc));
         yield* Effect.logInfo("Created new marimo notebook").pipe(

--- a/extension/src/services/Config.ts
+++ b/extension/src/services/Config.ts
@@ -1,24 +1,28 @@
 import { Effect } from "effect";
-import * as vscode from "vscode";
+import { VsCode } from "./VsCode.ts";
 
 /**
  * Provides access to the extension configuration settings.
  */
 export class Config extends Effect.Service<Config>()("Config", {
-  sync: () => ({
-    get lsp() {
-      return {
-        get executable(): undefined | { command: string; args: string[] } {
-          const lspPath = vscode.workspace
-            .getConfiguration("marimo.lsp")
-            .get<string[]>("path", []);
-          if (!lspPath || lspPath.length === 0) {
-            return undefined;
-          }
-          const [command, ...args] = lspPath;
-          return { command, args };
-        },
-      };
-    },
+  dependencies: [VsCode.Default],
+  effect: Effect.gen(function* () {
+    const code = yield* VsCode;
+    return {
+      get lsp() {
+        return {
+          get executable(): undefined | { command: string; args: string[] } {
+            const lspPath = code.workspace
+              .getConfiguration("marimo.lsp")
+              .get<string[]>("path", []);
+            if (!lspPath || lspPath.length === 0) {
+              return undefined;
+            }
+            const [command, ...args] = lspPath;
+            return { command, args };
+          },
+        };
+      },
+    };
   }),
 }) {}

--- a/extension/src/services/DebugAdapter.ts
+++ b/extension/src/services/DebugAdapter.ts
@@ -1,8 +1,9 @@
 import { Effect, Fiber, FiberSet } from "effect";
-import * as vscode from "vscode";
+import type * as vscode from "vscode";
 
 import { LanguageClient } from "./LanguageClient.ts";
 import { NotebookSerializer } from "./NotebookSerializer.ts";
+import { VsCode } from "./VsCode.ts";
 
 /**
  * Provides Debug Adapter Protocol (DAP) bridge for marimo notebooks.
@@ -10,11 +11,18 @@ import { NotebookSerializer } from "./NotebookSerializer.ts";
 export class DebugAdapter extends Effect.Service<DebugAdapter>()(
   "DebugAdapter",
   {
-    dependencies: [NotebookSerializer.Default, LanguageClient.Default],
+    dependencies: [
+      NotebookSerializer.Default,
+      LanguageClient.Default,
+      VsCode.Default,
+    ],
     scoped: Effect.gen(function* () {
       const debugType = "marimo";
-      const serializer = yield* NotebookSerializer;
+
+      const code = yield* VsCode;
       const marimo = yield* LanguageClient;
+      const serializer = yield* NotebookSerializer;
+
       const runFork = yield* FiberSet.makeRuntime();
 
       yield* Effect.logInfo("Setting up debug adapter").pipe(
@@ -42,91 +50,80 @@ export class DebugAdapter extends Effect.Service<DebugAdapter>()(
         ),
       );
 
-      yield* Effect.acquireRelease(
-        Effect.sync(() =>
-          vscode.debug.registerDebugAdapterDescriptorFactory("marimo", {
-            createDebugAdapterDescriptor(session) {
-              const emitter =
-                emitters.get(session.id) ?? new vscode.EventEmitter();
-              emitters.set(session.id, emitter);
+      yield* code.debug.registerDebugAdapterDescriptorFactory(debugType, {
+        createDebugAdapterDescriptor(session) {
+          const emitter = emitters.get(session.id) ?? new code.EventEmitter();
+          emitters.set(session.id, emitter);
 
-              return new vscode.DebugAdapterInlineImplementation({
-                onDidSendMessage: emitter.event,
-                handleMessage(message) {
-                  runFork<never, void>(
-                    Effect.gen(function* () {
-                      yield* Effect.logDebug("Sending DAP message to LSP").pipe(
-                        Effect.annotateLogs({
-                          component: "debug-adapter",
-                          sessionId: session.id,
-                          // @ts-expect-error - type is not include in vscode types
-                          type: message.type,
-                        }),
-                      );
-                      yield* marimo.dap({
-                        notebookUri: session.configuration.notebookUri,
-                        inner: {
-                          sessionId: session.id,
-                          message,
-                        },
-                      });
-                    }).pipe(
-                      Effect.catchTags({
-                        ExecuteCommandError: Effect.logError,
-                      }),
-                    ),
-                  );
-                },
-                dispose() {
-                  emitters.get(session.id)?.dispose();
-                  emitters.delete(session.id);
-                },
-              });
-            },
-          }),
-        ),
-        (disposer) => Effect.sync(() => disposer.dispose()),
-      );
-
-      yield* Effect.acquireRelease(
-        Effect.sync(() =>
-          vscode.debug.registerDebugConfigurationProvider("marimo", {
-            resolveDebugConfiguration(_workspaceFolder, config) {
-              return runFork<never, vscode.DebugConfiguration | undefined>(
+          return new code.DebugAdapterInlineImplementation({
+            onDidSendMessage: emitter.event,
+            handleMessage(message) {
+              runFork<never, void>(
                 Effect.gen(function* () {
-                  yield* Effect.logInfo("Resolving debug configuration").pipe(
+                  yield* Effect.logDebug("Sending DAP message to LSP").pipe(
                     Effect.annotateLogs({
                       component: "debug-adapter",
-                      config,
+                      sessionId: session.id,
+                      // @ts-expect-error - type is not include in vscode types
+                      type: message.type,
                     }),
                   );
-                  const notebook = vscode.window.activeNotebookEditor?.notebook;
-                  if (notebook?.notebookType !== serializer.notebookType) {
-                    yield* Effect.logWarning(
-                      "No active marimo notebook found",
-                    ).pipe(Effect.annotateLogs({ component: "debug-adapter" }));
-                    return undefined;
-                  }
-                  config.type = "marimo";
-                  config.name = config.name ?? "Debug Marimo";
-                  config.request = config.request ?? "launch";
-                  config.notebookUri = notebook.uri.toString();
-                  yield* Effect.logInfo("Configuration resolved").pipe(
-                    Effect.annotateLogs({
-                      component: "debug-adapter",
-                      notebookUri: config.notebookUri,
-                      type: config.type,
-                      request: config.request,
-                    }),
-                  );
-                  return config;
-                }),
-              ).pipe(Fiber.join, Effect.runPromise);
+                  yield* marimo.dap({
+                    notebookUri: session.configuration.notebookUri,
+                    inner: {
+                      sessionId: session.id,
+                      message,
+                    },
+                  });
+                }).pipe(
+                  Effect.catchTags({
+                    ExecuteCommandError: Effect.logError,
+                  }),
+                ),
+              );
             },
-          }),
-        ),
-        (disposer) => Effect.sync(() => disposer.dispose()),
-      );
+            dispose() {
+              emitters.get(session.id)?.dispose();
+              emitters.delete(session.id);
+            },
+          });
+        },
+      });
+
+      yield* code.debug.registerDebugConfigurationProvider(debugType, {
+        resolveDebugConfiguration(_workspaceFolder, config) {
+          return runFork<never, vscode.DebugConfiguration | undefined>(
+            Effect.gen(function* () {
+              yield* Effect.logInfo("Resolving debug configuration").pipe(
+                Effect.annotateLogs({
+                  component: "debug-adapter",
+                  config,
+                }),
+              );
+              const notebook = code.window.activeNotebookEditor?.notebook;
+              if (notebook?.notebookType !== serializer.notebookType) {
+                yield* Effect.logWarning(
+                  "No active marimo notebook found",
+                ).pipe(Effect.annotateLogs({ component: "debug-adapter" }));
+                return undefined;
+              }
+              config.type = "marimo";
+              config.name = config.name ?? "Debug Marimo";
+              config.request = config.request ?? "launch";
+              config.notebookUri = notebook.uri.toString();
+              yield* Effect.logInfo("Configuration resolved").pipe(
+                Effect.annotateLogs({
+                  component: "debug-adapter",
+                  notebookUri: config.notebookUri,
+                  type: config.type,
+                  request: config.request,
+                }),
+              );
+              return config;
+            }),
+          ).pipe(Fiber.join, Effect.runPromise);
+        },
+      });
 
       yield* Effect.logInfo("Debug adapter initialized").pipe(
         Effect.annotateLogs({ component: "debug-adapter" }),

--- a/extension/src/services/LanguageClient.ts
+++ b/extension/src/services/LanguageClient.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { Data, Effect, type ParseResult, Schema } from "effect";
-import * as vscode from "vscode";
+import type * as vscode from "vscode";
 import * as lsp from "vscode-languageclient/node";
 import { MarimoNotebook } from "../schemas.ts";
 import type {
@@ -137,7 +137,7 @@ export class LanguageClient extends Effect.Service<LanguageClient>()(
             return {
               metadata: metadata,
               cells: cells.map((cell) => ({
-                kind: vscode.NotebookCellKind.Code,
+                kind: code.NotebookCellKind.Code,
                 value: cell.code,
                 languageId: "python",
                 metadata: {

--- a/extension/src/services/NotebookRenderer.ts
+++ b/extension/src/services/NotebookRenderer.ts
@@ -1,6 +1,7 @@
 import { Effect } from "effect";
-import * as vscode from "vscode";
+import type * as vscode from "vscode";
 import type { RendererCommand, RendererReceiveMessage } from "../types.ts";
+import { VsCode } from "./VsCode.ts";
 
 /**
  * Manages communication with the marimo notebook renderer.
@@ -8,10 +9,12 @@ import type { RendererCommand, RendererReceiveMessage } from "../types.ts";
 export class NotebookRenderer extends Effect.Service<NotebookRenderer>()(
   "NotebookRenderer",
   {
-    sync: () => {
+    dependencies: [VsCode.Default],
+    effect: Effect.gen(function* () {
+      const code = yield* VsCode;
       // Defined in package.json
       const rendererId = "marimo-renderer";
-      const channel = vscode.notebooks.createRendererMessaging(rendererId);
+      const channel = code.notebooks.createRendererMessaging(rendererId);
       return {
         rendererId,
         postMessage(
@@ -32,6 +35,6 @@ export class NotebookRenderer extends Effect.Service<NotebookRenderer>()(
           );
         },
       };
-    },
+    }),
   },
 ) {}


### PR DESCRIPTION
Requires all imports in modules outside of `services/VsCode.ts` to be type-only. This ensures that we do not sideways inject various vscode apis throughout the code base. Instead, APIs should be exposed in a very controlled way within `VsCode.ts`.