### PR TITLE
Add `ms-python.python` as required extension dependency

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -7,6 +7,9 @@
   "engines": {
     "vscode": "^1.86.0"
   },
+  "extensionDependencies": [
+    "ms-python.python"
+  ],
   "publisher": "marimo-team",
   "repository": "https://github.com/marimo-team/marimo-lsp",
   "categories": [


### PR DESCRIPTION
Fixes #187

Will automatically prompt users to install the Python extension when they install marimo (if not already installed).