### PR TITLE
Refactor commands to use `Effect.fn` and contextual dependencies

### DIFF
--- a/extension/src/__mocks__/TestLanguageClient.ts
+++ b/extension/src/__mocks__/TestLanguageClient.ts
@@ -41,7 +41,7 @@ export const TestLanguageClientLive = Layer.scoped(
         name: "marimo-lsp",
         show() {},
       },
-      restart: Effect.void,
+      restart: () => Effect.void,
       executeCommand(cmd) {
         return Effect.tryPromise({
           try: () =>

--- a/extension/src/commands/createSetupCell.ts
+++ b/extension/src/commands/createSetupCell.ts
@@ -1,0 +1,58 @@
+import { Effect, Option } from "effect";
+import { SETUP_CELL_NAME } from "../constants.ts";
+import { encodeCellMetadata, MarimoNotebookDocument } from "../schemas.ts";
+import { VsCode } from "../services/VsCode.ts";
+
+export const createSetupCell = Effect.fn(function* () {
+  const code = yield* VsCode;
+  const notebook = Option.filterMap(
+    yield* code.window.getActiveNotebookEditor(),
+    (editor) => MarimoNotebookDocument.tryFrom(editor.notebook),
+  );
+
+  if (Option.isNone(notebook)) {
+    yield* code.window.showInformationMessage(
+      "No marimo notebook is currently open",
+    );
+    return;
+  }
+
+  // Check if setup cell already exists
+  const cells = notebook.value.getCells();
+  const existing = cells.find((cell) => {
+    return Option.isSome(cell.name) && cell.name.value === SETUP_CELL_NAME;
+  });
+
+  if (existing) {
+    // Show message and focus on existing setup cell
+    yield* code.window.showInformationMessage("Setup cell already exists");
+    yield* code.window.showNotebookDocument(
+      notebook.value.rawNotebookDocument,
+      {
+        selections: [
+          new code.NotebookRange(existing.index, existing.index + 1),
+        ],
+      },
+    );
+    return;
+  }
+
+  {
+    // Create new setup cell at index 0
+    const edit = new code.WorkspaceEdit();
+    const cell = new code.NotebookCellData(
+      code.NotebookCellKind.Code,
+      "# Initialization code that runs before all other cells",
+      "python",
+    );
+    cell.metadata = encodeCellMetadata({ name: SETUP_CELL_NAME });
+    edit.set(notebook.value.uri, [code.NotebookEdit.insertCells(0, [cell])]);
+    yield* code.workspace.applyEdit(edit);
+  }
+
+  yield* Effect.logInfo("Created setup cell").pipe(
+    Effect.annotateLogs({
+      notebook: notebook.value.uri.toString(),
+    }),
+  );
+});

--- a/extension/src/commands/exportNotebookAsHtml.ts
+++ b/extension/src/commands/exportNotebookAsHtml.ts
@@ -1,0 +1,106 @@
+import { Effect, Either, Option, Schema } from "effect";
+import { MarimoNotebookDocument } from "../schemas.ts";
+import { LanguageClient } from "../services/LanguageClient.ts";
+import { VsCode } from "../services/VsCode.ts";
+import { showErrorAndPromptLogs } from "../utils/showErrorAndPromptLogs.ts";
+
+export const exportNotebookAsHtml = Effect.fn(function* () {
+  const code = yield* VsCode;
+  const client = yield* LanguageClient;
+  const notebook = Option.filterMap(
+    yield* code.window.getActiveNotebookEditor(),
+    (editor) => MarimoNotebookDocument.tryFrom(editor.notebook),
+  );
+
+  if (Option.isNone(notebook)) {
+    yield* code.window.showWarningMessage(
+      "Must have an open marimo notebook to export as HTML.",
+    );
+    return;
+  }
+
+  const hasOutputs = notebook.value
+    .getCells()
+    .some((c) => c.outputs.length > 0);
+
+  if (!hasOutputs) {
+    yield* code.window.showWarningMessage(
+      "Cannot export to HTML. Run the notebook to generate outputs first.",
+    );
+    return;
+  }
+
+  // Ask user where to save the file
+  const saveUri = yield* code.window.showSaveDialog({
+    title: "Export notebook as HTML",
+    filters: { HTML: ["html"] },
+    defaultUri: code.utils
+      .parseUri(notebook.value.uri.toString().replace(/\.py$/, ".html"))
+      .pipe(Either.getOrUndefined),
+  });
+
+  if (Option.isNone(saveUri)) {
+    // User cancelled
+    return;
+  }
+
+  yield* code.window.withProgress(
+    {
+      location: code.ProgressLocation.Notification,
+      title: "Exporting notebook as HTML",
+      cancellable: false,
+    },
+    Effect.fnUntraced(function* () {
+      // Call the LSP API to export the notebook
+      const result = yield* client
+        .executeCommand({
+          command: "marimo.api",
+          params: {
+            method: "export-as-html",
+            params: {
+              notebookUri: notebook.value.id,
+              inner: {
+                download: false,
+                files: [],
+                includeCode: true,
+                assetUrl: null,
+              },
+            },
+          },
+        })
+        .pipe(
+          Effect.andThen(Schema.decodeUnknown(Schema.String)),
+          Effect.either,
+        );
+
+      if (Either.isLeft(result)) {
+        yield* Effect.logFatal("Failed to export notebook", result.left);
+        yield* showErrorAndPromptLogs("Failed to export notebook as HTML.");
+        return;
+      }
+
+      // Write the HTML to the file
+      yield* code.workspace.fs
+        .writeFile(saveUri.value, new TextEncoder().encode(result.right))
+        .pipe(
+          Effect.tap(() =>
+            Effect.logInfo("Exported notebook as HTML").pipe(
+              Effect.annotateLogs({
+                notebook: notebook.value.id,
+                output: saveUri.value.fsPath,
+              }),
+            ),
+          ),
+          Effect.tapError(() =>
+            Effect.logError("Failed to export notebook as HTML").pipe(
+              Effect.annotateLogs({
+                notebook: notebook.value.id,
+                output: saveUri.value.fsPath,
+              }),
+            ),
+          ),
+          Effect.ignore,
+        );
+    }),
+  );
+});

--- a/extension/src/commands/newMarimoNotebook.ts
+++ b/extension/src/commands/newMarimoNotebook.ts
@@ -1,0 +1,53 @@
+import { Effect, flow, Option } from "effect";
+import { Telemetry } from "../services/Telemetry.ts";
+import { VsCode } from "../services/VsCode.ts";
+import { showErrorAndPromptLogs } from "../utils/showErrorAndPromptLogs.ts";
+
+export const newMarimoNotebook = Effect.fn(
+  function* () {
+    const code = yield* VsCode;
+    const telemetry = yield* Telemetry;
+
+    const uri = yield* code.window.showSaveDialog({
+      filters: { Python: ["py"] },
+    });
+
+    if (Option.isNone(uri)) {
+      return;
+    }
+
+    yield* code.workspace.fs.writeFile(
+      uri.value,
+      new TextEncoder().encode(
+        `import marimo
+
+app = marimo.App()
+
+@app.cell
+def _():
+    return
+`.trim(),
+      ),
+    );
+
+    const notebook = yield* code.workspace.openNotebookDocument(uri.value);
+    yield* code.window.showNotebookDocument(notebook);
+
+    yield* Effect.logInfo("Created new marimo notebook").pipe(
+      Effect.annotateLogs({
+        uri: notebook.uri.toString(),
+      }),
+    );
+
+    yield* telemetry.capture("new_notebook_created");
+  },
+  flow(
+    Effect.catchTag(
+      "FileSystemError",
+      Effect.fnUntraced(function* (error) {
+        yield* Effect.logError("Failed to create notebook", { error });
+        yield* showErrorAndPromptLogs("Failed to create notebook.");
+      }),
+    ),
+  ),
+);

--- a/extension/src/commands/openAsMarimoNotebook.ts
+++ b/extension/src/commands/openAsMarimoNotebook.ts
@@ -1,0 +1,33 @@
+import { Effect, Option } from "effect";
+import { NOTEBOOK_TYPE } from "../constants.ts";
+import { VsCode } from "../services/VsCode.ts";
+
+export const openAsMarimoNotebook = Effect.fn(function* () {
+  const code = yield* VsCode;
+  const editor = yield* code.window.getActiveTextEditor();
+
+  if (Option.isNone(editor)) {
+    yield* code.window.showInformationMessage(
+      "No active file to open as notebook",
+    );
+    return;
+  }
+
+  const uri = editor.value.document.uri;
+
+  // We open first before closing to handle multi-window scenarios correctly:
+  // if we close first and it's the only editor in the window, the window
+  // closes before we can open the notebook in it.
+  yield* code.commands.executeCommand("vscode.openWith", uri, NOTEBOOK_TYPE);
+
+  // Find and close the original text editor tab (not the notebook we just opened).
+  // We find the tab after opening the notebook because tab references can become
+  // stale when VS Code reorganizes tabs.
+  yield* code.window.closeTextEditorTab(uri);
+
+  yield* Effect.logInfo("Opened Python file as marimo notebook").pipe(
+    Effect.annotateLogs({
+      uri: uri.toString(),
+    }),
+  );
+});

--- a/extension/src/commands/publishMarimoNotebook.ts
+++ b/extension/src/commands/publishMarimoNotebook.ts
@@ -1,0 +1,18 @@
+import { Effect, Option } from "effect";
+import { VsCode } from "../services/VsCode.ts";
+
+export const publishMarimoNotebook = Effect.fn(function* () {
+  const code = yield* VsCode;
+  const choice = yield* code.window.showQuickPickItems([
+    {
+      label: "GitHub Gist",
+      detail: "Publish marimo notebook as a GitHub Gist",
+    },
+  ]);
+  if (Option.isNone(choice)) {
+    return choice;
+  }
+  if (choice.value.label === "GitHub Gist") {
+    yield* code.commands.executeCommand("marimo.publishMarimoNotebookGist");
+  }
+});

--- a/extension/src/commands/publishMarimoNotebookGist.ts
+++ b/extension/src/commands/publishMarimoNotebookGist.ts
@@ -1,0 +1,94 @@
+import * as NodePath from "node:path";
+import { Cause, Chunk, Effect, Either, flow, Option } from "effect";
+import { MarimoNotebookDocument } from "../schemas.ts";
+import { GitHubClient } from "../services/GitHubClient.ts";
+import { NotebookSerializer } from "../services/NotebookSerializer.ts";
+import { VsCode } from "../services/VsCode.ts";
+import { showErrorAndPromptLogs } from "../utils/showErrorAndPromptLogs.ts";
+
+export const publishMarimoNotebookGist = Effect.fn(
+  function* () {
+    const code = yield* VsCode;
+    const gh = yield* GitHubClient;
+    const serializer = yield* NotebookSerializer;
+
+    const notebook = Option.filterMap(
+      yield* code.window.getActiveNotebookEditor(),
+      (editor) => MarimoNotebookDocument.tryFrom(editor.notebook),
+    );
+
+    if (Option.isNone(notebook)) {
+      yield* code.window.showWarningMessage(
+        "Must have an open marimo notebook to publish Gist.",
+      );
+      return;
+    }
+
+    const choice = yield* code.window.showQuickPick(["Public", "Secret"], {
+      placeHolder: "Gist visibility",
+    });
+
+    if (Option.isNone(choice)) {
+      // cancelled
+      return;
+    }
+
+    const bytes = yield* serializer.serializeEffect({
+      metadata: notebook.value.rawMetadata,
+      cells: notebook.value
+        .getCells()
+        .map(
+          (cell) =>
+            new code.NotebookCellData(
+              cell.kind,
+              cell.document.getText(),
+              cell.document.languageId,
+            ),
+        ),
+    });
+
+    const filename = NodePath.basename(notebook.value.uri.path);
+    const gist = yield* gh.Gists.create({
+      payload: {
+        description: filename,
+        public: choice.value === "Public",
+        files: {
+          [filename]: {
+            content: new TextDecoder().decode(bytes),
+          },
+        },
+      },
+    });
+
+    yield* Effect.logInfo(gist);
+
+    const selection = yield* code.window.showInformationMessage(
+      `Published Gist at ${gist.html_url}`,
+      { items: ["Open"] },
+    );
+
+    if (Option.isSome(selection)) {
+      // Open the URL
+      yield* code.env.openExternal(
+        Either.getOrThrow(code.utils.parseUri(gist.html_url)),
+      );
+    }
+  },
+  flow(
+    Effect.tapErrorCause(Effect.logError),
+    Effect.catchTag("RequestError", (error) =>
+      showErrorAndPromptLogs(
+        `Failed to create Gist: ${error.description ?? "Network error"}.`,
+      ),
+    ),
+    Effect.catchAllCause((cause) =>
+      showErrorAndPromptLogs(
+        `Failed to create Gist: ${Cause.failures(cause).pipe(
+          Chunk.get(0),
+          Option.map((fail) => fail.name),
+          Option.getOrElse(() => "UnknownError"),
+        )}`,
+      ),
+    ),
+  ),
+);

--- a/extension/src/commands/reportIssue.ts
+++ b/extension/src/commands/reportIssue.ts
@@ -1,0 +1,9 @@
+import { Effect, Either } from "effect";
+import { VsCode } from "../services/VsCode.ts";
+import { Links } from "../utils/links.ts";
+
+export const reportIssue = Effect.fn(function* () {
+  const code = yield* VsCode;
+  const uri = Either.getOrThrow(code.utils.parseUri(Links.issues));
+  yield* code.env.openExternal(uri);
+});

--- a/extension/src/commands/restartKernel.ts
+++ b/extension/src/commands/restartKernel.ts
@@ -1,0 +1,85 @@
+import { Effect, Either, Option } from "effect";
+import { MarimoNotebookDocument } from "../schemas.ts";
+import { ExecutionRegistry } from "../services/ExecutionRegistry.ts";
+import { LanguageClient } from "../services/LanguageClient.ts";
+import { VsCode } from "../services/VsCode.ts";
+import { showErrorAndPromptLogs } from "../utils/showErrorAndPromptLogs.ts";
+
+export const restartKernel = Effect.fn(function* () {
+  const code = yield* VsCode;
+  const client = yield* LanguageClient;
+  const executions = yield* ExecutionRegistry;
+
+  const editor = yield* code.window.getActiveNotebookEditor();
+  if (Option.isNone(editor)) {
+    yield* code.window.showInformationMessage(
+      "No notebook editor is currently open",
+    );
+    return;
+  }
+
+  const notebook = MarimoNotebookDocument.tryFrom(editor.value.notebook);
+  if (Option.isNone(notebook)) {
+    yield* code.window.showInformationMessage(
+      "No marimo notebook is currently open",
+    );
+    return;
+  }
+
+  yield* code.window.withProgress(
+    {
+      location: code.ProgressLocation.Window,
+      title: "Restarting kernel",
+      cancellable: true,
+    },
+    Effect.fnUntraced(function* (progress) {
+      progress.report({ message: "Closing session..." });
+
+      const result = yield* client
+        .executeCommand({
+          command: "marimo.api",
+          params: {
+            method: "close-session",
+            params: {
+              notebookUri: notebook.value.id,
+              inner: {},
+            },
+          },
+        })
+        .pipe(Effect.either);
+
+      if (Either.isLeft(result)) {
+        yield* Effect.logFatal("Failed to restart kernel", result.left);
+        yield* showErrorAndPromptLogs("Failed to restart kernel.");
+        return;
+      }
+
+      yield* executions.handleInterrupted(editor.value);
+
+      // Clear all cell outputs by replacing each cell with fresh version
+      const edit = new code.WorkspaceEdit();
+      const cells = editor.value.notebook.getCells();
+      const freshCells = cells.map((cell) => {
+        const freshCell = new code.NotebookCellData(
+          cell.kind,
+          cell.document.getText(),
+          cell.document.languageId,
+        );
+        freshCell.metadata = cell.metadata;
+        return freshCell;
+      });
+      edit.set(editor.value.notebook.uri, [
+        code.NotebookEdit.replaceCells(
+          new code.NotebookRange(0, cells.length),
+          freshCells,
+        ),
+      ]);
+      yield* code.workspace.applyEdit(edit);
+
+      progress.report({ message: "Kernel restarted." });
+      yield* Effect.sleep("500 millis");
+    }),
+  );
+
+  yield* code.window.showInformationMessage("Kernel restarted successfully");
+});

--- a/extension/src/commands/restartLsp.ts
+++ b/extension/src/commands/restartLsp.ts
@@ -1,0 +1,7 @@
+import { Effect } from "effect";
+import { LanguageClient } from "../services/LanguageClient.ts";
+
+export const restartLsp = Effect.fn(function* () {
+  const client = yield* LanguageClient;
+  yield* client.restart();
+});

--- a/extension/src/commands/runStale.ts
+++ b/extension/src/commands/runStale.ts
@@ -1,0 +1,50 @@
+import { Effect, flow, Option } from "effect";
+import { MarimoNotebookDocument } from "../schemas.ts";
+import { VsCode } from "../services/VsCode.ts";
+import { showErrorAndPromptLogs } from "../utils/showErrorAndPromptLogs.ts";
+
+export const runStale = Effect.fn(
+  function* () {
+    const code = yield* VsCode;
+    const notebook = Option.filterMap(
+      yield* code.window.getActiveNotebookEditor(),
+      (editor) => MarimoNotebookDocument.tryFrom(editor.notebook),
+    );
+
+    if (Option.isNone(notebook)) {
+      yield* showErrorAndPromptLogs(
+        "Must have an open marimo notebook to run stale cells.",
+      );
+      return;
+    }
+
+    const staleCells = notebook.value.getCells().filter((cell) => cell.isStale);
+
+    if (staleCells.length === 0) {
+      yield* Effect.logInfo("No stale cells found");
+      yield* code.window.showInformationMessage("No stale cells to run");
+      return;
+    }
+
+    yield* Effect.logInfo("Running stale cells").pipe(
+      Effect.annotateLogs({
+        staleCount: staleCells.length,
+        notebook: notebook.value.uri.toString(),
+      }),
+    );
+
+    // Execute stale cells using VS Code's notebook execution command
+    yield* code.commands.executeCommand("notebook.cell.execute", {
+      ranges: staleCells.map((cell) => ({
+        start: cell.index,
+        end: cell.index + 1,
+      })),
+    });
+  },
+  flow(
+    Effect.tapErrorCause(Effect.logError),
+    Effect.catchAllCause(() =>
+      showErrorAndPromptLogs("Failed to run stale cells."),
+    ),
+  ),
+);

--- a/extension/src/commands/showDiagnostics.ts
+++ b/extension/src/commands/showDiagnostics.ts
@@ -1,0 +1,7 @@
+import { Effect } from "effect";
+import { HealthService } from "../services/HealthService.ts";
+
+export const showDiagnostics = Effect.fn(function* () {
+  const healthService = yield* HealthService;
+  yield* healthService.showDiagnostics();
+});

--- a/extension/src/commands/toggleAutoReload.ts
+++ b/extension/src/commands/toggleAutoReload.ts
@@ -1,0 +1,36 @@
+import { createConfigToggle } from "../utils/createConfigToggle.ts";
+
+export const toggleAutoReload = () =>
+  createConfigToggle({
+    configPath: "runtime.auto_reload",
+    getCurrentValue: (config) => config.runtime?.auto_reload ?? "off",
+    choices: [
+      {
+        label: "Off",
+        detail: "Don't reload modules automatically",
+        value: "off" as const,
+      },
+      {
+        label: "Lazy",
+        detail: "Mark cells stale when modules change, don't autorun",
+        value: "lazy" as const,
+      },
+      {
+        label: "Auto-Run",
+        detail: "Reload modules and automatically run affected cells",
+        value: "autorun" as const,
+      },
+    ],
+    getDisplayName: (value) => {
+      switch (value) {
+        case "off":
+          return "Off";
+        case "lazy":
+          return "Lazy";
+        case "autorun":
+          return "Auto-Run";
+        default:
+          return value;
+      }
+    },
+  });

--- a/extension/src/commands/toggleOnCellChange.ts
+++ b/extension/src/commands/toggleOnCellChange.ts
@@ -1,0 +1,20 @@
+import { createConfigToggle } from "../utils/createConfigToggle.ts";
+
+export const toggleOnCellChange = () =>
+  createConfigToggle({
+    configPath: "runtime.on_cell_change",
+    getCurrentValue: (config) => config.runtime?.on_cell_change ?? "autorun",
+    choices: [
+      {
+        label: "Auto-Run",
+        detail: "Automatically run cells when their ancestors change",
+        value: "autorun" as const,
+      },
+      {
+        label: "Lazy",
+        detail: "Mark cells stale when ancestors change, don't autorun",
+        value: "lazy" as const,
+      },
+    ],
+    getDisplayName: (value) => (value === "autorun" ? "Auto-Run" : "Lazy"),
+  });

--- a/extension/src/commands/updateActivePythonEnvironment.ts
+++ b/extension/src/commands/updateActivePythonEnvironment.ts
@@ -1,0 +1,67 @@
+import { Effect, Either, Option } from "effect";
+import { MarimoNotebookDocument } from "../schemas.ts";
+import { ControllerRegistry } from "../services/ControllerRegistry.ts";
+import { PythonExtension } from "../services/PythonExtension.ts";
+import { Uv } from "../services/Uv.ts";
+import { VsCode } from "../services/VsCode.ts";
+import { getVenvPythonPath } from "../utils/getVenvPythonPath.ts";
+import { showErrorAndPromptLogs } from "../utils/showErrorAndPromptLogs.ts";
+
+export const updateActivePythonEnvironment = Effect.fn(function* () {
+  const uv = yield* Uv;
+  const code = yield* VsCode;
+  const py = yield* PythonExtension;
+  const controllers = yield* ControllerRegistry;
+
+  const editor = yield* code.window.getActiveNotebookEditor();
+
+  if (Option.isNone(editor)) {
+    yield* code.window.showInformationMessage(
+      "No marimo notebook is currently open",
+    );
+    return;
+  }
+
+  const notebook = MarimoNotebookDocument.tryFrom(editor.value.notebook);
+
+  if (Option.isNone(notebook)) {
+    yield* code.window.showInformationMessage(
+      "Active notebook is not a marimo notebook.",
+    );
+    return;
+  }
+
+  const controller = yield* controllers.getActiveController(notebook.value);
+
+  if (Option.isNone(controller)) {
+    yield* code.window.showInformationMessage(
+      "No active controller for the current marimo notebook found. Please select a kernel first.",
+    );
+    return;
+  }
+
+  let executable: string;
+  if (controller.value._tag === "PythonController") {
+    executable = controller.value.executable;
+  } else {
+    const script = editor.value.notebook.uri.fsPath;
+    const venvResult = yield* uv.syncScript({ script }).pipe(Effect.either);
+
+    if (Either.isLeft(venvResult)) {
+      return yield* showErrorAndPromptLogs(
+        "Failed to synchronize virtual environment for the current notebook.",
+        { channel: uv.channel },
+      );
+    }
+
+    executable = getVenvPythonPath(venvResult.right);
+  }
+
+  // update the active python environment
+  yield* py.updateActiveEnvironmentPath(executable);
+
+  // inform the user
+  yield* code.window.showInformationMessage(
+    `Active Python environment updated to: ${executable}`,
+  );
+});

--- a/extension/src/layers/RegisterCommands.ts
+++ b/extension/src/layers/RegisterCommands.ts
@@ -1,237 +1,91 @@
-import * as NodePath from "node:path";
-import {
-  Cause,
-  Chunk,
-  Effect,
-  Either,
-  Layer,
-  Option,
-  Schema,
-  Stream,
-} from "effect";
-import {
-  type MarimoCommand,
-  NOTEBOOK_TYPE,
-  SETUP_CELL_NAME,
-} from "../constants.ts";
-import { encodeCellMetadata, MarimoNotebookDocument } from "../schemas.ts";
-import { ControllerRegistry } from "../services/ControllerRegistry.ts";
-import { MarimoConfigurationService } from "../services/config/MarimoConfigurationService.ts";
-import { ExecutionRegistry } from "../services/ExecutionRegistry.ts";
-import { GitHubClient } from "../services/GitHubClient.ts";
-import { HealthService } from "../services/HealthService.ts";
-import { LanguageClient } from "../services/LanguageClient.ts";
-import { NotebookSerializer } from "../services/NotebookSerializer.ts";
-import { OutputChannel } from "../services/OutputChannel.ts";
-import { PythonExtension } from "../services/PythonExtension.ts";
+import { Effect, Either, Layer, Stream } from "effect";
+import { createSetupCell } from "../commands/createSetupCell.ts";
+import { exportNotebookAsHtml } from "../commands/exportNotebookAsHtml.ts";
+import { newMarimoNotebook } from "../commands/newMarimoNotebook.ts";
+import { openAsMarimoNotebook } from "../commands/openAsMarimoNotebook.ts";
+import { publishMarimoNotebook } from "../commands/publishMarimoNotebook.ts";
+import { publishMarimoNotebookGist } from "../commands/publishMarimoNotebookGist.ts";
+import { reportIssue } from "../commands/reportIssue.ts";
+import { restartKernel } from "../commands/restartKernel.ts";
+import { restartLsp } from "../commands/restartLsp.ts";
+import { runStale } from "../commands/runStale.ts";
+import { showDiagnostics } from "../commands/showDiagnostics.ts";
+import { toggleAutoReload } from "../commands/toggleAutoReload.ts";
+import { toggleOnCellChange } from "../commands/toggleOnCellChange.ts";
+import { updateActivePythonEnvironment } from "../commands/updateActivePythonEnvironment.ts";
+import type { MarimoCommand } from "../constants.ts";
 import { Telemetry } from "../services/Telemetry.ts";
-import { Uv } from "../services/Uv.ts";
 import { VsCode } from "../services/VsCode.ts";
-import type { MarimoConfig } from "../types.ts";
-import { getVenvPythonPath } from "../utils/getVenvPythonPath.ts";
-import { Links } from "../utils/links.ts";
-import { showErrorAndPromptLogs } from "../utils/showErrorAndPromptLogs.ts";
 
 /**
  * Registers VS Code commands for the marimo extension.
  */
 export const RegisterCommandsLive = Layer.scopedDiscard(
   Effect.gen(function* () {
-    const gh = yield* GitHubClient;
-    const py = yield* PythonExtension;
-    const uv = yield* Uv;
     const code = yield* VsCode;
-    const client = yield* LanguageClient;
-    const channel = yield* OutputChannel;
-    const executions = yield* ExecutionRegistry;
-    const serializer = yield* NotebookSerializer;
-    const configService = yield* MarimoConfigurationService;
-    const controllers = yield* ControllerRegistry;
-    const healthService = yield* HealthService;
     const telemetry = yield* Telemetry;
 
     yield* code.commands.registerCommand(
       "marimo.newMarimoNotebook",
-      newMarimoNotebook({ code, serializer, telemetry, channel }),
+      newMarimoNotebook,
     );
 
     yield* code.commands.registerCommand(
       "marimo.createSetupCell",
-      createSetupCell({ code, serializer }),
+      createSetupCell,
     );
 
     yield* code.commands.registerCommand(
       "marimo.openAsMarimoNotebook",
-      openAsMarimoNotebook({ code }),
+      openAsMarimoNotebook,
     );
 
     yield* code.commands.registerCommand(
       "marimo.publishMarimoNotebookGist",
-      createGist({ code, serializer, gh, channel }),
+      publishMarimoNotebookGist,
     );
 
     yield* code.commands.registerCommand(
       "marimo.publishMarimoNotebook",
-      Effect.gen(function* () {
-        const choice = yield* code.window.showQuickPickItems([
-          {
-            label: "GitHub Gist",
-            detail: "Publish marimo notebook as a GitHub Gist",
-          },
-        ]);
-        if (Option.isNone(choice)) {
-          return choice;
-        }
-        if (choice.value.label === "GitHub Gist") {
-          yield* code.commands.executeCommand(
-            "marimo.publishMarimoNotebookGist",
-          );
-        }
-      }),
+      publishMarimoNotebook,
     );
 
-    yield* code.commands.registerCommand(
-      "marimo.runStale",
-      runStale({ code, channel }),
-    );
+    yield* code.commands.registerCommand("marimo.runStale", runStale);
 
-    const onCellChangeCommands = [
+    for (const command of [
       "marimo.config.toggleOnCellChangeAutoRun",
       "marimo.config.toggleOnCellChangeLazy",
-    ] satisfies ReadonlyArray<MarimoCommand>;
-    for (const command of onCellChangeCommands) {
-      yield* code.commands.registerCommand(
-        command,
-        toggleOnCellChange({
-          code,
-          channel,
-          configService,
-        }),
-      );
+    ] satisfies ReadonlyArray<MarimoCommand>) {
+      yield* code.commands.registerCommand(command, toggleOnCellChange);
     }
 
-    const autoReloadCommands = [
+    for (const command of [
       "marimo.config.toggleAutoReloadOff",
       "marimo.config.toggleAutoReloadLazy",
       "marimo.config.toggleAutoReloadAutorun",
-    ] satisfies ReadonlyArray<MarimoCommand>;
-    for (const command of autoReloadCommands) {
-      yield* code.commands.registerCommand(
-        command,
-        toggleAutoReload({
-          code,
-          channel,
-          configService,
-        }),
-      );
+    ] satisfies ReadonlyArray<MarimoCommand>) {
+      yield* code.commands.registerCommand(command, toggleAutoReload);
     }
 
-    yield* code.commands.registerCommand(
-      "marimo.restartKernel",
-      Effect.gen(function* () {
-        const editor = yield* code.window.getActiveNotebookEditor();
-        if (Option.isNone(editor)) {
-          yield* code.window.showInformationMessage(
-            "No notebook editor is currently open",
-          );
-          return;
-        }
+    yield* code.commands.registerCommand("marimo.restartKernel", restartKernel);
 
-        const notebook = MarimoNotebookDocument.tryFrom(editor.value.notebook);
-        if (Option.isNone(notebook)) {
-          yield* code.window.showInformationMessage(
-            "No marimo notebook is currently open",
-          );
-          return;
-        }
-
-        yield* code.window.withProgress(
-          {
-            location: code.ProgressLocation.Window,
-            title: "Restarting kernel",
-            cancellable: true,
-          },
-          Effect.fnUntraced(function* (progress) {
-            progress.report({ message: "Closing session..." });
-
-            const result = yield* client
-              .executeCommand({
-                command: "marimo.api",
-                params: {
-                  method: "close-session",
-                  params: {
-                    notebookUri: notebook.value.id,
-                    inner: {},
-                  },
-                },
-              })
-              .pipe(Effect.either);
-
-            if (Either.isLeft(result)) {
-              yield* Effect.logFatal("Failed to restart kernel", result.left);
-              yield* showErrorAndPromptLogs("Failed to restart kernel.", {
-                channel,
-                code,
-              });
-              return;
-            }
-
-            yield* executions.handleInterrupted(editor.value);
-
-            // Clear all cell outputs by replacing each cell with fresh version
-            const edit = new code.WorkspaceEdit();
-            const cells = editor.value.notebook.getCells();
-            const freshCells = cells.map((cell) => {
-              const freshCell = new code.NotebookCellData(
-                cell.kind,
-                cell.document.getText(),
-                cell.document.languageId,
-              );
-              freshCell.metadata = cell.metadata;
-              return freshCell;
-            });
-            edit.set(editor.value.notebook.uri, [
-              code.NotebookEdit.replaceCells(
-                new code.NotebookRange(0, cells.length),
-                freshCells,
-              ),
-            ]);
-            yield* code.workspace.applyEdit(edit);
-
-            progress.report({ message: "Kernel restarted." });
-            yield* Effect.sleep("500 millis");
-          }),
-        );
-
-        yield* code.window.showInformationMessage(
-          "Kernel restarted successfully",
-        );
-      }),
-    );
-
-    yield* code.commands.registerCommand("marimo.restartLsp", client.restart);
+    yield* code.commands.registerCommand("marimo.restartLsp", restartLsp);
 
     yield* code.commands.registerCommand(
       "marimo.showDiagnostics",
-      healthService.showDiagnostics,
+      showDiagnostics,
     );
 
-    yield* code.commands.registerCommand(
-      "marimo.reportIssue",
-      Effect.gen(function* () {
-        const uri = Either.getOrThrow(code.utils.parseUri(Links.issues));
-        yield* code.env.openExternal(uri);
-      }),
-    );
+    yield* code.commands.registerCommand("marimo.reportIssue", reportIssue);
 
     yield* code.commands.registerCommand(
       "marimo.exportStaticHTML",
-      exportNotebookAsHTML({ code, client, channel }),
+      exportNotebookAsHtml,
     );
 
     yield* code.commands.registerCommand(
       "marimo.updateActivePythonEnvironment",
-      updateActivePythonEnvironment({ code, py, uv, controllers }),
+      updateActivePythonEnvironment,
     );
 
     // Telemetry for commands
@@ -258,641 +112,3 @@ export const RegisterCommandsLive = Layer.scopedDiscard(
     );
   }),
 );
-
-const newMarimoNotebook = ({
-  code,
-  channel,
-  telemetry,
-}: {
-  code: VsCode;
-  channel: OutputChannel;
-  serializer: NotebookSerializer;
-  telemetry: Telemetry;
-}) =>
-  Effect.gen(function* () {
-    const uri = yield* code.window.showSaveDialog({
-      filters: { Python: ["py"] },
-    });
-
-    if (Option.isNone(uri)) {
-      return;
-    }
-
-    yield* code.workspace.fs.writeFile(
-      uri.value,
-      new TextEncoder().encode(
-        `import marimo
-
-app = marimo.App()
-
-@app.cell
-def _():
-    return
-`.trim(),
-      ),
-    );
-
-    const notebook = yield* code.workspace.openNotebookDocument(uri.value);
-    yield* code.window.showNotebookDocument(notebook);
-
-    yield* Effect.logInfo("Created new marimo notebook").pipe(
-      Effect.annotateLogs({
-        uri: notebook.uri.toString(),
-      }),
-    );
-
-    yield* telemetry.capture("new_notebook_created");
-  }).pipe(
-    Effect.catchTag("FileSystemError", (error) =>
-      Effect.gen(function* () {
-        yield* Effect.logError("Failed to create notebook", { error });
-        yield* showErrorAndPromptLogs("Failed to create notebook.", {
-          channel,
-          code,
-        });
-      }),
-    ),
-  );
-
-const createSetupCell = ({
-  code,
-}: {
-  code: VsCode;
-  serializer: NotebookSerializer;
-}) =>
-  Effect.gen(function* () {
-    const notebook = Option.filterMap(
-      yield* code.window.getActiveNotebookEditor(),
-      (editor) => MarimoNotebookDocument.tryFrom(editor.notebook),
-    );
-
-    if (Option.isNone(notebook)) {
-      yield* code.window.showInformationMessage(
-        "No marimo notebook is currently open",
-      );
-      return;
-    }
-
-    // Check if setup cell already exists
-    const cells = notebook.value.getCells();
-    const existing = cells.find((cell) => {
-      return Option.isSome(cell.name) && cell.name.value === SETUP_CELL_NAME;
-    });
-
-    if (existing) {
-      // Show message and focus on existing setup cell
-      yield* code.window.showInformationMessage("Setup cell already exists");
-      yield* code.window.showNotebookDocument(
-        notebook.value.rawNotebookDocument,
-        {
-          selections: [
-            new code.NotebookRange(existing.index, existing.index + 1),
-          ],
-        },
-      );
-      return;
-    }
-
-    {
-      // Create new setup cell at index 0
-      const edit = new code.WorkspaceEdit();
-      const cell = new code.NotebookCellData(
-        code.NotebookCellKind.Code,
-        "# Initialization code that runs before all other cells",
-        "python",
-      );
-      cell.metadata = encodeCellMetadata({ name: SETUP_CELL_NAME });
-      edit.set(notebook.value.uri, [code.NotebookEdit.insertCells(0, [cell])]);
-      yield* code.workspace.applyEdit(edit);
-    }
-
-    yield* Effect.logInfo("Created setup cell").pipe(
-      Effect.annotateLogs({
-        notebook: notebook.value.uri.toString(),
-      }),
-    );
-  });
-
-const openAsMarimoNotebook = ({ code }: { code: VsCode }) =>
-  Effect.gen(function* () {
-    const editor = yield* code.window.getActiveTextEditor();
-
-    if (Option.isNone(editor)) {
-      yield* code.window.showInformationMessage(
-        "No active file to open as notebook",
-      );
-      return;
-    }
-
-    const uri = editor.value.document.uri;
-
-    // We open first before closing to handle multi-window scenarios correctly:
-    // if we close first and it's the only editor in the window, the window
-    // closes before we can open the notebook in it.
-    yield* code.commands.executeCommand("vscode.openWith", uri, NOTEBOOK_TYPE);
-
-    // Find and close the original text editor tab (not the notebook we just opened).
-    // We find the tab after opening the notebook because tab references can become
-    // stale when VS Code reorganizes tabs.
-    yield* code.window.closeTextEditorTab(uri);
-
-    yield* Effect.logInfo("Opened Python file as marimo notebook").pipe(
-      Effect.annotateLogs({
-        uri: uri.toString(),
-      }),
-    );
-  });
-
-const createGist = ({
-  code,
-  serializer,
-  gh,
-  channel,
-}: {
-  code: VsCode;
-  serializer: NotebookSerializer;
-  gh: GitHubClient;
-  channel: OutputChannel;
-}) =>
-  Effect.gen(function* () {
-    const notebook = Option.filterMap(
-      yield* code.window.getActiveNotebookEditor(),
-      (editor) => MarimoNotebookDocument.tryFrom(editor.notebook),
-    );
-
-    if (Option.isNone(notebook)) {
-      yield* code.window.showWarningMessage(
-        "Must have an open marimo notebook to publish Gist.",
-      );
-      return;
-    }
-
-    const choice = yield* code.window.showQuickPick(["Public", "Secret"], {
-      placeHolder: "Gist visibility",
-    });
-
-    if (Option.isNone(choice)) {
-      // cancelled
-      return;
-    }
-
-    const bytes = yield* serializer.serializeEffect({
-      metadata: notebook.value.rawMetadata,
-      cells: notebook.value
-        .getCells()
-        .map(
-          (cell) =>
-            new code.NotebookCellData(
-              cell.kind,
-              cell.document.getText(),
-              cell.document.languageId,
-            ),
-        ),
-    });
-
-    const filename = NodePath.basename(notebook.value.uri.path);
-    const gist = yield* gh.Gists.create({
-      payload: {
-        description: filename,
-        public: choice.value === "Public",
-        files: {
-          [filename]: {
-            content: new TextDecoder().decode(bytes),
-          },
-        },
-      },
-    });
-
-    yield* Effect.logInfo(gist);
-
-    const selection = yield* code.window.showInformationMessage(
-      `Published Gist at ${gist.html_url}`,
-      { items: ["Open"] },
-    );
-
-    if (Option.isSome(selection)) {
-      // Open the URL
-      yield* code.env.openExternal(
-        Either.getOrThrow(code.utils.parseUri(gist.html_url)),
-      );
-    }
-  }).pipe(
-    Effect.tapErrorCause(Effect.logError),
-    Effect.catchTag("RequestError", (error) =>
-      showErrorAndPromptLogs(
-        `Failed to create Gist: ${error.description ?? "Network error"}.`,
-        { code, channel },
-      ),
-    ),
-    Effect.catchAllCause((cause) =>
-      showErrorAndPromptLogs(
-        `Failed to create Gist: ${Cause.failures(cause).pipe(
-          Chunk.get(0),
-          Option.map((fail) => fail.name),
-          Option.getOrElse(() => "UnknownError"),
-        )}`,
-        {
-          code,
-          channel,
-        },
-      ),
-    ),
-  );
-
-const runStale = ({
-  code,
-  channel,
-}: {
-  code: VsCode;
-  channel: OutputChannel;
-}) =>
-  Effect.gen(function* () {
-    const notebook = Option.filterMap(
-      yield* code.window.getActiveNotebookEditor(),
-      (editor) => MarimoNotebookDocument.tryFrom(editor.notebook),
-    );
-
-    if (Option.isNone(notebook)) {
-      yield* showErrorAndPromptLogs(
-        "Must have an open marimo notebook to run stale cells.",
-        { code, channel },
-      );
-      return;
-    }
-
-    const staleCells = notebook.value.getCells().filter((cell) => cell.isStale);
-
-    if (staleCells.length === 0) {
-      yield* Effect.logInfo("No stale cells found");
-      yield* code.window.showInformationMessage("No stale cells to run");
-      return;
-    }
-
-    yield* Effect.logInfo("Running stale cells").pipe(
-      Effect.annotateLogs({
-        staleCount: staleCells.length,
-        notebook: notebook.value.uri.toString(),
-      }),
-    );
-
-    // Execute stale cells using VS Code's notebook execution command
-    yield* code.commands.executeCommand("notebook.cell.execute", {
-      ranges: staleCells.map((cell) => ({
-        start: cell.index,
-        end: cell.index + 1,
-      })),
-    });
-  }).pipe(
-    Effect.tapErrorCause(Effect.logError),
-    Effect.catchAllCause(() =>
-      showErrorAndPromptLogs("Failed to run stale cells.", { code, channel }),
-    ),
-  );
-
-/**
- * Generic configuration toggle function for marimo config options.
- * Creates a handler that shows a quick pick dialog with all available options.
- */
-const createConfigToggle = <T extends string>({
-  code,
-  channel,
-  configService,
-  configPath,
-  getCurrentValue,
-  choices,
-  getDisplayName,
-}: {
-  code: VsCode;
-  channel: OutputChannel;
-  configService: MarimoConfigurationService;
-  configPath: string;
-  getCurrentValue: (config: MarimoConfig) => T;
-  choices: ReadonlyArray<{
-    label: string;
-    detail: string;
-    value: T;
-  }>;
-  getDisplayName: (value: T) => string;
-}) =>
-  Effect.gen(function* () {
-    // Validate active notebook
-    const notebook = Option.filterMap(
-      yield* code.window.getActiveNotebookEditor(),
-      (editor) => MarimoNotebookDocument.tryFrom(editor.notebook),
-    );
-
-    if (Option.isNone(notebook)) {
-      yield* showErrorAndPromptLogs(
-        `Must have an open marimo notebook to toggle ${configPath}.`,
-        { code, channel },
-      );
-      return;
-    }
-
-    // Fetch current configuration
-    const config = yield* configService.getConfig(notebook.value.id);
-    const currentValue = getCurrentValue(config);
-
-    // Show quick pick with all choices, marking current
-    const choice = yield* code.window.showQuickPickItems(
-      choices.map((c) => ({
-        label: c.label,
-        description: c.value === currentValue ? "$(check) Current" : undefined,
-        detail: c.detail,
-        value: c.value,
-      })),
-    );
-
-    if (Option.isNone(choice)) {
-      return; // User cancelled
-    }
-
-    const newValue = choice.value.value;
-
-    if (newValue === currentValue) {
-      yield* Effect.logInfo("Value unchanged");
-      return;
-    }
-
-    // Update configuration
-    yield* Effect.logInfo(`Updating ${configPath}`).pipe(
-      Effect.annotateLogs({
-        notebook: notebook.value.id,
-        from: currentValue,
-        to: newValue,
-      }),
-    );
-
-    // Build nested config object from path (e.g., "runtime.on_cell_change" -> { runtime: { on_cell_change: value }})
-    const pathParts = configPath.split(".");
-    const partialConfig = pathParts.reduceRight(
-      (acc, part) => ({ [part]: acc }),
-      newValue as unknown as Record<string, unknown>,
-    );
-
-    yield* configService.updateConfig(notebook.value.id, partialConfig);
-
-    yield* code.window.showInformationMessage(
-      `${configPath} updated to: ${getDisplayName(newValue)}`,
-    );
-  }).pipe(
-    Effect.tapErrorCause(Effect.logError),
-    Effect.catchAllCause(() =>
-      showErrorAndPromptLogs(`Failed to toggle ${configPath}.`, {
-        code,
-        channel,
-      }),
-    ),
-  );
-
-const toggleOnCellChange = ({
-  code,
-  channel,
-  configService,
-}: {
-  code: VsCode;
-  channel: OutputChannel;
-  configService: MarimoConfigurationService;
-}) =>
-  createConfigToggle({
-    code,
-    channel,
-    configService,
-    configPath: "runtime.on_cell_change",
-    getCurrentValue: (config) => config.runtime?.on_cell_change ?? "autorun",
-    choices: [
-      {
-        label: "Auto-Run",
-        detail: "Automatically run cells when their ancestors change",
-        value: "autorun" as const,
-      },
-      {
-        label: "Lazy",
-        detail: "Mark cells stale when ancestors change, don't autorun",
-        value: "lazy" as const,
-      },
-    ],
-    getDisplayName: (value) => (value === "autorun" ? "Auto-Run" : "Lazy"),
-  });
-
-const toggleAutoReload = ({
-  code,
-  channel,
-  configService,
-}: {
-  code: VsCode;
-  channel: OutputChannel;
-  configService: MarimoConfigurationService;
-}) =>
-  createConfigToggle({
-    code,
-    channel,
-    configService,
-    configPath: "runtime.auto_reload",
-    getCurrentValue: (config) => config.runtime?.auto_reload ?? "off",
-    choices: [
-      {
-        label: "Off",
-        detail: "Don't reload modules automatically",
-        value: "off" as const,
-      },
-      {
-        label: "Lazy",
-        detail: "Mark cells stale when modules change, don't autorun",
-        value: "lazy" as const,
-      },
-      {
-        label: "Auto-Run",
-        detail: "Reload modules and automatically run affected cells",
-        value: "autorun" as const,
-      },
-    ],
-    getDisplayName: (value) => {
-      switch (value) {
-        case "off":
-          return "Off";
-        case "lazy":
-          return "Lazy";
-        case "autorun":
-          return "Auto-Run";
-        default:
-          return value;
-      }
-    },
-  });
-
-const exportNotebookAsHTML = ({
-  code,
-  client,
-  channel,
-}: {
-  code: VsCode;
-  client: LanguageClient;
-  channel: OutputChannel;
-}) =>
-  Effect.gen(function* () {
-    const notebook = Option.filterMap(
-      yield* code.window.getActiveNotebookEditor(),
-      (editor) => MarimoNotebookDocument.tryFrom(editor.notebook),
-    );
-
-    if (Option.isNone(notebook)) {
-      yield* code.window.showWarningMessage(
-        "Must have an open marimo notebook to export as HTML.",
-      );
-      return;
-    }
-
-    const hasOutputs = notebook.value
-      .getCells()
-      .some((c) => c.outputs.length > 0);
-
-    if (!hasOutputs) {
-      yield* code.window.showWarningMessage(
-        "Cannot export to HTML. Run the notebook to generate outputs first.",
-      );
-      return;
-    }
-
-    // Ask user where to save the file
-    const saveUri = yield* code.window.showSaveDialog({
-      title: "Export notebook as HTML",
-      filters: { HTML: ["html"] },
-      defaultUri: code.utils
-        .parseUri(notebook.value.uri.toString().replace(/\.py$/, ".html"))
-        .pipe(Either.getOrUndefined),
-    });
-
-    if (Option.isNone(saveUri)) {
-      // User cancelled
-      return;
-    }
-
-    yield* code.window.withProgress(
-      {
-        location: code.ProgressLocation.Notification,
-        title: "Exporting notebook as HTML",
-        cancellable: false,
-      },
-      Effect.fnUntraced(function* () {
-        // Call the LSP API to export the notebook
-        const result = yield* client
-          .executeCommand({
-            command: "marimo.api",
-            params: {
-              method: "export-as-html",
-              params: {
-                notebookUri: notebook.value.id,
-                inner: {
-                  download: false,
-                  files: [],
-                  includeCode: true,
-                  assetUrl: null,
-                },
-              },
-            },
-          })
-          .pipe(
-            Effect.andThen(Schema.decodeUnknown(Schema.String)),
-            Effect.either,
-          );
-
-        if (Either.isLeft(result)) {
-          yield* Effect.logFatal("Failed to export notebook", result.left);
-          yield* showErrorAndPromptLogs("Failed to export notebook as HTML.", {
-            channel,
-            code,
-          });
-          return;
-        }
-
-        // Write the HTML to the file
-        yield* code.workspace.fs
-          .writeFile(saveUri.value, new TextEncoder().encode(result.right))
-          .pipe(
-            Effect.tap(() =>
-              Effect.logInfo("Exported notebook as HTML").pipe(
-                Effect.annotateLogs({
-                  notebook: notebook.value.id,
-                  output: saveUri.value.fsPath,
-                }),
-              ),
-            ),
-            Effect.tapError(() =>
-              Effect.logError("Failed to export notebook as HTML").pipe(
-                Effect.annotateLogs({
-                  notebook: notebook.value.id,
-                  output: saveUri.value.fsPath,
-                }),
-              ),
-            ),
-            Effect.ignore,
-          );
-      }),
-    );
-  });
-
-const updateActivePythonEnvironment = ({
-  py,
-  uv,
-  code,
-  controllers,
-}: {
-  py: PythonExtension;
-  uv: Uv;
-  code: VsCode;
-  controllers: ControllerRegistry;
-}) =>
-  Effect.gen(function* () {
-    const editor = yield* code.window.getActiveNotebookEditor();
-
-    if (Option.isNone(editor)) {
-      yield* code.window.showInformationMessage(
-        "No marimo notebook is currently open",
-      );
-      return;
-    }
-
-    const notebook = MarimoNotebookDocument.tryFrom(editor.value.notebook);
-
-    if (Option.isNone(notebook)) {
-      yield* code.window.showInformationMessage(
-        "Active notebook is not a marimo notebook.",
-      );
-      return;
-    }
-
-    const controller = yield* controllers.getActiveController(notebook.value);
-
-    if (Option.isNone(controller)) {
-      yield* code.window.showInformationMessage(
-        "No active controller for the current marimo notebook found. Please select a kernel first.",
-      );
-      return;
-    }
-
-    let executable: string;
-    if (controller.value._tag === "PythonController") {
-      executable = controller.value.executable;
-    } else {
-      const script = editor.value.notebook.uri.fsPath;
-      const venvResult = yield* uv.syncScript({ script }).pipe(Effect.either);
-
-      if (Either.isLeft(venvResult)) {
-        return yield* showErrorAndPromptLogs(
-          "Failed to synchronize virtual environment for the current notebook.",
-          { code, channel: uv.channel },
-        );
-      }
-
-      executable = getVenvPythonPath(venvResult.right);
-    }
-
-    // update the active python environment
-    yield* py.updateActiveEnvironmentPath(executable);
-
-    // inform the user
-    yield* code.window.showInformationMessage(
-      `Active Python environment updated to: ${executable}`,
-    );
-  });

--- a/extension/src/services/Api.ts
+++ b/extension/src/services/Api.ts
@@ -19,6 +19,7 @@ import { Config } from "./Config.ts";
 import { ControllerRegistry } from "./ControllerRegistry.ts";
 import { scratchCellNotificationsToVsCodeOutput } from "./ExecutionRegistry.ts";
 import { KernelManager } from "./KernelManager.ts";
+import { OutputChannel } from "./OutputChannel.ts";
 import { Uv } from "./Uv.ts";
 import { VsCode } from "./VsCode.ts";
 
@@ -72,6 +73,7 @@ export class Api extends Effect.Service<Api>()("Api", {
     Uv.Default,
     Config.Default,
     KernelManager.Default,
+    OutputChannel.Default,
     ControllerRegistry.Default,
   ],
   scoped: Effect.gen(function* () {

--- a/extension/src/services/CellMetadataUIBindingService.ts
+++ b/extension/src/services/CellMetadataUIBindingService.ts
@@ -143,7 +143,7 @@ export class CellMetadataUIBindingService extends Effect.Service<CellMetadataUIB
           const commandId = dynamicCommand(`cell.metadata.${binding.id}`);
           yield* code.commands.registerCommand(
             commandId,
-            createBindingCommand(binding),
+            createBindingCommandFor(binding),
           );
 
           // Create provider for status bar item
@@ -184,8 +184,8 @@ export class CellMetadataUIBindingService extends Effect.Service<CellMetadataUIB
       /**
        * Create a command handler for a binding
        */
-      function createBindingCommand(binding: MetadataBinding) {
-        return Effect.gen(function* () {
+      function createBindingCommandFor(binding: MetadataBinding) {
+        return Effect.fn(function* () {
           const editor = yield* code.window.getActiveNotebookEditor();
 
           if (Option.isNone(editor)) {

--- a/extension/src/services/ControllerRegistry.ts
+++ b/extension/src/services/ControllerRegistry.ts
@@ -19,6 +19,7 @@ import {
   type NotebookControllerId,
   PythonController,
 } from "./NotebookControllerFactory.ts";
+import { OutputChannel } from "./OutputChannel.ts";
 import { PythonExtension } from "./PythonExtension.ts";
 import { SandboxController } from "./SandboxController.ts";
 import { Uv } from "./Uv.ts";
@@ -40,6 +41,7 @@ export class ControllerRegistry extends Effect.Service<ControllerRegistry>()(
   {
     dependencies: [
       Uv.Default,
+      OutputChannel.Default,
       SandboxController.Default,
       NotebookControllerFactory.Default,
     ],

--- a/extension/src/services/DebugAdapter.ts
+++ b/extension/src/services/DebugAdapter.ts
@@ -13,15 +13,14 @@ import { VsCode } from "./VsCode.ts";
 export class DebugAdapter extends Effect.Service<DebugAdapter>()(
   "DebugAdapter",
   {
-    dependencies: [NotebookSerializer.Default],
+    dependencies: [NotebookSerializer.Default, OutputChannel.Default],
     scoped: Effect.gen(function* () {
       const debugType = "marimo";
 
       const code = yield* VsCode;
       const client = yield* LanguageClient;
-      const channel = yield* OutputChannel;
 
-      const runtime = yield* Effect.runtime();
+      const runtime = yield* Effect.runtime<OutputChannel | VsCode>();
       const runFork = Runtime.runFork(runtime);
       const runPromise = Runtime.runPromise(runtime);
 
@@ -83,7 +82,6 @@ export class DebugAdapter extends Effect.Service<DebugAdapter>()(
                     LanguageClientStartError: Effect.fnUntraced(function* () {
                       yield* showErrorAndPromptLogs(
                         "marimo-lsp failed to start.",
-                        { code, channel },
                       );
                     }),
                   }),

--- a/extension/src/services/HealthService.ts
+++ b/extension/src/services/HealthService.ts
@@ -228,7 +228,7 @@ export class HealthService extends Effect.Service<HealthService>()(
          * Shows a text document with comprehensive diagnostics about the extension
          * and environment setup.
          */
-        showDiagnostics: Effect.gen(function* () {
+        showDiagnostics: Effect.fn(function* () {
           yield* Effect.logInfo("Showing diagnostics");
 
           const diagnosticText = yield* formatDiagnostics().pipe(

--- a/extension/src/services/KernelManager.ts
+++ b/extension/src/services/KernelManager.ts
@@ -63,7 +63,6 @@ export class KernelManager extends Effect.Service<KernelManager>()(
       yield* Effect.logInfo("Setting up kernel manager");
       const code = yield* VsCode;
       const client = yield* LanguageClient;
-      const channel = yield* OutputChannel;
       const renderer = yield* NotebookRenderer;
 
       const runPromise = Runtime.runPromise(yield* Effect.runtime());
@@ -108,9 +107,7 @@ export class KernelManager extends Effect.Service<KernelManager>()(
                   yield* Effect.logError(errorMessage, cause).pipe(
                     Effect.annotateLogs({ op: msg.operation.op }),
                   );
-                  yield* Effect.fork(
-                    showErrorAndPromptLogs(errorMessage, { code, channel }),
-                  );
+                  yield* Effect.fork(showErrorAndPromptLogs(errorMessage));
                 }),
               ),
             );

--- a/extension/src/services/__tests__/Api.test.ts
+++ b/extension/src/services/__tests__/Api.test.ts
@@ -26,7 +26,7 @@ const withTestCtx = Effect.fnUntraced(function* (
           LanguageClient,
           LanguageClient.make({
             channel: { name: "marimo-lsp-test", show() {} },
-            restart: Effect.void,
+            restart: () => Effect.void,
             executeCommand() {
               return Effect.die("not implemented");
             },

--- a/extension/src/services/__tests__/CellStateManager.test.ts
+++ b/extension/src/services/__tests__/CellStateManager.test.ts
@@ -27,7 +27,7 @@ const withTestCtx = Effect.fnUntraced(function* () {
             name: "marimo-lsp",
             show() {},
           },
-          restart: Effect.void,
+          restart: () => Effect.void,
           executeCommand(cmd) {
             return Ref.update(executions, (arr) => [...arr, cmd]);
           },

--- a/extension/src/services/__tests__/ControllerRegistry.test.ts
+++ b/extension/src/services/__tests__/ControllerRegistry.test.ts
@@ -19,7 +19,7 @@ const TestLanguageClientMock = Layer.succeed(
   LanguageClient,
   LanguageClient.make({
     channel: { name: "marimo-lsp", show() {} },
-    restart: Effect.void,
+    restart: () => Effect.void,
     executeCommand() {
       return Effect.void;
     },

--- a/extension/src/services/__tests__/ExecutionRegistry.test.ts
+++ b/extension/src/services/__tests__/ExecutionRegistry.test.ts
@@ -25,7 +25,7 @@ const TestLanguageClientMock = Layer.succeed(
   LanguageClient,
   LanguageClient.make({
     channel: { name: "marimo-lsp", show() {} },
-    restart: Effect.void,
+    restart: () => Effect.void,
     executeCommand() {
       return Effect.void;
     },

--- a/extension/src/services/config/MarimoConfigurationService.ts
+++ b/extension/src/services/config/MarimoConfigurationService.ts
@@ -23,14 +23,13 @@ export class MarimoConfigurationService extends Effect.Service<MarimoConfigurati
   "MarimoConfigurationService",
   {
     scoped: Effect.gen(function* () {
+      const client = yield* LanguageClient;
       const editorRegistry = yield* NotebookEditorRegistry;
 
       // Track configurations: NotebookUri -> MarimoConfig
       const configRef = yield* SubscriptionRef.make(
         HashMap.empty<NotebookId, MarimoConfig>(),
       );
-
-      const client = yield* LanguageClient;
 
       return {
         /**

--- a/extension/src/services/config/__tests__/MarimoConfigurationService.test.ts
+++ b/extension/src/services/config/__tests__/MarimoConfigurationService.test.ts
@@ -45,7 +45,7 @@ const withTestCtx = Effect.fnUntraced(function* (
             name: "marimo-lsp",
             show() {},
           },
-          restart: Effect.void,
+          restart: () => Effect.void,
           streamOf: () => Stream.never,
           executeCommand: Effect.fnUntraced(function* ({ command, params }) {
             if (!(command === "marimo.api")) {

--- a/extension/src/utils/createConfigToggle.ts
+++ b/extension/src/utils/createConfigToggle.ts
@@ -1,0 +1,95 @@
+import { Effect, Option } from "effect";
+import { MarimoNotebookDocument } from "../schemas.ts";
+import { MarimoConfigurationService } from "../services/config/MarimoConfigurationService.ts";
+import { VsCode } from "../services/VsCode.ts";
+import type { MarimoConfig } from "../types.ts";
+import { showErrorAndPromptLogs } from "../utils/showErrorAndPromptLogs.ts";
+
+/**
+ * Generic configuration toggle function for marimo config options.
+ * Creates a handler that shows a quick pick dialog with all available options.
+ */
+export const createConfigToggle = <T extends string>({
+  configPath,
+  getCurrentValue,
+  choices,
+  getDisplayName,
+}: {
+  configPath: string;
+  getCurrentValue: (config: MarimoConfig) => T;
+  choices: ReadonlyArray<{
+    label: string;
+    detail: string;
+    value: T;
+  }>;
+  getDisplayName: (value: T) => string;
+}) =>
+  Effect.gen(function* () {
+    const code = yield* VsCode;
+    const configService = yield* MarimoConfigurationService;
+
+    // Validate active notebook
+    const notebook = Option.filterMap(
+      yield* code.window.getActiveNotebookEditor(),
+      (editor) => MarimoNotebookDocument.tryFrom(editor.notebook),
+    );
+
+    if (Option.isNone(notebook)) {
+      yield* showErrorAndPromptLogs(
+        `Must have an open marimo notebook to toggle ${configPath}.`,
+      );
+      return;
+    }
+
+    // Fetch current configuration
+    const config = yield* configService.getConfig(notebook.value.id);
+    const currentValue = getCurrentValue(config);
+
+    // Show quick pick with all choices, marking current
+    const choice = yield* code.window.showQuickPickItems(
+      choices.map((c) => ({
+        label: c.label,
+        description: c.value === currentValue ? "$(check) Current" : undefined,
+        detail: c.detail,
+        value: c.value,
+      })),
+    );
+
+    if (Option.isNone(choice)) {
+      return; // User cancelled
+    }
+
+    const newValue = choice.value.value;
+
+    if (newValue === currentValue) {
+      yield* Effect.logInfo("Value unchanged");
+      return;
+    }
+
+    // Update configuration
+    yield* Effect.logInfo(`Updating ${configPath}`).pipe(
+      Effect.annotateLogs({
+        notebook: notebook.value.id,
+        from: currentValue,
+        to: newValue,
+      }),
+    );
+
+    // Build nested config object from path (e.g., "runtime.on_cell_change" -> { runtime: { on_cell_change: value }})
+    const pathParts = configPath.split(".");
+    const partialConfig = pathParts.reduceRight(
+      (acc, part) => ({ [part]: acc }),
+      newValue as unknown as Record<string, unknown>,
+    );
+
+    yield* configService.updateConfig(notebook.value.id, partialConfig);
+
+    yield* code.window.showInformationMessage(
+      `${configPath} updated to: ${getDisplayName(newValue)}`,
+    );
+  }).pipe(
+    Effect.tapErrorCause(Effect.logError),
+    Effect.catchAllCause(() =>
+      showErrorAndPromptLogs(`Failed to toggle ${configPath}.`),
+    ),
+  );

--- a/extension/src/utils/showErrorAndPromptLogs.ts
+++ b/extension/src/utils/showErrorAndPromptLogs.ts
@@ -1,20 +1,22 @@
 import { Effect, Option } from "effect";
-import type { VsCode } from "../services/VsCode.ts";
+import { OutputChannel } from "../services/OutputChannel.ts";
+import { VsCode } from "../services/VsCode.ts";
 
-export const showErrorAndPromptLogs = Effect.fnUntraced(function* (
+export const showErrorAndPromptLogs = Effect.fn(function* (
   msg: string,
-  deps: {
-    code: VsCode;
-    channel: { name: string; show(): void };
-  },
+  options: { channel?: { name: string; show(): void } } = {},
 ) {
-  const selection = yield* deps.code.window.showErrorMessage(
-    `${msg}\n\nSee ${deps.channel.name} logs for details.`,
+  const code = yield* VsCode;
+  const defaultChannel = yield* OutputChannel;
+  const channel = options.channel ?? defaultChannel;
+
+  const selection = yield* code.window.showErrorMessage(
+    `${msg}\n\nSee ${channel.name} logs for details.`,
     { items: ["Open Logs"] },
   );
 
   if (Option.isSome(selection)) {
-    deps.channel.show();
+    channel.show();
     return;
   }
 });

--- a/extension/src/views/PackagesView.ts
+++ b/extension/src/views/PackagesView.ts
@@ -161,7 +161,7 @@ export const PackagesViewLive = Layer.scopedDiscard(
     // Register command to refresh packages
     yield* code.commands.registerCommand(
       "marimo.refreshPackages",
-      Effect.gen(function* () {
+      Effect.fn(function* () {
         const activeNotebookUri = yield* editorRegistry.getActiveNotebookUri();
         if (Option.isNone(activeNotebookUri)) {
           yield* Log.warn("No active notebook to refresh packages");

--- a/extension/src/views/RecentNotebooks.ts
+++ b/extension/src/views/RecentNotebooks.ts
@@ -159,7 +159,7 @@ export const RecentNotebooksLive = Layer.scopedDiscard(
     // Register command to clear recent notebooks
     yield* code.commands.registerCommand(
       "marimo.clearRecentNotebooks",
-      Effect.gen(function* () {
+      Effect.fn(function* () {
         yield* Ref.set(recentNotebooks, []);
         yield* storage.workspace
           .set(RECENT_NOTEBOOKS_KEY, [])


### PR DESCRIPTION
Refactor commands to use Effect.fn and contextual dependencies

The `code.window.registerCommand` helper wasn't capturing the `OutputChannel` dependency, so logging in command handlers used the default logger instead of our custom one supplied by the runtime.

Commands now use `Effect.fn` and yield dependencies from context instead of receiving them as closure parameters. Inline commands are extracted to `src/commands/`. The `registerCommand` signature changes to accept `() => Effect` so commands can construct their runtime at invocation.
