### PR TITLE
Fix notebook opening in wrong window in multi-window scenarios

### DIFF
--- a/extension/src/__mocks__/TestVsCode.ts
+++ b/extension/src/__mocks__/TestVsCode.ts
@@ -1449,6 +1449,7 @@ export class TestVsCode extends Data.TaggedClass("TestVsCode")<{
             activeTextEditorChanges() {
               return activeTextEditor.changes;
             },
+            closeTextEditorTab: () => Effect.void,
             createTreeView<T>(viewId: string) {
               return Effect.acquireRelease(
                 Effect.gen(function* () {

--- a/extension/src/services/VsCode.ts
+++ b/extension/src/services/VsCode.ts
@@ -140,6 +140,22 @@ export class Window extends Effect.Service<Window>()("Window", {
       getActiveTextEditor() {
         return Effect.succeed(Option.fromNullable(api.activeTextEditor));
       },
+      closeTextEditorTab(uri: vscode.Uri) {
+        return Option.fromNullable(
+          api.tabGroups.all
+            .flatMap((group) => group.tabs)
+            .find(
+              (tab) =>
+                tab.input instanceof vscode.TabInputText &&
+                tab.input.uri.toString() === uri.toString(),
+            ),
+        ).pipe(
+          Option.match({
+            onSome: (tab) => Effect.promise(() => api.tabGroups.close(tab)),
+            onNone: () => Effect.void,
+          }),
+        );
+      },
       createTreeView<T>(viewId: string, options: vscode.TreeViewOptions<T>) {
         return Effect.acquireRelease(
           Effect.sync(() => api.createTreeView(viewId, options)),


### PR DESCRIPTION
Fixes #328. When a Python file was moved to a new VS Code window, clicking "Open as marimo notebook" would open it in the original window. This happened because closing the only editor in a window causes the window to close.

The fix opens the notebook first, then uses the tabGroups API to close just the text editor tab.