### PR TITLE
Mirror Python formatter setting for mo-python cells dynamically

### DIFF
--- a/extension/src/services/VsCode.ts
+++ b/extension/src/services/VsCode.ts
@@ -324,8 +324,8 @@ export class Workspace extends Effect.Service<Workspace>()("Workspace", {
       getNotebookDocuments() {
         return Effect.succeed(api.notebookDocuments);
       },
-      getConfiguration(section: string) {
-        return Effect.succeed(api.getConfiguration(section));
+      getConfiguration(section: string, scope?: vscode.ConfigurationScope) {
+        return Effect.succeed(api.getConfiguration(section, scope));
       },
       getWorkspaceFolders() {
         return Effect.succeed(Option.fromNullable(api.workspaceFolders));


### PR DESCRIPTION
Previously, the extension attempted to sync formatter configuration by writing to user settings when the Python formatter was set to Ruff. This approach had issues: it persisted changes the user didn't explicitly request, and the configuration listener used `affectsConfiguration("[python]")` which doesn't correctly detect language-specific setting changes (e.g., `[python,typescript]` wouldn't trigger it).

Instead of persisting settings, the middleware now checks the user's Python formatter preference dynamically on each format request. If the user has Ruff configured as their Python formatter, formatting proceeds through the managed Ruff server. If not, the middleware returns null, effectively disabling formatting without touching user settings.