### PR TITLE
Update `ty` Python environment via middleware

### DIFF
--- a/extension/src/layers/NotebookLanguageFeatures.ts
+++ b/extension/src/layers/NotebookLanguageFeatures.ts
@@ -3,6 +3,7 @@ import type * as vscode from "vscode";
 import { NOTEBOOK_TYPE } from "../constants.ts";
 import { LspProxy } from "../services/completions/LspProxy.ts";
 import { VsCode } from "../services/VsCode.ts";
+import { signalFromToken } from "../utils/signalFromToken.ts";
 
 /**
  * Language feature provider that uses virtual documents to provide LSP features
@@ -66,14 +67,3 @@ export const NotebookLanguageFeaturesLive = Layer.scopedDiscard(
     );
   }),
 );
-
-function signalFromToken(token: vscode.CancellationToken) {
-  const controller = new AbortController();
-  if (token.isCancellationRequested) {
-    controller.abort();
-  }
-  token.onCancellationRequested(() => {
-    controller.abort();
-  });
-  return controller.signal;
-}

--- a/extension/src/services/PythonExtension.ts
+++ b/extension/src/services/PythonExtension.ts
@@ -32,6 +32,28 @@ export class PythonExtension extends Effect.Service<PythonExtension>()(
             ),
           );
         },
+        activeEnvironmentPathChanges() {
+          return Stream.asyncPush<py.ActiveEnvironmentPathChangeEvent>((emit) =>
+            Effect.acquireRelease(
+              Effect.sync(() =>
+                api.environments.onDidChangeActiveEnvironmentPath((evt) =>
+                  emit.single(evt),
+                ),
+              ),
+              (disposable) => Effect.sync(() => disposable.dispose()),
+            ),
+          );
+        },
+        getActiveEnvironmentPath(resource?: py.Resource) {
+          return Effect.sync(() =>
+            api.environments.getActiveEnvironmentPath(resource),
+          );
+        },
+        resolveEnvironment(path: string | py.EnvironmentPath) {
+          return Effect.promise(() =>
+            api.environments.resolveEnvironment(path),
+          );
+        },
       };
     }),
   },

--- a/extension/src/utils/signalFromToken.ts
+++ b/extension/src/utils/signalFromToken.ts
@@ -1,0 +1,12 @@
+import type * as vscode from "vscode";
+
+export function signalFromToken(token: vscode.CancellationToken) {
+  const controller = new AbortController();
+  if (token.isCancellationRequested) {
+    controller.abort();
+  }
+  token.onCancellationRequested(() => {
+    controller.abort();
+  });
+  return controller.signal;
+}


### PR DESCRIPTION
Dynamically configure the `ty` language server with the active Python environment by implementing LSP `workspace/configuration` middleware that injects Python environment details into configuration requests.

Right now, ty doesn't support dynamic configuration changes after startup, so we also implement logic to restart the language server whenever the active Python environment changes, ensuring that the server always has the correct environment settings.