### PR TITLE
Add `marimo.restartLsp` command

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -167,6 +167,11 @@
         "title": "Open as marimo Notebook",
         "category": "marimo",
         "icon": "images/small-icon.png"
+      },
+      {
+        "command": "marimo.restartLsp",
+        "title": "Restart marimo language server (marimo-lsp)",
+        "shortTitle": "Restart marimo-lsp"
       }
     ],
     "viewsContainers": {

--- a/extension/src/__mocks__/TestLanguageClient.ts
+++ b/extension/src/__mocks__/TestLanguageClient.ts
@@ -37,6 +37,7 @@ export const TestLanguageClientLive = Layer.scoped(
         }),
     );
     return LanguageClient.make({
+      restart: Effect.void,
       executeCommand(cmd) {
         return Effect.tryPromise({
           try: () =>

--- a/extension/src/__tests__/extension.test.ts
+++ b/extension/src/__tests__/extension.test.ts
@@ -59,6 +59,7 @@ describe("extension.activate", () => {
             "marimo.publishMarimoNotebookGist",
             "marimo.refreshPackages",
             "marimo.restartKernel",
+            "marimo.restartLsp",
             "marimo.runStale",
             "marimo.showMarimoMenu",
             "marimo.toggleOnCellChangeAutoRun",

--- a/extension/src/constants.ts
+++ b/extension/src/constants.ts
@@ -9,6 +9,7 @@ export type MarimoCommand =
   | "marimo.publishMarimoNotebookGist"
   | "marimo.refreshPackages"
   | "marimo.restartKernel"
+  | "marimo.restartLsp"
   | "marimo.runStale"
   | "marimo.showMarimoMenu"
   | "marimo.toggleOnCellChangeAutoRun"

--- a/extension/src/layers/RegisterCommands.ts
+++ b/extension/src/layers/RegisterCommands.ts
@@ -143,6 +143,8 @@ export const RegisterCommandsLive = Layer.scopedDiscard(
         );
       }),
     );
+
+    yield* code.commands.registerCommand("marimo.restartLsp", client.restart);
   }),
 );
 

--- a/extension/src/services/__tests__/CellStateManager.test.ts
+++ b/extension/src/services/__tests__/CellStateManager.test.ts
@@ -21,6 +21,7 @@ const withTestCtx = Effect.fnUntraced(function* () {
       Layer.succeed(
         LanguageClient,
         LanguageClient.make({
+          restart: Effect.void,
           executeCommand(cmd) {
             return Ref.update(executions, (arr) => [...arr, cmd]);
           },

--- a/extension/src/services/config/__tests__/MarimoConfigurationService.test.ts
+++ b/extension/src/services/config/__tests__/MarimoConfigurationService.test.ts
@@ -39,6 +39,7 @@ const withTestCtx = Effect.fnUntraced(function* (
       Layer.succeed(
         LanguageClient,
         LanguageClient.make({
+          restart: Effect.void,
           streamOf: () => Stream.never,
           executeCommand: Effect.fnUntraced(function* ({ command, params }) {
             if (!(command === "marimo.api")) {

--- a/extension/tests/extension.test.cjs
+++ b/extension/tests/extension.test.cjs
@@ -45,6 +45,7 @@ suite("marimo Extension Hello World Tests", () => {
       "marimo.publishMarimoNotebookGist",
       "marimo.refreshPackages",
       "marimo.restartKernel",
+      "marimo.restartLsp",
       "marimo.runStale",
       "marimo.showMarimoMenu",
       "marimo.toggleOnCellChangeAutoRun",


### PR DESCRIPTION
Adds ability to restart `LanguageClient` in an active session. This should be used as a last resort, but allows for users to restart their sessions if anything goes with `marimo-lsp` without needing to restart VS Code and reload the extension.