### PR TITLE
Filter extension-only settings from ty server configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ tests/out/
 extension/.vscode-test/
 *.vsix
 .vscode-test/
+.claude/


### PR DESCRIPTION
Fixes #297

Port fix from ty-vscode (https://github.com/astral-sh/ty-vscode/pull/237) that filters out client-side settings (`logLevel`, `path`, `trace`, etc.) before sending configuration to the ty server, preventing "unknown options" warnings.