### PR TITLE
Fix release note generation in `release.yml` workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -305,6 +305,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: marimo-lsp
+          fetch-depth: 0
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
Adds `fetch-depth: 0` to the publish job's checkout so the release notes script can access the full git history and tags.