### PR TITLE
Add command to set Python interpreter to match notebook kernel

### DIFF
--- a/extension/README.md
+++ b/extension/README.md
@@ -49,20 +49,21 @@ icon in the editor title bar to open it as a notebook (see image above).
 
 ## Commands
 
-| Command                                               | Description                                                               |
-| ----------------------------------------------------- | ------------------------------------------------------------------------- |
-| `marimo: New marimo notebook`                         | Create a new marimo notebook                                              |
-| `marimo: Open as marimo notebook`                     | Open a Python file as a marimo notebook                                   |
-| `marimo: Toggle on-cell-change mode`                  | Switch between auto-run and lazy execution modes                          |
-| `marimo: Run stale cells`                             | Execute all cells that need to be re-run                                  |
-| `marimo: Restart notebook kernel`                     | Restart the notebook's Python kernel                                      |
-| `marimo: Create setup cell`                           | Create or navigate to an existing setup cell                              |
-| `marimo: Publish notebook as Gist`                    | Share your notebook as a GitHub Gist                                      |
-| `marimo: Publish notebook as...`                      | Export your notebook in various formats                                   |
-| `marimo: Export static HTML`                          | Export notebook with current outputs as HTML (without re-executing cells) |
-| `marimo: Restart marimo language server (marimo-lsp)` | Restart the LSP server if it becomes unresponsive                         |
-| `marimo: Report an issue or suggest a feature`        | Open GitHub to report bugs or request features                            |
-| `marimo: Show marimo diagnostics`                     | Display diagnostic information for troubleshooting                        |
+| Command                                                   | Description                                                               |
+| --------------------------------------------------------- | ------------------------------------------------------------------------- |
+| `marimo: New marimo notebook`                             | Create a new marimo notebook                                              |
+| `marimo: Open as marimo notebook`                         | Open a Python file as a marimo notebook                                   |
+| `marimo: Toggle on-cell-change mode`                      | Switch between auto-run and lazy execution modes                          |
+| `marimo: Run stale cells`                                 | Execute all cells that need to be re-run                                  |
+| `marimo: Restart notebook kernel`                         | Restart the notebook's Python kernel                                      |
+| `marimo: Create setup cell`                               | Create or navigate to an existing setup cell                              |
+| `marimo: Publish notebook as Gist`                        | Share your notebook as a GitHub Gist                                      |
+| `marimo: Publish notebook as...`                          | Export your notebook in various formats                                   |
+| `marimo: Export static HTML`                              | Export notebook with current outputs as HTML (without re-executing cells) |
+| `marimo: Set Python interpreter to match notebook kernel` | Set the active Python interpreter to match the notebook's kernel          |
+| `marimo: Restart marimo language server (marimo-lsp)`     | Restart the LSP server if it becomes unresponsive                         |
+| `marimo: Report an issue or suggest a feature`            | Open GitHub to report bugs or request features                            |
+| `marimo: Show marimo diagnostics`                         | Display diagnostic information for troubleshooting                        |
 
 ## Configuration
 

--- a/extension/package.json
+++ b/extension/package.json
@@ -259,6 +259,12 @@
         "shortTitle": "Export static HTML",
         "category": "marimo",
         "enablement": "notebookType == 'marimo-notebook'"
+      },
+      {
+        "command": "marimo.updateActivePythonEnvironment",
+        "title": "Set Python interpreter to match notebook kernel",
+        "category": "marimo",
+        "enablement": "notebookType == 'marimo-notebook'"
       }
     ],
     "viewsContainers": {

--- a/extension/src/constants.ts
+++ b/extension/src/constants.ts
@@ -18,7 +18,8 @@ export type MarimoCommand =
   | "marimo.showDiagnostics"
   | "marimo.showMarimoMenu"
   | "marimo.toggleOnCellChangeAutoRun"
-  | "marimo.toggleOnCellChangeLazy";
+  | "marimo.toggleOnCellChangeLazy"
+  | "marimo.updateActivePythonEnvironment";
 
 export type MarimoView =
   | "marimo-explorer-datasources"

--- a/extension/src/services/NotebookControllerFactory.ts
+++ b/extension/src/services/NotebookControllerFactory.ts
@@ -227,6 +227,7 @@ export class NotebookControllerFactory extends Effect.Service<NotebookController
 ) {}
 
 export class VenvPythonController {
+  readonly _tag = "VenvPythonController";
   #inner: Omit<vscode.NotebookController, "dispose">;
   executable: string;
   constructor(

--- a/extension/src/services/SandboxController.ts
+++ b/extension/src/services/SandboxController.ts
@@ -71,7 +71,14 @@ export class SandboxController extends Effect.Service<SandboxController>()(
             }
 
             // always ensure the env is up to date
-            const venv = yield* uv.syncScript({ script: notebook.uri.fsPath });
+            const venv = yield* uv
+              .syncScript({ script: notebook.uri.fsPath })
+              .pipe(
+                // Should be added by findRequirements or uvAddScriptSafe
+                Effect.catchTag("UvMissingPep723MetadataError", () =>
+                  Effect.die("Expected PEP 723 metadata to be present"),
+                ),
+              );
             const executable = NodePath.join(venv, "bin", "python");
             yield* python.updateActiveEnvironmentPath(executable);
 

--- a/extension/src/services/Uv.ts
+++ b/extension/src/services/Uv.ts
@@ -102,6 +102,11 @@ export class Uv extends Effect.Service<Uv>()("Uv", {
         }
         return uv({ args }).pipe(Effect.andThen(Effect.void));
       },
+      initScript({ script }: { script: string }) {
+        return uv({ args: ["init", "--script", script] }).pipe(
+          Effect.andThen(Effect.void),
+        );
+      },
       syncScript(options: { script: string }) {
         return Effect.andThen(
           uv({ args: ["sync", "--script", options.script] }),
@@ -114,7 +119,13 @@ export class Uv extends Effect.Service<Uv>()("Uv", {
             assert(path, `Expected path from uv, got: stderr=${stderr}`);
             return path;
           },
-        ).pipe(Effect.catchTag("UvUnknownError", UvResolutionError.refine));
+        ).pipe(
+          Effect.catchTag(
+            "UvUnknownError",
+            UvMissingPep723MetadataError.refine.bind(null, options.script),
+          ),
+          Effect.catchTag("UvUnknownError", UvResolutionError.refine),
+        );
       },
       addScript(options: {
         script: string;

--- a/extension/src/utils/installPackages.ts
+++ b/extension/src/utils/installPackages.ts
@@ -63,7 +63,12 @@ export function installPackages(
             );
 
             // sync the virtual env
-            yield* uv.syncScript({ script: notebook.uri.fsPath });
+            yield* uv.syncScript({ script: notebook.uri.fsPath }).pipe(
+              // Should be added by `uvAddScriptSafe`
+              Effect.catchTag("UvMissingPep723MetadataError", () =>
+                Effect.die("Expected PEP 723 metadata to be present"),
+              ),
+            );
           }
           progress.report({
             message: `Successfully installed ${packages.join(", ")}`,


### PR DESCRIPTION
Adds a new `marimo.updateActivePythonEnvironment` command that updates VS Code's active Python interpreter to match the currently active marimo notebook's kernel. This action ensures that static analysis tools and other Python-aware extensions use the same interpreter that executes the notebook cells, avoiding environment mismatches.

The command retrieves the executable path from the active controller (either from a venv-based controller or by syncing a PEP 723 script environment) and updates the Python extension's active environment accordingly. A confirmation message displays the updated interpreter path.