### PR TITLE
Remove type assertions from mocks

### DIFF
--- a/extension/src/services/VsCode.ts
+++ b/extension/src/services/VsCode.ts
@@ -447,7 +447,11 @@ export class VsCode extends Effect.Service<VsCode>()("VsCode", {
       Uri: vscode.Uri,
       MarkdownString: vscode.MarkdownString,
       version: vscode.version,
-      extensions: vscode.extensions,
+      extensions: {
+        getExtension<T = unknown>(extensionId: string) {
+          return vscode.extensions.getExtension<T>(extensionId);
+        },
+      },
       // helper
       utils: {
         parseUri(value: string) {


### PR DESCRIPTION
Removes type assertions from our mocks, instead returning the actual implementations. Might seem unnecessary, but I'd like to avoid lying to the type system and instead change the `VsCode` service to more simple/smaller API surface area (i.e., only what we need) so that we confidently have completely mocked.