### PR TITLE
Prompt reload when `disableManagedLanguageFeatures` changes

### DIFF
--- a/extension/src/layers/Main.ts
+++ b/extension/src/layers/Main.ts
@@ -54,6 +54,7 @@ import { CellStatusBarProviderLive } from "./CellStatusBarProvider.ts";
 import { MarimoCodeLensProviderLive } from "./MarimoCodeLensProvider.ts";
 import { MarimoFileDetectorLive } from "./MarimoFileDetector.ts";
 import { RegisterCommandsLive } from "./RegisterCommands.ts";
+import { ReloadOnConfigChangeLive } from "./ReloadOnConfigChange.ts";
 
 /**
  * Main application layer that wires together all services and layers
@@ -72,6 +73,7 @@ const MainLive = Layer.empty
     Layer.merge(PackagesViewLive),
     Layer.merge(CellStatusBarProviderLive),
     Layer.merge(CellMetadataBindingsLive),
+    Layer.merge(ReloadOnConfigChangeLive),
   )
   .pipe(
     Layer.provideMerge(Api.Default),

--- a/extension/src/layers/ReloadOnConfigChange.ts
+++ b/extension/src/layers/ReloadOnConfigChange.ts
@@ -1,0 +1,36 @@
+import { Effect, Layer, Option, Stream } from "effect";
+
+import { VsCode } from "../services/VsCode.ts";
+
+/**
+ * Watches for changes to `marimo.disableManagedLanguageFeatures` and prompts
+ * the user to reload the window, since this setting is read at startup and
+ * baked into service initialization.
+ */
+export const ReloadOnConfigChangeLive = Layer.scopedDiscard(
+  Effect.gen(function* () {
+    const code = yield* VsCode;
+
+    yield* Effect.forkScoped(
+      code.workspace.configurationChanges().pipe(
+        Stream.filter((event) =>
+          event.affectsConfiguration("marimo.disableManagedLanguageFeatures"),
+        ),
+        Stream.runForEach(() =>
+          Effect.gen(function* () {
+            const reload = yield* code.window.showInformationMessage(
+              "Changing managed language features requires reloading the window to take effect.",
+              { items: ["Reload Window"] },
+            );
+
+            if (Option.isSome(reload) && reload.value === "Reload Window") {
+              yield* code.commands.executeCommand(
+                "workbench.action.reloadWindow",
+              );
+            }
+          }),
+        ),
+      ),
+    );
+  }),
+);


### PR DESCRIPTION
The `marimo.disableManagedLanguageFeatures` setting is read at startup and baked into service initialization (language ID selection, whether Ty/Ruff servers start). Changing it at runtime has no effect, which confuses users who toggle it and expect immediate results.

This adds a `ReloadOnConfigChangeLive` layer that watches for changes to that setting and shows an information message prompting the user to reload the window, following the same pattern used for uv installation prompts.