### PR TITLE
Remove unnecessary Effect wrapper in `getExtensionVersion`

### DIFF
--- a/extension/src/services/HealthService.ts
+++ b/extension/src/services/HealthService.ts
@@ -126,7 +126,7 @@ export class HealthService extends Effect.Service<HealthService>()(
   },
 ) {}
 
-export const getExtensionVersion = Effect.fnUntraced(function* (code: VsCode) {
+export function getExtensionVersion(code: VsCode) {
   return code.extensions.getExtension(EXTENSION_PACKAGE.fullName).pipe(
     // Try parsing metadata if it's there
     Option.map((ext) =>
@@ -140,4 +140,4 @@ export const getExtensionVersion = Effect.fnUntraced(function* (code: VsCode) {
     // Otherwise fallback to unknown
     Option.getOrElse(() => Effect.succeed("unknown")),
   );
-});
+}


### PR DESCRIPTION
Replaces the `Effect.fnUntraced` generator with a plain function so the method returns the effect directly instead of wrapping it in a nested Effect.