### PR TITLE
Use structured JSON output for uv version detection

### DIFF
--- a/extension/src/services/HealthService.ts
+++ b/extension/src/services/HealthService.ts
@@ -67,7 +67,7 @@ export class HealthService extends Effect.Service<HealthService>()(
           });
 
           if (Option.isSome(uv.bin.version)) {
-            lines.push(`\tUV: ${uv.bin.version.value} ✓`);
+            lines.push(`\tUV: ${uv.bin.version.value.format()} ✓`);
           } else {
             lines.push("\tUV: Not found ✗");
           }


### PR DESCRIPTION
Switch from `uv --version` to `uv self version --output-format json` for more reliable version parsing. The new VersionInfo schema extracts version, commit hash, and date, displayed as "0.5.1 (abc1234 2024-01-15)".

Consolidates `UvNotInstalledError` into `UvExecutionError` since version parsing failures shouldn't prevent the extension from working... we now log a warning and proceed with "unknown" version instead.