### PR TITLE
Unify controller management by moving sandbox into `ControllerRegistry`

### DIFF
--- a/extension/src/services/__tests__/ControllerRegistry.test.ts
+++ b/extension/src/services/__tests__/ControllerRegistry.test.ts
@@ -206,6 +206,7 @@ it.effect(
         [
           "marimo-/home/user/.venv/bin/python",
           "marimo-/usr/local/bin/python3.11",
+          "marimo-sandbox",
         ]
       `);
 


### PR DESCRIPTION
Follow up to #204 

Previously `ControllerRegistry` and `SandboxController` were separate,
requiring `KernelManager` to depend on both and implement fallback
logic. This leaked `SandboxController` the service.

Now `ControllerRegistry` depends on `SandboxController` internally and
tracks both venv and sandbox selections in the same `selectionsRef`.
KernelManager only depends on ControllerRegistry and calls
`getActiveController()` without fallbacks.
