### PR TITLE
Add `marimo.restartKernel` command

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -156,6 +156,12 @@
         "shortTitle": "On cell change: Lazy",
         "category": "marimo",
         "icon": "$(symbol-interface)"
+      },
+      {
+        "command": "marimo.restartKernel",
+        "title": "Restart Notebook Kernel",
+        "shortTitle": "Restart Kernel",
+        "category": "marimo"
       }
     ],
     "viewsContainers": {
@@ -217,14 +223,19 @@
           "group": "navigation@1"
         },
         {
+          "command": "marimo.restartKernel",
+          "when": "notebookType == 'marimo-notebook'",
+          "group": "navigation@2"
+        },
+        {
           "command": "marimo.toggleOnCellChangeAutoRun",
           "when": "notebookType == 'marimo-notebook' && marimo.config.runtime.on_cell_change != 'lazy'",
-          "group": "navigation@2"
+          "group": "navigation@3"
         },
         {
           "command": "marimo.toggleOnCellChangeLazy",
           "when": "notebookType == 'marimo-notebook' && marimo.config.runtime.on_cell_change == 'lazy'",
-          "group": "navigation@2"
+          "group": "navigation@3"
         }
       ]
     }

--- a/extension/src/__tests__/extension.test.ts
+++ b/extension/src/__tests__/extension.test.ts
@@ -57,6 +57,7 @@ describe("extension.activate", () => {
             "marimo.publishMarimoNotebook",
             "marimo.publishMarimoNotebookGist",
             "marimo.refreshPackages",
+            "marimo.restartKernel",
             "marimo.runStale",
             "marimo.showMarimoMenu",
             "marimo.toggleOnCellChangeAutoRun",

--- a/extension/src/constants.ts
+++ b/extension/src/constants.ts
@@ -7,6 +7,7 @@ export type MarimoCommand =
   | "marimo.publishMarimoNotebook"
   | "marimo.publishMarimoNotebookGist"
   | "marimo.refreshPackages"
+  | "marimo.restartKernel"
   | "marimo.runStale"
   | "marimo.showMarimoMenu"
   | "marimo.toggleOnCellChangeAutoRun"
@@ -21,5 +22,5 @@ export type MarimoView =
 export const NOTEBOOK_TYPE = "marimo-notebook";
 
 export type MarimoContextKey =
-  | "marimo.notebook.hasStaleCells"
-  | "marimo.config.runtime.on_cell_change";
+  | "marimo.config.runtime.on_cell_change"
+  | "marimo.notebook.hasStaleCells";

--- a/extension/src/types.ts
+++ b/extension/src/types.ts
@@ -64,6 +64,9 @@ type ListPackagesRequest = {};
 type DependencyTreeRequest = {};
 // biome-ignore lint/complexity/noBannedTypes: We need this for over the wire
 type GetConfigurationRequest = {};
+// biome-ignore lint/complexity/noBannedTypes: We need this for over the wire
+type CloseSessionRequest = {};
+
 interface UpdateConfigurationRequest {
   config: Record<string, unknown>;
 }
@@ -81,6 +84,7 @@ type MarimoApiMethodMap = {
   get_dependency_tree: SessionScoped<DependencyTreeRequest>;
   get_configuration: NotebookScoped<GetConfigurationRequest>;
   update_configuration: NotebookScoped<UpdateConfigurationRequest>;
+  close_session: NotebookScoped<CloseSessionRequest>;
 };
 
 type ApiRequest<K extends keyof MarimoApiMethodMap> = {

--- a/extension/tests/extension.test.cjs
+++ b/extension/tests/extension.test.cjs
@@ -45,6 +45,7 @@ suite("marimo Extension Hello World Tests", () => {
       "marimo.publishMarimoNotebook",
       "marimo.publishMarimoNotebookGist",
       "marimo.refreshPackages",
+      "marimo.restartKernel",
       "marimo.runStale",
       "marimo.showMarimoMenu",
       "marimo.toggleOnCellChangeAutoRun",

--- a/src/marimo_lsp/api.py
+++ b/src/marimo_lsp/api.py
@@ -16,6 +16,7 @@ from marimo._utils.parse_dataclass import parse_raw
 from marimo_lsp.debug_adapter import handle_debug_adapter_request
 from marimo_lsp.loggers import get_logger
 from marimo_lsp.models import (
+    CloseSessionRequest,
     DebugAdapterRequest,
     DependencyTreeRequest,
     DeserializeRequest,
@@ -109,6 +110,14 @@ async def interrupt(
         logger.info(f"Interrupt request sent for {args.notebook_uri}")
     else:
         logger.warning(f"No session found for {args.notebook_uri}")
+
+
+async def close_session(
+    manager: LspSessionManager,
+    args: NotebookCommand[CloseSessionRequest],
+):
+    logger.info(f"close_session for {args.notebook_uri}")
+    manager.close_session(args.notebook_uri)
 
 
 async def get_package_list(
@@ -256,6 +265,12 @@ async def handle_api_command(  # noqa: C901, PLR0911
             ls,
             manager,
             msgspec.convert(params, type=NotebookCommand[DebugAdapterRequest]),
+        )
+
+    if method == "close_session":
+        return await close_session(
+            manager,
+            msgspec.convert(params, type=NotebookCommand[CloseSessionRequest]),
         )
 
     if method == "serialize":

--- a/src/marimo_lsp/models.py
+++ b/src/marimo_lsp/models.py
@@ -88,6 +88,10 @@ class GetConfigurationRequest(msgspec.Struct, rename="camel"):
     """A request to get the current configuration."""
 
 
+class CloseSessionRequest(msgspec.Struct, rename="camel"):
+    """A request to close the current session."""
+
+
 class UpdateConfigurationRequest(msgspec.Struct, rename="camel"):
     """A request to update the user configuration."""
 


### PR DESCRIPTION
Adds the ability to restart an active marimo kernel from both the UI and quick action.