### PR TITLE
Set `--python 3.13` in default `uv` command

### DIFF
--- a/extension/src/services/LanguageClient.ts
+++ b/extension/src/services/LanguageClient.ts
@@ -146,7 +146,7 @@ export const findLspExecutable = Effect.fnUntraced(function* () {
     );
     return {
       command: "uv",
-      args: ["tool", "run", "--from", sdist, "marimo-lsp"],
+      args: ["tool", "run", "--python", "3.13", "--from", sdist, "marimo-lsp"],
     };
   }
 


### PR DESCRIPTION
Fixes #155. Specifies a specific version of Python for running `marimo-lsp` via `uv tool run`.