### PR TITLE
Respect Python extension's infoVisibility setting for status bar

### DIFF
--- a/extension/src/views/StatusBar.ts
+++ b/extension/src/views/StatusBar.ts
@@ -4,6 +4,10 @@ import { VsCode } from "../services/VsCode.ts";
 export type StatusBarAlignment = "Left" | "Right";
 export type StatusBarCommand = string;
 
+export type StatusBarItem = Effect.Effect.Success<
+  ReturnType<StatusBar["createStatusBarItem"]>
+>;
+
 /**
  * Manages VS Code status bar items with automatic disposal.
  *


### PR DESCRIPTION
The Python extension's interpreter status bar only appears when `activeTextEditor.document.languageId === "python"`. Since marimo notebooks use `mo-python` as their language ID, users lose access to the familiar interpreter picker when editing marimo cells.

This refactors the fallback status bar to respect the Python extension's `python.interpreter.infoVisibility` setting. When set to "always" or "never", we defer to the user's explicit preference and hide our status bar. For the default "onPythonRelated" mode, we show our status bar whenever a marimo notebook is active, filling the gap left by the Python extension.

The implementation is simplified: mutable state tracking is removed in favor of recomputing visibility on each relevant event, and the logic is extracted into standalone functions. Tests are updated to verify the new behavior based on active notebook editor rather than visible editors.