### PR TITLE
Filter uv cache environments from controller list

### DIFF
--- a/extension/src/services/Uv.ts
+++ b/extension/src/services/Uv.ts
@@ -68,7 +68,10 @@ export class Uv extends Effect.Service<Uv>()("Uv", {
     const executor = yield* CommandExecutor.CommandExecutor;
     const channel = yield* code.window.createOutputChannel("marimo (uv)");
     const uv = createUv(executor, channel);
+
     return {
+      getCacheDir: () =>
+        uv({ args: ["cache", "dir"] }).pipe(Effect.map((e) => e.stdout.trim())),
       channel: {
         name: channel.name,
         show: channel.show.bind(channel),


### PR DESCRIPTION
Prevents the extension from creating notebook controllers for Uv cache directory environments. These are managed by the sandbox controller and would show as duplicates.