### PR TITLE
Color schema for tracebacks

### DIFF
--- a/extension/src/renderer/styles.css
+++ b/extension/src/renderer/styles.css
@@ -63,3 +63,13 @@
   ) {
   min-height: 350px;
 }
+
+[data-vscode-theme-kind="vscode-dark"] .codehilite,
+[data-vscode-theme-kind="vscode-high-contrast"] .codehilite {
+  color-scheme: dark;
+}
+
+[data-vscode-theme-kind="vscode-light"] .codehilite,
+[data-vscode-theme-kind="vscode-high-contrast-light"] .codehilite {
+  color-scheme: light;
+}


### PR DESCRIPTION
Fixes the traceback color scheme

<img width="682" height="234" alt="image" src="https://github.com/user-attachments/assets/f9e704f2-3bae-44ea-9798-c59ea7cbc4af" />
