### PR TITLE
Resolve Python executable path using platform-specific bin name

### DIFF
--- a/extension/src/layers/RegisterCommands.ts
+++ b/extension/src/layers/RegisterCommands.ts
@@ -24,6 +24,7 @@ import { PythonExtension } from "../services/PythonExtension.ts";
 import { type ITelemetry, Telemetry } from "../services/Telemetry.ts";
 import { Uv } from "../services/Uv.ts";
 import { VsCode } from "../services/VsCode.ts";
+import { getPythonBinName } from "../utils/getPythonBinName.ts";
 import { Links } from "../utils/links.ts";
 import { showErrorAndPromptLogs } from "../utils/showErrorAndPromptLogs.ts";
 
@@ -759,7 +760,7 @@ const updateActivePythonEnvironment = ({
         );
       }
 
-      executable = NodePath.join(venvResult.right, "bin", "python");
+      executable = NodePath.join(venvResult.right, "bin", getPythonBinName());
     }
 
     // update the active python environment

--- a/extension/src/services/SandboxController.ts
+++ b/extension/src/services/SandboxController.ts
@@ -9,6 +9,7 @@ import {
   SemVerFromString,
 } from "../schemas.ts";
 import { getCellExecutableCode } from "../utils/getCellExecutableCode.ts";
+import { getPythonBinName } from "../utils/getPythonBinName.ts";
 import { uvAddScriptSafe } from "../utils/installPackages.ts";
 import { showErrorAndPromptLogs } from "../utils/showErrorAndPromptLogs.ts";
 import { Constants } from "./Constants.ts";
@@ -86,7 +87,8 @@ export class SandboxController extends Effect.Service<SandboxController>()(
                   Effect.die("Expected PEP 723 metadata to be present"),
                 ),
               );
-            const executable = NodePath.join(venv, "bin", "python");
+
+            const executable = NodePath.join(venv, "bin", getPythonBinName());
             yield* python.updateActiveEnvironmentPath(executable);
 
             yield* client.executeCommand({

--- a/extension/src/utils/getPythonBinName.ts
+++ b/extension/src/utils/getPythonBinName.ts
@@ -1,0 +1,5 @@
+import * as NodeProcess from "node:process";
+
+export function getPythonBinName() {
+  return NodeProcess.platform === "win32" ? "python.exe" : "python";
+}


### PR DESCRIPTION
Fixes #275

Ensures the correct interpreter is selected across platforms by using the appropriate Python binary within virtual environments.