### PR TITLE
Support end-to-end `RequestClient.sendFunctionRequest` operations

### DIFF
--- a/extension/src/renderer/marimo-frontend.ts
+++ b/extension/src/renderer/marimo-frontend.ts
@@ -10,10 +10,23 @@
 // biome-ignore assist/source/organizeImports: Keep untyped imports at the top
 import * as untyped from "./marimo-frontend-untyped.js";
 
+/**
+ * Type imports from @marimo-team/frontend
+ *
+ * These network types are imported WITHOUT ?nocheck because they're the most
+ * likely to change as the API evolves. By keeping these type-checked, we ensure
+ * our RequestClient interface stays in sync with marimo's actual API contracts.
+ * Type errors here indicate breaking changes we need to handle.
+ */
+import type {
+  EditRequests,
+  RunRequests,
+} from "@marimo-team/frontend/unstable_internal/core/network/types.ts";
 import type {
   CellId,
   UIElementId,
 } from "@marimo-team/frontend/unstable_internal/core/cells/ids.ts";
+import type { RequestId } from "../../../../marimo/frontend/src/core/network/DeferredRequestRegistry.ts";
 import { requestClientAtom } from "@marimo-team/frontend/unstable_internal/core/network/requests.ts";
 import { store } from "@marimo-team/frontend/unstable_internal/core/state/jotai.ts";
 import {
@@ -21,9 +34,8 @@ import {
   isMessageWidgetState,
   MODEL_MANAGER,
 } from "@marimo-team/frontend/unstable_internal/plugins/impl/anywidget/model.ts";
+import { FUNCTIONS_REGISTRY } from "@marimo-team/frontend/unstable_internal/core/functions/FunctionRegistry.ts";
 import { safeExtractSetUIElementMessageBuffers } from "@marimo-team/frontend/unstable_internal/utils/json/base64.ts";
-
-export { useTheme } from "@marimo-team/frontend/unstable_internal/theme/useTheme.ts";
 
 import "@marimo-team/frontend/unstable_internal/css/common.css";
 import "@marimo-team/frontend/unstable_internal/css/globals.css";
@@ -36,6 +48,8 @@ import "@marimo-team/frontend/unstable_internal/css/table.css";
 
 import type { CellRuntimeState } from "../shared/cells.ts";
 import type { MessageOperationOf } from "../types.ts";
+
+export { useTheme } from "@marimo-team/frontend/unstable_internal/theme/useTheme.ts";
 
 export type RequestClient = EditRequests & RunRequests;
 export type { CellRuntimeState, CellId };
@@ -75,6 +89,13 @@ export function handleSendUiElementMessage(
   }
 }
 
+export function handleFunctionCallResult(
+  msg: MessageOperationOf<"function-call-result">,
+) {
+  FUNCTIONS_REGISTRY.resolve(msg.function_call_id as RequestId, msg);
+  return;
+}
+
 export function handleRemoveUIElements(
   msg: MessageOperationOf<"remove-ui-elements">,
 ) {
@@ -103,16 +124,3 @@ export const ConsoleOutput: React.FC<{
 
 export const TooltipProvider: React.FC<React.PropsWithChildren> =
   untyped.TooltipProvider;
-
-/**
- * Type imports from @marimo-team/frontend
- *
- * These network types are imported WITHOUT ?nocheck because they're the most
- * likely to change as the API evolves. By keeping these type-checked, we ensure
- * our RequestClient interface stays in sync with marimo's actual API contracts.
- * Type errors here indicate breaking changes we need to handle.
- */
-import type {
-  EditRequests,
-  RunRequests,
-} from "@marimo-team/frontend/unstable_internal/core/network/types.ts";

--- a/extension/src/renderer/renderer.tsx
+++ b/extension/src/renderer/renderer.tsx
@@ -10,6 +10,7 @@ import { CellOutput } from "./CellOutput.tsx";
 import {
   type CellId,
   type CellRuntimeState,
+  handleFunctionCallResult,
   handleRemoveUIElements,
   handleSendUiElementMessage,
   initialize,
@@ -32,6 +33,10 @@ export const activate: vscode.ActivationFunction = (context) => {
       }
       case "remove-ui-elements": {
         handleRemoveUIElements(msg);
+        return;
+      }
+      case "function-call-result": {
+        handleFunctionCallResult(msg);
         return;
       }
       default: {

--- a/extension/src/renderer/utils.ts
+++ b/extension/src/renderer/utils.ts
@@ -32,6 +32,13 @@ export function createRequestClient(
   );
 
   const client = {
+    async sendFunctionRequest(request) {
+      context.postMessage({
+        command: "marimo.function_call_request",
+        params: request,
+      });
+      return null;
+    },
     async sendComponentValues(request) {
       context.postMessage({
         command: "marimo.set_ui_element_value",

--- a/extension/src/services/LanguageClient.ts
+++ b/extension/src/services/LanguageClient.ts
@@ -94,6 +94,14 @@ export class LanguageClient extends Effect.Service<LanguageClient>()(
             params,
           });
         },
+        functionCallRequest(
+          params: ParamsFor<"marimo.function_call_request">,
+        ): Effect.Effect<void, ExecuteCommandError, never> {
+          return executeCommand(client, {
+            command: "marimo.function_call_request",
+            params,
+          });
+        },
         interrupt(
           params: ParamsFor<"marimo.interrupt">,
         ): Effect.Effect<void, ExecuteCommandError, never> {

--- a/extension/src/services/VsCode.ts
+++ b/extension/src/services/VsCode.ts
@@ -35,6 +35,9 @@ export class Window extends Effect.Service<Window>()("Window", {
       getActiveNotebookEditor() {
         return Option.fromNullable(api.activeNotebookEditor);
       },
+      getVisibleNotebookEditors() {
+        return api.visibleNotebookEditors;
+      },
     };
   }),
 }) {}

--- a/extension/src/types.ts
+++ b/extension/src/types.ts
@@ -24,6 +24,7 @@ interface SessionScoped<T> extends NotebookScoped<T> {
 
 type RunRequest = Schemas["RunRequest"];
 type SetUIElementValueRequest = Schemas["SetUIElementValueRequest"];
+type FunctionCallRequest = Schemas["FunctionCallRequest"];
 interface DeserializeRequest {
   source: string;
 }
@@ -41,6 +42,7 @@ type InterruptRequest = {};
 type MarimoCommandMap = {
   "marimo.run": SessionScoped<RunRequest>;
   "marimo.set_ui_element_value": NotebookScoped<SetUIElementValueRequest>;
+  "marimo.function_call_request": NotebookScoped<FunctionCallRequest>;
   "marimo.dap": NotebookScoped<DebugAdapterRequest>;
   "marimo.interrupt": NotebookScoped<InterruptRequest>;
   "marimo.serialize": SerializeRequest;
@@ -56,7 +58,9 @@ type MarimoCommandMessageOf<K extends keyof MarimoCommandMap> = {
 
 /** Subset of commands allowed to be dispatched by the renderer */
 type RendererCommandMap = {
-  [K in "marimo.set_ui_element_value"]: MarimoCommandMap[K]["inner"];
+  [K in
+    | "marimo.set_ui_element_value"
+    | "marimo.function_call_request"]: MarimoCommandMap[K]["inner"];
 };
 type RendererCommandMessageOf<K extends keyof RendererCommandMap> = {
   [C in keyof RendererCommandMap]: {
@@ -75,7 +79,8 @@ export type RendererCommand = RendererCommandMessageOf<
 // extension -> renderer
 export type RendererReceiveMessage =
   | MessageOperationOf<"remove-ui-elements">
-  | MessageOperationOf<"send-ui-element-message">;
+  | MessageOperationOf<"send-ui-element-message">
+  | MessageOperationOf<"function-call-result">;
 
 // Language server -> client
 type MarimoNotificationMap = {

--- a/extension/tests/extension.test.cjs
+++ b/extension/tests/extension.test.cjs
@@ -39,6 +39,7 @@ suite("marimo Extension Hello World Tests", () => {
       "marimo.createGist",
       "marimo.dap",
       "marimo.deserialize",
+      "marimo.function_call_request",
       "marimo.interrupt",
       "marimo.newMarimoNotebook",
       "marimo.run",

--- a/src/marimo_lsp/server.py
+++ b/src/marimo_lsp/server.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any, Callable, TypeVar, cast
 import lsprotocol.types as lsp
 import msgspec
 from marimo._convert.converters import MarimoConvert
+from marimo._runtime.requests import FunctionCallRequest
 from marimo._schemas.serialization import NotebookSerialization
 from marimo._utils.parse_dataclass import parse_raw
 from pygls.lsp.server import LanguageServer
@@ -177,6 +178,18 @@ def create_server() -> LanguageServer:  # noqa: C901, PLR0915
         args: NotebookCommand[SetUIElementValueRequest],
     ):
         logger.info("marimo.kernel.set_ui_element_value")
+        session = manager.get_session(args.notebook_uri)
+        assert session, f"No session in workspace for {args.notebook_uri}"
+        session.put_control_request(args.inner, from_consumer_id=None)
+
+    @command(
+        server, "marimo.function_call_request", NotebookCommand[FunctionCallRequest]
+    )
+    async def function_call_request(
+        ls: LanguageServer,  # noqa: ARG001
+        args: NotebookCommand[FunctionCallRequest],
+    ):
+        logger.info("marimo.kernel.function_call_request")
         session = manager.get_session(args.notebook_uri)
         assert session, f"No session in workspace for {args.notebook_uri}"
         session.put_control_request(args.inner, from_consumer_id=None)


### PR DESCRIPTION
Implements the `RequestClient.sendFunctionRequest` in our renderer, along with the round-trip forwarding `function-call-result` back to the frontend. Interactive elements like tables and charts and now supported.

https://github.com/user-attachments/assets/0ec55acd-3c64-40d6-964c-69cd2527d185

