### PR TITLE
Skip oxlint in pre-commit CI 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 fail_fast: false
 
 ci:
-  skip: [oxfmt]
+  skip: [oxfmt, oxlint]
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
oxlint v1.46.0 panics in pre-commit CI due to a thread pool allocation failure in oxc_allocator's fixed-size pool. This is a bug in oxlint itself that surfaces in resource-constrained CI environments. Limiting to a single thread works around the issue.