### PR TITLE
Fix ty language server restart storm on notebook open

### DIFF
--- a/extension/src/services/completions/TyLanguageServer.ts
+++ b/extension/src/services/completions/TyLanguageServer.ts
@@ -4,6 +4,7 @@ import { NodeContext } from "@effect/platform-node";
 import {
   type Cause,
   Data,
+  Duration,
   Effect,
   Exit,
   Option,
@@ -201,11 +202,17 @@ export class TyLanguageServer extends Effect.Service<TyLanguageServer>()(
                 );
               });
 
-              // Restart the language server when Python environment changes
+              // Restart the language server when Python environment changes.
               // ty needs restart to pick up environment changes since it doesn't
-              // support workspace/didChangeConfiguration for environment updates
+              // support workspace/didChangeConfiguration for environment updates.
+              //
+              // Debounce to avoid restart storms: the Python extension can fire
+              // multiple rapid environment-change events during workspace
+              // activation (e.g. when opening a notebook). We collapse them into
+              // a single restart after 2 seconds of quiet.
               yield* Effect.forkScoped(
                 pyExt.activeEnvironmentPathChanges().pipe(
+                  Stream.debounce(Duration.seconds(2)),
                   Stream.runForEach(
                     Effect.fnUntraced(function* (event) {
                       yield* client

--- a/extension/src/utils/createManagedLanguageClient.ts
+++ b/extension/src/utils/createManagedLanguageClient.ts
@@ -191,7 +191,11 @@ export const createManagedLanguageClient = Effect.fn(function* (
 
   const stop = () =>
     Effect.tryPromise({
-      try: () => client.stop(Infinity),
+      // Use a finite timeout (10s) so a hung server process doesn't block
+      // restarts indefinitely. The outer restart() has its own 30s timeout,
+      // but letting stop() wait forever (Infinity) can deadlock when the
+      // server is stuck mid-initialization and can't respond to shutdown.
+      try: () => client.stop(10_000),
       catch: (cause) => new LanguageClientError({ cause }),
     });
 


### PR DESCRIPTION
The Python extension fires `onDidChangeActiveEnvironmentPath` multiple times in rapid succession during workspace activation, e.g. when opening a notebook. Each event triggered a full ty server restart, but the server was often still initializing and couldn't respond to the LSP shutdown request. This caused `client.stop(Infinity)` to hang until the 30-second Effect timeout, at which point VS Code's LanguageClient would log "Stopping server timed out", kill the process, auto-restart it, and the cycle would repeat.

Two changes fix this. The environment-change stream is now debounced by 2 seconds so rapid-fire events during activation collapse into a single restart. And `client.stop()` now uses a 10-second timeout instead of `Infinity`, so a stuck shutdown fails fast rather than deadlocking until the outer timeout kills it. Ruff was never affected because it only restarts on `ruff.*` config changes, not environment events.