### PR TITLE
Drop non-serializable ASTs from cells during deserialization

### DIFF
--- a/extension/src/__mocks__/notebooks/with_elipse.txt
+++ b/extension/src/__mocks__/notebooks/with_elipse.txt
@@ -1,0 +1,24 @@
+import marimo
+
+__generated_with = "0.17.6"
+app = marimo.App(width="medium")
+
+with app.setup:
+    from typing import Protocol
+
+
+@app.class_definition
+class GoodProtocol(Protocol):
+    @property
+    def prop(self) -> float:
+        pass
+
+
+@app.class_definition
+class BadProtocol(Protocol):
+    @property
+    def prop(self) -> float: ...
+
+
+if __name__ == "__main__":
+    app.run()

--- a/extension/src/services/__tests__/NotebookSerializer.test.ts
+++ b/extension/src/services/__tests__/NotebookSerializer.test.ts
@@ -132,6 +132,7 @@ it.layer(NotebookSerializerLive)("NotebookSerializer", (it) => {
     ["notebook with multiline cells", "multiline.txt"],
     ["notebook with cell options", "with_options.txt"],
     ["notebook with setup cell", "with_setup.txt"],
+    ["notebook with elipse", "with_elipse.txt"],
   ] as const)("identity: %s", ([_name, filename]) => {
     return Effect.gen(function* () {
       const serializer = yield* NotebookSerializer;

--- a/src/marimo_lsp/api.py
+++ b/src/marimo_lsp/api.py
@@ -190,7 +190,15 @@ async def serialize(args: SerializeRequest):
 
 async def deserialize(args: DeserializeRequest):
     converter = MarimoConvert.from_py(args.source)
-    return dataclasses.asdict(converter.to_ir())
+    ir = converter.to_ir()
+
+    # The `_ast` field on each `CellDef` holds a parsed Python AST, which isn't
+    # serializable. Since the AST isn't used on the other side of the wire,
+    # we can safely drop it before serialization.
+    for cell in ir.cells:
+        cell._ast = None  # noqa: SLF001
+
+    return dataclasses.asdict(ir)
 
 
 async def dap(


### PR DESCRIPTION
Some `CellDef._ast` fields contained non-serializable Python AST nodes (e.g., `Ellipsis`), which caused errors when opening notebooks. Since the AST isn't used on the other side of the wire, we now clear it out before serialization to avoid these issues.

Fixes #186