### PR TITLE
Pin `ty` v0.0.11 for managed Python language server

### DIFF
--- a/extension/src/services/completions/PythonLanguageServer.ts
+++ b/extension/src/services/completions/PythonLanguageServer.ts
@@ -9,7 +9,7 @@ import { VsCode } from "../VsCode.ts";
 
 // TODO: make TY_VERSION configurable?
 // For now, since we are doing rolling releases, we can bump this as needed.
-const TY_VERSION = "0.0.8";
+const TY_VERSION = "0.0.11";
 
 export class PythonLanguageServerStartError extends Data.TaggedError(
   "PythonLanguageServerStartError",


### PR DESCRIPTION
Bumps the version of the `ty` package used for the managed Python language server from v0.0.8 to v0.0.11.