### PR TITLE
Ignore `.js.map` and `.mjs.map` files in the VSCode extension package

### DIFF
--- a/extension/.vscodeignore
+++ b/extension/.vscodeignore
@@ -6,12 +6,17 @@ scripts/**
 *.vsix
 pnpm-lock.yaml
 tsconfig.json
+.turbo/**
 turbo.json
 vite.config.mjs
 .tsbuildinfo
 .vscode-test
 .claude
 tests
+
+# Ignore sourcemap files (use ** to match all subdirectories)
+**/*.js.map
+**/*.mjs.map
 
 # Include tutorial files in the extension package
 !tutorials/**


### PR DESCRIPTION
Decrease the size of the VSCode extension package by ignoring unnecessary source map files.