### PR TITLE
Enable GitHub Releases in publish workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,9 +105,9 @@ jobs:
         env:
           OVSX_PAT: ${{ secrets.OPEN_VSX_TOKEN }}
 
-      # - name: Create GitHub release
-      #   working-directory: marimo-lsp/extension
-      #   run: |
-      #     gh release create $(cat package.json | jq -r '.version') --generate-notes *.vsix --latest=false
-      #   env:
-      #     GH_TOKEN: ${{ github.token }}
+      - name: Create GitHub Release
+        working-directory: marimo-lsp/extension
+        run: |
+          gh release create $(cat package.json | jq -r '.version') --generate-notes *.vsix
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Auto generates releases with `.vsix` as an artifact others can download and install.