### PR TITLE
Derive `MINIMUM_MARIMO_VERSION` from pyproject.toml

### DIFF
--- a/extension/scripts/codegen.mjs
+++ b/extension/scripts/codegen.mjs
@@ -16,6 +16,22 @@ import * as NodeUrl from "node:url";
 
 import pkg from "../package.json" with { type: "json" };
 
+/** @returns {{ major: number; minor: number; patch: number }} */
+function getMinimumMarimoVersion() {
+  const pyproject = NodeFs.readFileSync(
+    NodeUrl.fileURLToPath(new URL("../../pyproject.toml", import.meta.url)),
+    "utf-8",
+  );
+  const match = pyproject.match(/marimo>=([\d.]+)/);
+  assert(match, "Could not find marimo lower bound in pyproject.toml");
+  const parts = match[1].split(".").map(Number);
+  assert(parts.length === 3, `Expected semver with 3 parts, got "${match[1]}"`);
+  const [major, minor, patch] = parts;
+  return { major, minor, patch };
+}
+
+const minimumMarimoVersion = getMinimumMarimoVersion();
+
 /** @type {(arr: Array<string>) => string} */
 const union = (arr) =>
   arr
@@ -82,6 +98,12 @@ export const LanguageId = {
   Sql: "sql",
   /** Language ID for Markdown cells in marimo notebooks. */
   Markdown: "markdown",
+} as const;
+
+export const MINIMUM_MARIMO_VERSION = {
+  major: ${minimumMarimoVersion.major},
+  minor: ${minimumMarimoVersion.minor},
+  patch: ${minimumMarimoVersion.patch},
 } as const;
 
 export type MarimoContextKey = ${union(contextKeys)};

--- a/extension/src/constants.ts
+++ b/extension/src/constants.ts
@@ -51,6 +51,12 @@ export const LanguageId = {
   Markdown: "markdown",
 } as const;
 
+export const MINIMUM_MARIMO_VERSION = {
+  major: 0,
+  minor: 19,
+  patch: 10,
+} as const;
+
 export type MarimoContextKey =
   | "marimo.config.runtime.auto_reload"
   | "marimo.config.runtime.on_cell_change"

--- a/extension/src/services/EnvironmentValidator.ts
+++ b/extension/src/services/EnvironmentValidator.ts
@@ -6,13 +6,8 @@ import { NodeContext } from "@effect/platform-node";
 import * as semver from "@std/semver";
 import { Data, Effect, type ParseResult, Schema } from "effect";
 
+import { MINIMUM_MARIMO_VERSION } from "../constants.ts";
 import { SemVerFromString } from "../schemas.ts";
-
-export const MINIMUM_MARIMO_VERSION = {
-  major: 0,
-  minor: 19,
-  patch: 10,
-} satisfies semver.SemVer;
 
 class InvalidExecutableError extends Data.TaggedError(
   "InvalidExecutableError",

--- a/extension/src/services/HealthService.ts
+++ b/extension/src/services/HealthService.ts
@@ -2,6 +2,7 @@ import * as semver from "@std/semver";
 import { Effect, Option } from "effect";
 import * as NodeProcess from "node:process";
 
+import { MINIMUM_MARIMO_VERSION } from "../constants.ts";
 import { getExtensionVersion } from "../utils/getExtensionVersion.ts";
 import {
   RuffLanguageServer,
@@ -12,7 +13,6 @@ import {
   TyLanguageServerStatus,
 } from "./completions/TyLanguageServer.ts";
 import { Config } from "./Config.ts";
-import { MINIMUM_MARIMO_VERSION } from "./EnvironmentValidator.ts";
 import { PythonExtension } from "./PythonExtension.ts";
 import { Uv, UvBin } from "./Uv.ts";
 import { VsCode } from "./VsCode.ts";

--- a/extension/src/services/SandboxController.ts
+++ b/extension/src/services/SandboxController.ts
@@ -3,6 +3,7 @@ import type * as vscode from "vscode";
 import * as semver from "@std/semver";
 import { Effect, Option, Runtime, Schema, Stream } from "effect";
 
+import { MINIMUM_MARIMO_VERSION } from "../constants.ts";
 import { SANDBOX_CONTROLLER_ID } from "../ids.ts";
 import {
   type MarimoNotebookCell,
@@ -15,7 +16,6 @@ import { getVenvPythonPath } from "../utils/getVenvPythonPath.ts";
 import { uvAddScriptSafe } from "../utils/installPackages.ts";
 import { showErrorAndPromptLogs } from "../utils/showErrorAndPromptLogs.ts";
 import { Constants } from "./Constants.ts";
-import { MINIMUM_MARIMO_VERSION } from "./EnvironmentValidator.ts";
 import { LanguageClient } from "./LanguageClient.ts";
 import { OutputChannel } from "./OutputChannel.ts";
 import { PythonExtension } from "./PythonExtension.ts";


### PR DESCRIPTION
The minimum marimo version was hardcoded in `EnvironmentValidator.ts` and had to be kept in sync with the `marimo>=` lower bound in `pyproject.toml`. This extends the existing codegen script to parse the lower bound from `pyproject.toml` and emit it as a generated constant in `constants.ts`, making `pyproject.toml` the single source of truth.