### PR TITLE
Harden `cell.metadata` schema; use `cell.languageId` as source of truth

### DIFF
--- a/extension/src/utils/getCellExecutableCode.ts
+++ b/extension/src/utils/getCellExecutableCode.ts
@@ -1,17 +1,31 @@
 import { SQLParser } from "@marimo-team/smart-cells";
+import { Option } from "effect";
 import type * as vscode from "vscode";
+import { assert } from "../assert.ts";
+import { decodeCellMetadata } from "../schemas.ts";
 
 /**
  * Get the executable code for a cell, transforming SQL cells to Python mo.sql() wrapper
  */
 export function getCellExecutableCode(cell: vscode.NotebookCell): string {
+  const languageId = cell.document.languageId;
+  const meta = decodeCellMetadata(cell.metadata);
+
+  assert(
+    cell.document.languageId === "sql" || cell.document.languageId === "python",
+    `Expected Python or SQL cell. Got "${languageId}".`,
+  );
+
   // Transform SQL cells to Python mo.sql() wrapper
-  if (cell.metadata?.language === "sql") {
+  if (languageId === "sql") {
     const sqlParser = new SQLParser();
-    const languageMetadata = cell.metadata?.languageMetadata ?? {};
     const result = sqlParser.transformOut(
       cell.document.getText(),
-      languageMetadata,
+      // Either stored on the cell, or we fallback to default ...
+      meta.pipe(
+        Option.flatMap((x) => Option.fromNullable(x.languageMetadata?.sql)),
+        Option.getOrElse(() => sqlParser.defaultMetadata),
+      ),
     );
     return result.code;
   }


### PR DESCRIPTION
These changes strengthens how VS Code cell metadata is defined and validated. It also removes the `language` field from cell metadata, in preference of using `cell.languageId` as the source of truth for the "current" state of the cell.

Previously, the serializer would write this value, but it could easily drift from the actual cell language in the VS Code UI. The untyped nature of `cell.metadata` lead to hidden any's that didn't help us spot this.