### PR TITLE
Migrate `disableManagedLanguageFeatures` to `languageFeatures` enum

### DIFF
--- a/extension/README.md
+++ b/extension/README.md
@@ -44,23 +44,32 @@ icon in the editor title bar to open it as a notebook (see image above).
 
 ## Configuration
 
-| Setting                                 | Type      | Default | Description                                                                                                                                                                                         |
-| --------------------------------------- | --------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `marimo.lsp.path`                       | `array`   | `[]`    | Path to a custom `marimo-lsp` executable, e.g., `["/path/to/marimo-lsp"]`. Leave empty to use the bundled version via `uvx`.                                                                        |
-| `marimo.uv.path`                        | `string`  |         | Path to the `uv` binary, e.g., `/Users/me/.local/bin/uv`. Leave empty to use `uv` from the system PATH.                                                                                             |
-| `marimo.ruff.path`                      | `string`  |         | Path to a custom `ruff` binary, e.g., `/usr/local/bin/ruff`. Useful for offline environments. Leave empty to auto-discover or install via uv.                                                       |
-| `marimo.ty.path`                        | `string`  |         | Path to a custom `ty` binary, e.g., `/usr/local/bin/ty`. Useful for offline environments. Leave empty to auto-discover or install via uv.                                                           |
-| `marimo.disableUvIntegration`           | `boolean` | `false` | Disable uv integration features such as automatic package installation prompts.                                                                                                                     |
-| `marimo.disableManagedLanguageFeatures` | `boolean` | `false` | Disable marimo's managed Python language features (completions, diagnostics, formatting). When enabled, notebook cells use the standard `python` language ID and rely on external language servers. |
-| `marimo.telemetry`                      | `boolean` | `true`  | Anonymous usage data. This helps us prioritize features for the marimo VSCode extension.                                                                                                            |
+| Setting                                 | Type      | Default  | Description                                                                                                                                                                                         |
+| --------------------------------------- | --------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `marimo.lsp.path`                       | `array`   | `[]`     | Path to a custom `marimo-lsp` executable, e.g., `["/path/to/marimo-lsp"]`. Leave empty to use the bundled version via `uvx`.                                                                        |
+| `marimo.uv.path`                        | `string`  |          | Path to the `uv` binary, e.g., `/Users/me/.local/bin/uv`. Leave empty to use `uv` from the system PATH.                                                                                             |
+| `marimo.ruff.path`                      | `string`  |          | Path to a custom `ruff` binary, e.g., `/usr/local/bin/ruff`. Useful for offline environments. Leave empty to auto-discover or install via uv.                                                       |
+| `marimo.ty.path`                        | `string`  |          | Path to a custom `ty` binary, e.g., `/usr/local/bin/ty`. Useful for offline environments. Leave empty to auto-discover or install via uv.                                                           |
+| `marimo.disableUvIntegration`           | `boolean` | `false`  | Disable uv integration features such as automatic package installation prompts.                                                                                                                     |
+| `marimo.languageFeatures`               | `string`  | `"none"` | Controls how Python language features are provided for notebook cells. See [Language Features](#language-features) below.                                                                           |
+| `marimo.disableManagedLanguageFeatures` | `boolean` | `false`  | Disable marimo's managed Python language features (completions, diagnostics, formatting). When enabled, notebook cells use the standard `python` language ID and rely on external language servers. |
+| `marimo.telemetry`                      | `boolean` | `true`   | Anonymous usage data. This helps us prioritize features for the marimo VSCode extension.                                                                                                            |
 
 ### Language Features
 
-By default, marimo provides managed Python language features (completions, diagnostics, formatting) for notebook cells using a dedicated language server. This prevents conflicts with external Python language servers and ensures a consistent editing experience.
+The `marimo.languageFeatures` setting controls how Python language features are provided for notebook cells. There are three modes:
 
-**Why managed mode?** Notebook cells use a custom language ID (`mo-python`) to isolate them from external language servers like Pylance or Jedi. This prevents duplicate completions, conflicting diagnostics, and other interference while editing marimo notebooks.
+| Mode               | Language ID | ty + Ruff started | External servers attach |
+| ------------------ | ----------- | ----------------- | ----------------------- |
+| `"managed"`        | `mo-python` | Yes               | No                      |
+| `"external"`       | `python`    | No                | Yes                     |
+| `"none"` (default) | `mo-python` | No                | No                      |
 
-**When to disable managed mode:** If you prefer to use your own Python language server configuration (e.g., Pylance, pyright, or another LSP), enable `marimo.notebook.disableManagedLanguageFeatures`. This switches cells to use the standard `python` language ID, allowing external language servers to provide completions and diagnostics. Note that this may result in some language features not working as expected in the notebook context.
+- **`"managed"`** — marimo manages Python language features using dedicated ty and Ruff language servers. Cells use the `mo-python` language ID to prevent conflicts with external servers like Pylance.
+- **`"external"`** — Cells use the standard `python` language ID so external language servers (Pylance, pyright, etc.) can attach. marimo's managed servers are not started.
+- **`"none"`** — No language features at all. Cells use `mo-python` to prevent external servers from attaching, and marimo's managed servers are not started.
+
+> **Migration:** The deprecated `marimo.disableManagedLanguageFeatures` boolean still works during the transition period. If you had it set to `true`, it maps to `"external"`. If set to `false`, it maps to `"managed"`. Setting the new `marimo.languageFeatures` enum takes priority over the old boolean.
 
 ## Support
 

--- a/extension/package.json
+++ b/extension/package.json
@@ -106,11 +106,28 @@
           "markdownDescription": "Path to a custom `ty` binary, e.g., `/usr/local/bin/ty`. Useful for offline environments. Leave empty to auto-discover or install via uv.",
           "scope": "resource"
         },
+        "marimo.languageFeatures": {
+          "type": "string",
+          "enum": [
+            "managed",
+            "external",
+            "none"
+          ],
+          "default": "none",
+          "enumDescriptions": [
+            "marimo manages Python language features (ty + Ruff). Cells use the `mo-python` language ID to prevent conflicts with external servers.",
+            "Cells use the standard `python` language ID so external language servers (Pylance, pyright, etc.) can attach. marimo's managed ty and Ruff servers are not started.",
+            "No language features at all. Cells use `mo-python` to prevent external servers from attaching, and marimo's managed servers are not started."
+          ],
+          "markdownDescription": "Controls how Python language features are provided for marimo notebook cells.",
+          "scope": "resource"
+        },
         "marimo.disableManagedLanguageFeatures": {
           "type": "boolean",
           "default": false,
           "markdownDescription": "Disable marimo's managed Python language features (completions, diagnostics, formatting). When enabled, notebook cells use the standard `python` language ID and rely on external language servers.",
-          "scope": "resource"
+          "scope": "resource",
+          "deprecationMessage": "Use `marimo.languageFeatures` instead. Set to \"external\" to use external language servers, or \"none\" to disable all language features."
         }
       }
     },

--- a/extension/src/layers/ReloadOnConfigChange.ts
+++ b/extension/src/layers/ReloadOnConfigChange.ts
@@ -1,0 +1,39 @@
+import { Effect, Layer, Option, Stream } from "effect";
+
+import { VsCode } from "../services/VsCode.ts";
+
+/**
+ * Watches for changes to `marimo.languageFeatures` (and the deprecated
+ * `marimo.disableManagedLanguageFeatures`) and prompts the user to reload the
+ * window, since this setting is read at startup and baked into service
+ * initialization.
+ */
+export const ReloadOnConfigChangeLive = Layer.scopedDiscard(
+  Effect.gen(function* () {
+    const code = yield* VsCode;
+
+    yield* Effect.forkScoped(
+      code.workspace.configurationChanges().pipe(
+        Stream.filter(
+          (event) =>
+            event.affectsConfiguration("marimo.languageFeatures") ||
+            event.affectsConfiguration("marimo.disableManagedLanguageFeatures"),
+        ),
+        Stream.runForEach(() =>
+          Effect.gen(function* () {
+            const reload = yield* code.window.showInformationMessage(
+              "Changing the language features mode requires reloading the window to take effect.",
+              { items: ["Reload Window"] },
+            );
+
+            if (Option.isSome(reload) && reload.value === "Reload Window") {
+              yield* code.commands.executeCommand(
+                "workbench.action.reloadWindow",
+              );
+            }
+          }),
+        ),
+      ),
+    );
+  }),
+);

--- a/extension/src/services/Config.ts
+++ b/extension/src/services/Config.ts
@@ -1,0 +1,134 @@
+import { Effect, Option } from "effect";
+
+import { VsCode } from "./VsCode.ts";
+
+export type LanguageFeaturesMode = "managed" | "external" | "none";
+
+/**
+ * Provides access to the extension configuration settings.
+ */
+export class Config extends Effect.Service<Config>()("Config", {
+  effect: Effect.gen(function* () {
+    const code = yield* Effect.serviceOption(VsCode);
+
+    if (Option.isNone(code)) {
+      yield* Effect.logWarning(
+        "VsCode API is not available. Using default configuration values.",
+      );
+      return {
+        uv: {
+          path: Effect.succeed(Option.none<string>()),
+          enabled: Effect.succeed(false),
+        },
+        ruff: {
+          path: Effect.succeed(Option.none<string>()),
+        },
+        ty: {
+          path: Effect.succeed(Option.none<string>()),
+        },
+        lsp: {
+          executable: Effect.succeed(Option.none()),
+        },
+        getLanguageFeaturesMode() {
+          return Effect.succeed("none" as LanguageFeaturesMode);
+        },
+      };
+    }
+
+    return {
+      uv: {
+        get path() {
+          return Effect.map(
+            code.value.workspace.getConfiguration("marimo.uv"),
+            (config) =>
+              Option.fromNullable(config.get<string>("path")).pipe(
+                Option.filter((p) => p.length > 0),
+              ),
+          );
+        },
+        get enabled() {
+          return Effect.andThen(
+            code.value.workspace.getConfiguration("marimo"),
+            (config) => !config.get<boolean>("disableUvIntegration", false),
+          );
+        },
+      },
+      ruff: {
+        get path() {
+          return Effect.map(
+            code.value.workspace.getConfiguration("marimo.ruff"),
+            (config) =>
+              Option.fromNullable(config.get<string>("path")).pipe(
+                Option.filter((p) => p.length > 0),
+              ),
+          );
+        },
+      },
+      ty: {
+        get path() {
+          return Effect.map(
+            code.value.workspace.getConfiguration("marimo.ty"),
+            (config) =>
+              Option.fromNullable(config.get<string>("path")).pipe(
+                Option.filter((p) => p.length > 0),
+              ),
+          );
+        },
+      },
+      lsp: {
+        get executable() {
+          return Effect.gen(function* () {
+            const config =
+              yield* code.value.workspace.getConfiguration("marimo.lsp");
+            return Option.fromNullable(config.get<string[]>("path")).pipe(
+              Option.filter((path) => path.length > 0),
+              Option.map(([command, ...args]) => ({
+                command,
+                args,
+              })),
+            );
+          });
+        },
+      },
+      getLanguageFeaturesMode() {
+        return Effect.andThen(
+          code.value.workspace.getConfiguration("marimo"),
+          (config): LanguageFeaturesMode => {
+            // If the new setting was explicitly set, use it
+            const inspected =
+              config.inspect<LanguageFeaturesMode>("languageFeatures");
+            if (
+              inspected?.workspaceFolderValue !== undefined ||
+              inspected?.workspaceValue !== undefined ||
+              inspected?.globalValue !== undefined
+            ) {
+              return config.get<LanguageFeaturesMode>(
+                "languageFeatures",
+                "managed",
+              );
+            }
+
+            // Fall back to deprecated boolean
+            const inspectedOld = config.inspect<boolean>(
+              "disableManagedLanguageFeatures",
+            );
+            if (
+              inspectedOld?.workspaceFolderValue !== undefined ||
+              inspectedOld?.workspaceValue !== undefined ||
+              inspectedOld?.globalValue !== undefined
+            ) {
+              const disabled = config.get<boolean>(
+                "disableManagedLanguageFeatures",
+                false,
+              );
+              return disabled ? "external" : "managed";
+            }
+
+            // Neither setting explicitly set — default to "none"
+            return "none";
+          },
+        );
+      },
+    };
+  }),
+}) {}

--- a/extension/src/services/Constants.ts
+++ b/extension/src/services/Constants.ts
@@ -1,0 +1,25 @@
+import { Effect } from "effect";
+
+import { Config } from "./Config.ts";
+
+export class Constants extends Effect.Service<Constants>()("Constants", {
+  dependencies: [Config.Default],
+  effect: Effect.gen(function* () {
+    const config = yield* Config;
+    const languageFeaturesMode = yield* config.getLanguageFeaturesMode();
+
+    const constants = {
+      LanguageId: {
+        Python: languageFeaturesMode === "external" ? "python" : "mo-python",
+        Sql: "sql",
+        Markdown: "markdown",
+      } as const,
+    };
+
+    yield* Effect.logDebug(
+      `Language Features Mode: ${languageFeaturesMode}`,
+    ).pipe(Effect.annotateLogs({ constants }));
+
+    return constants;
+  }),
+}) {}

--- a/extension/src/services/HealthService.ts
+++ b/extension/src/services/HealthService.ts
@@ -1,0 +1,274 @@
+import * as NodeProcess from "node:process";
+
+import * as semver from "@std/semver";
+import { Effect, Option } from "effect";
+
+import { MINIMUM_MARIMO_VERSION } from "../constants.ts";
+import { BinarySource } from "../utils/binaryResolution.ts";
+import { getExtensionVersion } from "../utils/getExtensionVersion.ts";
+import {
+  RuffLanguageServer,
+  RuffLanguageServerStatus,
+} from "./completions/RuffLanguageServer.ts";
+import {
+  TyLanguageServer,
+  TyLanguageServerStatus,
+} from "./completions/TyLanguageServer.ts";
+import { Config } from "./Config.ts";
+import { PythonExtension } from "./PythonExtension.ts";
+import { Uv, UvBin } from "./Uv.ts";
+import { VsCode } from "./VsCode.ts";
+
+/**
+ * Provides health check and diagnostic information for the marimo extension.
+ */
+export class HealthService extends Effect.Service<HealthService>()(
+  "HealthService",
+  {
+    dependencies: [Uv.Default],
+    scoped: Effect.gen(function* () {
+      const uv = yield* Uv;
+      const code = yield* VsCode;
+      const config = yield* Config;
+      const pyExt = yield* PythonExtension;
+      const tyLsp = yield* TyLanguageServer;
+      const ruffLsp = yield* RuffLanguageServer;
+
+      const getLspStatus = () => Effect.succeed({ isAvailable: true });
+
+      const formatDiagnostics = () =>
+        Effect.gen(function* () {
+          const [lspCustomPath, uvDisabled, extVersion] = yield* Effect.all([
+            config.lsp.executable,
+            Effect.map(config.uv.enabled, (enabled) => !enabled),
+            getExtensionVersion().pipe(Effect.provideService(VsCode, code)),
+          ]);
+
+          const lines: string[] = [];
+
+          // Header
+          lines.push("marimo VS Code Extension Diagnostics");
+          lines.push("=====================================");
+          lines.push("");
+
+          // LSP Status
+          lines.push("Language Server (LSP):");
+
+          UvBin.$match(uv.bin, {
+            Bundled: (bin) =>
+              lines.push(`\tUV Bin: Bundled (${bin.executable})`),
+            Default: (bin) =>
+              lines.push(`\tUV Bin: Default (${bin.executable})`),
+            Configured: (bin) =>
+              lines.push(`\tUV Bin: Configured (${bin.executable})`),
+            Discovered: (bin) =>
+              lines.push(`\tUV Bin: Discovered (${bin.executable})`),
+          });
+
+          if (Option.isSome(uv.bin.version)) {
+            lines.push(`\tUV: ${uv.bin.version.value.format()} ✓`);
+          } else {
+            lines.push("\tUV: Not found ✗");
+          }
+
+          if (Option.isSome(lspCustomPath)) {
+            const { command, args = [] } = lspCustomPath.value as {
+              command: string;
+              args?: string[];
+            };
+            lines.push(`\tCustom path: ${command} ${args.join(" ")} `);
+          } else {
+            lines.push("\tUsing bundled marimo-lsp via uvx");
+          }
+
+          lines.push("");
+
+          // Python Extension Environment
+          lines.push("Python Extension:");
+          const pyEnvPath = yield* pyExt
+            .getActiveEnvironmentPath()
+            .pipe(Effect.option);
+          if (Option.isNone(pyEnvPath)) {
+            lines.push("\tNot available (Python extension not found)");
+          } else {
+            const resolved = yield* pyExt
+              .resolveEnvironment(pyEnvPath.value)
+              .pipe(Effect.option);
+            const env = Option.flatten(resolved);
+            if (Option.isNone(env)) {
+              lines.push(`\tInterpreter: ${pyEnvPath.value.path}`);
+              lines.push("\tVersion: Unknown");
+            } else {
+              const e = env.value;
+              lines.push(
+                `\tInterpreter: ${e.executable.uri?.fsPath ?? e.path ?? "Unknown"}`,
+              );
+              lines.push(`\tVersion: ${e.version?.sysVersion ?? "Unknown"}`);
+              if (e.environment) {
+                lines.push(
+                  `\tEnvironment: ${e.environment.type} (${e.environment.name})`,
+                );
+              }
+            }
+          }
+
+          lines.push("");
+
+          // Python Language Server (ty) - only show if managed language features enabled
+          const languageFeaturesMode = yield* config.getLanguageFeaturesMode();
+
+          if (languageFeaturesMode === "managed") {
+            lines.push("Python Language Server (ty):");
+
+            TyLanguageServerStatus.$match(yield* tyLsp.getHealthStatus(), {
+              Disabled: ({ reason }) => {
+                lines.push("\tStatus: disabled");
+                lines.push(`\tReason: ${reason}`);
+              },
+              Starting: () => {
+                lines.push("\tStatus: starting...");
+              },
+              Running: ({ serverVersion, binarySource, pythonEnvironment }) => {
+                lines.push("\tStatus: running ✓");
+                lines.push(`\tVersion: ${serverVersion}`);
+                lines.push(`\tBinary: ${formatBinarySource(binarySource)}`);
+                if (Option.isSome(pythonEnvironment)) {
+                  const pyPath = pythonEnvironment.value.path;
+                  const pyVersion = pythonEnvironment.value.version
+                    ? ` (${pythonEnvironment.value.version})`
+                    : "";
+                  lines.push(`\tPython: ${pyPath}${pyVersion}`);
+                }
+              },
+              Failed: ({ message }) => {
+                lines.push("\tStatus: failed ✗");
+                lines.push(`\tError: ${message}`);
+              },
+            });
+
+            lines.push("");
+
+            // Ruff Language Server
+            lines.push("Ruff Language Server:");
+            RuffLanguageServerStatus.$match(yield* ruffLsp.getHealthStatus(), {
+              Disabled: ({ reason }) => {
+                lines.push("\tStatus: disabled");
+                lines.push(`\tReason: ${reason}`);
+              },
+              Starting: () => {
+                lines.push("\tStatus: starting...");
+              },
+              Running: ({ serverVersion, binarySource }) => {
+                lines.push("\tStatus: running ✓");
+                lines.push(`\tVersion: ${serverVersion}`);
+                lines.push(`\tBinary: ${formatBinarySource(binarySource)}`);
+              },
+              Failed: ({ message }) => {
+                lines.push("\tStatus: failed ✗");
+                lines.push(`\tError: ${message}`);
+              },
+            });
+
+            lines.push("");
+          }
+
+          // Extension Configuration
+          lines.push("Extension Configuration:");
+          lines.push(
+            `\tVersion: ${Option.getOrElse(extVersion, () => "unknown")} `,
+          );
+          lines.push(`\tLanguage Features Mode: ${languageFeaturesMode} `);
+          lines.push(`\tUV integration disabled: ${uvDisabled} `);
+
+          lines.push("");
+
+          // System Information
+          lines.push("System Information:");
+          lines.push(`\tHost: ${code.env.appHost} `);
+          lines.push(`\tIDE: ${code.env.appName} `);
+          lines.push(`\tIDE version: ${code.version} `);
+          lines.push(`\tPlatform: ${NodeProcess.platform} `);
+          lines.push(`\tArchitecture: ${NodeProcess.arch} `);
+          lines.push(`\tNode version: ${NodeProcess.version} `);
+          lines.push("");
+
+          if (UvBin.$is("Default")(uv.bin)) {
+            // If using default UV (i.e., "uv"), show PATH for debugging
+
+            // PATH (formatted for readability)
+            lines.push("PATH:");
+            const pathValue = NodeProcess.env.PATH;
+            if (pathValue) {
+              const separator = NodeProcess.platform === "win32" ? ";" : ":";
+              for (const entry of pathValue.split(separator)) {
+                lines.push(`\t${entry} `);
+              }
+            } else {
+              lines.push("\t(not set)");
+            }
+            lines.push("");
+          }
+
+          // Troubleshooting
+          const lspStatus = yield* getLspStatus();
+          if (!lspStatus.isAvailable) {
+            lines.push("Troubleshooting:");
+            lines.push("\t1. Check the 'marimo-lsp' output channel for errors");
+            lines.push(
+              "\t2. Ensure uv is installed: https://docs.astral.sh/uv/",
+            );
+            lines.push("\t3. Try reloading the VS Code window");
+          } else {
+            lines.push("Common Issues:");
+            lines.push("\t1. If notebooks won't open:");
+            lines.push("\t\t- Check Python interpreter is selected");
+            lines.push("\t\t- Ensure marimo and pyzmq are installed");
+            lines.push("\t\t- Check 'marimo-lsp' output channel for errors");
+            lines.push("\t2. If features are missing:");
+            lines.push(
+              `\t\t - Ensure marimo version is >= ${semver.format(MINIMUM_MARIMO_VERSION)}`,
+            );
+            lines.push("\t\t- Try reloading the window");
+          }
+
+          return lines.join("\n");
+        });
+
+      return {
+        /**
+         * Shows a text document with comprehensive diagnostics about the extension
+         * and environment setup.
+         */
+        showDiagnostics: Effect.fn(function* () {
+          yield* Effect.logInfo("Showing diagnostics");
+
+          const diagnosticText = yield* formatDiagnostics().pipe(
+            Effect.catchAll((error) =>
+              Effect.succeed(
+                `Error generating diagnostics: \n\n${String(error)} `,
+              ),
+            ),
+          );
+
+          const doc = yield* code.workspace.openUntitledTextDocument({
+            content: diagnosticText,
+            language: "plaintext",
+          });
+
+          yield* code.window.showTextDocument(doc);
+
+          return doc;
+        }),
+      };
+    }),
+  },
+) {}
+
+function formatBinarySource(source: BinarySource): string {
+  return BinarySource.$match(source, {
+    UserConfigured: ({ path }) => `UserConfigured (${path})`,
+    CompanionExtension: ({ extensionId, path, kind }) =>
+      `CompanionExtension/${kind} (${extensionId}, ${path})`,
+    UvInstalled: ({ path }) => `UvInstalled (${path})`,
+  });
+}

--- a/extension/src/services/completions/RuffLanguageServer.ts
+++ b/extension/src/services/completions/RuffLanguageServer.ts
@@ -1,0 +1,503 @@
+import * as NodePath from "node:path";
+
+import {
+  type Cause,
+  Data,
+  Effect,
+  Exit,
+  Option,
+  Ref,
+  Runtime,
+  Stream,
+} from "effect";
+import type * as vscode from "vscode";
+import * as lsp from "vscode-languageclient/node";
+
+import {
+  BinarySource,
+  companionExtensionBundledBinary,
+  companionExtensionConfiguredPath,
+  resolveBinary,
+  userConfiguredPath,
+} from "../../utils/binaryResolution.ts";
+import {
+  createManagedLanguageClient,
+  type ManagedLanguageClient,
+} from "../../utils/createManagedLanguageClient.ts";
+import { showErrorAndPromptLogs } from "../../utils/showErrorAndPromptLogs.ts";
+import { Config } from "../Config.ts";
+import { OutputChannel } from "../OutputChannel.ts";
+import { Sentry } from "../Sentry.ts";
+import { ExtensionContext } from "../Storage.ts";
+import { Telemetry } from "../Telemetry.ts";
+import { Uv } from "../Uv.ts";
+import { VariablesService } from "../variables/VariablesService.ts";
+import { VsCode } from "../VsCode.ts";
+import {
+  type ClientNotebookSync,
+  NotebookSyncService,
+} from "./NotebookSyncService.ts";
+
+// Pin Ruff version for stability, matching ruff-vscode's approach.
+// Bump this as needed for new features or fixes.
+const RUFF_SERVER = { name: "ruff", version: "0.15.8" } as const;
+const RUFF_EXTENSION_ID = "charliermarsh.ruff";
+
+export const RuffLanguageServerStatus =
+  Data.taggedEnum<RuffLanguageServerStatus>();
+
+type RuffLanguageServerStatus = Data.TaggedEnum<{
+  Starting: {};
+  Disabled: { readonly reason: string };
+  Running: {
+    readonly client: ManagedLanguageClient;
+    readonly serverVersion: string;
+    readonly binarySource: BinarySource;
+  };
+  Failed: {
+    readonly message: string;
+    readonly cause?: Cause.Cause<unknown>;
+  };
+}>;
+
+/**
+ * Manages a dedicated Ruff language server instance for marimo notebooks.
+ * Provides linting diagnostics for notebook cells.
+ *
+ * Ruff has native notebook support. We configure automatic notebook sync
+ * and use middleware to map mo-python -> python language IDs.
+ */
+export class RuffLanguageServer extends Effect.Service<RuffLanguageServer>()(
+  "RuffLanguageServer",
+  {
+    dependencies: [
+      Uv.Default,
+      Config.Default,
+      VariablesService.Default,
+      NotebookSyncService.Default,
+      OutputChannel.Default,
+    ],
+    scoped: Effect.gen(function* () {
+      const code = yield* VsCode;
+      const sync = yield* NotebookSyncService;
+      const sentry = yield* Effect.serviceOption(Sentry);
+      const telemetry = yield* Effect.serviceOption(Telemetry);
+
+      const statusRef = yield* Ref.make<RuffLanguageServerStatus>(
+        RuffLanguageServerStatus.Starting(),
+      );
+
+      const disabledReasonOption = yield* getRuffDisabledReason();
+      if (Option.isSome(disabledReasonOption)) {
+        yield* Ref.set(
+          statusRef,
+          RuffLanguageServerStatus.Disabled({
+            reason: disabledReasonOption.value,
+          }),
+        );
+      }
+
+      yield* Effect.forkScoped(
+        Effect.gen(function* () {
+          if (Option.isSome(disabledReasonOption)) {
+            // Skip startup completely if disabled for any reason
+            return;
+          }
+
+          // Phase 1: Resolve the ruff binary using 3-tier strategy
+          yield* Effect.logInfo("Starting language server").pipe(
+            Effect.annotateLogs({
+              server: RUFF_SERVER.name,
+              version: RUFF_SERVER.version,
+            }),
+          );
+
+          const resolved = yield* resolveRuffBinary();
+
+          // Create isolated sync instance with its own cell count tracking.
+          const notebookSync = yield* sync.forClient();
+
+          // Build initializationOptions from ruff.* settings
+          const ruffConfig = yield* code.workspace.getConfiguration("ruff");
+          const workspaceFolders = yield* code.workspace.getWorkspaceFolders();
+          const settings = Option.getOrElse(workspaceFolders, () => []).map(
+            (folder) => getRuffSettings(ruffConfig, folder),
+          );
+          const globalSettings = getGlobalRuffSettings(ruffConfig);
+
+          yield* Effect.logDebug("Ruff initialization options", {
+            settings,
+            globalSettings,
+          });
+
+          const installExit = yield* Effect.exit(
+            createManagedLanguageClient(RUFF_SERVER, resolved.path, {
+              notebookSync,
+              clientOptions: {
+                outputChannelName: "marimo (ruff)",
+                revealOutputChannelOn: lsp.RevealOutputChannelOn.Never,
+                middleware: yield* createRuffMiddleware(notebookSync),
+                documentSelector: sync.getDocumentSelector(),
+                transformServerCapabilities: sync.extendNotebookCellLanguages(),
+                initializationOptions: { settings, globalSettings },
+              },
+            }),
+          );
+
+          if (!Exit.isSuccess(installExit)) {
+            const cause = installExit.cause;
+            const message = "Failed to install language server";
+            yield* Ref.set(
+              statusRef,
+              RuffLanguageServerStatus.Failed({ message, cause }),
+            );
+            yield* Effect.logError(message).pipe(
+              Effect.annotateLogs({
+                server: RUFF_SERVER.name,
+                version: RUFF_SERVER.version,
+                cause,
+              }),
+            );
+            yield* Effect.forkScoped(showErrorAndPromptLogs(message));
+            return;
+          }
+
+          // Phase 2: Start the server
+          const client = installExit.value;
+          yield* Effect.forkScoped(
+            Effect.gen(function* () {
+              const startExit = yield* Effect.exit(client.start());
+
+              if (!Exit.isSuccess(startExit)) {
+                const cause = startExit.cause;
+                const message = "Failed to start language server";
+                yield* Ref.set(
+                  statusRef,
+                  RuffLanguageServerStatus.Failed({ message, cause }),
+                );
+                yield* Effect.logError(message).pipe(
+                  Effect.annotateLogs({
+                    server: RUFF_SERVER.name,
+                    version: RUFF_SERVER.version,
+                    cause,
+                  }),
+                );
+                yield* Effect.forkScoped(showErrorAndPromptLogs(message));
+                return;
+              }
+
+              const serverVersion = startExit.value.pipe(
+                Option.map((info) => info.version),
+                Option.getOrElse(() => "unknown"),
+              );
+
+              yield* Effect.logInfo("Language server started").pipe(
+                Effect.annotateLogs({
+                  server: RUFF_SERVER.name,
+                  version: serverVersion,
+                }),
+              );
+
+              if (Option.isSome(sentry)) {
+                yield* sentry.value.setTag("ruff.version", serverVersion);
+              }
+              if (Option.isSome(telemetry)) {
+                yield* telemetry.value.reportBinaryResolved(
+                  "ruff",
+                  resolved,
+                  serverVersion,
+                );
+              }
+
+              yield* Ref.set(
+                statusRef,
+                RuffLanguageServerStatus.Running({
+                  client,
+                  serverVersion,
+                  binarySource: resolved,
+                }),
+              );
+
+              // Restart the language server when ruff.* settings change
+              yield* Effect.forkScoped(
+                code.workspace.configurationChanges().pipe(
+                  Stream.filter((event) => event.affectsConfiguration("ruff")),
+                  Stream.runForEach(() =>
+                    client.restart("Ruff settings changed").pipe(
+                      Effect.catchAllCause((cause) =>
+                        Effect.logError(
+                          "Failed to restart language server",
+                        ).pipe(
+                          Effect.annotateLogs({
+                            server: RUFF_SERVER.name,
+                            cause,
+                          }),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              );
+            }),
+          );
+        }),
+      );
+
+      return {
+        getHealthStatus: () => Ref.get(statusRef),
+      };
+    }),
+  },
+) {}
+
+/**
+ * Resolves the ruff binary path using a 3-tier strategy:
+ * 1. User-configured path (`marimo.ruff.path`)
+ * 2. Companion extension discovery — first `ruff.path` setting, then bundled binary
+ * 3. Fallback to `uv pip install`
+ */
+const resolveRuffBinary = Effect.fn(function* () {
+  const code = yield* VsCode;
+  const config = yield* Config;
+  const uv = yield* Uv;
+  const context = yield* ExtensionContext;
+
+  const ruffExtension = code.extensions.getExtension(RUFF_EXTENSION_ID);
+
+  const ruffExtConfiguredPath = Effect.gen(function* () {
+    const ruffExtConfig = yield* code.workspace.getConfiguration("ruff");
+    return Option.fromNullable(ruffExtConfig.get<string>("path")).pipe(
+      Option.filter((p) => p.length > 0),
+    );
+  });
+
+  return yield* resolveBinary(
+    RUFF_SERVER.name,
+    [
+      userConfiguredPath("ruff", RUFF_SERVER.version, config.ruff.path),
+      companionExtensionConfiguredPath(
+        "ruff",
+        RUFF_SERVER.version,
+        RUFF_EXTENSION_ID,
+        ruffExtConfiguredPath,
+      ),
+      companionExtensionBundledBinary(
+        "ruff",
+        RUFF_SERVER.version,
+        RUFF_EXTENSION_ID,
+        ruffExtension,
+      ),
+    ],
+    {
+      label: "uv install",
+      resolve: Effect.gen(function* () {
+        const targetPath = NodePath.resolve(
+          context.globalStorageUri.fsPath,
+          "libs",
+        );
+        const binaryPath = yield* uv.ensureLanguageServerBinaryInstalled(
+          RUFF_SERVER,
+          {
+            targetPath,
+          },
+        );
+        return Option.some(BinarySource.UvInstalled({ path: binaryPath }));
+      }),
+    },
+  );
+});
+
+/**
+ * Read ruff.* settings from a WorkspaceConfiguration and return them in the format
+ * expected by the Ruff language server's initializationOptions.
+ *
+ * Based on ruff-vscode's getWorkspaceSettings:
+ * https://github.com/astral-sh/ruff-vscode/blob/main/src/common/settings.ts
+ */
+function getRuffSettings(
+  config: vscode.WorkspaceConfiguration,
+  folder: vscode.WorkspaceFolder,
+): Record<string, unknown> {
+  return {
+    cwd: folder.uri.fsPath,
+    workspace: folder.uri.toString(),
+    configuration: config.get("configuration") ?? null,
+    configurationPreference:
+      config.get("configurationPreference") ?? "editorFirst",
+    lineLength: config.get("lineLength"),
+    exclude: config.get("exclude"),
+    lint: {
+      enable: config.get("lint.enable") ?? true,
+      preview: config.get("lint.preview"),
+      select: config.get("lint.select"),
+      extendSelect: config.get("lint.extendSelect"),
+      ignore: config.get<string[]>("lint.ignore", []),
+    },
+    format: {
+      preview: config.get("format.preview"),
+      backend: config.get("format.backend") ?? "internal",
+    },
+    codeAction: config.get("codeAction") ?? {},
+    organizeImports: config.get("organizeImports") ?? true,
+    fixAll: config.get("fixAll") ?? true,
+    showSyntaxErrors: config.get("showSyntaxErrors") ?? true,
+    logLevel: config.get("logLevel"),
+    logFile: config.get("logFile"),
+  };
+}
+
+/**
+ * Read global ruff.* settings (not workspace-specific).
+ *
+ * Based on ruff-vscode's getGlobalSettings:
+ * https://github.com/astral-sh/ruff-vscode/blob/main/src/common/settings.ts
+ */
+function getGlobalRuffSettings(
+  config: vscode.WorkspaceConfiguration,
+): Record<string, unknown> {
+  const getGlobal = <T>(key: string, defaultValue?: T): T | undefined => {
+    const inspect = config.inspect<T>(key);
+    return inspect?.globalValue ?? inspect?.defaultValue ?? defaultValue;
+  };
+  return {
+    cwd: process.cwd(),
+    workspace: process.cwd(),
+    configuration: getGlobal("configuration", null),
+    configurationPreference: getGlobal(
+      "configurationPreference",
+      "editorFirst",
+    ),
+    lineLength: getGlobal("lineLength"),
+    exclude: getGlobal("exclude"),
+    lint: {
+      enable: getGlobal("lint.enable", true),
+      preview: getGlobal("lint.preview"),
+      select: getGlobal("lint.select"),
+      extendSelect: getGlobal("lint.extendSelect"),
+      ignore: config.get<string[]>("lint.ignore", []),
+    },
+    format: {
+      preview: getGlobal("format.preview"),
+      backend: getGlobal("format.backend", "internal"),
+    },
+    codeAction: getGlobal("codeAction", {}),
+    organizeImports: getGlobal("organizeImports", true),
+    fixAll: getGlobal("fixAll", true),
+    showSyntaxErrors: getGlobal("showSyntaxErrors", true),
+    logLevel: getGlobal("logLevel"),
+    logFile: getGlobal("logFile"),
+  };
+}
+
+/**
+ * Creates LSP middleware that adapts marimo notebook documents for Ruff.
+ *
+ * Uses the provided notebook middleware for base notebook handling,
+ * and adds Ruff-specific formatting and code action middleware.
+ */
+function createRuffMiddleware(
+  sync: ClientNotebookSync,
+): Effect.Effect<lsp.Middleware, never, VsCode> {
+  return Effect.gen(function* () {
+    const runtime = yield* Effect.runtime<VsCode>();
+    const runPromise = Runtime.runPromise(runtime);
+
+    const isRuffFormatEnabled = () =>
+      ruffConfiguredAsDefaultPythonFormatter().pipe(
+        Effect.tap((enabled) =>
+          enabled
+            ? Effect.void
+            : Effect.logWarning(
+                `Ruff is not configured as default Python formatter; skipping marimo format.`,
+              ),
+        ),
+        runPromise,
+      );
+
+    return {
+      notebooks: sync.notebookMiddleware,
+      didOpen: (doc, next) => next(sync.adapter.document(doc)),
+      didClose: (doc, next) => next(sync.adapter.document(doc)),
+      didChange: (change, next) =>
+        next({ ...change, document: sync.adapter.document(change.document) }),
+      async provideDocumentFormattingEdits(document, options, token, next) {
+        const shouldFormat = await isRuffFormatEnabled();
+        return shouldFormat
+          ? next(sync.adapter.document(document), options, token)
+          : null;
+      },
+      async provideDocumentRangeFormattingEdits(
+        document,
+        range,
+        options,
+        token,
+        next,
+      ) {
+        const shouldFormat = await isRuffFormatEnabled();
+        return shouldFormat
+          ? next(sync.adapter.document(document), range, options, token)
+          : null;
+      },
+      provideCodeActions: (document, range, context, token, next) =>
+        next(sync.adapter.document(document), range, context, token),
+    };
+  });
+}
+
+/**
+ * Returns the reason why the Ruff language server is disabled, or None if enabled.
+ */
+const getRuffDisabledReason = Effect.fn(function* () {
+  const code = yield* VsCode;
+  const config = yield* Config;
+
+  const mode = yield* config.getLanguageFeaturesMode();
+
+  if (mode !== "managed") {
+    const reason =
+      mode === "external"
+        ? 'Language features mode is set to "external". Using external language servers instead of managed Ruff.'
+        : 'Language features mode is set to "none". All language features are disabled.';
+    yield* Effect.logInfo(
+      `Not starting managed Ruff language server: ${reason}`,
+    );
+    return Option.some(reason);
+  }
+
+  const ruffExtension = code.extensions.getExtension(RUFF_EXTENSION_ID);
+  if (Option.isNone(ruffExtension)) {
+    yield* Effect.logInfo(
+      "Ruff extension is not installed. Not starting managed Ruff language server.",
+    );
+    return Option.some(
+      `Ruff extension (${RUFF_EXTENSION_ID}) is not installed.`,
+    );
+  }
+
+  const ruffConfig = yield* code.workspace.getConfiguration("ruff");
+  const ruffEnabled = ruffConfig.get<boolean>("enable", true);
+
+  if (!ruffEnabled) {
+    yield* Effect.logInfo(
+      "Ruff extension is disabled via ruff.enable setting. Not starting managed Ruff language server.",
+    );
+    return Option.some("Ruff extension is disabled (ruff.enable = false).");
+  }
+
+  return Option.none();
+});
+
+/**
+ * Checks if Ruff is configured as the default Python formatter in VS Code settings.
+ *
+ * Ref: https://github.com/astral-sh/ruff-vscode?tab=readme-ov-file#configuring-vs-code
+ */
+const ruffConfiguredAsDefaultPythonFormatter = Effect.fn(function* () {
+  const code = yield* VsCode;
+  const pythonConfig = yield* code.workspace.getConfiguration("", {
+    languageId: "python",
+  });
+  return (
+    pythonConfig.get<unknown>("editor.defaultFormatter") === RUFF_EXTENSION_ID
+  );
+});

--- a/extension/src/services/completions/TyLanguageServer.ts
+++ b/extension/src/services/completions/TyLanguageServer.ts
@@ -1,0 +1,574 @@
+import * as NodePath from "node:path";
+
+import { NodeContext } from "@effect/platform-node";
+import {
+  type Cause,
+  Data,
+  Duration,
+  Effect,
+  Exit,
+  Option,
+  Ref,
+  Runtime,
+  Stream,
+} from "effect";
+import * as lsp from "vscode-languageclient/node";
+import { ResponseError } from "vscode-languageclient/node";
+
+import {
+  BinarySource,
+  companionExtensionBundledBinary,
+  companionExtensionConfiguredPath,
+  resolveBinary,
+  userConfiguredPath,
+} from "../../utils/binaryResolution.ts";
+import {
+  createManagedLanguageClient,
+  type ManagedLanguageClient,
+} from "../../utils/createManagedLanguageClient.ts";
+import { showErrorAndPromptLogs } from "../../utils/showErrorAndPromptLogs.ts";
+import { signalFromToken } from "../../utils/signalFromToken.ts";
+import { Config } from "../Config.ts";
+import { Constants } from "../Constants.ts";
+import { OutputChannel } from "../OutputChannel.ts";
+import { PythonExtension } from "../PythonExtension.ts";
+import { Sentry } from "../Sentry.ts";
+import { ExtensionContext } from "../Storage.ts";
+import { Telemetry } from "../Telemetry.ts";
+import { Uv } from "../Uv.ts";
+import { VariablesService } from "../variables/VariablesService.ts";
+import { VsCode } from "../VsCode.ts";
+import {
+  type ClientNotebookSync,
+  NotebookSyncService,
+} from "./NotebookSyncService.ts";
+
+// TODO: make TY_VERSION configurable?
+// For now, since we are doing rolling releases, we can bump this as needed.
+const TY_SERVER = { name: "ty", version: "0.0.26" } as const;
+const TY_EXTENSION_ID = "astral-sh.ty";
+
+export const TyLanguageServerStatus = Data.taggedEnum<TyLanguageServerStatus>();
+
+type TyLanguageServerStatus = Data.TaggedEnum<{
+  Starting: {};
+  Disabled: { readonly reason: string };
+  Running: {
+    readonly client: ManagedLanguageClient;
+    readonly serverVersion: string;
+    readonly binarySource: BinarySource;
+    readonly pythonEnvironment: Option.Option<{
+      path: string;
+      version: string | null;
+    }>;
+  };
+  Failed: {
+    readonly message: string;
+    readonly cause?: Cause.Cause<unknown>;
+  };
+}>;
+
+/**
+ * Manages a dedicated ty language server instance (using ty via uvx)
+ * for marimo notebooks. Provides LSP features (completions, hover, definitions,
+ * signature help, semantic tokens) for notebook cells.
+ *
+ * ty has native notebook support. We configure automatic notebook sync
+ * and use middleware to map mo-python -> python language IDs and enrich
+ * configuration with Python environment information.
+ */
+export class TyLanguageServer extends Effect.Service<TyLanguageServer>()(
+  "TyLanguageServer",
+  {
+    dependencies: [
+      NodeContext.layer,
+      Uv.Default,
+      Config.Default,
+      Constants.Default,
+      VariablesService.Default,
+      NotebookSyncService.Default,
+      OutputChannel.Default,
+    ],
+    scoped: Effect.gen(function* () {
+      const pyExt = yield* PythonExtension;
+      const sync = yield* NotebookSyncService;
+      const sentry = yield* Effect.serviceOption(Sentry);
+      const telemetry = yield* Effect.serviceOption(Telemetry);
+
+      const statusRef = yield* Ref.make<TyLanguageServerStatus>(
+        TyLanguageServerStatus.Starting(),
+      );
+
+      const disabledReasonOption = yield* getTyDisabledReason();
+      if (Option.isSome(disabledReasonOption)) {
+        yield* Ref.set(
+          statusRef,
+          TyLanguageServerStatus.Disabled({
+            reason: disabledReasonOption.value,
+          }),
+        );
+      }
+
+      yield* Effect.forkScoped(
+        Effect.gen(function* () {
+          if (Option.isSome(disabledReasonOption)) {
+            // skip startup completely if disabled for any reason
+            return;
+          }
+
+          // Phase 1: Resolve the ty binary using 3-tier strategy
+          yield* Effect.logInfo("Starting language server").pipe(
+            Effect.annotateLogs({
+              server: TY_SERVER.name,
+              version: TY_SERVER.version,
+            }),
+          );
+
+          const resolved = yield* resolveTyBinary();
+
+          // Create isolated sync instance with its own cell count tracking
+          const notebookSync = yield* sync.forClient();
+
+          const installExit = yield* Effect.exit(
+            createManagedLanguageClient(TY_SERVER, resolved.path, {
+              notebookSync,
+              clientOptions: {
+                outputChannelName: "marimo (ty)",
+                revealOutputChannelOn: lsp.RevealOutputChannelOn.Never,
+                middleware: yield* createTyMiddleware(notebookSync),
+                documentSelector: sync.getDocumentSelector(),
+                transformServerCapabilities: sync.extendNotebookCellLanguages(),
+                initializationOptions: {},
+              },
+            }),
+          );
+
+          if (!Exit.isSuccess(installExit)) {
+            const cause = installExit.cause;
+            const message = "Failed to install language server";
+            yield* Ref.set(
+              statusRef,
+              TyLanguageServerStatus.Failed({ message, cause }),
+            );
+            yield* Effect.logError(message).pipe(
+              Effect.annotateLogs({
+                server: TY_SERVER.name,
+                version: TY_SERVER.version,
+                cause,
+              }),
+            );
+            yield* Effect.forkScoped(showErrorAndPromptLogs(message));
+            return;
+          }
+
+          // Phase 2: Start the server
+          const client = installExit.value;
+          yield* Effect.forkScoped(
+            Effect.gen(function* () {
+              const startExit = yield* Effect.exit(client.start());
+
+              if (!Exit.isSuccess(startExit)) {
+                const cause = startExit.cause;
+                const message = "Failed to start language server";
+                yield* Ref.set(
+                  statusRef,
+                  TyLanguageServerStatus.Failed({ message, cause }),
+                );
+                yield* Effect.logError(message).pipe(
+                  Effect.annotateLogs({
+                    server: TY_SERVER.name,
+                    version: TY_SERVER.version,
+                    cause,
+                  }),
+                );
+                yield* Effect.forkScoped(showErrorAndPromptLogs(message));
+                return;
+              }
+
+              const serverVersion = startExit.value.pipe(
+                Option.map((info) => info.version),
+                Option.getOrElse(() => "unknown"),
+              );
+
+              yield* Effect.logInfo("Language server started").pipe(
+                Effect.annotateLogs({
+                  server: TY_SERVER.name,
+                  version: serverVersion,
+                }),
+              );
+
+              if (Option.isSome(sentry)) {
+                yield* sentry.value.setTag("ty.version", serverVersion);
+              }
+              if (Option.isSome(telemetry)) {
+                yield* telemetry.value.reportBinaryResolved(
+                  "ty",
+                  resolved,
+                  serverVersion,
+                );
+              }
+
+              const updateRunningStatus = Effect.fn(function* () {
+                const activePath = yield* pyExt.getActiveEnvironmentPath();
+                const resolvedEnv = yield* pyExt.resolveEnvironment(activePath);
+                const pythonEnvironment = Option.map(resolvedEnv, (env) => ({
+                  path: env.executable.uri?.fsPath ?? env.path ?? "Unknown",
+                  version: env.version?.sysVersion ?? null,
+                }));
+                yield* Ref.set(
+                  statusRef,
+                  TyLanguageServerStatus.Running({
+                    client,
+                    serverVersion,
+                    binarySource: resolved,
+                    pythonEnvironment,
+                  }),
+                );
+              });
+
+              // Restart the language server when Python environment changes.
+              // ty needs restart to pick up environment changes since it doesn't
+              // support workspace/didChangeConfiguration for environment updates.
+              //
+              // Debounce to avoid restart storms: the Python extension can fire
+              // multiple rapid environment-change events during workspace
+              // activation (e.g. when opening a notebook). We collapse them into
+              // a single restart after 2 seconds of quiet.
+              yield* Effect.forkScoped(
+                pyExt.activeEnvironmentPathChanges().pipe(
+                  Stream.debounce(Duration.seconds(2)),
+                  Stream.runForEach(
+                    Effect.fn(function* (event) {
+                      yield* client
+                        .restart(`Python environment changed to: ${event.path}`)
+                        .pipe(
+                          Effect.catchAllCause((cause) =>
+                            Effect.logError(
+                              "Failed to restart language server",
+                            ).pipe(
+                              Effect.annotateLogs({
+                                server: TY_SERVER.name,
+                                cause,
+                              }),
+                            ),
+                          ),
+                        );
+                      yield* updateRunningStatus();
+                    }),
+                  ),
+                ),
+              );
+
+              yield* updateRunningStatus();
+            }),
+          );
+        }),
+      );
+
+      return {
+        getHealthStatus: () => Ref.get(statusRef),
+        /**
+         * Restart the language server to pick up new packages or environment changes.
+         * This is useful after installing packages, as ty doesn't support
+         * workspace/didChangeConfiguration.
+         */
+        restart: Effect.fn(function* (reason: string) {
+          const status = yield* Ref.get(statusRef);
+          if (!TyLanguageServerStatus.$is("Running")(status)) {
+            yield* Effect.logWarning(
+              "Cannot restart language server: server is not running",
+            ).pipe(Effect.annotateLogs({ server: TY_SERVER.name }));
+            return;
+          }
+          return yield* status.client.restart(reason).pipe(
+            Effect.catchAllCause((cause) =>
+              Effect.logError("Failed to restart language server").pipe(
+                Effect.annotateLogs({
+                  server: TY_SERVER.name,
+                  cause,
+                }),
+              ),
+            ),
+          );
+        }),
+      };
+    }),
+  },
+) {}
+
+/**
+ * Resolves the ty binary path using a 3-tier strategy:
+ * 1. User-configured path (`marimo.ty.path`)
+ * 2. Companion extension discovery — first `ty.path` setting, then bundled binary
+ * 3. Fallback to `uv pip install`
+ */
+const resolveTyBinary = Effect.fn(function* () {
+  const code = yield* VsCode;
+  const config = yield* Config;
+  const uv = yield* Uv;
+  const context = yield* ExtensionContext;
+
+  const tyExtension = code.extensions.getExtension(TY_EXTENSION_ID);
+
+  // ty.path is string[] (first element), unlike ruff.path which is string
+  const tyExtConfiguredPath = Effect.gen(function* () {
+    const tyExtConfig = yield* code.workspace.getConfiguration("ty");
+    return Option.fromNullable(tyExtConfig.get<string[]>("path")).pipe(
+      Option.filter((p) => p.length > 0),
+      Option.map((p) => p[0]),
+    );
+  });
+
+  return yield* resolveBinary(
+    TY_SERVER.name,
+    [
+      userConfiguredPath("ty", TY_SERVER.version, config.ty.path),
+      companionExtensionConfiguredPath(
+        "ty",
+        TY_SERVER.version,
+        TY_EXTENSION_ID,
+        tyExtConfiguredPath,
+      ),
+      companionExtensionBundledBinary(
+        "ty",
+        TY_SERVER.version,
+        TY_EXTENSION_ID,
+        tyExtension,
+      ),
+    ],
+    {
+      label: "uv install",
+      resolve: Effect.gen(function* () {
+        const targetPath = NodePath.resolve(
+          context.globalStorageUri.fsPath,
+          "libs",
+        );
+        const binaryPath = yield* uv.ensureLanguageServerBinaryInstalled(
+          TY_SERVER,
+          {
+            targetPath,
+          },
+        );
+        return Option.some(BinarySource.UvInstalled({ path: binaryPath }));
+      }),
+    },
+  );
+});
+
+interface InitializationOptions {
+  logLevel?: "error" | "warn" | "info" | "debug" | "trace";
+  logFile?: string;
+}
+
+interface ExtensionSettings {
+  cwd: string;
+  path: string[];
+  interpreter: string[];
+  importStrategy: "fromEnvironment" | "useBundled";
+}
+
+// Keys that are handled by the extension and should not be sent to the server
+type ExtensionOnlyKeys =
+  | keyof InitializationOptions
+  | keyof ExtensionSettings
+  | "trace";
+
+/**
+ * Keys that are handled by the extension and should not be sent to the ty server.
+ * These are extension-specific settings that the server doesn't recognize.
+ *
+ * Adapted from https://github.com/astral-sh/ty-vscode/blob/221a8d1a/src/client.ts
+ */
+const EXTENSION_ONLY_KEYS = {
+  // InitializationOptions
+  logLevel: true,
+  logFile: true,
+  // ExtensionSettings
+  cwd: true,
+  path: true,
+  interpreter: true,
+  importStrategy: true,
+  // Client-handled settings
+  trace: true,
+} as const satisfies Record<ExtensionOnlyKeys, true>;
+
+function isExtensionOnlyKey(key: string): key is ExtensionOnlyKeys {
+  return key in EXTENSION_ONLY_KEYS;
+}
+
+/**
+ * Creates LSP middleware that adapts marimo notebook documents for ty.
+ *
+ * Uses the provided notebook middleware for base notebook handling,
+ * and adds ty-specific workspace configuration middleware to enrich
+ * responses with Python environment information.
+ */
+function createTyMiddleware(
+  sync: ClientNotebookSync,
+): Effect.Effect<lsp.Middleware, never, VsCode | PythonExtension> {
+  return Effect.gen(function* () {
+    const runtime = yield* Effect.runtime<VsCode | PythonExtension>();
+    const runPromise = Runtime.runPromise(runtime);
+
+    // Helper to wrap document with language ID mapping (mo-python -> python)
+    const wrapDocument = sync.adapter.document.bind(sync.adapter);
+
+    return {
+      notebooks: sync.notebookMiddleware,
+      // Language ID mapping for request handlers
+      // ty needs "python" language ID, but marimo uses "mo-python" to avoid conflicts
+      didOpen: (doc, next) => next(wrapDocument(doc)),
+      didClose: (doc, next) => next(wrapDocument(doc)),
+      didChange: (change, next) =>
+        next({ ...change, document: wrapDocument(change.document) }),
+      provideHover: (doc, position, token, next) =>
+        next(wrapDocument(doc), position, token),
+      provideDefinition: (doc, position, token, next) =>
+        next(wrapDocument(doc), position, token),
+      provideTypeDefinition: (doc, position, token, next) =>
+        next(wrapDocument(doc), position, token),
+      provideReferences: (doc, position, context, token, next) =>
+        next(wrapDocument(doc), position, context, token),
+      provideRenameEdits: (doc, position, newName, token, next) =>
+        next(wrapDocument(doc), position, newName, token),
+      prepareRename: (doc, position, token, next) =>
+        next(wrapDocument(doc), position, token),
+      provideCompletionItem: (doc, position, context, token, next) =>
+        next(wrapDocument(doc), position, context, token),
+      provideSignatureHelp: (doc, position, context, token, next) =>
+        next(wrapDocument(doc), position, context, token),
+      provideDocumentHighlights: (doc, position, token, next) =>
+        next(wrapDocument(doc), position, token),
+      provideDocumentSymbols: (doc, token, next) =>
+        next(wrapDocument(doc), token),
+      provideInlayHints: (doc, range, token, next) =>
+        next(wrapDocument(doc), range, token),
+
+      // WORKAROUND: ty panics when receiving textDocument/diagnostic for (.py) notebook
+      // cells because it only supports text document diagnostics, not notebook
+      // documents. We suppress these requests client-side until ty adds full
+      // notebook diagnostics support.
+      provideDiagnostics(doc, previousResultId, token, next) {
+        const uri = "scheme" in doc ? doc : doc.uri;
+        if (uri.scheme === "vscode-notebook-cell") {
+          return null;
+        }
+        return next(uri, previousResultId, token);
+      },
+      workspace: {
+        /**
+         * Enriches the configuration response with the active Python environment
+         * as reported by the Python extension (respecting the scope URI).
+         */
+        async configuration(params, token, next) {
+          const response = await next(params, token);
+
+          if (response instanceof ResponseError) {
+            return response;
+          }
+
+          const enrichedResponse = await runPromise(
+            Effect.all(
+              params.items.map(
+                Effect.fn(function* (param, index) {
+                  const code = yield* VsCode;
+                  const pythonExtension = yield* PythonExtension;
+
+                  const result = response[index];
+
+                  // Only enrich ty configuration requests
+                  if (param.section === "ty") {
+                    const scopeUri = param.scopeUri
+                      ? code.Uri.parse(param.scopeUri, true)
+                      : undefined;
+
+                    const path =
+                      yield* pythonExtension.getActiveEnvironmentPath(scopeUri);
+
+                    const resolved =
+                      yield* pythonExtension.resolveEnvironment(path);
+
+                    const env = Option.getOrNull(resolved);
+
+                    yield* Effect.logDebug(
+                      `Enriching ty config with Python env: ${env?.path || "null"} (${env?.version?.sysVersion || "unknown version"})`,
+                    );
+
+                    const activeEnvironment =
+                      env == null
+                        ? null
+                        : {
+                            version:
+                              env.version == null
+                                ? null
+                                : {
+                                    major: env.version.major,
+                                    minor: env.version.minor,
+                                    patch: env.version.micro,
+                                    sysVersion: env.version.sysVersion,
+                                  },
+                            environment:
+                              env.environment == null
+                                ? null
+                                : {
+                                    folderUri:
+                                      env.environment.folderUri.toString(),
+                                    name: env.environment.name,
+                                    type: env.environment.type,
+                                  },
+                            executable: {
+                              uri: env.executable.uri?.toString(),
+                              sysPrefix: env.executable.sysPrefix,
+                            },
+                          };
+
+                    // Filter out extension-only settings that shouldn't be sent to the server
+                    const serverSettings = Object.fromEntries(
+                      Object.entries(result ?? {}).filter(
+                        ([key]) => !isExtensionOnlyKey(key),
+                      ),
+                    );
+
+                    return {
+                      ...serverSettings,
+                      pythonExtension: {
+                        ...result?.pythonExtension,
+                        activeEnvironment,
+                      },
+                    };
+                  }
+
+                  return result;
+                }),
+              ),
+            ),
+            { signal: signalFromToken(token) },
+          );
+
+          return enrichedResponse;
+        },
+      },
+    };
+  });
+}
+
+/**
+ * Checks if the managed ty language server should be enabled.
+ * Returns Some(reason) if disabled, None if enabled.
+ */
+const getTyDisabledReason = Effect.fn(function* () {
+  const config = yield* Config;
+
+  const mode = yield* config.getLanguageFeaturesMode();
+
+  if (mode !== "managed") {
+    const reason =
+      mode === "external"
+        ? 'Language features mode is set to "external". Using external language servers instead of managed ty.'
+        : 'Language features mode is set to "none". All language features are disabled.';
+    yield* Effect.logInfo(`Not starting managed ty language server: ${reason}`);
+    return Option.some(reason);
+  }
+
+  return Option.none();
+});

--- a/extension/src/utils/__tests__/getCellExecutableCode.test.ts
+++ b/extension/src/utils/__tests__/getCellExecutableCode.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect } from "effect";
+import type * as vscode from "vscode";
+
+import {
+  createNotebookCell,
+  createNotebookUri,
+  createTestNotebookDocument,
+} from "../../__mocks__/TestVsCode.ts";
+import { type CellMetadata, MarimoNotebookCell } from "../../schemas.ts";
+import { Constants } from "../../services/Constants.ts";
+import { getCellExecutableCode } from "../getCellExecutableCode.ts";
+
+const notebookUri = createNotebookUri("file:///test/notebook_mo.py");
+
+// Helper to create a mock cell with proper MarimoNotebookCell wrapping
+function createMockCell(
+  uri: vscode.Uri,
+  languageId: string,
+  value: string,
+  metadata: Partial<CellMetadata> = {},
+) {
+  const rawCell = createNotebookCell(
+    createTestNotebookDocument(uri),
+    {
+      kind: 2, // Code
+      value,
+      languageId,
+      metadata,
+    },
+    0,
+  );
+  return MarimoNotebookCell.from(rawCell);
+}
+
+describe("getCellExecutableCode", () => {
+  it.effect("should transform SQL cell with custom dataframe name", () =>
+    Effect.gen(function* () {
+      const { LanguageId } = yield* Constants;
+
+      const cell = createMockCell(notebookUri, "sql", "SELECT * FROM users", {
+        languageMetadata: {
+          sql: {
+            dataframeName: "my_results",
+            quotePrefix: "f",
+            commentLines: [],
+            showOutput: true,
+            engine: "__marimo_duckdb",
+          },
+        },
+        stableId: "test-cell-id",
+      });
+
+      const code = getCellExecutableCode(cell, LanguageId);
+
+      // Should contain the custom dataframe name
+      expect(code).toContain("my_results = mo.sql(");
+      // Should not use default _df
+      expect(code).not.toContain("_df = mo.sql(");
+    }).pipe(Effect.provide(Constants.Default)),
+  );
+
+  it.effect("should use default metadata when SQL cell has no metadata", () =>
+    Effect.gen(function* () {
+      const { LanguageId } = yield* Constants;
+
+      const cell = createMockCell(notebookUri, "sql", "SELECT * FROM users", {
+        stableId: "test-cell-id",
+        // No languageMetadata.sql
+      });
+
+      const code = getCellExecutableCode(cell, LanguageId);
+
+      // Should use default _df when no metadata
+      expect(code).toContain("_df = mo.sql(");
+    }).pipe(Effect.provide(Constants.Default)),
+  );
+
+  it.effect("should pass through Python cells unchanged", () =>
+    Effect.gen(function* () {
+      const { LanguageId } = yield* Constants;
+
+      const pythonCode = "x = 1 + 2";
+      const cell = createMockCell(notebookUri, LanguageId.Python, pythonCode, {
+        stableId: "test-cell-id",
+      });
+
+      const code = getCellExecutableCode(cell, LanguageId);
+
+      expect(code).toBe(pythonCode);
+    }).pipe(Effect.provide(Constants.Default)),
+  );
+
+  it.effect("should handle SQL metadata with output=False", () =>
+    Effect.gen(function* () {
+      const { LanguageId } = yield* Constants;
+
+      const cell = createMockCell(notebookUri, "sql", "CREATE TABLE test", {
+        languageMetadata: {
+          sql: {
+            dataframeName: "result",
+            quotePrefix: "f",
+            commentLines: [],
+            showOutput: false,
+            engine: "__marimo_duckdb",
+          },
+        },
+        stableId: "test-cell-id",
+      });
+
+      const code = getCellExecutableCode(cell, LanguageId);
+
+      expect(code).toContain("result = mo.sql(");
+      expect(code).toContain("output=False");
+    }).pipe(Effect.provide(Constants.Default)),
+  );
+
+  it.effect("should handle SQL metadata with custom engine", () =>
+    Effect.gen(function* () {
+      const { LanguageId } = yield* Constants;
+
+      const cell = createMockCell(notebookUri, "sql", "SELECT 1", {
+        languageMetadata: {
+          sql: {
+            dataframeName: "df",
+            quotePrefix: "f",
+            commentLines: [],
+            showOutput: true,
+            engine: "postgres_conn",
+          },
+        },
+        stableId: "test-cell-id",
+      });
+
+      const code = getCellExecutableCode(cell, LanguageId);
+
+      expect(code).toContain("df = mo.sql(");
+      expect(code).toContain("engine=postgres_conn");
+    }).pipe(Effect.provide(Constants.Default)),
+  );
+});


### PR DESCRIPTION
The old boolean toggle only offered two states: managed features on or off. This changes the default to `"none"`. There are some rough edges with ty installs that cause users issues, so we'd rather folks opt in to managed features explicitly.

This introduces `marimo.languageFeatures` with three modes:

| Mode       | Language ID | ty/Ruff | External servers |
|------------|-------------|---------|------------------|
| `managed`  | `mo-python` | Yes     | No               |
| `external` | `python`    | No      | Yes              |
| `none`     | `mo-python` | No      | No               |

The default is `"none"`. The old boolean is deprecated but still honored during migration via `config.inspect()` to detect explicit user settings, with the new enum taking priority.