### PR TITLE
Activate extension `onStartupFinished`

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -13,7 +13,9 @@
     "Notebooks",
     "Data Science"
   ],
-  "activationEvents": [],
+  "activationEvents": [
+    "onStartupFinished"
+  ],
   "main": "./dist/extension.js",
   "contributes": {
     "iconThemes": [


### PR DESCRIPTION
VS Code extensions support various activation events that control when an extension loads. Previously, the marimo extension only activated lazily when interacting with marimo notebooks.

This change switches to `onStartupFinished`, which activates the extension after VS Code finishes starting up. This ensures the marimo UI (panel views, commands, etc.) is available immediately, rather than waiting for the user to open or interact with a marimo notebook first.