### PR TITLE
Remove `use`/`useInfallible` from VS Code services

### DIFF
--- a/extension/src/layers/Lsp.ts
+++ b/extension/src/layers/Lsp.ts
@@ -25,12 +25,11 @@ export const LspLive = Layer.scopedDiscard(
         if (error.exec.command === "uv" && !isUvInstalled()) {
           yield* Effect.logError("uv is not installed in PATH");
 
-          const result = yield* code.window.useInfallible((api) =>
-            api.showErrorMessage(
-              "The marimo VS Code extension currently requires uv to be installed.",
-              "Install uv",
-              "Try Again",
-            ),
+          const result = yield* code.window.showErrorMessage(
+            "The marimo VS Code extension currently requires uv to be installed.",
+            {
+              items: ["Install uv", "Try Again"],
+            },
           );
 
           if (result === "Install uv") {
@@ -39,7 +38,7 @@ export const LspLive = Layer.scopedDiscard(
                 "https://docs.astral.sh/uv/getting-started/installation/",
               ),
             );
-            yield* code.env.useInfallible((api) => api.openExternal(uri));
+            yield* code.env.openExternal(uri);
           } else if (result === "Try Again") {
             // Reload the window to retry
             yield* code.commands.executeCommand(
@@ -51,10 +50,8 @@ export const LspLive = Layer.scopedDiscard(
             logNever(result);
           }
         } else {
-          yield* code.window.useInfallible((api) =>
-            api.showErrorMessage(
-              `marimo-lsp failed to start. See marimo logs for more info.`,
-            ),
+          yield* code.window.showErrorMessage(
+            `marimo-lsp failed to start. See marimo logs for more info.`,
           );
         }
       }),

--- a/extension/src/operations.ts
+++ b/extension/src/operations.ts
@@ -102,14 +102,13 @@ function handleMissingPackageAlert(
     }
 
     const choice = Option.fromNullable(
-      yield* code.window.useInfallible((api) =>
-        api.showInformationMessage(
-          operation.packages.length === 1
-            ? `Missing package: ${operation.packages[0]}. Install with uv?`
-            : `Missing packages: ${operation.packages.join(", ")}. Install with uv?`,
-          "Install All",
-          "Customize...",
-        ),
+      yield* code.window.showInformationMessage(
+        operation.packages.length === 1
+          ? `Missing package: ${operation.packages[0]}. Install with uv?`
+          : `Missing packages: ${operation.packages.join(", ")}. Install with uv?`,
+        {
+          items: ["Install All", "Customize..."],
+        },
       ),
     );
 
@@ -126,15 +125,11 @@ function handleMissingPackageAlert(
     }
 
     if (choice.value === "Customize...") {
-      const response = yield* code.window
-        .useInfallible((api) =>
-          api.showInputBox({
-            prompt: "Add packages",
-            value: operation.packages.join(" "),
-            placeHolder: "package1 package2 package3",
-          }),
-        )
-        .pipe(Effect.map(Option.fromNullable));
+      const response = yield* code.window.showInputBox({
+        prompt: "Add packages",
+        value: operation.packages.join(" "),
+        placeHolder: "package1 package2 package3",
+      });
 
       if (Option.isNone(response)) {
         return;

--- a/extension/src/utils/installPackages.ts
+++ b/extension/src/utils/installPackages.ts
@@ -1,63 +1,13 @@
 import { Effect } from "effect";
-import type * as vscode from "vscode";
 import type { Uv } from "../services/Uv";
 import type { VsCode } from "../services/VsCode";
-
-function withProgress(
-  code: VsCode,
-  options: {
-    location: vscode.ProgressLocation;
-    title: string;
-    cancellable: boolean;
-  },
-  factory: (
-    progress: vscode.Progress<{
-      readonly message: string;
-      readonly increment?: number;
-    }>,
-  ) => Effect.Effect<void, never, never>,
-) {
-  const outer = Promise.withResolvers<void>();
-  const inner =
-    Promise.withResolvers<
-      vscode.Progress<{
-        readonly message: string;
-        readonly increment?: number;
-      }>
-    >();
-
-  return Effect.gen(function* () {
-    const { progress, finished } = yield* code.window.useInfallible(
-      async (api) => {
-        const handle = api.withProgress(options, (task) => {
-          inner.resolve(task);
-          return outer.promise;
-        });
-        return inner.promise.then((progress) => ({
-          progress,
-          finished: Effect.promise(() => handle),
-        }));
-      },
-    );
-
-    // run the work
-    yield* factory(progress);
-
-    // ✅ allow the UI to close
-    outer.resolve();
-
-    // wait for VS Code to finish closing the UI
-    yield* finished;
-  });
-}
 
 export const installPackages = (
   venv: string,
   packages: ReadonlyArray<string>,
   { uv, code }: { uv: Uv; code: VsCode },
 ) =>
-  withProgress(
-    code,
+  code.window.withProgress(
     {
       location: code.ProcessLocation.Notification,
       title: `Installing ${packages.length > 1 ? "packages" : "package"}`,
@@ -88,10 +38,8 @@ export const installPackages = (
       }).pipe(
         Effect.tapError(Effect.logError),
         Effect.catchAllCause((_) =>
-          code.window.useInfallible((api) =>
-            api.showErrorMessage(
-              `Failed to install ${packages.join(", ")}. See marimo logs for details.`,
-            ),
+          code.window.showErrorMessage(
+            `Failed to install ${packages.join(", ")}. See marimo logs for details.`,
           ),
         ),
       ),

--- a/extension/src/utils/showErrorAndPromptLogs.ts
+++ b/extension/src/utils/showErrorAndPromptLogs.ts
@@ -10,9 +10,9 @@ export const showErrorAndPromptLogs = (
   },
 ) =>
   deps.code.window
-    .useInfallible((api) =>
-      api.showErrorMessage(`${msg}\n\nSee logs for details.`, "Open Logs"),
-    )
+    .showErrorMessage(`${msg}\n\nSee logs for details.`, {
+      items: ["Open Logs"],
+    })
     .pipe(
       Effect.tap((selection) =>
         selection === "Open Logs"

--- a/extension/src/utils/tokenFromSignal.ts
+++ b/extension/src/utils/tokenFromSignal.ts
@@ -1,0 +1,23 @@
+import type vscode from "vscode";
+
+/**
+ * Creates a cancellation token from VS Code from a web-standard AbortSignal
+ */
+export function tokenFromSignal(signal: AbortSignal): vscode.CancellationToken {
+  return {
+    get isCancellationRequested() {
+      return signal.aborted;
+    },
+    onCancellationRequested(listener, thisArgs, disposables) {
+      const handler = () => listener.call(thisArgs, undefined);
+      signal.addEventListener("abort", handler);
+      const disposable = {
+        dispose: () => signal.removeEventListener("abort", handler),
+      };
+      if (disposables) {
+        disposables.push(disposable);
+      }
+      return disposable;
+    },
+  };
+}

--- a/extension/src/views/StatusBar.ts
+++ b/extension/src/views/StatusBar.ts
@@ -50,7 +50,7 @@ export type StatusBarCommand = string;
 export class StatusBar extends Effect.Service<StatusBar>()("StatusBar", {
   dependencies: [VsCode.Default],
   scoped: Effect.gen(function* () {
-    yield* VsCode;
+    const code = yield* VsCode;
 
     return {
       /**
@@ -67,7 +67,6 @@ export class StatusBar extends Effect.Service<StatusBar>()("StatusBar", {
       ) {
         // Import the actual vscode module inside the callback
         return Effect.gen(function* () {
-          const code = yield* VsCode;
           const alignmentValue =
             alignment === "Left"
               ? code.StatusBarAlignment.Left


### PR DESCRIPTION
The `use` pattern is convenient for initial prototyping, but it exposes a larger API surface area to cover in our testing services. These changes harden our VsCode service.