### PR TITLE
Route all error context through structured log annotations

### DIFF
--- a/extension/src/commands/newMarimoNotebook.ts
+++ b/extension/src/commands/newMarimoNotebook.ts
@@ -1,4 +1,4 @@
-import { Effect, flow, Option } from "effect";
+import { Cause, Effect, flow, Option } from "effect";
 import { Telemetry } from "../services/Telemetry.ts";
 import { VsCode } from "../services/VsCode.ts";
 import { showErrorAndPromptLogs } from "../utils/showErrorAndPromptLogs.ts";
@@ -43,7 +43,9 @@ def _():
     Effect.catchTag(
       "FileSystemError",
       Effect.fnUntraced(function* (error) {
-        yield* Effect.logError("Failed to create notebook", { error });
+        yield* Effect.logError("Failed to create notebook").pipe(
+          Effect.annotateLogs({ cause: Cause.fail(error) }),
+        );
         yield* showErrorAndPromptLogs("Failed to create notebook.");
       }),
     ),

--- a/extension/src/services/ControllerRegistry.ts
+++ b/extension/src/services/ControllerRegistry.ts
@@ -1,6 +1,7 @@
 import * as NodePath from "node:path";
 import type * as py from "@vscode/python-extension";
 import {
+  Cause,
   Effect,
   Exit,
   HashMap,
@@ -55,7 +56,9 @@ export class ControllerRegistry extends Effect.Service<ControllerRegistry>()(
       const uvCacheDir = yield* uv.getCacheDir().pipe(
         Effect.map((path) => code.Uri.file(path)),
         Effect.tapError((err) =>
-          Effect.logError("Failed to get uv cache directory", err),
+          Effect.logError("Failed to get uv cache directory").pipe(
+            Effect.annotateLogs({ cause: Cause.fail(err) }),
+          ),
         ),
         Effect.option,
       );

--- a/extension/src/services/ExecutionRegistry.ts
+++ b/extension/src/services/ExecutionRegistry.ts
@@ -257,7 +257,9 @@ class RunningExecutionHandle extends Data.TaggedClass(
     return Effect.tryPromise(() => this.inner.replaceOutput(outputs)).pipe(
       Effect.annotateLogs({ cellId }),
       Effect.catchAllCause((cause) =>
-        Effect.logError("Failed to update cell output", cause),
+        Effect.logError("Failed to update cell output").pipe(
+          Effect.annotateLogs({ cause }),
+        ),
       ),
     );
   }
@@ -411,7 +413,9 @@ class CellEntry extends Data.TaggedClass("CellEntry")<{
       })
       .pipe(
         Effect.catchAllCause((cause) =>
-          Effect.logError("Failed to update cell output", cause),
+          Effect.logError("Failed to update cell output").pipe(
+            Effect.annotateLogs({ cause }),
+          ),
         ),
         Effect.annotateLogs({ cellId }),
       );

--- a/extension/src/services/KernelManager.ts
+++ b/extension/src/services/KernelManager.ts
@@ -98,8 +98,7 @@ export class KernelManager extends Effect.Service<KernelManager>()(
                 Effect.fnUntraced(function* (cause) {
                   yield* Effect.logError(
                     "Failed to process marimo operation",
-                    cause,
-                  );
+                  ).pipe(Effect.annotateLogs({ cause }));
                   yield* Effect.fork(
                     showErrorAndPromptLogs(
                       "Failed to process marimo operation.",

--- a/extension/src/services/LanguageClient.ts
+++ b/extension/src/services/LanguageClient.ts
@@ -1,6 +1,6 @@
 import * as NodeFs from "node:fs";
 import * as NodePath from "node:path";
-import { Data, Effect, Option, Stream } from "effect";
+import { Cause, Data, Effect, Option, Stream } from "effect";
 import * as lsp from "vscode-languageclient/node";
 import { NOTEBOOK_TYPE } from "../constants.ts";
 import type {
@@ -108,7 +108,9 @@ export class LanguageClient extends Effect.Service<LanguageClient>()(
                   "LanguageClientStartError",
                   Effect.fnUntraced(function* (error) {
                     const msg = "Failed to restart marimo-lsp.";
-                    yield* Effect.logError(msg, error);
+                    yield* Effect.logError(msg).pipe(
+                      Effect.annotateLogs({ cause: Cause.fail(error) }),
+                    );
                     yield* showErrorAndPromptLogs(msg, {
                       channel: outputChannel,
                     });

--- a/extension/src/services/NotebookSerializer.ts
+++ b/extension/src/services/NotebookSerializer.ts
@@ -164,7 +164,9 @@ export class NotebookSerializer extends Effect.Service<NotebookSerializer>()(
                   return yield* Fiber.join(fiber);
                 }).pipe(
                   Effect.tapErrorCause((cause) =>
-                    Effect.logError(`Notebook serialize failed.`, cause),
+                    Effect.logError(`Notebook serialize failed`).pipe(
+                      Effect.annotateLogs({ cause }),
+                    ),
                   ),
                   Effect.mapError(
                     () =>
@@ -185,7 +187,9 @@ export class NotebookSerializer extends Effect.Service<NotebookSerializer>()(
                   return yield* Fiber.join(fiber);
                 }).pipe(
                   Effect.tapErrorCause((cause) =>
-                    Effect.logError(`Notebook deserialize failed.`, cause),
+                    Effect.logError(`Notebook deserialize failed`).pipe(
+                      Effect.annotateLogs({ cause }),
+                    ),
                   ),
                   Effect.mapError(
                     () =>

--- a/extension/src/services/SandboxController.ts
+++ b/extension/src/services/SandboxController.ts
@@ -168,7 +168,9 @@ export class SandboxController extends Effect.Service<SandboxController>()(
             }),
             Effect.catchAllCause(
               Effect.fnUntraced(function* (cause) {
-                yield* Effect.logError("Failed to interrupt execution", cause);
+                yield* Effect.logError("Failed to interrupt execution").pipe(
+                  Effect.annotateLogs({ cause }),
+                );
                 yield* showErrorAndPromptLogs("Failed to interrupt execution.");
               }),
             ),

--- a/extension/src/utils/createManagedLanguageClient.ts
+++ b/extension/src/utils/createManagedLanguageClient.ts
@@ -1,6 +1,6 @@
 import * as NodePath from "node:path";
 import * as NodeProcess from "node:process";
-import { Data, Effect, flow, Option, pipe } from "effect";
+import { Cause, Data, Effect, flow, Option, pipe } from "effect";
 import * as lsp from "vscode-languageclient/node";
 import type { ClientNotebookSync } from "../services/completions/NotebookSyncService.ts";
 import { ExtensionContext } from "../services/Storage.ts";
@@ -168,7 +168,7 @@ export const createManagedLanguageClient = Effect.fn(function* (
       Effect.timeout("30 seconds"),
       Effect.catchTag("TimeoutException", "UnknownException", (error) =>
         Effect.logWarning("Language client dispose failed").pipe(
-          Effect.annotateLogs({ error, server }),
+          Effect.annotateLogs({ cause: Cause.fail(error), server }),
         ),
       ),
     ),

--- a/extension/src/utils/installPackages.ts
+++ b/extension/src/utils/installPackages.ts
@@ -76,7 +76,9 @@ export function installPackages(
         }).pipe(
           Effect.catchAllCause(
             Effect.fnUntraced(function* (cause) {
-              yield* Effect.logError("Failed to install", cause);
+              yield* Effect.logError("Failed to install").pipe(
+                Effect.annotateLogs({ cause }),
+              );
               yield* code.window.showErrorMessage(
                 `Failed to install ${packages.join(", ")}. See marimo logs for details.`,
               );

--- a/extension/src/views/MarimoStatusBar.ts
+++ b/extension/src/views/MarimoStatusBar.ts
@@ -1,6 +1,6 @@
 import * as NodeOs from "node:os";
 import * as NodePath from "node:path";
-import { Effect, Either, Layer, Option } from "effect";
+import { Cause, Effect, Either, Layer, Option } from "effect";
 import { unreachable } from "../assert.ts";
 import { NotebookSerializer } from "../services/NotebookSerializer.ts";
 import { ExtensionContext } from "../services/Storage.ts";
@@ -66,7 +66,9 @@ export const MarimoStatusBarLive = Layer.scopedDiscard(
             yield* tutorialCommands().pipe(
               Effect.catchAll(
                 Effect.fnUntraced(function* (error) {
-                  yield* Effect.logError("Failed to open tutorial", error);
+                  yield* Effect.logError("Failed to open tutorial").pipe(
+                    Effect.annotateLogs({ cause: Cause.fail(error) }),
+                  );
                   yield* code.window.showErrorMessage(
                     "Failed to open tutorial. See marimo logs for more info.",
                   );
@@ -106,7 +108,9 @@ export const MarimoStatusBarLive = Layer.scopedDiscard(
       tutorialCommands().pipe(
         Effect.catchAll((error) =>
           Effect.gen(function* () {
-            yield* Effect.logError("Failed to open tutorial", error);
+            yield* Effect.logError("Failed to open tutorial").pipe(
+              Effect.annotateLogs({ cause: Cause.fail(error) }),
+            );
             yield* code.window.showErrorMessage(
               "Failed to open tutorial. See marimo logs for more info.",
             );
@@ -135,7 +139,9 @@ export const MarimoStatusBarLive = Layer.scopedDiscard(
  */
 const openUrl = Effect.fn(function* (url: `https://${string}`) {
   const code = yield* VsCode;
-  return code.env.openExternal(Either.getOrThrow(code.utils.parseUri(url)));
+  return yield* code.env.openExternal(
+    Either.getOrThrow(code.utils.parseUri(url)),
+  );
 });
 
 const TUTORIALS = [

--- a/extension/src/views/RecentNotebooks.ts
+++ b/extension/src/views/RecentNotebooks.ts
@@ -127,7 +127,9 @@ export const RecentNotebooksLive = Layer.scopedDiscard(
         .set(RECENT_NOTEBOOKS_KEY, updated)
         .pipe(
           Effect.catchAllCause((cause) =>
-            Effect.logWarning("Failed to persist recent notebooks", cause),
+            Effect.logWarning("Failed to persist recent notebooks").pipe(
+              Effect.annotateLogs({ cause }),
+            ),
           ),
         );
 
@@ -165,7 +167,9 @@ export const RecentNotebooksLive = Layer.scopedDiscard(
           .set(RECENT_NOTEBOOKS_KEY, [])
           .pipe(
             Effect.catchAllCause((cause) =>
-              Effect.logWarning("Failed to clear recent notebooks", cause),
+              Effect.logWarning("Failed to clear recent notebooks").pipe(
+                Effect.annotateLogs({ cause }),
+              ),
             ),
           );
         yield* provider.refresh();


### PR DESCRIPTION
All error logging now uses `Effect.annotateLogs({ cause })` so values flow through structuredMessage, where `Cause.isCause` pretty-prints the full error chain including nested Error.cause. Raw errors from catchAll and catchTag handlers are wrapped with `Cause.fail()` for uniform serialization through the same path.