### PR TITLE
Use global vsce install instead of npx to avoid cache issues

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -222,10 +222,11 @@ jobs:
         working-directory: marimo-lsp/extension
         shell: bash
         run: |
+          npm install -g @vscode/vsce
           if [ "${{ inputs.pre-release }}" = "true" ]; then
-            npx @vscode/vsce package -o ./dist/marimo-${{ matrix.code-target }}.vsix --target ${{ matrix.code-target }} --pre-release
+            vsce package -o ./dist/marimo-${{ matrix.code-target }}.vsix --target ${{ matrix.code-target }} --pre-release
           else
-            npx @vscode/vsce package -o ./dist/marimo-${{ matrix.code-target }}.vsix --target ${{ matrix.code-target }}
+            vsce package -o ./dist/marimo-${{ matrix.code-target }}.vsix --target ${{ matrix.code-target }}
           fi
 
       - name: Upload artifact
@@ -288,10 +289,11 @@ jobs:
       - name: Package universal extension
         working-directory: marimo-lsp/extension
         run: |
+          npm install -g @vscode/vsce
           if [ "${{ inputs.pre-release }}" = "true" ]; then
-            npx @vscode/vsce package -o ./dist/marimo-universal.vsix --pre-release
+            vsce package -o ./dist/marimo-universal.vsix --pre-release
           else
-            npx @vscode/vsce package -o ./dist/marimo-universal.vsix
+            vsce package -o ./dist/marimo-universal.vsix
           fi
 
       - name: Upload artifact


### PR DESCRIPTION
Windows runners were failing with `ECOMPROMISED` / `Lock compromised` errors when npx tried to download and cache the vsce package. By installing `@vscode/vsce` globally first and then invoking `vsce` directly, we avoid the npm cache entirely and sidestep these transient cache corruption issues.