### PR TITLE
Replace `FiberSet.makeRuntimePromise` with `Runtime.runPromise`

### DIFF
--- a/extension/src/layers/KernelManager.ts
+++ b/extension/src/layers/KernelManager.ts
@@ -1,4 +1,4 @@
-import { Effect, FiberSet, Layer, Option, Queue, Stream } from "effect";
+import { Effect, Layer, Option, Queue, Runtime, Stream } from "effect";
 import { unreachable } from "../assert.ts";
 import { routeOperation } from "../operations.ts";
 import { Config } from "../services/Config.ts";
@@ -47,7 +47,7 @@ export const KernelManagerLive = Layer.scopedDiscard(
     const variables = yield* VariablesService;
     const datasources = yield* DatasourcesService;
 
-    const runPromise = yield* FiberSet.makeRuntimePromise();
+    const runPromise = Runtime.runPromise(yield* Effect.runtime());
 
     const queue = yield* Queue.unbounded<MarimoOperation>();
 

--- a/extension/src/services/CellStateManager.ts
+++ b/extension/src/services/CellStateManager.ts
@@ -32,9 +32,10 @@ export class CellStateManager extends Effect.Service<CellStateManager>()(
 
       // Helper to update context based on current state
       const updateContext = Effect.fnUntraced(function* () {
-        const staleMap = yield* SubscriptionRef.get(staleStateRef);
-        const activeMarimoNotebook =
-          yield* editorRegistry.getActiveNotebookUri();
+        const [staleMap, activeMarimoNotebook] = yield* Effect.all([
+          SubscriptionRef.get(staleStateRef),
+          editorRegistry.getActiveNotebookUri(),
+        ]);
 
         // Check if the active marimo notebook has any stale cells
         const hasStaleCells = Option.match(activeMarimoNotebook, {

--- a/extension/src/services/ExecutionRegistry.ts
+++ b/extension/src/services/ExecutionRegistry.ts
@@ -5,10 +5,10 @@ import {
   type Brand,
   Data,
   Effect,
-  FiberSet,
   HashMap,
   Option,
   Ref,
+  Runtime,
   String,
 } from "effect";
 import type * as vscode from "vscode";
@@ -39,7 +39,10 @@ export class ExecutionRegistry extends Effect.Service<ExecutionRegistry>()(
           return HashMap.empty();
         }),
       );
-      const runFork = yield* FiberSet.makeRuntime();
+
+      const runtime = yield* Effect.runtime();
+      const runFork = Runtime.runFork(runtime);
+
       return {
         handleInterrupted(editor: vscode.NotebookEditor) {
           return Ref.update(ref, (map) =>

--- a/extension/src/services/NotebookControllerFactory.ts
+++ b/extension/src/services/NotebookControllerFactory.ts
@@ -1,6 +1,6 @@
 import * as semver from "@std/semver";
 import type * as py from "@vscode/python-extension";
-import { Brand, Data, Effect, FiberSet, Option } from "effect";
+import { Brand, Data, Effect, Option, Runtime } from "effect";
 import type * as vscode from "vscode";
 import { unreachable } from "../assert.ts";
 import { getNotebookUri } from "../types.ts";
@@ -34,7 +34,8 @@ export class NotebookControllerFactory extends Effect.Service<NotebookController
       const validator = yield* EnvironmentValidator;
       const serializer = yield* NotebookSerializer;
 
-      const runPromise = yield* FiberSet.makeRuntimePromise();
+      const runtime = yield* Effect.runtime();
+      const runPromise = Runtime.runPromise(runtime);
 
       return {
         createNotebookController: Effect.fnUntraced(function* (options: {

--- a/extension/src/services/NotebookSerializer.ts
+++ b/extension/src/services/NotebookSerializer.ts
@@ -2,9 +2,9 @@ import {
   type Brand,
   Effect,
   Fiber,
-  FiberSet,
   Option,
   type ParseResult,
+  Runtime,
   Schema,
 } from "effect";
 import type * as vscode from "vscode";
@@ -83,7 +83,7 @@ export class NotebookSerializer extends Effect.Service<NotebookSerializer>()(
 
       if (Option.isSome(code)) {
         // Register with VS Code if present
-        const runPromise = yield* FiberSet.makeRuntimePromise();
+        const runPromise = Runtime.runPromise(yield* Effect.runtime());
 
         yield* code.value.workspace.registerNotebookSerializer(NOTEBOOK_TYPE, {
           serializeNotebook(notebook, token) {

--- a/extension/src/services/PythonExtension.ts
+++ b/extension/src/services/PythonExtension.ts
@@ -1,5 +1,5 @@
 import * as py from "@vscode/python-extension";
-import { Effect, FiberSet } from "effect";
+import { Effect, Runtime } from "effect";
 
 /**
  * Provides access to the VS Code Python extension API for
@@ -10,7 +10,7 @@ export class PythonExtension extends Effect.Service<PythonExtension>()(
   {
     scoped: Effect.gen(function* () {
       const api = yield* Effect.promise(() => py.PythonExtension.api());
-      const runPromise = yield* FiberSet.makeRuntimePromise();
+      const runPromise = Runtime.runPromise(yield* Effect.runtime());
       return {
         getKnownEnvironments() {
           return api.environments.known;


### PR DESCRIPTION
The latter allows us to use the same runtime without creating other fibers at the boundary of our application.