### PR TITLE
Update target to chrome138 for compatibility

### DIFF
--- a/extension/vite.config.mjs
+++ b/extension/vite.config.mjs
@@ -9,7 +9,7 @@ import stylesheet from "./scripts/vite-plugin-virtual-stylesheet.mjs";
 export default vite.defineConfig({
   build: {
     // Shipped in: Electron 37.7, VSCode 1.106
-    target: "chrome138", 
+    target: "chrome138",
     minify: process.env.NODE_ENV === "production",
     sourcemap: process.env.NODE_ENV === "development" ? "inline" : false,
     lib: {


### PR DESCRIPTION
Updates the target to a later version so we can avoid unnecessary css/js transpilation and polyfills. This fixes the coloring of below:

<img width="750" height="805" alt="image" src="https://github.com/user-attachments/assets/2e014ae4-8ced-4290-b4cb-00ff8c399f58" />
