### PR TITLE
Try to cleanup `ConfigContextManager.test.ts`

### DIFF
--- a/extension/src/services/NotebookEditorRegistry.ts
+++ b/extension/src/services/NotebookEditorRegistry.ts
@@ -36,9 +36,7 @@ export class NotebookEditorRegistry extends Effect.Service<NotebookEditorRegistr
                 return;
               }
 
-              yield* Ref.update(ref, (map) =>
-                HashMap.set(map, notebookUri, editor.value),
-              );
+              yield* Ref.update(ref, HashMap.set(notebookUri, editor.value));
 
               yield* Log.info("Active notebook changed", {
                 notebookUri,
@@ -100,7 +98,7 @@ export class NotebookEditorRegistry extends Effect.Service<NotebookEditorRegistr
          * Stream of active notebook URI changes
          */
         streamActiveNotebookChanges() {
-          return activeNotebookRef.changes.pipe(Stream.changes);
+          return Stream.changes(activeNotebookRef.changes);
         },
       };
     }),

--- a/extension/src/services/config/MarimoConfigurationService.ts
+++ b/extension/src/services/config/MarimoConfigurationService.ts
@@ -63,8 +63,9 @@ export class MarimoConfigurationService extends Effect.Service<MarimoConfigurati
             )(result);
 
             // Cache the result
-            yield* SubscriptionRef.update(configRef, (map) =>
-              HashMap.set(map, notebookUri, config.config),
+            yield* SubscriptionRef.update(
+              configRef,
+              HashMap.set(notebookUri, config.config),
             );
 
             yield* Log.trace("Configuration fetched and cached", {
@@ -104,8 +105,9 @@ export class MarimoConfigurationService extends Effect.Service<MarimoConfigurati
             )(result);
 
             // Update cached config
-            yield* SubscriptionRef.update(configRef, (map) =>
-              HashMap.set(map, notebookUri, config.config),
+            yield* SubscriptionRef.update(
+              configRef,
+              HashMap.set(notebookUri, config.config),
             );
 
             yield* Log.trace("Configuration updated successfully", {
@@ -134,7 +136,6 @@ export class MarimoConfigurationService extends Effect.Service<MarimoConfigurati
             yield* SubscriptionRef.update(configRef, (map) =>
               HashMap.remove(map, notebookUri),
             );
-
             yield* Log.trace("Cleared configuration cache", { notebookUri });
           });
         },
@@ -178,9 +179,7 @@ export class MarimoConfigurationService extends Effect.Service<MarimoConfigurati
           mapper: (config: MarimoConfig) => R,
         ): Stream.Stream<Option.Option<R>> {
           return this.streamActiveConfigChanges().pipe(
-            Stream.map((config) => {
-              return Option.map(config, mapper);
-            }),
+            Stream.map(Option.map(mapper)),
             Stream.changes,
           );
         },


### PR DESCRIPTION
Moves to the `withTestCtx` pattern we've used in other tests. Rather than mocking the `NotebookEditorRegistry`, which has derived values, I've tried to use the `TestVsCode` harness to emit active editor changes and capture the executed commands. 

Something isn't working, i think it's related to `Stream.changes`.