### PR TITLE
Fix Windows URI lookup failure with percent-encoded drive letters

### DIFF
--- a/extension/src/commands/createSetupCell.ts
+++ b/extension/src/commands/createSetupCell.ts
@@ -53,7 +53,7 @@ export const createSetupCell = Effect.fn(function* () {
 
   yield* Effect.logInfo("Created setup cell").pipe(
     Effect.annotateLogs({
-      notebook: notebook.value.uri.toString(),
+      notebook: notebook.value.id,
     }),
   );
 });

--- a/extension/src/commands/runStale.ts
+++ b/extension/src/commands/runStale.ts
@@ -30,7 +30,7 @@ export const runStale = Effect.fn("command.runStale")(
     yield* Effect.logInfo("Running stale cells").pipe(
       Effect.annotateLogs({
         staleCount: staleCells.length,
-        notebook: notebook.value.uri.toString(),
+        notebook: notebook.value.id,
       }),
     );
 

--- a/extension/src/schemas/vscode-notebook.ts
+++ b/extension/src/schemas/vscode-notebook.ts
@@ -270,7 +270,9 @@ export class MarimoNotebookDocument {
   }
 
   get id() {
-    return NotebookId(this.#raw.uri.toString());
+    // The LSP server keys notebook documents by the URI from notebookDocument/didOpen,
+    // which VS Code sends without percent-encoding. We should match that form here.
+    return NotebookId(this.#raw.uri.toString(/* skipEncoding */ true));
   }
 
   get header() {

--- a/extension/src/services/ControllerRegistry.ts
+++ b/extension/src/services/ControllerRegistry.ts
@@ -194,7 +194,7 @@ const updateNotebookAffinityEffect = Effect.fnUntraced(function* (options: {
   if (notebook.header.includes("/// script")) {
     yield* Effect.logDebug(
       "Setting affinity to sandbox controller (script header detected)",
-    ).pipe(Effect.annotateLogs({ notebookUri: notebook.uri.toString() }));
+    ).pipe(Effect.annotateLogs({ notebookUri: notebook.id }));
 
     // Prefer sandbox controller
     yield* sandboxController.updateNotebookAffinity(
@@ -214,7 +214,7 @@ const updateNotebookAffinityEffect = Effect.fnUntraced(function* (options: {
       "Setting affinity to venv controller (venv detected)",
     ).pipe(
       Effect.annotateLogs({
-        notebookUri: notebook.uri.toString(),
+        notebookUri: notebook.id,
         venvPath: venvPath.value,
       }),
     );
@@ -260,7 +260,7 @@ const trackControllerSelections = (
         yield* Effect.logDebug("Updated controller for notebook").pipe(
           Effect.annotateLogs({
             controllerId: controller.id,
-            notebookUri: e.notebook.uri.toString(),
+            notebookUri: notebook.id,
           }),
         );
       }),

--- a/extension/src/services/DebugAdapter.ts
+++ b/extension/src/services/DebugAdapter.ts
@@ -115,7 +115,7 @@ export class DebugAdapter extends Effect.Service<DebugAdapter>()(
               config.type = "marimo";
               config.name = config.name ?? "Debug Marimo";
               config.request = config.request ?? "launch";
-              config.notebookUri = notebook.value.uri.toString();
+              config.notebookUri = notebook.value.id;
               yield* Effect.logInfo("Configuration resolved").pipe(
                 Effect.annotateLogs({
                   notebookUri: config.notebookUri,

--- a/src/marimo_lsp/app_file_manager.py
+++ b/src/marimo_lsp/app_file_manager.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pathlib
 from typing import TYPE_CHECKING, Any, cast
+from urllib.parse import unquote
 
 from marimo._ast.app import App, InternalApp
 from pygls.uris import to_fs_path
@@ -11,6 +12,7 @@ from pygls.uris import to_fs_path
 from marimo_lsp.utils import decode_marimo_cell_metadata
 
 if TYPE_CHECKING:
+    import lsprotocol.types as lsp
     from marimo._ast.cell import CellConfig
     from marimo._types.ids import CellId_t
     from pygls.lsp.server import LanguageServer
@@ -107,11 +109,33 @@ class LspAppFileManager:
         return None
 
 
+def _find_notebook_document(
+    workspace: Workspace, notebook_uri: str
+) -> lsp.NotebookDocument:
+    """Find a notebook document, handling percent-encoded URIs.
+
+    VS Code may percent-encode the Windows drive letter colon in file URIs
+    (e.g., ``file:///c%3A/...`` vs ``file:///c:/...``). This helper normalizes
+    both the lookup URI and the stored keys so the document is found regardless
+    of encoding.
+    """
+    doc = workspace.notebook_documents.get(notebook_uri)
+    if doc is not None:
+        return doc
+
+    normalized = unquote(notebook_uri)
+    for key, doc in workspace.notebook_documents.items():
+        if unquote(key) == normalized:
+            return doc
+
+    raise KeyError(notebook_uri)
+
+
 def sync_app_with_workspace(
     workspace: Workspace, notebook_uri: str, app: InternalApp | None
 ) -> InternalApp:
     """Sync workspace with InternalApp."""
-    notebook = workspace.notebook_documents[notebook_uri]
+    notebook = _find_notebook_document(workspace, notebook_uri)
 
     # lsp.LSPObject at runtime is just a dict...
     app_config = cast("dict", notebook.metadata or {})

--- a/tests/test_app_file_manager.py
+++ b/tests/test_app_file_manager.py
@@ -1,0 +1,60 @@
+"""Tests for app_file_manager URI normalization."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import lsprotocol.types as lsp
+import pytest
+
+from marimo_lsp.app_file_manager import _find_notebook_document
+
+
+def _make_workspace(uris: list[str]) -> MagicMock:
+    """Create a mock workspace with notebook documents keyed by the given URIs."""
+    workspace = MagicMock()
+    workspace.notebook_documents = {
+        uri: lsp.NotebookDocument(
+            uri=uri,
+            notebook_type="marimo-notebook",
+            version=0,
+            cells=[],
+        )
+        for uri in uris
+    }
+    return workspace
+
+
+class TestFindNotebookDocument:
+    def test_direct_lookup(self) -> None:
+        uri = "file:///home/user/notebook.py"
+        ws = _make_workspace([uri])
+        doc = _find_notebook_document(ws, uri)
+        assert doc.uri == uri
+
+    def test_encoded_lookup_finds_decoded_key(self) -> None:
+        """URI with %3A should match a key stored with literal colon."""
+        stored = "file:///c:/Users/test/notebook.py"
+        lookup = "file:///c%3A/Users/test/notebook.py"
+        ws = _make_workspace([stored])
+        doc = _find_notebook_document(ws, lookup)
+        assert doc.uri == stored
+
+    def test_decoded_lookup_finds_encoded_key(self) -> None:
+        """URI with literal colon should match a key stored with %3A."""
+        stored = "file:///c%3A/Users/test/notebook.py"
+        lookup = "file:///c:/Users/test/notebook.py"
+        ws = _make_workspace([stored])
+        doc = _find_notebook_document(ws, lookup)
+        assert doc.uri == stored
+
+    def test_keyerror_when_no_match(self) -> None:
+        ws = _make_workspace(["file:///other/notebook.py"])
+        with pytest.raises(KeyError):
+            _find_notebook_document(ws, "file:///missing/notebook.py")
+
+    def test_untitled_uri_unaffected(self) -> None:
+        uri = "untitled:Untitled-1"
+        ws = _make_workspace([uri])
+        doc = _find_notebook_document(ws, uri)
+        assert doc.uri == uri


### PR DESCRIPTION
Fixes #439, #440.

VS Code recently started percent-encoding the Windows drive letter colon
in file URIs (e.g., `file:///c%3A/...` instead of `file:///c:/...`).
This caused a `KeyError` in `sync_app_with_workspace` because the
notebook URI sent by the extension didn't match the key pygls stored
from `notebookDocument/didOpen`.

The fix is two-sided. On the server, `_find_notebook_document` falls
back to `urllib.parse.unquote` normalization when a direct dict lookup
misses. On the extension, `MarimoNotebookDocument.id` now calls
`uri.toString(/* skipEncoding */ true)` so the URI we send to the LSP
matches the form pygls uses internally. Callers that were using
`.uri.toString()` directly are updated to use `.id` instead.
