### PR TITLE
Add SQL smart-cell support

### DIFF
--- a/extension/src/schemas/vscode-notebook.ts
+++ b/extension/src/schemas/vscode-notebook.ts
@@ -6,6 +6,12 @@ import { Schema } from "effect";
 export const CellState = Schema.Literal("idle", "queued", "running", "stale");
 export type CellState = typeof CellState.Type;
 
+/**
+ * Cell language
+ */
+export const CellLanguage = Schema.Literal("python", "sql");
+export type CellLanguage = typeof CellLanguage.Type;
+
 // TODO: passthrough unknown fields
 /**
  * VS Code notebook cell metadata (runtime state)
@@ -19,6 +25,15 @@ export const CellMetadata = Schema.Struct({
 
   // Cell configuration options
   options: Schema.Record({
+    key: Schema.String,
+    value: Schema.Unknown,
+  }).pipe(Schema.optional),
+
+  // Cell language (for smart-cells support)
+  language: CellLanguage.pipe(Schema.optional),
+
+  // Language-specific metadata (e.g., SQL engine, output flag)
+  languageMetadata: Schema.Record({
     key: Schema.String,
     value: Schema.Unknown,
   }).pipe(Schema.optional),

--- a/extension/src/services/NotebookControllerFactory.ts
+++ b/extension/src/services/NotebookControllerFactory.ts
@@ -6,6 +6,7 @@ import { unreachable } from "../assert.ts";
 import { getNotebookUri } from "../types.ts";
 import { findVenvPath } from "../utils/findVenvPath.ts";
 import { formatControllerLabel } from "../utils/formatControllerLabel.ts";
+import { getCellExecutableCode } from "../utils/getCellExecutableCode.ts";
 import { installPackages } from "../utils/installPackages.ts";
 import { getNotebookCellId } from "../utils/notebook.ts";
 import { Config } from "./Config.ts";
@@ -51,7 +52,7 @@ export class NotebookControllerFactory extends Effect.Service<NotebookController
           );
 
           // Add metadata
-          controller.supportedLanguages = ["python"];
+          controller.supportedLanguages = ["python", "sql"];
           controller.description = options.env.path;
 
           // Set up execution handler
@@ -75,7 +76,7 @@ export class NotebookControllerFactory extends Effect.Service<NotebookController
                       executable: validEnv.executable,
                       inner: {
                         cellIds: cells.map((cell) => getNotebookCellId(cell)),
-                        codes: cells.map((cell) => cell.document.getText()),
+                        codes: cells.map((cell) => getCellExecutableCode(cell)),
                       },
                     },
                   },

--- a/extension/src/services/SandboxController.ts
+++ b/extension/src/services/SandboxController.ts
@@ -3,6 +3,7 @@ import { Effect, Option, Runtime, Schema } from "effect";
 import type * as vscode from "vscode";
 import { SemVerFromString } from "../schemas.ts";
 import { getNotebookUri } from "../types.ts";
+import { getCellExecutableCode } from "../utils/getCellExecutableCode.ts";
 import { uvAddScriptSafe } from "../utils/installPackages.ts";
 import { getNotebookCellId } from "../utils/notebook.ts";
 import { MINIMUM_MARIMO_VERSION } from "./EnvironmentValidator.ts";
@@ -29,7 +30,7 @@ export class SandboxController extends Effect.Service<SandboxController>()(
       );
 
       // Add metadata
-      controller.supportedLanguages = ["python"];
+      controller.supportedLanguages = ["python", "sql"];
       controller.description = "marimo sandbox controller";
 
       // Set up execution handler
@@ -59,7 +60,7 @@ export class SandboxController extends Effect.Service<SandboxController>()(
                   executable,
                   inner: {
                     cellIds: cells.map((cell) => getNotebookCellId(cell)),
-                    codes: cells.map((cell) => cell.document.getText()),
+                    codes: cells.map((cell) => getCellExecutableCode(cell)),
                   },
                 },
               },

--- a/extension/src/utils/getCellExecutableCode.ts
+++ b/extension/src/utils/getCellExecutableCode.ts
@@ -1,0 +1,21 @@
+import { SQLParser } from "@marimo-team/smart-cells";
+import type * as vscode from "vscode";
+
+/**
+ * Get the executable code for a cell, transforming SQL cells to Python mo.sql() wrapper
+ */
+export function getCellExecutableCode(cell: vscode.NotebookCell): string {
+  // Transform SQL cells to Python mo.sql() wrapper
+  if (cell.metadata?.language === "sql") {
+    const sqlParser = new SQLParser();
+    const languageMetadata = cell.metadata?.languageMetadata ?? {};
+    const result = sqlParser.transformOut(
+      cell.document.getText(),
+      languageMetadata,
+    );
+    return result.code;
+  }
+
+  // Return Python cells as-is
+  return cell.document.getText();
+}

--- a/src/marimo_lsp/server.py
+++ b/src/marimo_lsp/server.py
@@ -29,12 +29,11 @@ def create_server() -> LanguageServer:  # noqa: C901, PLR0915
         notebook_document_sync=lsp.NotebookDocumentSyncOptions(
             notebook_selector=[
                 lsp.NotebookDocumentFilterWithCells(
-                    cells=[lsp.NotebookCellLanguage(language="python")],
                     notebook="marimo-notebook",
-                ),
-                lsp.NotebookDocumentFilterWithCells(
-                    cells=[lsp.NotebookCellLanguage(language="python")],
-                    notebook="marimo-notebook-generic",
+                    cells=[
+                        lsp.NotebookCellLanguage(language="python"),
+                        lsp.NotebookCellLanguage(language="sql"),
+                    ],
                 ),
             ],
             save=True,


### PR DESCRIPTION
Adds support for SQL cells in the VS Code extension. The marimo web UI already supports smart-cells where users write plain SQL that gets serialized as `mo.sql()` calls in Python. This brings that capability to VS Code (will explore markdown in followup).

When opening a notebook with SQL cells, the extension detects `mo.sql()` calls and extracts the plain SQL for editing. Users see only SQL with syntax highlighting while metadata preserves the dataframe name, database engine, and output flags. The serializer transforms between plain SQL in the editor and Python `mo.sql()` wrappers in the file.

The cell metadata schema now includes optional `language` and `languageMetadata` fields. Both notebook controllers support Python and SQL languages, enabling the language picker in cells. A helper function `getCellExecutableCode()` wraps SQL cells in `mo.sql()` calls before execution. The LSP configuration now recognizes and syncs both cell types.