### PR TITLE
Fix language alias conflict breaking Jupyter notebook features

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -62,7 +62,7 @@
       {
         "id": "mo-python",
         "aliases": [
-          "Python",
+          "Python (marimo)",
           "mo-python"
         ],
         "configuration": "./language-configuration.json"


### PR DESCRIPTION
Closes #283, #291

We register a custom language ID (`mo-python`) to isolate marimo cells from external language servers that don't understand cell-based execution. This prevents false warnings and enables our own completions across cells.

When registering `mo-python`, we included `"Python"` as an alias, assuming aliases were just display names. This was wrong. It caused all Python language features to break in standard Jupyter notebooks when marimo was enabled.

The fix uses `"Python (marimo)"` as the alias instead, avoiding collision with the real Python language.