### PR TITLE
Remove separate safe/unsafe accessors for stableId

### DIFF
--- a/extension/src/layers/KernelManager.ts
+++ b/extension/src/layers/KernelManager.ts
@@ -154,7 +154,12 @@ export const KernelManagerLive = Layer.scopedDiscard(
                   editor.value.notebook,
                 )
                   .getCells()
-                  .findIndex((cell) => cell.id === cellId);
+                  .findIndex((cell) =>
+                    Option.match(cell.id, {
+                      onSome: (id) => id === cellId,
+                      onNone: () => false,
+                    }),
+                  );
 
                 yield* Effect.logDebug(
                   `Navigating to cell at index ${cellIndex}`,

--- a/extension/src/schemas/vscode-notebook.ts
+++ b/extension/src/schemas/vscode-notebook.ts
@@ -118,13 +118,6 @@ export class MarimoNotebookCell {
   }
 
   get id() {
-    return Option.getOrThrowWith(
-      this.maybeId,
-      () => new Error("Expected cell id"),
-    );
-  }
-
-  get maybeId() {
     return this.metadata.pipe(
       Option.flatMap((meta) => Option.fromNullable(meta.stableId)),
       Option.map((stableId) => NotebookCellId(stableId)),
@@ -366,7 +359,12 @@ export function findNotebookCell(
   cellId: NotebookCellId,
 ) {
   return Effect.gen(function* () {
-    const cell = notebook.getCells().find((c) => c.id === cellId);
+    const cell = notebook.getCells().find((c) =>
+      Option.match(c.id, {
+        onSome: (id) => id === cellId,
+        onNone: () => false,
+      }),
+    );
     if (!cell) {
       return yield* new NotebookCellNotFoundError({ cellId, notebook });
     }

--- a/extension/src/services/CellStateManager.ts
+++ b/extension/src/services/CellStateManager.ts
@@ -108,16 +108,16 @@ export class CellStateManager extends Effect.Service<CellStateManager>()(
               for (const change of event.contentChanges) {
                 for (const rawCell of change.removedCells) {
                   const cell = MarimoNotebookCell.from(rawCell);
-                  if (Option.isSome(cell.maybeId)) {
-                    removedCellIds.add(cell.maybeId.value);
-                    removedCellsMap.set(cell.maybeId.value, cell);
+                  if (Option.isSome(cell.id)) {
+                    removedCellIds.add(cell.id.value);
+                    removedCellsMap.set(cell.id.value, cell);
                   }
                 }
 
                 for (const rawCell of change.addedCells) {
                   const cell = MarimoNotebookCell.from(rawCell);
-                  if (Option.isSome(cell.maybeId)) {
-                    addedCellIds.add(cell.maybeId.value);
+                  if (Option.isSome(cell.id)) {
+                    addedCellIds.add(cell.id.value);
                   } else {
                     // Cell added from UI without a stableId (so we need to create one)
                     edits.push(

--- a/extension/src/services/ExecutionRegistry.ts
+++ b/extension/src/services/ExecutionRegistry.ts
@@ -585,7 +585,12 @@ function createCellIdMapper(
 ): (cellId: NotebookCellId) => string | undefined {
   return (cellId: NotebookCellId) => {
     // Find the cell by matching its URI to get the visual index (0-based)
-    const cellIndex = notebook.getCells().findIndex((c) => c.id === cellId);
+    const cellIndex = notebook.getCells().findIndex((cell) =>
+      Option.match(cell.id, {
+        onSome: (id) => id === cellId,
+        onNone: () => false,
+      }),
+    );
     if (cellIndex === -1) {
       return undefined;
     }

--- a/extension/src/services/NotebookDataCache.ts
+++ b/extension/src/services/NotebookDataCache.ts
@@ -180,10 +180,7 @@ const matchRecentNotebookFromData = (
   // Find a notebook that has any of these stableIds
   for (const doc of recentlyEdited.take(5)) {
     for (const cell of doc.getCells()) {
-      if (
-        Option.isSome(cell.maybeId) &&
-        dataStableIds.has(cell.maybeId.value)
-      ) {
+      if (Option.isSome(cell.id) && dataStableIds.has(cell.id.value)) {
         return Option.some(doc);
       }
     }

--- a/extension/src/services/__tests__/ExecutionRegistry.test.ts
+++ b/extension/src/services/__tests__/ExecutionRegistry.test.ts
@@ -904,7 +904,7 @@ it.scoped(
       // Send a message with staleInputs: true
       const message: CellMessage = {
         op: "cell-op",
-        cell_id: cell.id,
+        cell_id: Option.getOrThrow(cell.id),
         status: "idle",
         stale_inputs: true,
       };
@@ -980,7 +980,7 @@ it.scoped(
       // Send a queued message
       const message: CellMessage = {
         op: "cell-op",
-        cell_id: cell.id,
+        cell_id: Option.getOrThrow(cell.id),
         status: "queued",
         run_id: "test-run-id",
       };

--- a/extension/src/utils/extractExecuteCodeRequest.ts
+++ b/extension/src/utils/extractExecuteCodeRequest.ts
@@ -1,0 +1,36 @@
+import { Option } from "effect";
+import type * as vscode from "vscode";
+import { MarimoNotebookCell, type NotebookCellId } from "../schemas.ts";
+import type { Constants } from "../services/Constants.ts";
+import { getCellExecutableCode } from "./getCellExecutableCode.ts";
+
+export function extractExecuteCodeRequest(
+  rawCells: Array<vscode.NotebookCell>,
+  LanguageId: Constants["LanguageId"],
+): Option.Option<{
+  codes: Array<string>;
+  cellIds: Array<NotebookCellId>;
+}> {
+  const codes: Array<string> = [];
+  const cellIds: Array<NotebookCellId> = [];
+
+  for (const rawCell of rawCells) {
+    const cell = MarimoNotebookCell.from(rawCell);
+    if (Option.isNone(cell.id)) {
+      continue;
+    }
+
+    const code = getCellExecutableCode(cell, LanguageId);
+    const cellId = cell.id.value;
+
+    codes.push(code);
+    cellIds.push(cellId);
+  }
+
+  if (codes.length === 0) {
+    // no request
+    Option.none();
+  }
+
+  return Option.some({ codes, cellIds });
+}


### PR DESCRIPTION
These changes make `MarimoNotebookCell.id` an `Option<NotebookCellId>`, eliminating the previous split between `id` (unchecked) and `maybeId` (checked). All callers are updated to match on the optional ID directly, and decide how to handle/report missing IDs.