### PR TITLE
Add concurrency control to cancel outdated CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   TURBO_TEAM: marimo


### PR DESCRIPTION
When pushing multiple commits to the same branch or PR, previous CI runs will now be automatically cancelled in favor of running only the latest commit.