### PR TITLE
Refactor `CellStateManager` to use cell IDs instead of indices

### DIFF
--- a/extension/src/services/ExecutionRegistry.ts
+++ b/extension/src/services/ExecutionRegistry.ts
@@ -99,19 +99,13 @@ export class ExecutionRegistry extends Effect.Service<ExecutionRegistry>()(
 
             // If cell has stale inputs, mark it as stale
             if (cell.state.staleInputs) {
-              yield* cellStateManager.markCellStale(
-                notebook.id,
-                notebookCell.index,
-              );
+              yield* cellStateManager.markCellStale(notebook.id, cellId);
             }
 
             switch (msg.status) {
               case "queued": {
                 // Clear stale state when cell is queued for execution
-                yield* cellStateManager.clearCellStale(
-                  notebook.id,
-                  notebookCell.index,
-                );
+                yield* cellStateManager.clearCellStale(notebook.id, cellId);
 
                 yield* Ref.update(ref, (map) => {
                   const handle = HashMap.get(map, cellId).pipe(

--- a/extension/src/services/__tests__/CellStateManager.test.ts
+++ b/extension/src/services/__tests__/CellStateManager.test.ts
@@ -234,19 +234,22 @@ describe("CellStateManager", () => {
       yield* Effect.gen(function* () {
         const code = yield* VsCode;
 
+        const cellData0 = new code.NotebookCellData(
+          code.NotebookCellKind.Code,
+          "x = 1",
+          "python",
+        );
+        cellData0.metadata = { stableId: "cell-0" };
+
+        const cellData1 = new code.NotebookCellData(
+          code.NotebookCellKind.Code,
+          "y = 2",
+          "python",
+        );
+        cellData1.metadata = { stableId: "cell-1" };
+
         const editor = TestVsCode.makeNotebookEditor("/test/notebook.py", {
-          data: new code.NotebookData([
-            new code.NotebookCellData(
-              code.NotebookCellKind.Code,
-              "x = 1",
-              "python",
-            ),
-            new code.NotebookCellData(
-              code.NotebookCellKind.Code,
-              "y = 2",
-              "python",
-            ),
-          ]),
+          data: new code.NotebookData([cellData0, cellData1]),
         });
 
         yield* ctx.vscode.addNotebookDocument(editor.notebook);


### PR DESCRIPTION
Follow-up to #277 and #279 which introduced stable cell IDs.

Cell indices are fragile since they change whenever cells are moved, added, or deleted. This refactors the stale state tracking to use stable cell IDs throughout, both internally and in the public API.