### PR TITLE
Log warning when no active notebook editor is found

### DIFF
--- a/extension/src/layers/KernelManager.ts
+++ b/extension/src/layers/KernelManager.ts
@@ -208,11 +208,16 @@ function processOperation(
       code,
       config,
     } = deps;
-    const editor = Option.getOrThrowWith(
-      yield* editors.getLastNotebookEditor(notebookUri),
-      () => new Error(`Expected NotebookEditor for ${notebookUri}`),
-    );
+    const maybeEditor = yield* editors.getLastNotebookEditor(notebookUri);
 
+    if (Option.isNone(maybeEditor)) {
+      yield* Effect.logWarning(
+        "No active notebook editor, skipping operation",
+      ).pipe(Effect.annotateLogs({ op: operation.op }));
+      return;
+    }
+
+    const editor = Option.getOrThrow(maybeEditor);
     const maybeController = yield* controllers.getActiveController(
       editor.notebook,
     );

--- a/extension/src/services/LanguageClient.ts
+++ b/extension/src/services/LanguageClient.ts
@@ -144,7 +144,9 @@ export class LanguageClient extends Effect.Service<LanguageClient>()(
           return Stream.asyncPush<MarimoNotificationOf<Notification>>((emit) =>
             Effect.acquireRelease(
               Effect.sync(() =>
-                client.onNotification(notification, (msg) => emit.single(msg)),
+                client.onNotification(notification, (msg) => {
+                  emit.single(msg);
+                }),
               ),
               (disposable) => Effect.sync(() => disposable.dispose()),
             ),


### PR DESCRIPTION
Instead of throwing an error when no active notebook editor is found for a given notebook URI, log a warning and skip processing the operation. This prevents crashes in scenarios where the editor context is not available.