### PR TITLE
Set `RevealOutputChannelOn.Never` for managed language clients

### DIFF
--- a/extension/src/services/completions/RuffLanguageServer.ts
+++ b/extension/src/services/completions/RuffLanguageServer.ts
@@ -9,7 +9,7 @@ import {
   Stream,
 } from "effect";
 import type * as vscode from "vscode";
-import type * as lsp from "vscode-languageclient/node";
+import * as lsp from "vscode-languageclient/node";
 
 import {
   createManagedLanguageClient,
@@ -120,6 +120,7 @@ export class RuffLanguageServer extends Effect.Service<RuffLanguageServer>()(
               notebookSync,
               clientOptions: {
                 outputChannelName: "marimo (ruff)",
+                revealOutputChannelOn: lsp.RevealOutputChannelOn.Never,
                 middleware: yield* createRuffMiddleware(notebookSync),
                 documentSelector: sync.getDocumentSelector(),
                 transformServerCapabilities: sync.extendNotebookCellLanguages(),

--- a/extension/src/services/completions/TyLanguageServer.ts
+++ b/extension/src/services/completions/TyLanguageServer.ts
@@ -10,7 +10,7 @@ import {
   Runtime,
   Stream,
 } from "effect";
-import type * as lsp from "vscode-languageclient/node";
+import * as lsp from "vscode-languageclient/node";
 import { ResponseError } from "vscode-languageclient/node";
 
 import {
@@ -118,6 +118,7 @@ export class TyLanguageServer extends Effect.Service<TyLanguageServer>()(
               notebookSync,
               clientOptions: {
                 outputChannelName: "marimo (ty)",
+                revealOutputChannelOn: lsp.RevealOutputChannelOn.Never,
                 middleware: yield* createTyMiddleware(notebookSync),
                 documentSelector: sync.getDocumentSelector(),
                 transformServerCapabilities: sync.extendNotebookCellLanguages(),


### PR DESCRIPTION
The language clients erroring popped open the logs previously.