### PR TITLE
Pin ty version and add health check to diagnostics

### DIFF
--- a/extension/src/__mocks__/TestPythonLanguageServer.ts
+++ b/extension/src/__mocks__/TestPythonLanguageServer.ts
@@ -19,5 +19,11 @@ export const TestPythonLanguageServerLive = Layer.succeed(
     getSignatureHelp: () => Effect.succeed(null),
     getSemanticTokensLegend: () => Effect.succeed(Option.none()),
     getSemanticTokensFull: () => Effect.succeed(Option.none()),
+    getHealthStatus: Effect.succeed({
+      status: "running" as const,
+      version: null,
+      error: null,
+      pythonEnvironment: null,
+    }),
   }),
 );


### PR DESCRIPTION
The ty language server was being invoked without a version pin, meaning builds could break when ty releases incompatible changes. This pins ty to the lastest version (0.0.8) via `ty@0.0.8` in the uvx invocation. We can pin semver range in the future, but since we are doing rolling releases I think this is a good move.

Additionally, debugging language server issues was difficult without visibility into the server's state. The diagnostics panel now shows Python extension environment info and ty health status (when managed language features are enabled), including running state, version, any startup errors, and which Python environment is in use.

Example output:

```
marimo VS Code Extension Diagnostics
=====================================

...

Python Extension:
	Interpreter: /Users/manzt/.cache/uv/environments-v2/testtest-ff8730a8695599a1/bin/python
	Version: 3.13.3.final.0
	Environment: VirtualEnvironment (testtest.py)

Python Language Server (ty):
	Status: running ✓
	Version: 0.0.8 (aa7559db8 2025-12-29)
	Python: /Users/manzt/.cache/uv/environments-v2/testtest-ff8730a8695599a1/bin/python (3.13.3.final.0)
```
