### PR TITLE
Add Language Model tool for executing Python in notebooks

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -38,7 +38,7 @@
     "@types/node": "^24.7.2",
     "@types/react": "^19.2.2",
     "@types/react-dom": "^19.2.2",
-    "@types/vscode": "^1.86.0",
+    "@types/vscode": "^1.95.0",
     "@types/vscode-notebook-renderer": "^1.72.4",
     "@typescript/native-preview": "7.0.0-dev.20251015.1",
     "@vitest/coverage-v8": "^4.0.0",
@@ -496,7 +496,7 @@
   ],
   "icon": "images/icon.png",
   "engines": {
-    "vscode": "^1.86.0"
+    "vscode": "^1.95.0"
   },
   "packageManager": "pnpm@10.28.2",
   "pnpm": {
@@ -504,5 +504,28 @@
       "vite": "npm:@voidzero-dev/vite-plus-core@0.1.18",
       "vitest": "npm:@voidzero-dev/vite-plus-test@0.1.18"
     }
-  }
+  },
+  "languageModelTools": [
+    {
+      "name": "marimo_execute_python",
+      "displayName": "Run Python",
+      "toolReferenceName": "marimo",
+      "icon": "$(notebook)",
+      "userDescription": "Run Python code in the active marimo notebook",
+      "modelDescription": "Run Python in the active marimo notebook. DO NOT import packages or libraries, just use available variables in the notebook. You can inspect variables with Python builtins.",
+      "canBeReferencedInPrompt": true,
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "Python code to run"
+          }
+        },
+        "required": [
+          "code"
+        ]
+      }
+    }
+  ]
 }

--- a/extension/pnpm-lock.yaml
+++ b/extension/pnpm-lock.yaml
@@ -55,7 +55,7 @@ importers:
         specifier: ^19.2.2
         version: 19.2.2(@types/react@19.2.2)
       '@types/vscode':
-        specifier: ^1.86.0
+        specifier: ^1.95.0
         version: 1.105.0
       '@types/vscode-notebook-renderer':
         specifier: ^1.72.4

--- a/extension/src/__mocks__/TestVsCode.ts
+++ b/extension/src/__mocks__/TestVsCode.ts
@@ -1442,6 +1442,82 @@ class DiagnosticCollection implements vscode.DiagnosticCollection {
   }
 }
 
+class LanguageModelTextPart implements vscode.LanguageModelTextPart {
+  readonly value: string;
+  constructor(value: string) {
+    this.value = value;
+  }
+}
+
+class LanguageModelToolResult implements vscode.LanguageModelToolResult {
+  readonly content: Array<
+    vscode.LanguageModelTextPart | vscode.LanguageModelPromptTsxPart | unknown
+  >;
+  constructor(
+    content: Array<
+      vscode.LanguageModelTextPart | vscode.LanguageModelPromptTsxPart | unknown
+    >,
+  ) {
+    this.content = content;
+  }
+}
+
+class LanguageModelChatMessage implements vscode.LanguageModelChatMessage {
+  readonly role: vscode.LanguageModelChatMessageRole;
+  readonly content: Array<
+    | vscode.LanguageModelTextPart
+    | vscode.LanguageModelToolResultPart
+    | vscode.LanguageModelToolCallPart
+  >;
+  readonly name: string | undefined;
+
+  constructor(
+    role: vscode.LanguageModelChatMessageRole,
+    content: Array<
+      | vscode.LanguageModelTextPart
+      | vscode.LanguageModelToolResultPart
+      | vscode.LanguageModelToolCallPart
+    >,
+    name?: string,
+  ) {
+    this.role = role;
+    this.content = content;
+    this.name = name;
+  }
+
+  static User(
+    content:
+      | string
+      | Array<
+          vscode.LanguageModelTextPart | vscode.LanguageModelToolResultPart
+        >,
+    name?: string,
+  ) {
+    return new LanguageModelChatMessage(
+      1,
+      typeof content === "string"
+        ? [new LanguageModelTextPart(content)]
+        : content,
+      name,
+    );
+  }
+  static Assistant(
+    content:
+      | string
+      | Array<vscode.LanguageModelTextPart | vscode.LanguageModelToolCallPart>,
+    name: string,
+  ) {
+    return new LanguageModelChatMessage(
+      2,
+      typeof content === "string"
+        ? [new LanguageModelTextPart(content)]
+        : content,
+      name,
+    );
+  }
+}
+
+
 export function createTestNotebookDocument(
   uri: Uri | string,
   options: {
@@ -2129,6 +2205,9 @@ export class TestVsCode extends Data.TaggedClass("TestVsCode")<{
         Position,
         Range,
         Location,
+        LanguageModelTextPart,
+        LanguageModelToolResult,
+        LanguageModelChatMessage,
         Hover,
         TextEdit,
         SignatureHelp,
@@ -2184,6 +2263,7 @@ export class TestVsCode extends Data.TaggedClass("TestVsCode")<{
         extensions: {
           getExtension: () => Option.none(),
         },
+        lm: { tools: [], registerTool: () => Effect.void },
         languages: Languages.make({
           registerCodeLensProvider: () => Effect.void,
           createDiagnosticCollection: (name: string) =>

--- a/extension/src/layers/ChatParticipant.ts
+++ b/extension/src/layers/ChatParticipant.ts
@@ -1,0 +1,112 @@
+import { Effect, Either, Layer, Option, Runtime, Stream } from "effect";
+
+import { MarimoNotebookDocument } from "../schemas.ts";
+import { scratchCellNotificationsToVsCodeOutput } from "../services/ExecutionRegistry.ts";
+import { KernelManager } from "../services/KernelManager.ts";
+import { NotebookEditorRegistry } from "../services/NotebookEditorRegistry.ts";
+import { VsCode } from "../services/VsCode.ts";
+
+const TOOL_NAME = "marimo_execute_python";
+
+interface ExecutePythonInput {
+  code: string;
+}
+
+/**
+ * Registers a Language Model Tool that can execute Python code
+ * in the active marimo notebook. Agents like Copilot can invoke this tool.
+ */
+export const ChatParticipantLive = Layer.scopedDiscard(
+  Effect.gen(function* () {
+    const code = yield* VsCode;
+    const kernel = yield* KernelManager;
+    const editors = yield* NotebookEditorRegistry;
+    const runPromise = Runtime.runPromise(yield* Effect.runtime());
+
+    yield* code.lm.registerTool<ExecutePythonInput>(TOOL_NAME, {
+      invoke: ({ input }, _token) =>
+        runPromise(
+          Effect.gen(function* () {
+            yield* Effect.logDebug("Tool invoked").pipe(
+              Effect.annotateLogs({ code: input.code.slice(0, 100) }),
+            );
+
+            const editorOpt = yield* editors.getActiveNotebookEditor();
+
+            if (Option.isNone(editorOpt)) {
+              yield* Effect.logWarning("No active notebook for tool execution");
+              return new code.LanguageModelToolResult([
+                new code.LanguageModelTextPart(
+                  "Error: No active marimo notebook. Please open a notebook first.",
+                ),
+              ]);
+            }
+
+            const editor = editorOpt.value;
+            const notebook = MarimoNotebookDocument.from(editor.notebook);
+
+            const result = yield* kernel
+              .executeCodeUnsafe(notebook.id, input.code)
+              .pipe(
+                Stream.filterMap((op) =>
+                  scratchCellNotificationsToVsCodeOutput(op, code),
+                ),
+                Stream.runCollect,
+                Effect.either,
+              );
+
+            if (Either.isLeft(result)) {
+              yield* Effect.logError("Tool execution failed", result.left);
+              return new code.LanguageModelToolResult([
+                new code.LanguageModelTextPart(`Error: ${result.left.message}`),
+              ]);
+            }
+
+            const itemsByChannel = Object.groupBy(
+              Array.from(result.right),
+              (item) =>
+                typeof item.metadata?.channel === "string"
+                  ? item.metadata.channel
+                  : "output",
+            );
+
+            const decoder = new TextDecoder();
+            const parts: string[] = [];
+
+            for (const ch of ["stdout", "stderr", "output"]) {
+              const outputs = itemsByChannel[ch];
+              if (!outputs?.length) continue;
+
+              const text = outputs
+                .flatMap((o) => o.items)
+                .map((item) => {
+                  if (item.mime.startsWith("image/")) return "";
+                  try {
+                    return decoder.decode(item.data);
+                  } catch {
+                    return "";
+                  }
+                })
+                .join("");
+
+              if (text) {
+                parts.push(`[${ch}]\n${text}`);
+              }
+            }
+
+            const outputText = parts.join("\n\n") || "(no output)";
+
+            yield* Effect.logDebug("Tool execution complete").pipe(
+              Effect.annotateLogs({ outputLength: outputText.length }),
+            );
+
+            return new code.LanguageModelToolResult([
+              new code.LanguageModelTextPart(outputText),
+            ]);
+          }),
+        ),
+    });
+
+    yield* Effect.logInfo(`Language model tool registered: ${TOOL_NAME}`);
+  }),
+);

--- a/extension/src/layers/Main.ts
+++ b/extension/src/layers/Main.ts
@@ -1,0 +1,158 @@
+import {
+  Context,
+  Effect,
+  Exit,
+  Layer,
+  Logger,
+  type LogLevel,
+  pipe,
+  Scope,
+} from "effect";
+import type * as vscode from "vscode";
+
+import { Api, type MarimoApi } from "../services/Api.ts";
+import { CellMetadataUIBindingService } from "../services/CellMetadataUIBindingService.ts";
+import { CellStateManager } from "../services/CellStateManager.ts";
+import type { RuffLanguageServer } from "../services/completions/RuffLanguageServer.ts";
+import type { TyLanguageServer } from "../services/completions/TyLanguageServer.ts";
+import { Config } from "../services/Config.ts";
+import { ConfigContextManager } from "../services/config/ConfigContextManager.ts";
+import { MarimoConfigurationService } from "../services/config/MarimoConfigurationService.ts";
+import { Constants } from "../services/Constants.ts";
+import { ControllerRegistry } from "../services/ControllerRegistry.ts";
+import { DatasourcesService } from "../services/datasources/DatasourcesService.ts";
+import { DebugAdapter } from "../services/DebugAdapter.ts";
+import { ExecutionRegistry } from "../services/ExecutionRegistry.ts";
+import { GitHubClient } from "../services/GitHubClient.ts";
+import { HealthService } from "../services/HealthService.ts";
+import { KernelManager } from "../services/KernelManager.ts";
+import type { LanguageClient } from "../services/LanguageClient.ts";
+import { NotebookEditorRegistry } from "../services/NotebookEditorRegistry.ts";
+import { NotebookRenderer } from "../services/NotebookRenderer.ts";
+import { NotebookSerializer } from "../services/NotebookSerializer.ts";
+import { OutputChannel } from "../services/OutputChannel.ts";
+import { PackagesService } from "../services/packages/PackagesService.ts";
+import type { PythonExtension } from "../services/PythonExtension.ts";
+import { SandboxController } from "../services/SandboxController.ts";
+import type { Sentry } from "../services/Sentry.ts";
+import { SessionStateManager } from "../services/SessionStateManager.ts";
+import { ExtensionContext, Storage } from "../services/Storage.ts";
+import type { Telemetry } from "../services/Telemetry.ts";
+import { Uv } from "../services/Uv.ts";
+import { VariablesService } from "../services/variables/VariablesService.ts";
+import type { VsCode } from "../services/VsCode.ts";
+import { DatasourcesViewLive } from "../views/DatasourcesView.ts";
+import { MarimoStatusBarLive } from "../views/MarimoStatusBar.ts";
+import { PackagesViewLive } from "../views/PackagesView.ts";
+import { PythonEnvironmentStatusBarLive } from "../views/PythonEnvironmentStatusBar.ts";
+import { RecentNotebooksLive } from "../views/RecentNotebooks.ts";
+import { StatusBar } from "../views/StatusBar.ts";
+import { TreeView } from "../views/TreeView.ts";
+import { VariablesViewLive } from "../views/VariablesView.ts";
+import { CellMetadataBindingsLive } from "./CellMetadataBindings.ts";
+import { CellStatusBarProviderLive } from "./CellStatusBarProvider.ts";
+import { DebugLayerLive } from "./DebugLayer.ts";
+import { ChatParticipantLive } from "./ChatParticipant.ts";
+import { MarimoCodeLensProviderLive } from "./MarimoCodeLensProvider.ts";
+import { MarimoFileDetectorLive } from "./MarimoFileDetector.ts";
+import { RegisterCommandsLive } from "./RegisterCommands.ts";
+import { ReloadOnConfigChangeLive } from "./ReloadOnConfigChange.ts";
+import { ThemeSyncLive } from "./ThemeSync.ts";
+
+/**
+ * Main application layer that wires together all services and layers
+ * required for the marimo VS Code extension to function.
+ */
+const MainLive = Layer.empty
+  .pipe(
+    Layer.merge(RegisterCommandsLive),
+    Layer.merge(MarimoStatusBarLive),
+    Layer.merge(PythonEnvironmentStatusBarLive),
+    Layer.merge(MarimoFileDetectorLive),
+    Layer.merge(MarimoCodeLensProviderLive),
+    Layer.merge(RecentNotebooksLive),
+    Layer.merge(VariablesViewLive),
+    Layer.merge(DatasourcesViewLive),
+    Layer.merge(PackagesViewLive),
+    Layer.merge(CellStatusBarProviderLive),
+    Layer.merge(CellMetadataBindingsLive),
+    Layer.merge(ReloadOnConfigChangeLive),
+    Layer.merge(ThemeSyncLive),
+    Layer.merge(DebugLayerLive),
+    Layer.merge(ChatParticipantLive),
+  )
+  .pipe(
+    Layer.provideMerge(Api.Default),
+    Layer.provide(DebugAdapter.Default),
+    Layer.provide(KernelManager.Default),
+    Layer.provide(GitHubClient.Default),
+    Layer.provide(NotebookRenderer.Default),
+    Layer.provide(NotebookSerializer.Default),
+    Layer.provide(ExecutionRegistry.Default),
+    Layer.provide(VariablesService.Default),
+    Layer.provide(DatasourcesService.Default),
+    Layer.provide(PackagesService.Default),
+    Layer.provide(HealthService.Default),
+    Layer.provide(CellMetadataUIBindingService.Default),
+  )
+  .pipe(
+    Layer.provide(MarimoConfigurationService.Default),
+    Layer.provide(ConfigContextManager.Default),
+    Layer.provide(CellStateManager.Default),
+    Layer.provide(SessionStateManager.Default),
+    Layer.provide(ControllerRegistry.Default),
+    Layer.provide(NotebookEditorRegistry.Default),
+    Layer.provide(SandboxController.Default),
+    Layer.provide(Uv.Default),
+    Layer.provide(TreeView.Default),
+    Layer.provide(StatusBar.Default),
+    Layer.provide(Storage.Default),
+    Layer.provide(Constants.Default),
+    Layer.provide(Config.Default),
+    Layer.provide(OutputChannel.Default),
+  );
+
+export function makeActivate(
+  layer: Layer.Layer<
+    | LanguageClient
+    | VsCode
+    | PythonExtension
+    | Telemetry
+    | Sentry
+    | TyLanguageServer
+    | RuffLanguageServer,
+    never,
+    ExtensionContext
+  >,
+  minimumLogLevel: LogLevel.LogLevel,
+): (
+  context: Pick<
+    vscode.ExtensionContext,
+    "workspaceState" | "globalState" | "extensionUri" | "globalStorageUri"
+  >,
+) => Promise<vscode.Disposable & MarimoApi> {
+  return (context) =>
+    pipe(
+      Effect.gen(function*() {
+        // Create a scope and build layers with it. Layer.buildWithScope completes
+        // once all layer initialization finishes (commands registered, serializer
+        // registered, notification streams set up). The LSP client will start lazily
+        // on first use. Resources are kept alive by extending their lifetime to the
+        // manually-managed scope, and are only released when we explicitly close the
+        // scope on deactivation.
+        const scope = yield* Scope.make();
+        const ctx = yield* Layer.buildWithScope(
+          Layer.provide(MainLive, layer),
+          scope,
+        );
+        const api = Context.get(ctx, Api);
+        return {
+          ...api,
+          dispose: () => Effect.runPromise(Scope.close(scope, Exit.void)),
+        };
+      }),
+      Effect.provideService(ExtensionContext, context),
+      Logger.withMinimumLogLevel(minimumLogLevel),
+      Effect.runPromise,
+    );
+}

--- a/extension/src/services/VsCode.ts
+++ b/extension/src/services/VsCode.ts
@@ -1,0 +1,723 @@
+import {
+  Cause,
+  Data,
+  Effect,
+  Either,
+  Exit,
+  Fiber,
+  Option,
+  PubSub,
+  Runtime,
+  Scope,
+  Stream,
+  SubscriptionRef,
+} from "effect";
+// VsCode.ts centralizes and restricts access to the VS Code API.
+//
+// All other modules should use type-only imports and access the API through this service.
+//
+// We only expose the APIs we actually need. Being selective gives us a cleaner,
+// easier testing story. The goal is NOT to hide APIs that are hard to mock,
+// but to limit surface area to what's necessary for correctness and clarity.
+//
+// oxlint-disable-next-line marimo/vscode-type-only"
+import * as vscode from "vscode";
+
+import type { DynamicCommand, VscodeBuiltinCommand } from "../commands.ts";
+import type { MarimoCommand, MarimoContextKey } from "../constants.ts";
+import { acquireDisposable } from "../utils/acquireDisposable.ts";
+import { tokenFromSignal } from "../utils/tokenFromSignal.ts";
+
+export class VsCodeError extends Data.TaggedError("VsCodeError")<{
+  cause: unknown;
+}> {}
+
+export class FileSystemError extends Data.TaggedError("FileSystemError")<{
+  cause: unknown;
+}> {}
+
+export class DebugSessionStartError extends Data.TaggedError(
+  "DebugSessionStartError",
+)<{
+  readonly configuration: string | vscode.DebugConfiguration;
+}> {}
+
+export class Window extends Effect.Service<Window>()("Window", {
+  effect: Effect.gen(function* () {
+    const api = vscode.window;
+
+    const resolve = (kind: vscode.ColorThemeKind): "light" | "dark" =>
+      kind === vscode.ColorThemeKind.Dark ||
+      kind === vscode.ColorThemeKind.HighContrast
+        ? "dark"
+        : "light";
+
+    const colorThemeRef = yield* SubscriptionRef.make(
+      resolve(api.activeColorTheme.kind),
+    );
+    api.onDidChangeActiveColorTheme((theme) => {
+      Effect.runSync(SubscriptionRef.set(colorThemeRef, resolve(theme.kind)));
+    });
+
+    return {
+      createTerminal(
+        options: vscode.TerminalOptions,
+      ): Effect.Effect<
+        Pick<vscode.Terminal, "show" | "sendText">,
+        never,
+        Scope.Scope
+      > {
+        return acquireDisposable(() => api.createTerminal(options));
+      },
+      showSaveDialog(options?: vscode.SaveDialogOptions) {
+        return Effect.map(
+          Effect.promise(() => api.showSaveDialog(options)),
+          Option.fromNullable,
+        );
+      },
+      showInputBox(
+        options?: vscode.InputBoxOptions,
+      ): Effect.Effect<Option.Option<string>> {
+        return Effect.map(
+          Effect.promise((signal) =>
+            api.showInputBox(options, tokenFromSignal(signal)),
+          ),
+          Option.fromNullable,
+        );
+      },
+      showInformationMessage<T extends string>(
+        message: string,
+        options: vscode.MessageOptions & { items?: readonly T[] } = {},
+      ) {
+        const { items = [], ...rest } = options;
+        return Effect.map(
+          Effect.promise(() =>
+            api.showInformationMessage(message, rest, ...items),
+          ),
+          Option.fromNullable,
+        );
+      },
+      showWarningMessage<T extends string>(
+        message: string,
+        options: vscode.MessageOptions & { items?: readonly T[] } = {},
+      ) {
+        const { items = [], ...rest } = options;
+        return Effect.map(
+          Effect.promise(() => api.showWarningMessage(message, rest, ...items)),
+          Option.fromNullable,
+        );
+      },
+      showErrorMessage<T extends string>(
+        message: string,
+        options: vscode.MessageOptions & { items?: readonly T[] } = {},
+      ) {
+        const { items = [], ...rest } = options;
+        return Effect.map(
+          Effect.promise(() => api.showErrorMessage(message, rest, ...items)),
+          Option.fromNullable,
+        );
+      },
+      showQuickPick(
+        items: readonly string[],
+        options: Omit<vscode.QuickPickOptions, "canPickMany"> = {},
+      ) {
+        return Effect.map(
+          Effect.promise((signal) =>
+            api.showQuickPick(items, options, tokenFromSignal(signal)),
+          ),
+          Option.fromNullable,
+        );
+      },
+      showQuickPickItems<T extends vscode.QuickPickItem>(
+        items: readonly T[],
+        options: Omit<vscode.QuickPickOptions, "canPickMany"> = {},
+      ) {
+        return Effect.map(
+          Effect.promise((signal) =>
+            api.showQuickPick(items, options, tokenFromSignal(signal)),
+          ),
+          Option.fromNullable,
+        );
+      },
+      createOutputChannel(name: string) {
+        return acquireDisposable(() => api.createOutputChannel(name));
+      },
+      createLogOutputChannel(name: string) {
+        return acquireDisposable(() =>
+          api.createOutputChannel(name, { log: true }),
+        );
+      },
+      getActiveNotebookEditor() {
+        return Effect.succeed(Option.fromNullable(api.activeNotebookEditor));
+      },
+      getVisibleNotebookEditors() {
+        return Effect.succeed(api.visibleNotebookEditors);
+      },
+      getVisibleTextEditors() {
+        return Effect.succeed(api.visibleTextEditors);
+      },
+      getActiveTextEditor() {
+        return Effect.succeed(Option.fromNullable(api.activeTextEditor));
+      },
+      closeTextEditorTab(uri: vscode.Uri) {
+        return Option.fromNullable(
+          api.tabGroups.all
+            .flatMap((group) => group.tabs)
+            .find(
+              (tab) =>
+                tab.input instanceof vscode.TabInputText &&
+                tab.input.uri.toString() === uri.toString(),
+            ),
+        ).pipe(
+          Option.match({
+            onSome: (tab) => Effect.promise(() => api.tabGroups.close(tab)),
+            onNone: () => Effect.void,
+          }),
+        );
+      },
+      createTreeView<T>(viewId: string, options: vscode.TreeViewOptions<T>) {
+        return acquireDisposable(() => api.createTreeView(viewId, options));
+      },
+      createStatusBarItem(
+        id: string,
+        alignment: vscode.StatusBarAlignment,
+        priority?: number,
+      ) {
+        return acquireDisposable(() =>
+          api.createStatusBarItem(id, alignment, priority),
+        );
+      },
+      colorThemeChanges(): Stream.Stream<"light" | "dark"> {
+        return colorThemeRef.changes;
+      },
+      activeNotebookEditorChanges(): Stream.Stream<
+        Option.Option<vscode.NotebookEditor>
+      > {
+        return Stream.asyncPush((emit) =>
+          acquireDisposable(() =>
+            api.onDidChangeActiveNotebookEditor((e) =>
+              emit.single(Option.fromNullable(e)),
+            ),
+          ),
+        );
+      },
+      visibleNotebookEditorsChanges(): Stream.Stream<
+        ReadonlyArray<vscode.NotebookEditor>
+      > {
+        return Stream.asyncPush((emit) =>
+          acquireDisposable(() =>
+            api.onDidChangeVisibleNotebookEditors((e) => emit.single(e)),
+          ),
+        );
+      },
+      visibleTextEditorsChanges(): Stream.Stream<
+        ReadonlyArray<vscode.TextEditor>
+      > {
+        return Stream.asyncPush((emit) =>
+          acquireDisposable(() =>
+            api.onDidChangeVisibleTextEditors((e) => emit.single(e)),
+          ),
+        );
+      },
+      activeTextEditorChanges(): Stream.Stream<
+        Option.Option<vscode.TextEditor>
+      > {
+        return Stream.asyncPush((emit) =>
+          acquireDisposable(() =>
+            api.onDidChangeActiveTextEditor((e) =>
+              emit.single(Option.fromNullable(e)),
+            ),
+          ),
+        );
+      },
+      showNotebookDocument(
+        doc: vscode.NotebookDocument,
+        options?: vscode.NotebookDocumentShowOptions,
+      ) {
+        return Effect.promise(() => api.showNotebookDocument(doc, options));
+      },
+      showTextDocument(doc: vscode.TextDocument) {
+        // Could return the vscode.TextEditor, but skipping it simplifies mocks/tests
+        return Effect.asVoid(Effect.promise(() => api.showTextDocument(doc)));
+      },
+      withProgress<A, E, R>(
+        options: {
+          location: vscode.ProgressLocation;
+          title: string;
+          cancellable: boolean;
+        },
+        fn: (
+          progress: vscode.Progress<{
+            message: string;
+            increment?: number;
+          }>,
+        ) => Effect.Effect<A, E, R>,
+      ) {
+        return Effect.gen(function* () {
+          const runPromise = Runtime.runPromise(yield* Effect.runtime<R>());
+          yield* Effect.promise((signal) =>
+            api.withProgress(options, (progress, token) =>
+              runPromise(
+                Effect.gen(function* () {
+                  const fiber = yield* Effect.forkScoped(fn(progress));
+                  const kill = () => runPromise(Fiber.interrupt(fiber));
+                  yield* acquireDisposable(() =>
+                    token.onCancellationRequested(kill),
+                  );
+                  yield* Fiber.join(fiber);
+                }).pipe(Effect.scoped),
+                { signal },
+              ),
+            ),
+          );
+        });
+      },
+    };
+  }),
+}) {}
+
+type ExecutableCommand = VscodeBuiltinCommand | MarimoCommand | DynamicCommand;
+
+type ContextMap = {
+  "marimo.config.runtime.on_cell_change": "autorun" | "lazy";
+  "marimo.config.runtime.auto_reload": "off" | "lazy" | "autorun";
+  "marimo.isPythonFileMarimoNotebook": boolean;
+  "marimo.notebook.hasStaleCells": boolean;
+  "marimo.notebook.hasKernel": boolean;
+};
+
+export class Commands extends Effect.Service<Commands>()("Commands", {
+  dependencies: [Window.Default],
+  scoped: Effect.gen(function* () {
+    const win = yield* Window;
+    const api = vscode.commands;
+    // Pubsub of the commands run and their results
+    // Left is the command that failed, right is the command that succeeded
+    const commandPubSub =
+      yield* PubSub.unbounded<Either.Either<string, string>>();
+
+    return {
+      subscribeToCommands() {
+        return PubSub.subscribe(commandPubSub);
+      },
+      executeCommand(command: ExecutableCommand, ...args: unknown[]) {
+        return Effect.promise(() => api.executeCommand(command, ...args));
+      },
+      setContext<K extends MarimoContextKey>(key: K, value: ContextMap[K]) {
+        return Effect.promise(() =>
+          api.executeCommand("setContext", key, value),
+        );
+      },
+      registerCommand<A, E, R>(
+        command: MarimoCommand | DynamicCommand,
+        fn: () => Effect.Effect<A, E, R>,
+      ) {
+        return Effect.gen(function* () {
+          const runPromise = Runtime.runPromise(yield* Effect.runtime<R>());
+          const callback = () =>
+            fn().pipe(
+              Effect.tap(() =>
+                PubSub.publish(commandPubSub, Either.right(command)),
+              ),
+              Effect.catchAllCause(
+                Effect.fn(function* (cause) {
+                  // Skip logging for interruptions/cancellations (e.g., user
+                  // cancels a progress dialog, VS Code disposes resources
+                  // during kernel restart). These are expected and not errors.
+                  if (
+                    Cause.isInterruptedOnly(cause) ||
+                    [...Cause.defects(cause)].some(
+                      (defect: unknown) =>
+                        defect instanceof Error && defect.name === "Canceled",
+                    )
+                  ) {
+                    yield* PubSub.publish(commandPubSub, Either.left(command));
+                    return;
+                  }
+                  yield* Effect.logError(cause);
+                  yield* PubSub.publish(commandPubSub, Either.left(command));
+                  yield* win.showWarningMessage(
+                    `Something went wrong in ${JSON.stringify(command)}. See marimo logs for more info.`,
+                  );
+                }),
+              ),
+              runPromise,
+            );
+          yield* acquireDisposable(() =>
+            api.registerCommand(command, callback),
+          );
+        });
+      },
+    };
+  }),
+}) {}
+
+export class Workspace extends Effect.Service<Workspace>()("Workspace", {
+  sync: () => {
+    const api = vscode.workspace;
+    return {
+      fs: {
+        readFile(uri: vscode.Uri) {
+          return Effect.tryPromise({
+            try: () => api.fs.readFile(uri),
+            catch: (cause) => new FileSystemError({ cause }),
+          });
+        },
+        writeFile(uri: vscode.Uri, contents: Uint8Array) {
+          return Effect.tryPromise({
+            try: () => api.fs.writeFile(uri, contents),
+            catch: (cause) => new FileSystemError({ cause }),
+          });
+        },
+      },
+      getNotebookDocuments() {
+        return Effect.succeed(api.notebookDocuments);
+      },
+      getConfiguration(section: string, scope?: vscode.ConfigurationScope) {
+        return Effect.succeed(api.getConfiguration(section, scope));
+      },
+      getWorkspaceFolders() {
+        return Effect.succeed(Option.fromNullable(api.workspaceFolders));
+      },
+      isTrusted() {
+        return api.isTrusted;
+      },
+      registerNotebookSerializer(
+        notebookType: string,
+        impl: vscode.NotebookSerializer,
+        options?: vscode.NotebookDocumentContentOptions,
+      ) {
+        return acquireDisposable(() =>
+          api.registerNotebookSerializer(notebookType, impl, options),
+        ).pipe(Effect.andThen(Effect.void));
+      },
+      notebookDocumentChanges() {
+        return Stream.asyncPush<vscode.NotebookDocumentChangeEvent>((emit) =>
+          acquireDisposable(() =>
+            api.onDidChangeNotebookDocument((event) => emit.single(event)),
+          ),
+        );
+      },
+      notebookDocumentOpened() {
+        return Stream.asyncPush<vscode.NotebookDocument>((emit) =>
+          acquireDisposable(() =>
+            api.onDidOpenNotebookDocument((event) => emit.single(event)),
+          ),
+        );
+      },
+      configurationChanges() {
+        return Stream.asyncPush<vscode.ConfigurationChangeEvent>((emit) =>
+          acquireDisposable(() =>
+            api.onDidChangeConfiguration((event) => emit.single(event)),
+          ),
+        );
+      },
+      applyEdit(edit: vscode.WorkspaceEdit) {
+        return Effect.promise(() => api.applyEdit(edit));
+      },
+      openNotebookDocument(uri: vscode.Uri) {
+        return Effect.promise(() => api.openNotebookDocument(uri));
+      },
+      openUntitledNotebookDocument(
+        notebookType: string,
+        content?: vscode.NotebookData,
+      ) {
+        return Effect.promise(() =>
+          api.openNotebookDocument(notebookType, content),
+        );
+      },
+      openUntitledTextDocument(options: {
+        content?: string;
+        language?: string;
+      }) {
+        return Effect.promise(() => api.openTextDocument(options));
+      },
+    };
+  },
+}) {}
+
+export class Env extends Effect.Service<Env>()("Env", {
+  sync: () => {
+    const api = vscode.env;
+    return {
+      appName: api.appName,
+      appRoot: api.appRoot,
+      appHost: api.appHost,
+      machineId: api.machineId,
+      openExternal(target: vscode.Uri): Effect.Effect<boolean> {
+        return Effect.promise(() => api.openExternal(target));
+      },
+    };
+  },
+}) {}
+
+export class Debug extends Effect.Service<Debug>()("Debug", {
+  effect: Effect.sync(() => {
+    const api = vscode.debug;
+    return {
+      registerDebugConfigurationProvider(
+        debugType: string,
+        factory: vscode.DebugConfigurationProvider,
+      ) {
+        return acquireDisposable(() =>
+          api.registerDebugConfigurationProvider(debugType, factory),
+        ).pipe(Effect.asVoid);
+      },
+      registerDebugAdapterDescriptorFactory<R = never>(
+        debugType: string,
+        factory: {
+          createDebugAdapter(
+            session: vscode.DebugSession,
+            executable: vscode.DebugAdapterExecutable | undefined,
+          ): Effect.Effect<
+            Option.Option<Omit<vscode.DebugAdapter, "dispose">>,
+            never,
+            Scope.Scope | R
+          >;
+        },
+      ): Effect.Effect<void, never, Scope.Scope | R> {
+        return Effect.gen(function* () {
+          const runPromise = Runtime.runPromise(yield* Effect.runtime<R>());
+
+          yield* acquireDisposable(() =>
+            api.registerDebugAdapterDescriptorFactory(debugType, {
+              createDebugAdapterDescriptor: (session, executable) =>
+                runPromise(
+                  Effect.gen(function* () {
+                    const scope = yield* Scope.make();
+                    const adapter = yield* factory
+                      .createDebugAdapter(session, executable)
+                      .pipe(Scope.extend(scope));
+
+                    if (Option.isNone(adapter)) {
+                      yield* Scope.close(scope, Exit.void);
+                      return null;
+                    }
+
+                    return new vscode.DebugAdapterInlineImplementation(
+                      Object.assign(adapter.value, {
+                        dispose: () =>
+                          Effect.runFork(Scope.close(scope, Exit.void)),
+                      }),
+                    );
+                  }),
+                ),
+            }),
+          );
+        });
+      },
+      startDebugging(
+        folder: vscode.WorkspaceFolder | undefined,
+        nameOrConfiguration: string | vscode.DebugConfiguration,
+      ) {
+        return Effect.tryPromise({
+          try: () => api.startDebugging(folder, nameOrConfiguration),
+          catch: (cause) => new VsCodeError({ cause }),
+        }).pipe(
+          Effect.filterOrFail(
+            (success) => success,
+            () =>
+              new DebugSessionStartError({
+                configuration: nameOrConfiguration,
+              }),
+          ),
+          Effect.asVoid,
+        );
+      },
+      stopDebugging(sessionId?: string) {
+        // Find the session by ID if provided, otherwise stop all
+        const session = sessionId
+          ? vscode.debug.activeDebugSession?.id === sessionId
+            ? vscode.debug.activeDebugSession
+            : undefined
+          : undefined;
+        return Effect.promise(() => api.stopDebugging(session));
+      },
+      onDidTerminateDebugSession(
+        listener: (session: vscode.DebugSession) => Effect.Effect<void>,
+      ) {
+        return acquireDisposable(() =>
+          api.onDidTerminateDebugSession((session) => {
+            void Effect.runPromise(listener(session));
+          }),
+        ).pipe(Effect.asVoid);
+      },
+    };
+  }),
+}) {}
+
+export class Notebooks extends Effect.Service<Notebooks>()("Notebooks", {
+  effect: Effect.sync(() => {
+    const api = vscode.notebooks;
+    return {
+      createRendererMessaging(rendererId: string) {
+        return Effect.succeed(api.createRendererMessaging(rendererId));
+      },
+      createNotebookController(
+        id: string,
+        notebookType: string,
+        label: string,
+      ): Effect.Effect<
+        Omit<vscode.NotebookController, "dispose">,
+        never,
+        Scope.Scope
+      > {
+        return acquireDisposable(() =>
+          api.createNotebookController(id, notebookType, label),
+        );
+      },
+      registerNotebookCellStatusBarItemProvider(
+        notebookType: string,
+        provider: vscode.NotebookCellStatusBarItemProvider,
+      ) {
+        return acquireDisposable(() =>
+          api.registerNotebookCellStatusBarItemProvider(notebookType, provider),
+        );
+      },
+    };
+  }),
+}) {}
+
+export class AuthError extends Data.TaggedError("AuthError")<{
+  cause: unknown;
+}> {}
+
+export class Auth extends Effect.Service<Auth>()("Auth", {
+  effect: Effect.sync(() => {
+    const api = vscode.authentication;
+    return {
+      getSession(
+        providerId: "github" | "microsoft", // could be custom but these are default
+        scopes: ReadonlyArray<string>,
+        options: vscode.AuthenticationGetSessionOptions,
+      ) {
+        return Effect.map(
+          Effect.tryPromise({
+            try: () => api.getSession(providerId, scopes, options),
+            catch: (cause) => new AuthError({ cause }),
+          }),
+          Option.fromNullable,
+        );
+      },
+    };
+  }),
+}) {}
+
+export class ParseUriError extends Data.TaggedError("ParseUriError")<{
+  cause: unknown;
+}> {}
+
+/**
+ * Wraps VS Code API functionality in Effect services
+ */
+export class VsCode extends Effect.Service<VsCode>()("VsCode", {
+  effect: Effect.gen(function* () {
+    // Expose the raw vscode module for runtime inspection via --inspect-extensions.
+    // Only active when MARIMO_DEBUG=1 (set by launch-dev.sh).
+    if (process.env.MARIMO_DEBUG === "1") {
+      (globalThis as any).__marimoVsCode = vscode;
+    }
+
+    return {
+      // namespaces
+      window: yield* Window,
+      commands: yield* Commands,
+      workspace: yield* Workspace,
+      env: yield* Env,
+      debug: yield* Debug,
+      notebooks: yield* Notebooks,
+      auth: yield* Auth,
+      languages: {
+        registerCodeLensProvider(
+          selector: vscode.DocumentSelector,
+          provider: vscode.CodeLensProvider,
+        ) {
+          return Effect.andThen(
+            acquireDisposable(() =>
+              vscode.languages.registerCodeLensProvider(selector, provider),
+            ),
+            Effect.void,
+          );
+        },
+      },
+
+      lm: {
+        get tools() {
+          return vscode.lm.tools;
+        },
+        registerTool: <T = unknown>(
+          name: string,
+          tool: vscode.LanguageModelTool<T>,
+        ) =>
+          Effect.andThen(
+            acquireDisposable(() => vscode.lm.registerTool(name, tool)),
+            Effect.void,
+          ),
+      },
+      Hover: vscode.Hover,
+      CompletionTriggerKind: vscode.CompletionTriggerKind,
+      CompletionItem: vscode.CompletionItem,
+      CompletionList: vscode.CompletionList,
+      MarkdownString: vscode.MarkdownString,
+      SignatureInformation: vscode.SignatureInformation,
+      ParameterInformation: vscode.ParameterInformation,
+      CodeLens: vscode.CodeLens,
+      SemanticTokensLegend: vscode.SemanticTokensLegend,
+      SemanticTokens: vscode.SemanticTokens,
+      // data types
+      NotebookData: vscode.NotebookData,
+      NotebookCellData: vscode.NotebookCellData,
+      NotebookCellKind: vscode.NotebookCellKind,
+      NotebookCellOutput: vscode.NotebookCellOutput,
+      NotebookCellOutputItem: vscode.NotebookCellOutputItem,
+      NotebookEditorRevealType: vscode.NotebookEditorRevealType,
+      NotebookEdit: vscode.NotebookEdit,
+      NotebookRange: vscode.NotebookRange,
+      NotebookCellStatusBarItem: vscode.NotebookCellStatusBarItem,
+      NotebookControllerAffinity: vscode.NotebookControllerAffinity,
+      NotebookCellStatusBarAlignment: vscode.NotebookCellStatusBarAlignment,
+      WorkspaceEdit: vscode.WorkspaceEdit,
+      Position: vscode.Position,
+      EventEmitter: vscode.EventEmitter,
+      DebugAdapterInlineImplementation: vscode.DebugAdapterInlineImplementation,
+      ProgressLocation: vscode.ProgressLocation,
+      ThemeIcon: vscode.ThemeIcon,
+      TreeItem: vscode.TreeItem,
+      TreeItemCollapsibleState: vscode.TreeItemCollapsibleState,
+      ThemeColor: vscode.ThemeColor,
+      StatusBarAlignment: vscode.StatusBarAlignment,
+      Location: vscode.Location,
+      Uri: vscode.Uri,
+      Range: vscode.Range,
+      LanguageModelTextPart: vscode.LanguageModelTextPart,
+      LanguageModelToolResult: vscode.LanguageModelToolResult,
+      LanguageModelChatMessage: vscode.LanguageModelChatMessage,
+      version: vscode.version,
+      extensions: {
+        getExtension<T = unknown>(extensionId: string) {
+          return Option.fromNullable(
+            vscode.extensions.getExtension<T>(extensionId),
+          );
+        },
+      },
+      // helper
+      utils: {
+        parseUri(value: string) {
+          return Either.try({
+            try: () => vscode.Uri.parse(value, /* strict*/ true),
+            catch: (cause) => new ParseUriError({ cause }),
+          });
+        },
+      },
+    };
+  }),
+  dependencies: [
+    Window.Default,
+    Workspace.Default,
+    Commands.Default,
+    Env.Default,
+    Debug.Default,
+    Notebooks.Default,
+    Auth.Default,
+  ],
+}) {}


### PR DESCRIPTION
Wires up scratchpad execution as a VS Code Language Model "tool" that AI agents like Copilot can invoke. When called, the tool runs Python code in the active marimo notebook and returns stdout/stderr/output back to the agent.

This required bumping the VS Code engine to 1.95.0 when the LM Tool API was stabilized. Also refactored VsCode.ts to consolidate the repetitive acquire/release pattern into `acquireDisposable`.