### PR TITLE
fix: dont override token so ui elements get dedupe

### DIFF
--- a/extension/src/renderer/utils.ts
+++ b/extension/src/renderer/utils.ts
@@ -42,8 +42,7 @@ export function createRequestClient(
     async sendComponentValues(request) {
       context.postMessage({
         command: "set_ui_element_value",
-        // FIXME: The token is required by "set_ui_element_value" (but not needed)
-        params: { ...request, token: "" },
+        params: { ...request },
       });
       return null;
     },


### PR DESCRIPTION
This removes setting an empty token, so the backend can properly set a unique ID to the token request