### PR TITLE
Support all Python environments from vscode-python

### DIFF
--- a/extension/src/layers/RegisterCommands.ts
+++ b/extension/src/layers/RegisterCommands.ts
@@ -848,7 +848,7 @@ const updateActivePythonEnvironment = ({
     }
 
     let executable: string;
-    if (controller.value._tag === "VenvPythonController") {
+    if (controller.value._tag === "PythonController") {
       executable = controller.value.executable;
     } else {
       const script = editor.value.notebook.uri.fsPath;

--- a/extension/src/services/ExecutionRegistry.ts
+++ b/extension/src/services/ExecutionRegistry.ts
@@ -30,7 +30,7 @@ import {
 } from "../types.ts";
 import { prettyErrorMessage } from "../utils/errors.ts";
 import { CellStateManager } from "./CellStateManager.ts";
-import type { VenvPythonController } from "./NotebookControllerFactory.ts";
+import type { PythonController } from "./NotebookControllerFactory.ts";
 import type { SandboxController } from "./SandboxController.ts";
 import { VsCode } from "./VsCode.ts";
 
@@ -78,7 +78,7 @@ export class ExecutionRegistry extends Effect.Service<ExecutionRegistry>()(
           msg: CellMessage,
           options: {
             editor: vscode.NotebookEditor;
-            controller: VenvPythonController | SandboxController;
+            controller: PythonController | SandboxController;
           },
         ) =>
           Effect.gen(function* () {
@@ -367,7 +367,7 @@ class CellEntry extends Data.TaggedClass("CellEntry")<{
     code: VsCode,
     deps?: {
       editor: vscode.NotebookEditor;
-      controller: VenvPythonController | SandboxController;
+      controller: PythonController | SandboxController;
     },
   ) {
     const { pendingExecution, id: cellId, state } = cell;

--- a/extension/src/services/__tests__/ControllerRegistry.test.ts
+++ b/extension/src/services/__tests__/ControllerRegistry.test.ts
@@ -87,6 +87,10 @@ it.effect(
             "executable": "/home/user/.venv/bin/python",
             "id": "marimo-/home/user/.venv/bin/python",
           },
+          {
+            "executable": "/usr/local/bin/python3.11",
+            "id": "marimo-/usr/local/bin/python3.11",
+          },
         ],
         "selections": [],
       }
@@ -156,7 +160,7 @@ it.effect(
     yield* Effect.gen(function* () {
       const registry = yield* ControllerRegistry;
 
-      // Initial state - should have two controllers (global env filtered out)
+      // Initial state - should have three controllers (includes global env)
       const snapshot1 = yield* registry.snapshot();
       expect(snapshot1).toMatchInlineSnapshot(`
         {
@@ -164,6 +168,10 @@ it.effect(
             {
               "executable": "/home/user/.venv/bin/python",
               "id": "marimo-/home/user/.venv/bin/python",
+            },
+            {
+              "executable": "/opt/homebrew/bin/python3",
+              "id": "marimo-/opt/homebrew/bin/python3",
             },
             {
               "executable": "/usr/local/bin/python3.11",
@@ -181,7 +189,7 @@ it.effect(
       // Give time for the stream to process
       yield* TestClock.adjust("100 millis");
 
-      // Should now have one controller (global env still filtered)
+      // Should now have two controllers
       const snapshot2 = yield* registry.snapshot();
       expect(snapshot2).toMatchInlineSnapshot(`
         {
@@ -189,6 +197,10 @@ it.effect(
             {
               "executable": "/home/user/.venv/bin/python",
               "id": "marimo-/home/user/.venv/bin/python",
+            },
+            {
+              "executable": "/opt/homebrew/bin/python3",
+              "id": "marimo-/opt/homebrew/bin/python3",
             },
             {
               "executable": "/usr/local/bin/python3.11",
@@ -224,11 +236,12 @@ it.effect(
         createTestNotebookDocument(code.Uri.file("/test/notebook2_mo.py")),
       );
 
-      // Get controllers from vscode snapshot
+      // Get controllers from vscode snapshot (includes global env)
       const vsSnapshot = yield* vscode.snapshot();
       expect(vsSnapshot.controllers).toMatchInlineSnapshot(`
         [
           "marimo-/home/user/.venv/bin/python",
+          "marimo-/opt/homebrew/bin/python3",
           "marimo-/usr/local/bin/python3.11",
           "marimo-sandbox",
         ]
@@ -241,7 +254,7 @@ it.effect(
       assert(Option.isNone(controller1));
       assert(Option.isNone(controller2));
 
-      // Verify snapshot shows no selections
+      // Verify snapshot shows no selections (includes global env)
       const snapshot = yield* registry.snapshot();
       expect(snapshot).toMatchInlineSnapshot(`
         {
@@ -249,6 +262,10 @@ it.effect(
             {
               "executable": "/home/user/.venv/bin/python",
               "id": "marimo-/home/user/.venv/bin/python",
+            },
+            {
+              "executable": "/opt/homebrew/bin/python3",
+              "id": "marimo-/opt/homebrew/bin/python3",
             },
             {
               "executable": "/usr/local/bin/python3.11",
@@ -338,11 +355,15 @@ it.effect(
       const env2 = TestPythonExtension.makeVenv("/home/user/.venv/bin/python");
       const env3 = TestPythonExtension.makeVenv("/opt/python3.12/bin/python");
 
-      // Initial: 1 controller (global env filtered out)
+      // Initial: 2 controllers (includes global env)
       let snapshot = yield* registry.snapshot();
       expect(snapshot).toMatchInlineSnapshot(`
         {
           "controllers": [
+            {
+              "executable": "/opt/homebrew/bin/python3",
+              "id": "marimo-/opt/homebrew/bin/python3",
+            },
             {
               "executable": "/usr/local/bin/python3.11",
               "id": "marimo-/usr/local/bin/python3.11",
@@ -360,6 +381,10 @@ it.effect(
       expect(snapshot).toMatchInlineSnapshot(`
         {
           "controllers": [
+            {
+              "executable": "/opt/homebrew/bin/python3",
+              "id": "marimo-/opt/homebrew/bin/python3",
+            },
             {
               "executable": "/usr/local/bin/python3.11",
               "id": "marimo-/usr/local/bin/python3.11",
@@ -380,6 +405,10 @@ it.effect(
             {
               "executable": "/home/user/.venv/bin/python",
               "id": "marimo-/home/user/.venv/bin/python",
+            },
+            {
+              "executable": "/opt/homebrew/bin/python3",
+              "id": "marimo-/opt/homebrew/bin/python3",
             },
             {
               "executable": "/opt/python3.12/bin/python",
@@ -403,6 +432,10 @@ it.effect(
         {
           "controllers": [
             {
+              "executable": "/opt/homebrew/bin/python3",
+              "id": "marimo-/opt/homebrew/bin/python3",
+            },
+            {
               "executable": "/opt/python3.12/bin/python",
               "id": "marimo-/opt/python3.12/bin/python",
             },
@@ -423,6 +456,10 @@ it.effect(
       expect(snapshot).toMatchInlineSnapshot(`
         {
           "controllers": [
+            {
+              "executable": "/opt/homebrew/bin/python3",
+              "id": "marimo-/opt/homebrew/bin/python3",
+            },
             {
               "executable": "/opt/python3.12/bin/python",
               "id": "marimo-/opt/python3.12/bin/python",

--- a/extension/src/services/__tests__/ExecutionRegistry.test.ts
+++ b/extension/src/services/__tests__/ExecutionRegistry.test.ts
@@ -14,7 +14,7 @@ import type { CellMessage, CellRuntimeState } from "../../types.ts";
 import { CellStateManager } from "../CellStateManager.ts";
 import { buildCellOutputs, ExecutionRegistry } from "../ExecutionRegistry.ts";
 import { LanguageClient } from "../LanguageClient.ts";
-import { VenvPythonController } from "../NotebookControllerFactory.ts";
+import { PythonController } from "../NotebookControllerFactory.ts";
 import { VsCode } from "../VsCode.ts";
 
 // Simple mock LanguageClient that doesn't spawn a real LSP process
@@ -926,7 +926,7 @@ it.scoped(
 
       yield* registry.handleCellOperation(message, {
         editor,
-        controller: new VenvPythonController(controller, "test-controller"),
+        controller: new PythonController(controller, "test-controller"),
       });
 
       // Check that CellStateManager tracked the cell as stale
@@ -1002,7 +1002,7 @@ it.scoped(
 
       yield* registry.handleCellOperation(message, {
         editor,
-        controller: new VenvPythonController(controller, "test-controller"),
+        controller: new PythonController(controller, "test-controller"),
       });
 
       // Check that the cell's stale state was cleared


### PR DESCRIPTION
Closes #264, #243

Previously, the extension filtered out "global" Python interpreters and only showed virtual environments in the kernel selector. This was because we have uv integration for auto-installing packages, which only works with standard venvs that have a `pyvenv.cfg` file.

This change removes that filter so all Python environments discovered by vscode-python now appear as kernel options, matching how the Jupyter extension works. This enables users with pixi, conda, bazel, or other non-venv Python setups to use marimo notebooks by selecting their interpreter via VS Code's `Python: Select Interpreter` command.

The uv package management features (install prompts on missing packages, environment validation) now check for `pyvenv.cfg` via `findVenvPath` before showing any install prompts. This handles all non-venv environments correctly: pixi (`.pixi/envs/`), conda, global Python, and custom paths like bazel. Users with these environments will see the missing package error without a confusing "Install with uv?" prompt that would fail.