### PR TITLE
Set pre-release default to `false` for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       pre-release:
         description: "Release as pre-release"
         required: true
-        default: true
+        default: false
         type: boolean
       version-bump:
         description: "Version bump type"


### PR DESCRIPTION
We stopped publishing pre-releases, so the default should be false.