### PR TITLE
Add `acquireDisposable` helper

### DIFF
--- a/extension/src/__mocks__/TestLanguageClient.ts
+++ b/extension/src/__mocks__/TestLanguageClient.ts
@@ -7,6 +7,7 @@ import {
   findLspExecutable,
   LanguageClient,
 } from "../services/LanguageClient.ts";
+import { acquireDisposable } from "../utils/acquireDisposable.ts";
 
 export const TestLanguageClientLive = Layer.scoped(
   LanguageClient,
@@ -55,11 +56,8 @@ export const TestLanguageClientLive = Layer.scoped(
       },
       streamOf(notification) {
         return Stream.asyncPush((emit) =>
-          Effect.acquireRelease(
-            Effect.sync(() =>
-              conn.onNotification(notification, (msg) => emit.single(msg)),
-            ),
-            (disposable) => Effect.sync(() => disposable.dispose()),
+          acquireDisposable(() =>
+            conn.onNotification(notification, (msg) => emit.single(msg)),
           ),
         );
       },

--- a/extension/src/__mocks__/TestVsCode.ts
+++ b/extension/src/__mocks__/TestVsCode.ts
@@ -32,6 +32,7 @@ import {
   Window,
   Workspace,
 } from "../services/VsCode.ts";
+import { acquireDisposable } from "../utils/acquireDisposable.ts";
 
 class NotebookCellData implements vscode.NotebookCellData {
   kind: vscode.NotebookCellKind;
@@ -1410,31 +1411,28 @@ export class TestVsCode extends Data.TaggedClass("TestVsCode")<{
             });
           },
           createLogOutputChannel(name) {
-            return Effect.acquireRelease(
-              Effect.sync(() => {
-                const emitter = new EventEmitter<vscode.LogLevel>();
-                return {
-                  name,
-                  logLevel: 0,
-                  onDidChangeLogLevel: emitter.event,
-                  dispose() {
-                    emitter.dispose();
-                  },
-                  append() {},
-                  appendLine() {},
-                  replace() {},
-                  clear() {},
-                  show() {},
-                  hide() {},
-                  trace() {},
-                  debug() {},
-                  info() {},
-                  warn() {},
-                  error() {},
-                };
-              }),
-              (disposable) => Effect.sync(() => disposable.dispose()),
-            );
+            return acquireDisposable(() => {
+              const emitter = new EventEmitter<vscode.LogLevel>();
+              return {
+                name,
+                logLevel: 0,
+                onDidChangeLogLevel: emitter.event,
+                dispose() {
+                  emitter.dispose();
+                },
+                append() {},
+                appendLine() {},
+                replace() {},
+                clear() {},
+                show() {},
+                hide() {},
+                trace() {},
+                debug() {},
+                info() {},
+                warn() {},
+                error() {},
+              };
+            });
           },
           getVisibleNotebookEditors() {
             return SubscriptionRef.get(visibleNotebookEditors);
@@ -1509,24 +1507,21 @@ export class TestVsCode extends Data.TaggedClass("TestVsCode")<{
             alignment: vscode.StatusBarAlignment,
             priority?: number,
           ) {
-            return Effect.acquireRelease(
-              Effect.sync(() => ({
-                id,
-                alignment,
-                priority,
-                text: "",
-                name: undefined,
-                tooltip: undefined,
-                color: undefined,
-                backgroundColor: undefined,
-                command: undefined,
-                accessibilityInformation: undefined,
-                show() {},
-                hide() {},
-                dispose() {},
-              })),
-              (disposable) => Effect.sync(() => disposable.dispose()),
-            );
+            return acquireDisposable(() => ({
+              id,
+              alignment,
+              priority,
+              text: "",
+              name: undefined,
+              tooltip: undefined,
+              color: undefined,
+              backgroundColor: undefined,
+              command: undefined,
+              accessibilityInformation: undefined,
+              show() {},
+              hide() {},
+              dispose() {},
+            }));
           },
           showNotebookDocument(
             doc: vscode.NotebookDocument,
@@ -1681,16 +1676,10 @@ export class TestVsCode extends Data.TaggedClass("TestVsCode")<{
         }),
         debug: Debug.make({
           registerDebugConfigurationProvider() {
-            return Effect.acquireRelease(
-              Effect.succeed({ dispose() {} }),
-              (disposable) => Effect.sync(() => disposable.dispose()),
-            );
+            return acquireDisposable(() => ({ dispose() {} }));
           },
           registerDebugAdapterDescriptorFactory() {
-            return Effect.acquireRelease(
-              Effect.succeed({ dispose() {} }),
-              (disposable) => Effect.sync(() => disposable.dispose()),
-            );
+            return acquireDisposable(() => ({ dispose() {} }));
           },
         }),
         notebooks: Notebooks.make({

--- a/extension/src/services/LanguageClient.ts
+++ b/extension/src/services/LanguageClient.ts
@@ -10,6 +10,7 @@ import type {
 } from "../types.ts";
 
 import { NOTEBOOK_TYPE } from "../constants.ts";
+import { acquireDisposable } from "../utils/acquireDisposable.ts";
 import { showErrorAndPromptLogs } from "../utils/showErrorAndPromptLogs.ts";
 import { tokenFromSignal } from "../utils/tokenFromSignal.ts";
 import { Config } from "./Config.ts";
@@ -151,13 +152,10 @@ export class LanguageClient extends Effect.Service<LanguageClient>()(
         ) {
           return Stream.asyncPush<MarimoLspNotificationOf<Notification>>(
             (emit) =>
-              Effect.acquireRelease(
-                Effect.sync(() =>
-                  client.onNotification(notification, (msg) => {
-                    emit.single(msg);
-                  }),
-                ),
-                (disposable) => Effect.sync(() => disposable.dispose()),
+              acquireDisposable(() =>
+                client.onNotification(notification, (msg) => {
+                  emit.single(msg);
+                }),
               ),
           );
         },

--- a/extension/src/services/NotebookControllerFactory.ts
+++ b/extension/src/services/NotebookControllerFactory.ts
@@ -7,6 +7,7 @@ import { Brand, Cause, Effect, Option, Runtime, Stream } from "effect";
 import { unreachable } from "../assert.ts";
 import { type MarimoNotebookCell, MarimoNotebookDocument } from "../schemas.ts";
 import { Constants } from "../services/Constants.ts";
+import { acquireDisposable } from "../utils/acquireDisposable.ts";
 import { extractExecuteCodeRequest } from "../utils/extractExecuteCodeRequest.ts";
 import { findVenvPath } from "../utils/findVenvPath.ts";
 import { formatControllerLabel } from "../utils/formatControllerLabel.ts";
@@ -270,11 +271,8 @@ export class PythonController {
       notebook: vscode.NotebookDocument;
       selected: boolean;
     }>((emit) =>
-      Effect.acquireRelease(
-        Effect.sync(() =>
-          this.#inner.onDidChangeSelectedNotebooks((e) => emit.single(e)),
-        ),
-        (disposable) => Effect.sync(() => disposable.dispose()),
+      acquireDisposable(() =>
+        this.#inner.onDidChangeSelectedNotebooks((e) => emit.single(e)),
       ),
     );
   }

--- a/extension/src/services/NotebookRenderer.ts
+++ b/extension/src/services/NotebookRenderer.ts
@@ -4,6 +4,7 @@ import { Effect, Stream } from "effect";
 
 import type { RendererCommand, RendererReceiveMessage } from "../types.ts";
 
+import { acquireDisposable } from "../utils/acquireDisposable.ts";
 import { VsCode } from "./VsCode.ts";
 
 /**
@@ -30,11 +31,8 @@ export class NotebookRenderer extends Effect.Service<NotebookRenderer>()(
           message: RendererCommand;
         }> {
           return Stream.asyncPush((emit) =>
-            Effect.acquireRelease(
-              Effect.sync(() =>
-                channel.onDidReceiveMessage((msg) => emit.single(msg)),
-              ),
-              (disposable) => Effect.sync(() => disposable.dispose()),
+            acquireDisposable(() =>
+              channel.onDidReceiveMessage((msg) => emit.single(msg)),
             ),
           );
         },

--- a/extension/src/services/PythonExtension.ts
+++ b/extension/src/services/PythonExtension.ts
@@ -1,6 +1,8 @@
 import * as py from "@vscode/python-extension";
 import { Effect, Option, Stream } from "effect";
 
+import { acquireDisposable } from "../utils/acquireDisposable.ts";
+
 /**
  * Provides access to the VS Code Python extension API for
  * querying and managing Python environments.
@@ -22,25 +24,19 @@ export class PythonExtension extends Effect.Service<PythonExtension>()(
         },
         environmentChanges() {
           return Stream.asyncPush<py.EnvironmentsChangeEvent>((emit) =>
-            Effect.acquireRelease(
-              Effect.sync(() =>
-                api.environments.onDidChangeEnvironments((evt) =>
-                  emit.single(evt),
-                ),
+            acquireDisposable(() =>
+              api.environments.onDidChangeEnvironments((evt) =>
+                emit.single(evt),
               ),
-              (disposable) => Effect.sync(() => disposable.dispose()),
             ),
           );
         },
         activeEnvironmentPathChanges() {
           return Stream.asyncPush<py.ActiveEnvironmentPathChangeEvent>((emit) =>
-            Effect.acquireRelease(
-              Effect.sync(() =>
-                api.environments.onDidChangeActiveEnvironmentPath((evt) =>
-                  emit.single(evt),
-                ),
+            acquireDisposable(() =>
+              api.environments.onDidChangeActiveEnvironmentPath((evt) =>
+                emit.single(evt),
               ),
-              (disposable) => Effect.sync(() => disposable.dispose()),
             ),
           );
         },

--- a/extension/src/services/SandboxController.ts
+++ b/extension/src/services/SandboxController.ts
@@ -9,6 +9,7 @@ import {
   MarimoNotebookDocument,
   SemVerFromString,
 } from "../schemas.ts";
+import { acquireDisposable } from "../utils/acquireDisposable.ts";
 import { extractExecuteCodeRequest } from "../utils/extractExecuteCodeRequest.ts";
 import { getVenvPythonPath } from "../utils/getVenvPythonPath.ts";
 import { uvAddScriptSafe } from "../utils/installPackages.ts";
@@ -189,11 +190,8 @@ export class SandboxController extends Effect.Service<SandboxController>()(
             notebook: vscode.NotebookDocument;
             selected: boolean;
           }>((emit) =>
-            Effect.acquireRelease(
-              Effect.sync(() =>
-                controller.onDidChangeSelectedNotebooks((e) => emit.single(e)),
-              ),
-              (disposable) => Effect.sync(() => disposable.dispose()),
+            acquireDisposable(() =>
+              controller.onDidChangeSelectedNotebooks((e) => emit.single(e)),
             ),
           );
         },

--- a/extension/src/utils/acquireDisposable.ts
+++ b/extension/src/utils/acquireDisposable.ts
@@ -1,0 +1,11 @@
+import { Effect } from "effect";
+
+export const acquireDisposable = <
+  T extends { dispose: () => Thenable<void> | void },
+>(
+  fn: () => Thenable<T> | T,
+) =>
+  Effect.acquireRelease(
+    Effect.promise(async () => fn()),
+    (disposable) => Effect.promise(async () => disposable.dispose()),
+  );


### PR DESCRIPTION
Many VS Code APIs return a `Disposable`, which the caller is responsible for cleaning up imperatively `.dispose()`. We use
`Effect.acquireRelease` to clean up automatically tied to Effect scopes, and these changes extract that pattern in to a helper.