### PR TITLE
Pretty-print Effect Cause values

### DIFF
--- a/extension/src/views/MarimoStatusBar.ts
+++ b/extension/src/views/MarimoStatusBar.ts
@@ -135,7 +135,9 @@ export const MarimoStatusBarLive = Layer.scopedDiscard(
  */
 const openUrl = Effect.fn(function* (url: `https://${string}`) {
   const code = yield* VsCode;
-  return code.env.openExternal(Either.getOrThrow(code.utils.parseUri(url)));
+  return yield* code.env.openExternal(
+    Either.getOrThrow(code.utils.parseUri(url)),
+  );
 });
 
 const TUTORIALS = [


### PR DESCRIPTION
When a language server install fails, the error's Effect Cause object gets passed as a log annotation and serialized via `Inspectable.toJSON`. This produces a deeply nested object that Sentry's depth normalization truncates, rendering fields like `attempts` and `server` as opaque `[Array]` and `[Object]` in the dashboard.