### PR TITLE
Set `min-height` for specific marimo web components

### DIFF
--- a/extension/src/renderer/styles.css
+++ b/extension/src/renderer/styles.css
@@ -50,3 +50,16 @@
   --link: var(--vscode-textLink-foreground);
   --link-visited: var(--vscode-textLink-activeForeground);
 }
+
+/**
+ * Set minimum height for cell outputs containing elements with large popovers
+ * This prevents popovers from being cut off in VS Code's output rendering
+ */
+.marimo-cell-output:has(
+    marimo-date,
+    marimo-date-range,
+    marimo-datetime,
+    marimo-multiselect
+  ) {
+  min-height: 350px;
+}


### PR DESCRIPTION
Some UI elements are clipped still. This is a quick workaround to just set a min-height for `marimo-cell-output`s that contain some known elements that overflow.