### PR TITLE
Make `PythonExtension` service more effectful

### DIFF
--- a/extension/src/__mocks__/TestPythonExtension.ts
+++ b/extension/src/__mocks__/TestPythonExtension.ts
@@ -1,17 +1,50 @@
-import { Effect, Layer } from "effect";
+import type * as py from "@vscode/python-extension";
+import { Data, Effect, HashSet, Layer, PubSub, Ref, Stream } from "effect";
 import { PythonExtension } from "../services/PythonExtension.ts";
 
-export const TestPythonExtensionLive = Layer.succeed(
-  PythonExtension,
-  PythonExtension.make({
-    getKnownEnvironments() {
-      return [];
-    },
-    onDidChangeEnvironments() {
-      return Effect.acquireRelease(
-        Effect.succeed({ dispose: () => {} }),
-        (disposable) => Effect.sync(() => disposable.dispose()),
-      );
-    },
-  }),
-);
+export class TestPythonExtension extends Data.TaggedClass(
+  "TestPythonExtension",
+)<{
+  readonly layer: Layer.Layer<PythonExtension>;
+}> {
+  static make = Effect.fnUntraced(function* (envs: Array<py.Environment> = []) {
+    const pubsub = yield* PubSub.unbounded<py.EnvironmentsChangeEvent>();
+    const changes = Stream.fromPubSub(pubsub);
+
+    const known = yield* Ref.make(HashSet.make(...envs));
+    yield* Effect.forkScoped(
+      changes.pipe(
+        Stream.mapEffect((change) =>
+          Ref.update(known, (set) =>
+            change.type === "remove"
+              ? HashSet.remove(set, change.env)
+              : HashSet.add(set, change.env),
+          ),
+        ),
+        Stream.runDrain,
+      ),
+    );
+
+    return new TestPythonExtension({
+      layer: Layer.scoped(
+        PythonExtension,
+        Effect.gen(function* () {
+          return PythonExtension.make({
+            knownEnvironments() {
+              return Effect.map(Ref.get(known), (set) => HashSet.toValues(set));
+            },
+            environmentChanges() {
+              return changes;
+            },
+          });
+        }),
+      ),
+    });
+  });
+
+  static Default = TestPythonExtension.make([]).pipe(
+    Effect.map((py) => py.layer),
+    Effect.scoped,
+    Layer.unwrapEffect,
+  );
+}

--- a/extension/src/__mocks__/TestVsCode.ts
+++ b/extension/src/__mocks__/TestVsCode.ts
@@ -1149,3 +1149,10 @@ class NotebookDocument implements vscode.NotebookDocument {
     return Promise.resolve(true);
   }
 }
+
+export function createTestNotebookDocument(
+  uri: Uri,
+  content?: vscode.NotebookData,
+): vscode.NotebookDocument {
+  return new NotebookDocument("marimo-notebook", uri, content);
+}

--- a/extension/src/__tests__/extension.test.ts
+++ b/extension/src/__tests__/extension.test.ts
@@ -2,13 +2,13 @@ import { describe, expect, it } from "@effect/vitest";
 import { Layer, LogLevel } from "effect";
 import { getExtensionContext } from "../__mocks__/TestExtensionContext.ts";
 import { TestLanguageClientLive } from "../__mocks__/TestLanguageClient.ts";
-import { TestPythonExtensionLive } from "../__mocks__/TestPythonExtension.ts";
+import { TestPythonExtension } from "../__mocks__/TestPythonExtension.ts";
 import { TestVsCodeLive } from "../__mocks__/TestVsCode.ts";
 import { makeActivate } from "../layers/Main.ts";
 
 const activate = makeActivate(
   Layer.empty.pipe(
-    Layer.provideMerge(TestPythonExtensionLive),
+    Layer.provideMerge(TestPythonExtension.Default),
     Layer.provideMerge(TestLanguageClientLive),
     Layer.provideMerge(TestVsCodeLive),
   ),

--- a/extension/src/services/__tests__/ControllerRegistry.test.ts
+++ b/extension/src/services/__tests__/ControllerRegistry.test.ts
@@ -1,0 +1,42 @@
+import { expect, it } from "@effect/vitest";
+import { Effect, Layer, Option } from "effect";
+import { TestLanguageClientLive } from "../../__mocks__/TestLanguageClient.ts";
+import { TestPythonExtension } from "../../__mocks__/TestPythonExtension.ts";
+import {
+  createTestNotebookDocument,
+  TestVsCodeLive,
+} from "../../__mocks__/TestVsCode.ts";
+import { ControllerRegistry } from "../ControllerRegistry.ts";
+import { VsCode } from "../VsCode.ts";
+
+const ControllerRegistryLive = Layer.empty.pipe(
+  Layer.provideMerge(ControllerRegistry.Default),
+  Layer.provide(TestLanguageClientLive),
+  Layer.provideMerge(TestVsCodeLive),
+  Layer.provide(TestPythonExtension.Default),
+);
+
+it.layer(ControllerRegistryLive)("ControllerRegistry", (it) => {
+  it.effect(
+    "should initialize",
+    Effect.fnUntraced(function* () {
+      const registry = yield* ControllerRegistry;
+      expect(registry).toBeDefined();
+    }),
+  );
+
+  it.effect(
+    "should return None for active controller when no notebook is selected",
+    Effect.fnUntraced(function* () {
+      const code = yield* VsCode;
+      const registry = yield* ControllerRegistry;
+
+      const notebook = createTestNotebookDocument(
+        code.Uri.file("/test/notebook_mo.py"),
+      );
+
+      const controller = yield* registry.getActiveController(notebook);
+      expect(Option.isNone(controller)).toBe(true);
+    }),
+  );
+});


### PR DESCRIPTION
Uses streams and effects for public API. Also adds some helpers to create controlled test environment.