### PR TITLE
Remove incorrect UV bin line from HealthService

### DIFF
--- a/extension/src/services/HealthService.ts
+++ b/extension/src/services/HealthService.ts
@@ -63,7 +63,6 @@ export class HealthService extends Effect.Service<HealthService>()(
             lines.push(`\tUV Bin: Discovered (${bin.executable})`),
         });
 
-        lines.push(`\tUV: ${uv.bin}`);
         if (Option.isSome(uvVersion)) {
           lines.push(`\tUV: ${uvVersion.value} ✓`);
         } else {


### PR DESCRIPTION
We already report the executable above, and this was improperly formatted leading to `[Object object]` in the logs.