### PR TITLE
Add lint rule to disallow `@/*` imports

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -5,7 +5,10 @@
     "clientKind": "git",
     "useIgnoreFile": true
   },
-  "plugins": ["./extension/lint/vscode-type-only.grit"],
+  "plugins": [
+    "./extension/lint/vscode-type-only.grit",
+    "./extension/lint/no-at-imports.grit"
+  ],
   "files": {
     "ignoreUnknown": false
   },

--- a/extension/lint/no-at-imports.grit
+++ b/extension/lint/no-at-imports.grit
@@ -1,0 +1,6 @@
+language js
+
+`import $_ from $path` where {
+  $path <: r"['\"]@/.*['\"]",
+  register_diagnostic(span=$path, message="Do not use @/* imports. Use @marimo-team/frontend/unstable_internal/* instead, preferably with type-only imports. Use sparingly and with caution.", severity="error")
+}

--- a/extension/src/layers/Lsp.ts
+++ b/extension/src/layers/Lsp.ts
@@ -1,6 +1,6 @@
 import * as NodeChildProcess from "node:child_process";
 import { Effect, Either, Layer, Option } from "effect";
-import { logNever } from "@/utils/assertNever.ts";
+import { unreachable } from "../assert.ts";
 import { LanguageClient } from "../services/LanguageClient.ts";
 import { VsCode } from "../services/VsCode.ts";
 
@@ -54,7 +54,7 @@ export const LspLive = Layer.scopedDiscard(
               return;
             }
             default:
-              logNever(result.value);
+              unreachable(result.value);
           }
         } else {
           yield* code.window.showErrorMessage(

--- a/extension/src/services/ExecutionRegistry.ts
+++ b/extension/src/services/ExecutionRegistry.ts
@@ -1,6 +1,7 @@
 // @ts-expect-error
 import { transitionCell as untypedTransitionCell } from "@marimo-team/frontend/unstable_internal/core/cells/cell.ts?nocheck";
 import { createCellRuntimeState } from "@marimo-team/frontend/unstable_internal/core/cells/types.ts";
+import type { CellOutput } from "@marimo-team/frontend/unstable_internal/core/kernel/messages.ts";
 import {
   type Brand,
   Data,
@@ -12,7 +13,6 @@ import {
   Runtime,
 } from "effect";
 import type * as vscode from "vscode";
-import type { CellOutput } from "@/core/kernel/messages.ts";
 import { assert } from "../assert.ts";
 import {
   type CellMessage,

--- a/extension/src/utils/errors.ts
+++ b/extension/src/utils/errors.ts
@@ -1,4 +1,5 @@
-import type { CellOutput } from "@/core/kernel/messages";
+import type { CellOutput } from "@marimo-team/frontend/unstable_internal/core/kernel/messages.ts";
+import { unreachable } from "../assert.ts";
 
 export type ExtendsArray<T> = T extends Array<infer U> ? U : never;
 
@@ -33,9 +34,7 @@ export function prettyErrorMessage(error: MarimoError): string {
     case "unknown":
       return `${error.error_type ? `${error.error_type}: ` : ""}${error.msg}`;
     default: {
-      // Exhaustiveness check
-      const _exhaustive: never = error;
-      return "Unknown error";
+      unreachable(error);
     }
   }
 }

--- a/extension/src/views/MarimoStatusBar.ts
+++ b/extension/src/views/MarimoStatusBar.ts
@@ -1,5 +1,5 @@
 import { Effect, Either, Layer, Option } from "effect";
-import { logNever } from "@/utils/assertNever.ts";
+import { unreachable } from "../assert.ts";
 import { VsCode } from "../services/VsCode.ts";
 import { StatusBar } from "./StatusBar.ts";
 
@@ -67,8 +67,7 @@ export const MarimoStatusBarLive = Layer.scopedDiscard(
             break;
           }
           default: {
-            logNever(selection.value);
-            break;
+            unreachable(selection.value);
           }
         }
       }),


### PR DESCRIPTION
The `@/*` imports are aliased in the `tsconfig.json` to allow for type-checking of modules imported from `@marimo-team/frontend`. These changes add a linting rule to prevent directly importing from `@/*` and instead require a more verbose import from`@marimo-team/frontend/unstable_internal`. 

I may add another rule that also requires all imports from `@marimo-team/frontend/unstable_internal` live in a single file. It is a very challenging dependency and we should be careful what we import from it.