### PR TITLE
Fix release workflow by using bundled uv for sdist build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -213,6 +213,12 @@ jobs:
         run: |
           pnpm install
           pnpm build
+          # Use the bundled uv binary for building the sdist
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            export UV_BINARY="./bundled/libs/bin/uv.exe"
+          else
+            export UV_BINARY="./bundled/libs/bin/uv"
+          fi
           pnpm embed-sdist
 
       - name: Package extension

--- a/extension/scripts/embed-sdist.mjs
+++ b/extension/scripts/embed-sdist.mjs
@@ -11,10 +11,14 @@ import * as tar from "tar";
 const extensionDir = new URL("..", import.meta.url);
 const distDir = NodePath.join(NodeUrl.fileURLToPath(extensionDir), "dist");
 
+// Use UV_BINARY env var if set (e.g., for bundled uv in CI), otherwise fall back to "uv"
+const uvBinary = process.env.UV_BINARY || "uv";
+
 // Step 1: Run uv build
-console.log("Building Python sdist...");
-NodeChildProcess.execSync(
-  `uv build --directory=.. --out-dir=extension/dist --sdist`,
+console.log(`Building Python sdist using: ${uvBinary}`);
+NodeChildProcess.execFileSync(
+  uvBinary,
+  ["build", "--directory=..", "--out-dir=extension/dist", "--sdist"],
   {
     cwd: extensionDir,
     stdio: "inherit",


### PR DESCRIPTION
The platform-specific builds bundle uv into the extension but don't install it globally, so `pnpm embed-sdist` was failing with "uv: not found" when trying to build the Python sdist.

The fix adds a `UV_BINARY` env var that the embed-sdist script respects. Platform builds set this to point to the bundled binary they just installed, while the universal build and local dev continue using system uv.