### PR TITLE
Allow usage of `vscode.workspace.notebookDocuments` directly

### DIFF
--- a/extension/src/layers/KernelManager.ts
+++ b/extension/src/layers/KernelManager.ts
@@ -1,10 +1,12 @@
 import { Effect, FiberSet, Layer, Option } from "effect";
+// biome-ignore lint: For some reason mocking VsCode.workspace.* accessors aren't working
+import * as vscode from "vscode";
 import { assert } from "../assert.ts";
 import * as ops from "../operations.ts";
 import { LanguageClient } from "../services/LanguageClient.ts";
 import { NotebookControllers } from "../services/NotebookControllers.ts";
 import { NotebookRenderer } from "../services/NotebookRenderer.ts";
-import { VsCode } from "../services/VsCode.ts";
+import type { VsCode } from "../services/VsCode.ts";
 
 /**
  * Orchestrates kernel operations for marimo notebooks by composing
@@ -19,7 +21,6 @@ export const KernelManagerLive = Layer.scopedDiscard(
     yield* Effect.logInfo("Setting up kernel manager").pipe(
       Effect.annotateLogs({ component: "kernel-manager" }),
     );
-    const code = yield* VsCode;
     const marimo = yield* LanguageClient;
     const renderer = yield* NotebookRenderer;
     const controllers = yield* NotebookControllers;
@@ -38,7 +39,7 @@ export const KernelManagerLive = Layer.scopedDiscard(
           let context = contexts.get(notebookUri);
 
           if (!context) {
-            const notebook = code.workspace.notebookDocuments.find(
+            const notebook = vscode.workspace.notebookDocuments.find(
               (doc) => doc.uri.toString() === notebookUri,
             );
             assert(notebook, `Expected notebook document for ${notebookUri}`);
@@ -52,6 +53,7 @@ export const KernelManagerLive = Layer.scopedDiscard(
           const controller = yield* controllers.getActiveController(
             context.notebook,
           );
+
           assert(
             Option.isSome(controller),
             `Expected notebook controller for ${notebookUri}`,


### PR DESCRIPTION
This is a hot fix. Apparently our aliasing of `vscode.workspace` within the Effect `VsCode` broke accessing the latest state of the notebookDocuments and the VS Code extension. I'm allowing our linting rule just to put out the fix until we can sort out what's going on.