### PR TITLE
Remove `vscode:extension` link badge from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # marimo-lsp
 
-[![Install in VS Code](https://img.shields.io/badge/Install%20in-VS%20Code-007ACC?logo=visualstudiocode)](vscode:extension/marimo-team.vscode-marimo)
 [![VS Code Marketplace](https://img.shields.io/visual-studio-marketplace/v/marimo-team.vscode-marimo?label=VS%20Code%20Marketplace)](https://marketplace.visualstudio.com/items?itemName=marimo-team.vscode-marimo)
 [![Open VSX](https://img.shields.io/open-vsx/v/marimo-team/vscode-marimo?label=Open%20VSX)](https://open-vsx.org/extension/marimo-team/vscode-marimo)
 


### PR DESCRIPTION
The `vscode:extension` protocol only works if registered as a custom protocol handler in the user's OS, which is not the case by default.

The fallback behavior when clicking such a link in most environments just goes to the image itself, which is not very useful.