### PR TITLE
Remove redundant initial calls for `SubscriptionRef` streams

### DIFF
--- a/extension/src/services/CellStateManager.ts
+++ b/extension/src/services/CellStateManager.ts
@@ -62,9 +62,6 @@ export class CellStateManager extends Effect.Service<CellStateManager>()(
         yield* Log.debug("Updated stale context", { hasStaleCells });
       });
 
-      // Set initial context state
-      yield* Effect.forkScoped(updateContext());
-
       // Subscribe to stale state changes to update VSCode context
       yield* Effect.forkScoped(
         staleStateRef.changes.pipe(
@@ -294,7 +291,9 @@ export class CellStateManager extends Effect.Service<CellStateManager>()(
         },
 
         /**
-         * Get the changes stream for external subscriptions
+         * Stream of stale state changes.
+         *
+         * Emits the current value on subscription, then all subsequent changes.
          */
         get changes() {
           return staleStateRef.changes;

--- a/extension/src/services/NotebookEditorRegistry.ts
+++ b/extension/src/services/NotebookEditorRegistry.ts
@@ -116,7 +116,10 @@ export class NotebookEditorRegistry extends Effect.Service<NotebookEditorRegistr
         },
 
         /**
-         * Stream of active notebook URI changes
+         * Stream of active notebook URI changes.
+         *
+         * Emits the current value on subscription, then all subsequent changes.
+         * Filters consecutive duplicates via Stream.changes.
          */
         streamActiveNotebookChanges() {
           return activeNotebookRef.changes.pipe(Stream.changes);

--- a/extension/src/services/config/MarimoConfigurationService.ts
+++ b/extension/src/services/config/MarimoConfigurationService.ts
@@ -153,14 +153,20 @@ export class MarimoConfigurationService extends Effect.Service<MarimoConfigurati
         },
 
         /**
-         * Stream of configuration changes
+         * Stream of configuration changes.
+         *
+         * Emits the current value on subscription, then all subsequent changes.
+         * Filters consecutive duplicates via Stream.changes.
          */
         streamConfigChanges() {
           return configRef.changes.pipe(Stream.changes);
         },
 
         /**
-         * Stream of configuration changes for the active notebook
+         * Stream of configuration changes for the active notebook.
+         *
+         * Emits the current value on subscription, then all subsequent changes.
+         * Filters consecutive duplicates via Stream.changes.
          */
         streamActiveConfigChanges() {
           return Stream.zipLatest(
@@ -178,7 +184,10 @@ export class MarimoConfigurationService extends Effect.Service<MarimoConfigurati
         },
 
         /**
-         * Stream of configuration changes for the active notebook
+         * Stream of mapped configuration values for the active notebook.
+         *
+         * Emits the current value on subscription, then all subsequent changes.
+         * Filters consecutive duplicates via Stream.changes.
          */
         streamOf<R>(
           mapper: (config: MarimoConfig) => R,

--- a/extension/src/services/datasources/DatasourcesService.ts
+++ b/extension/src/services/datasources/DatasourcesService.ts
@@ -383,35 +383,45 @@ export class DatasourcesService extends Effect.Service<DatasourcesService>()(
         },
 
         /**
-         * Stream of data source connection changes
+         * Stream of data source connection changes.
+         *
+         * Emits the current value on subscription, then all subsequent changes.
          */
         streamConnectionsChanges() {
           return connectionsRef.changes;
         },
 
         /**
-         * Stream of dataset changes
+         * Stream of dataset changes.
+         *
+         * Emits the current value on subscription, then all subsequent changes.
          */
         streamDatasetsChanges() {
           return datasetsRef.changes;
         },
 
         /**
-         * Stream of table preview changes
+         * Stream of table preview changes.
+         *
+         * Emits the current value on subscription, then all subsequent changes.
          */
         streamTablePreviewsChanges() {
           return tablePreviewsRef.changes;
         },
 
         /**
-         * Stream of table list preview changes
+         * Stream of table list preview changes.
+         *
+         * Emits the current value on subscription, then all subsequent changes.
          */
         streamTableListPreviewsChanges() {
           return tableListPreviewsRef.changes;
         },
 
         /**
-         * Stream of column preview changes
+         * Stream of column preview changes.
+         *
+         * Emits the current value on subscription, then all subsequent changes.
          */
         streamColumnPreviewsChanges() {
           return columnPreviewsRef.changes;

--- a/extension/src/services/packages/PackagesService.ts
+++ b/extension/src/services/packages/PackagesService.ts
@@ -387,14 +387,18 @@ export class PackagesService extends Effect.Service<PackagesService>()(
         },
 
         /**
-         * Stream of package list changes
+         * Stream of package list changes.
+         *
+         * Emits the current value on subscription, then all subsequent changes.
          */
         streamPackageListChanges() {
           return packageListsRef.changes;
         },
 
         /**
-         * Stream of dependency tree changes
+         * Stream of dependency tree changes.
+         *
+         * Emits the current value on subscription, then all subsequent changes.
          */
         streamDependencyTreeChanges() {
           return dependencyTreesRef.changes;

--- a/extension/src/services/variables/VariablesService.ts
+++ b/extension/src/services/variables/VariablesService.ts
@@ -162,14 +162,20 @@ export class VariablesService extends Effect.Service<VariablesService>()(
         },
 
         /**
-         * Stream of variable declaration changes
+         * Stream of variable declaration changes.
+         *
+         * Emits the current value on subscription, then all subsequent changes.
+         * Filters consecutive duplicates via Stream.changes.
          */
         streamVariablesChanges() {
           return variablesRef.changes.pipe(Stream.changes);
         },
 
         /**
-         * Stream of variable value changes
+         * Stream of variable value changes.
+         *
+         * Emits the current value on subscription, then all subsequent changes.
+         * Filters consecutive duplicates via Stream.changes.
          */
         streamVariableValuesChanges() {
           return variableValuesRef.changes.pipe(Stream.changes);

--- a/extension/src/views/DatasourcesView.ts
+++ b/extension/src/views/DatasourcesView.ts
@@ -395,9 +395,6 @@ export const DatasourcesViewLive = Layer.scopedDiscard(
       ),
     );
 
-    // Initialize with current state
-    yield* Effect.forkScoped(refreshDatasources());
-
     yield* Effect.logInfo("Datasources view initialized");
   }),
 );

--- a/extension/src/views/PackagesView.ts
+++ b/extension/src/views/PackagesView.ts
@@ -158,9 +158,6 @@ export const PackagesViewLive = Layer.scopedDiscard(
       ),
     );
 
-    // Initialize with current state
-    yield* Effect.forkScoped(refreshPackages());
-
     // Register command to refresh packages
     yield* code.commands.registerCommand(
       "marimo.refreshPackages",

--- a/extension/src/views/VariablesView.ts
+++ b/extension/src/views/VariablesView.ts
@@ -167,9 +167,6 @@ export const VariablesViewLive = Layer.scopedDiscard(
       ),
     );
 
-    // Initialize with current state
-    yield* Effect.forkScoped(refreshVariables());
-
     yield* Effect.logInfo("Variables view initialized");
   }),
 );


### PR DESCRIPTION
These changes remove redundant "initialize with current state" calls that were running the same handler twice on startup (once explicitly, once from the stream's initial emission).

From the Effect [documentation](https://effect.website/docs/state-management/subscriptionref/) on `SubscriptionRef`:

> "The changes stream allows you to observe the current value at the moment of subscription and receive all subsequent changes. Every time  the stream is run, it emits the current value and tracks future updates."