### PR TITLE
Add "Open in molab" badge and session metadata to gist publish

### DIFF
--- a/extension/src/commands/publishMarimoNotebookGist.ts
+++ b/extension/src/commands/publishMarimoNotebookGist.ts
@@ -1,9 +1,10 @@
 import * as NodePath from "node:path";
 
-import { Cause, Chunk, Effect, Either, flow, Option } from "effect";
+import { Cause, Chunk, Effect, Either, flow, Schema, Option } from "effect";
 
 import { MarimoNotebookDocument } from "../schemas.ts";
 import { GitHubClient } from "../services/GitHubClient.ts";
+import { LanguageClient } from "../services/LanguageClient.ts";
 import { NotebookSerializer } from "../services/NotebookSerializer.ts";
 import { VsCode } from "../services/VsCode.ts";
 import { showErrorAndPromptLogs } from "../utils/showErrorAndPromptLogs.ts";
@@ -14,6 +15,7 @@ export const publishMarimoNotebookGist = Effect.fn(
   function* () {
     const code = yield* VsCode;
     const gh = yield* GitHubClient;
+    const client = yield* LanguageClient;
     const serializer = yield* NotebookSerializer;
 
     const notebook = Option.filterMap(
@@ -52,19 +54,61 @@ export const publishMarimoNotebookGist = Effect.fn(
     });
 
     const filename = NodePath.basename(notebook.value.uri.path);
-    const gist = yield* gh.Gists.create({
-      payload: {
-        description: filename,
-        public: choice.value === "Public",
-        files: {
-          [filename]: {
-            content: new TextDecoder().decode(bytes),
+    const ipynbFilename = filename.replace(/\.py$/, ".ipynb");
+    const files: Record<string, { content: string }> = {
+      [filename]: {
+        content: new TextDecoder().decode(bytes),
+      },
+    };
+
+    // Try to export ipynb with outputs for GitHub rendering
+    const ipynbResult = yield* client
+      .executeCommand({
+        command: "marimo.api",
+        params: {
+          method: "export-as-ipynb",
+          params: {
+            notebookUri: notebook.value.id,
+            inner: {},
           },
         },
+      })
+      .pipe(Effect.andThen(Schema.decodeUnknown(Schema.String)), Effect.either);
+
+    if (Either.isRight(ipynbResult)) {
+      files[ipynbFilename] = { content: ipynbResult.right };
+    } else {
+      yield* Effect.logWarning(
+        "Could not export ipynb for gist — publishing .py only",
+      ).pipe(
+        Effect.annotateLogs({
+          cause: Cause.fail(ipynbResult.left),
+        }),
+      );
+    }
+
+    const gist = yield* gh.Gists.create({
+      payload: {
+        public: choice.value === "Public",
+        files,
       },
     });
 
-    yield* Effect.logInfo(gist);
+    yield* Effect.logInfo("Published gist").pipe(Effect.annotateLogs({ gist }));
+
+    // Update the gist with a molab badge in the ipynb
+    if (Either.isRight(ipynbResult)) {
+      const ipynb = JSON.parse(ipynbResult.right);
+      ipynb.cells.unshift(createMolabMarkdownBadgeCell(gist));
+      yield* gh.Gists.update({
+        path: { id: gist.id },
+        payload: {
+          files: {
+            [ipynbFilename]: { content: JSON.stringify(ipynb, null, 2) },
+          },
+        },
+      });
+    }
 
     const selection = yield* code.window.showInformationMessage(
       `Published Gist at ${gist.html_url}`,
@@ -96,3 +140,14 @@ export const publishMarimoNotebookGist = Effect.fn(
     ),
   ),
 );
+
+function createMolabMarkdownBadgeCell(gist: { html_url: string }) {
+  const molabHref = `https://molab.marimo.io/github/${gist.html_url.replace(/^https?:\/\//, "")}`;
+  return {
+    cell_type: "markdown",
+    metadata: {},
+    source: [
+      `[![Open in molab](https://molab.marimo.io/molab-shield.svg)](${molabHref})`,
+    ],
+  };
+}

--- a/extension/src/services/GitHubClient.ts
+++ b/extension/src/services/GitHubClient.ts
@@ -13,7 +13,6 @@ import { Effect, flow, Option, Schema } from "effect";
 import { VsCode } from "./VsCode.ts";
 
 const GistRequest = Schema.Struct({
-  description: Schema.String,
   public: Schema.Boolean,
   files: Schema.Record({
     key: Schema.String,
@@ -26,12 +25,26 @@ const GistResponse = Schema.Struct({
   html_url: Schema.String,
 });
 
+const GistUpdateRequest = Schema.Struct({
+  files: Schema.Record({
+    key: Schema.String,
+    value: Schema.Struct({ content: Schema.String }),
+  }),
+});
+
 const GitHubApi = HttpApi.make("GitHubApi").add(
-  HttpApiGroup.make("Gists").add(
-    HttpApiEndpoint.post("create", "/gists")
-      .setPayload(GistRequest)
-      .addSuccess(GistResponse, { status: 201 }),
-  ),
+  HttpApiGroup.make("Gists")
+    .add(
+      HttpApiEndpoint.post("create", "/gists")
+        .setPayload(GistRequest)
+        .addSuccess(GistResponse, { status: 201 }),
+    )
+    .add(
+      HttpApiEndpoint.patch("update", "/gists/:id")
+        .setPath(Schema.Struct({ id: Schema.String }))
+        .setPayload(GistUpdateRequest)
+        .addSuccess(GistResponse),
+    ),
 );
 
 export class GitHubClient extends Effect.Service<GitHubClient>()(

--- a/extension/src/types.ts
+++ b/extension/src/types.ts
@@ -57,6 +57,7 @@ type ListPackagesRequest = {};
 type DependencyTreeRequest = {};
 type GetConfigurationRequest = {};
 type CloseSessionRequest = {};
+type ExportAsIpynbRequest = {};
 
 interface ExecuteScratchRequest {
   code: string;
@@ -81,6 +82,7 @@ type MarimoApiMethodMap = {
   "close-session": NotebookScoped<CloseSessionRequest>;
   "execute-scratchpad": NotebookScoped<ExecuteScratchRequest>;
   "export-as-html": NotebookScoped<ExportAsHtmlRequest>;
+  "export-as-ipynb": NotebookScoped<ExportAsIpynbRequest>;
   interrupt: NotebookScoped<InterruptRequest>;
   // marimo-lsp API
   dap: NotebookScoped<DebugAdapterRequest>;

--- a/src/marimo_lsp/api.py
+++ b/src/marimo_lsp/api.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import dataclasses
+import json
 from typing import TYPE_CHECKING, cast
 
 import msgspec
@@ -17,6 +18,7 @@ from marimo._schemas.serialization import NotebookSerialization
 from marimo._server.export.exporter import Exporter
 from marimo._server.models.export import ExportAsHTMLRequest
 from marimo._server.models.models import InstantiateNotebookRequest
+from marimo._session.state.serialize import serialize_session_view
 from marimo._utils.parse_dataclass import parse_raw
 
 from marimo_lsp.debug_adapter import handle_debug_adapter_request
@@ -29,6 +31,7 @@ from marimo_lsp.models import (
     DeserializeRequest,
     ExecuteCellsRequest,
     ExecuteScratchRequest,
+    ExportAsIpynbRequest,
     GetConfigurationRequest,
     InterruptRequest,
     ListPackagesRequest,
@@ -310,6 +313,32 @@ async def export_as_html(
     return html
 
 
+async def export_as_ipynb(
+    manager: LspSessionManager,
+    args: NotebookCommand[ExportAsIpynbRequest],
+) -> str:
+    """Export the notebook as ipynb with current outputs."""
+    logger.info(f"export_as_ipynb for {args.notebook_uri}")
+    session = manager.get_session(args.notebook_uri)
+    assert session, f"No session in workspace for {args.notebook_uri}"
+
+    ipynb_str = Exporter().export_as_ipynb(
+        app=session.app_file_manager.app,
+        sort_mode="top-down",
+        session_view=session.session_view,
+    )
+
+    # inject 'session.json' under top-level notebook metadata
+    # -> metadata.marimo.session
+    ipynb = json.loads(ipynb_str)
+    session_data = serialize_session_view(
+        session.session_view,
+        cell_ids=session.app_file_manager.app.cell_manager.cell_ids(),
+    )
+    ipynb.setdefault("metadata", {}).setdefault("marimo", {})["session"] = session_data
+    return json.dumps(ipynb)
+
+
 async def handle_api_command(  # noqa: C901, PLR0911, PLR0912
     ls: LanguageServer, manager: LspSessionManager, method: str, params: dict
 ) -> object:
@@ -396,6 +425,12 @@ async def handle_api_command(  # noqa: C901, PLR0911, PLR0912
         return await export_as_html(
             manager,
             msgspec.convert(params, type=NotebookCommand[ExportAsHTMLRequest]),
+        )
+
+    if method == "export-as-ipynb":
+        return await export_as_ipynb(
+            manager,
+            msgspec.convert(params, type=NotebookCommand[ExportAsIpynbRequest]),
         )
 
     if method == "execute-scratchpad":

--- a/src/marimo_lsp/models.py
+++ b/src/marimo_lsp/models.py
@@ -91,6 +91,10 @@ class CloseSessionRequest(msgspec.Struct, rename="camel"):
     """A request to close the current session."""
 
 
+class ExportAsIpynbRequest(msgspec.Struct, rename="camel"):
+    """A request to export the notebook as ipynb."""
+
+
 class ExecuteScratchRequest(msgspec.Struct, rename="camel"):
     """Execute arbitrary Python code outside the dependency graph."""
 

--- a/src/marimo_lsp/session.py
+++ b/src/marimo_lsp/session.py
@@ -76,6 +76,7 @@ class LspSession:
             while not self._closed:
                 try:
                     msg = stream_queue.get(timeout=0.1)
+                    self.session_view.add_raw_notification(msg)
                     self._consumer.notify(msg)
                 except queue.Empty:  # noqa: PERF203
                     continue


### PR DESCRIPTION
Publishing a marimo notebook as a GitHub Gist now creates two commits: the first with the `.py` and `.ipynb` files, and the second updating the `.ipynb` with a markdown badge cell linking to molab. This mirrors the pattern Google Colab uses for its "Open in Colab" badges. The local `.ipynb` file is also updated with the badge.

The ipynb export also now embeds the serialized session view under `metadata.marimo.session` for potential consumption from molab.