### PR TITLE
fix: Ty/Ruff pass down env NamespacedLanguageClient

### DIFF
--- a/extension/src/services/completions/RuffLanguageServer.ts
+++ b/extension/src/services/completions/RuffLanguageServer.ts
@@ -1,3 +1,4 @@
+import * as NodeProcess from "node:process";
 import { Data, Effect, Either, Option, Runtime, Stream } from "effect";
 import type * as vscode from "vscode";
 import type * as lsp from "vscode-languageclient/node";
@@ -94,7 +95,11 @@ export class RuffLanguageServer extends Effect.Service<RuffLanguageServer>()(
       const serverOptions: lsp.ServerOptions = {
         command: uv.bin.executable,
         args: ["tool", "run", `ruff@${RUFF_VERSION}`, "server"],
-        options: {},
+        options: {
+          env: {
+            ...NodeProcess.env,
+          },
+        },
       };
 
       const getClient = yield* Effect.tryPromise({

--- a/extension/src/services/completions/TyLanguageServer.ts
+++ b/extension/src/services/completions/TyLanguageServer.ts
@@ -1,3 +1,4 @@
+import * as NodeProcess from "node:process";
 import { Data, Effect, Either, Option, Runtime, Stream } from "effect";
 import type * as lsp from "vscode-languageclient/node";
 import { ResponseError } from "vscode-languageclient/node";
@@ -79,7 +80,11 @@ export class TyLanguageServer extends Effect.Service<TyLanguageServer>()(
       const serverOptions: lsp.ServerOptions = {
         command: uv.bin.executable,
         args: ["tool", "run", `ty@${TY_VERSION}`, "server"],
-        options: {},
+        options: {
+          env: {
+            ...NodeProcess.env,
+          },
+        },
       };
 
       const clientOptions: lsp.LanguageClientOptions = {


### PR DESCRIPTION
Unfortunately i was not able to repro ty/ruff not starting, but some this might help in some environments: passing down the env from the parent to the subprocess