### PR TITLE
Replace dismissible toast with modal for missing `uv`

### DIFF
--- a/extension/src/services/LanguageClient.ts
+++ b/extension/src/services/LanguageClient.ts
@@ -190,8 +190,9 @@ function maybeHandleLanguageClientStartError(error: LanguageClientStartError) {
       yield* Effect.logError("uv is not installed in PATH");
 
       const result = yield* code.window.showErrorMessage(
-        "The marimo VS Code extension currently requires uv to be installed.",
+        "The marimo VS Code extension requires `uv` to be installed in your system PATH.",
         {
+          modal: true,
           items: ["Install uv", "Try Again"],
         },
       );


### PR DESCRIPTION
Fixes #195 

The previous toast error warning about missing uv was easy to miss or dismiss. This change switches it to a modal dialog and updates the text to clarify that uv must be installed and available in the system `PATH`.

<img width="500" src="https://github.com/user-attachments/assets/1d243a24-093d-4691-8d76-c1e2613f5e9d" />
