### PR TITLE
Remove unused language provider registrations from VsCode service

### DIFF
--- a/extension/src/__mocks__/TestVsCode.ts
+++ b/extension/src/__mocks__/TestVsCode.ts
@@ -1852,22 +1852,7 @@ export class TestVsCode extends Data.TaggedClass("TestVsCode")<{
           getExtension: () => Option.none(),
         },
         languages: {
-          registerHoverProvider() {
-            return Effect.void;
-          },
-          registerSignatureHelpProvider() {
-            return Effect.void;
-          },
-          registerDefinitionProvider() {
-            return Effect.void;
-          },
-          registerCompletionItemProvider() {
-            return Effect.void;
-          },
           registerCodeLensProvider() {
-            return Effect.void;
-          },
-          registerDocumentSemanticTokensProvider() {
             return Effect.void;
           },
         },

--- a/extension/src/services/VsCode.ts
+++ b/extension/src/services/VsCode.ts
@@ -515,86 +515,16 @@ export class VsCode extends Effect.Service<VsCode>()("VsCode", {
       notebooks: yield* Notebooks,
       auth: yield* Auth,
       languages: {
-        registerSignatureHelpProvider(
-          selector: vscode.DocumentSelector,
-          provider: vscode.SignatureHelpProvider,
-          ...triggerCharacters: readonly string[]
-        ) {
-          return Effect.acquireRelease(
-            Effect.sync(() =>
-              vscode.languages.registerSignatureHelpProvider(
-                selector,
-                provider,
-                ...triggerCharacters,
-              ),
-            ),
-            (disposable) => Effect.sync(() => disposable.dispose()),
-          ).pipe(Effect.andThen(Effect.void));
-        },
-        registerDefinitionProvider(
-          selector: vscode.DocumentSelector,
-          provider: vscode.DefinitionProvider,
-        ) {
-          return Effect.acquireRelease(
-            Effect.sync(() =>
-              vscode.languages.registerDefinitionProvider(selector, provider),
-            ),
-            (disposable) => Effect.sync(() => disposable.dispose()),
-          ).pipe(Effect.andThen(Effect.void));
-        },
-        registerHoverProvider(
-          selector: vscode.DocumentSelector,
-          provider: vscode.HoverProvider,
-        ) {
-          return Effect.acquireRelease(
-            Effect.sync(() =>
-              vscode.languages.registerHoverProvider(selector, provider),
-            ),
-            (disposable) => Effect.sync(() => disposable.dispose()),
-          ).pipe(Effect.andThen(Effect.void));
-        },
-        registerCompletionItemProvider(
-          selector: vscode.DocumentSelector,
-          provider: vscode.CompletionItemProvider,
-          ...triggerCharacters: readonly string[]
-        ) {
-          return Effect.acquireRelease(
-            Effect.sync(() =>
-              vscode.languages.registerCompletionItemProvider(
-                selector,
-                provider,
-                ...triggerCharacters,
-              ),
-            ),
-            (disposable) => Effect.sync(() => disposable.dispose()),
-          ).pipe(Effect.andThen(Effect.void));
-        },
         registerCodeLensProvider(
           selector: vscode.DocumentSelector,
           provider: vscode.CodeLensProvider,
         ) {
-          return Effect.acquireRelease(
-            Effect.sync(() =>
+          return Effect.andThen(
+            acquireDisposable(() =>
               vscode.languages.registerCodeLensProvider(selector, provider),
             ),
-            (disposable) => Effect.sync(() => disposable.dispose()),
-          ).pipe(Effect.andThen(Effect.void));
-        },
-        registerDocumentSemanticTokensProvider(
-          selector: vscode.DocumentSelector,
-          provider: vscode.DocumentSemanticTokensProvider,
-          legend: vscode.SemanticTokensLegend,
-        ) {
-          return Effect.acquireRelease(
-            Effect.sync(() =>
-              vscode.languages.registerDocumentSemanticTokensProvider(
-                selector,
-                provider,
-                legend,
-              ),
-            ),
-            (disposable) => Effect.sync(() => disposable.dispose()),
-          ).pipe(Effect.andThen(Effect.void));
+            Effect.void,
+          );
         },
       },
       Hover: vscode.Hover,


### PR DESCRIPTION
These registrations (hover, signature help, definition, completion, semantic tokens) were wired up in the VsCode service but are no longer used now that the language server handles them directly. Keeping dead registration methods adds surface area to the VsCode service interface and requires corresponding mock implementations in tests. Only `registerCodeLensProvider` remains as it is still actively used.