### PR TITLE
Delegate to turbo to run `prepare` script

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -184,8 +184,9 @@
     }
   },
   "scripts": {
-    "prepare": "effect-language-service patch",
-    "build": "turbo build:renderer --no-cache && turbo build:extension --no-cache",
+    "prepare": "turbo patch-tsc",
+    "patch-tsc": "effect-language-service patch",
+    "build": "turbo build:renderer && turbo build:extension",
     "build:extension": "esbuild --format=cjs --define:import.meta.env.DEV=false --platform=node --minify --external:vscode --bundle --sourcemap src/extension.ts --outdir=dist",
     "build:renderer": "vite build",
     "fix": "biome check --write",

--- a/extension/turbo.json
+++ b/extension/turbo.json
@@ -11,6 +11,9 @@
       "inputs": ["src/**/*.ts", "!src/renderer/**", "package.json"],
       "env": ["NODE_ENV", "MODE"]
     },
+    "patch-tsc": {
+      "inputs": ["package.json"]
+    },
     "typecheck": {},
     "typecheck-ci": {},
     "fix": {},


### PR DESCRIPTION
Our prepare script takes a while only patching tsc, and it's slowing down dev speed of building and testing extension.