### PR TITLE
Add setup-uv to platform-specific builds for sdist build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,6 +190,9 @@ jobs:
             fi
           fi
 
+      # Install system uv for building sdist (bundled uv may be cross-compiled and not executable on the runner)
+      - uses: astral-sh/setup-uv@v6
+
       - uses: pnpm/action-setup@v4
         with:
           package_json_file: marimo-lsp/extension/package.json
@@ -213,12 +216,6 @@ jobs:
         run: |
           pnpm install
           pnpm build
-          # Use the bundled uv binary for building the sdist
-          if [ "$RUNNER_OS" = "Windows" ]; then
-            export UV_BINARY="./bundled/libs/bin/uv.exe"
-          else
-            export UV_BINARY="./bundled/libs/bin/uv"
-          fi
           pnpm embed-sdist
 
       - name: Package extension

--- a/extension/scripts/embed-sdist.mjs
+++ b/extension/scripts/embed-sdist.mjs
@@ -11,13 +11,10 @@ import * as tar from "tar";
 const extensionDir = new URL("..", import.meta.url);
 const distDir = NodePath.join(NodeUrl.fileURLToPath(extensionDir), "dist");
 
-// Use UV_BINARY env var if set (e.g., for bundled uv in CI), otherwise fall back to "uv"
-const uvBinary = process.env.UV_BINARY || "uv";
-
 // Step 1: Run uv build
-console.log(`Building Python sdist using: ${uvBinary}`);
+console.log("Building Python sdist...");
 NodeChildProcess.execFileSync(
-  uvBinary,
+  "uv",
   ["build", "--directory=..", "--out-dir=extension/dist", "--sdist"],
   {
     cwd: extensionDir,


### PR DESCRIPTION
PR #356 added platform-specific build jobs but didn't include setup-uv, causing `uv: not found` errors. PR #363 attempted to fix this by using the bundled uv binary, but that fails on cross-compiled builds because the bundled binary is for the target architecture (e.g., ARM) and can't execute on the x86_64 runner.

This adds setup-uv to install a system uv that runs natively on the runner, and reverts the UV_BINARY workaround from #363 since it's no longer needed. The bundled uv is still packaged for distribution, but system uv handles the build process.