### PR TITLE
Ensure notebook is saved for sandbox controller

### DIFF
--- a/extension/src/layers/RegisterCommands.ts
+++ b/extension/src/layers/RegisterCommands.ts
@@ -172,18 +172,17 @@ const newMarimoNotebook = ({
   serializer: NotebookSerializer;
 }) =>
   Effect.gen(function* () {
-    const doc = yield* code.workspace.openUntitledNotebookDocument(
+    const notebook = yield* code.workspace.openUntitledNotebookDocument(
       serializer.notebookType,
       new code.NotebookData([
         new code.NotebookCellData(code.NotebookCellKind.Code, "", "python"),
       ]),
     );
-
-    yield* code.window.showNotebookDocument(doc);
+    yield* code.window.showNotebookDocument(notebook);
 
     yield* Effect.logInfo("Created new marimo notebook").pipe(
       Effect.annotateLogs({
-        uri: doc.uri.toString(),
+        uri: notebook.uri.toString(),
       }),
     );
   });

--- a/extension/src/services/SandboxController.ts
+++ b/extension/src/services/SandboxController.ts
@@ -38,6 +38,24 @@ export class SandboxController extends Effect.Service<SandboxController>()(
       controller.executeHandler = (cells, notebook) =>
         runPromise(
           Effect.gen(function* () {
+            // sandboxing only works with titled (saved) notebooks
+            if (notebook.isUntitled) {
+              const choice = yield* code.window.showInformationMessage(
+                "Sandboxing requires a saved file. Please save your notebook and re-run cells.",
+                {
+                  modal: true,
+                  items: ["Save"],
+                },
+              );
+
+              if (Option.isNone(choice)) {
+                return;
+              }
+
+              yield* Effect.promise(() => notebook.save());
+              return;
+            }
+
             const requirements = yield* findRequirements(uv, notebook);
 
             if (requirements.length > 0) {


### PR DESCRIPTION
Adds a guard ensuring a notebook is saved before using the sandbox controller. This way we ensure that uv can manage the inline script metadata.