### PR TITLE
Fix GitHub release title containing release notes content

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -356,6 +356,7 @@ jobs:
         run: |
           gh release create ${{ needs.version-bump.outputs.version }} \
             --repo ${{ github.repository }} \
+            --title "${{ needs.version-bump.outputs.version }}" \
             --notes-file marimo-lsp/release_notes.md \
             ./dist/*.vsix
         env:


### PR DESCRIPTION
Without an explicit --title flag, gh release create was auto-generating a title from commit messages or release notes content instead of using just the version tag. This caused releases to have titles like "0.9.8 - Some PR title..." rather than simply "0.9.8".