### PR TITLE
Replace `Effect.fnUntraced` with `Effect.fn`

### DIFF
--- a/extension/src/__mocks__/TestPythonExtension.ts
+++ b/extension/src/__mocks__/TestPythonExtension.ts
@@ -48,9 +48,7 @@ export class TestPythonExtension extends Data.TaggedClass(
       },
     };
   }
-  static make = Effect.fnUntraced(function* (
-    envs: Array<py.ResolvedEnvironment> = [],
-  ) {
+  static make = Effect.fn(function* (envs: Array<py.ResolvedEnvironment> = []) {
     const known = yield* Ref.make(HashSet.make(...envs));
     const pubsub = yield* PubSub.unbounded<py.EnvironmentsChangeEvent>();
     const activePathPubsub =

--- a/extension/src/__mocks__/TestVsCode.ts
+++ b/extension/src/__mocks__/TestVsCode.ts
@@ -1312,7 +1312,7 @@ export class TestVsCode extends Data.TaggedClass("TestVsCode")<{
     return PubSub.publish(this.documentOpenedPubSub, doc);
   }
 
-  static make = Effect.fnUntraced(function* (
+  static make = Effect.fn(function* (
     options: {
       initialDocuments?: Array<vscode.NotebookDocument>;
       version?: string;

--- a/extension/src/__tests__/TestVsCode.test.ts
+++ b/extension/src/__tests__/TestVsCode.test.ts
@@ -8,7 +8,7 @@ import { VsCode } from "../services/VsCode.ts";
 describe("TestVsCode", () => {
   it.effect(
     "defaults to None active editor",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const vscode = yield* TestVsCode.make();
 
       const editor = yield* Effect.gen(function* () {
@@ -23,7 +23,7 @@ describe("TestVsCode", () => {
 
   it.effect(
     "supports initializing with notebook documents",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const editor1 = TestVsCode.makeNotebookEditor("/test/foo_mo.py");
       const editor2 = TestVsCode.makeNotebookEditor("/test/bar_mo.py");
       const vscode = yield* TestVsCode.make({
@@ -47,7 +47,7 @@ describe("TestVsCode", () => {
 
   it.effect(
     "supports setting notebook editor",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const editor = TestVsCode.makeNotebookEditor("/test/foo_mo.py");
       const vscode = yield* TestVsCode.make({
         initialDocuments: [editor.notebook],
@@ -67,7 +67,7 @@ describe("TestVsCode", () => {
 
   it.effect(
     "should emit changes to active editor stream",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const editors = [
         TestVsCode.makeNotebookEditor("/test/foo_mo.py"),
         TestVsCode.makeNotebookEditor("/test/foo_mo.py"),

--- a/extension/src/__tests__/extension.test.ts
+++ b/extension/src/__tests__/extension.test.ts
@@ -14,7 +14,7 @@ import { NOTEBOOK_TYPE } from "../constants.ts";
 import { SANDBOX_CONTROLLER_ID } from "../ids.ts";
 import { makeActivate } from "../layers/Main.ts";
 
-const withTestCtx = Effect.fnUntraced(function* () {
+const withTestCtx = Effect.fn(function* () {
   const vscode = yield* TestVsCode.make();
   const layer = Layer.empty.pipe(
     Layer.provideMerge(vscode.layer),
@@ -35,7 +35,7 @@ const withTestCtx = Effect.fnUntraced(function* () {
 describe("extension.activate", () => {
   it.scoped(
     "should return a disposable",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const { activate } = yield* withTestCtx();
 
       const context = yield* getTestExtensionContext();
@@ -56,7 +56,7 @@ describe("extension.activate", () => {
 
   it.scoped(
     "should register contributions on activation",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const { vscode, activate } = yield* withTestCtx();
 
       // activate the extension

--- a/extension/src/commands/exportNotebookAsHtml.ts
+++ b/extension/src/commands/exportNotebookAsHtml.ts
@@ -52,7 +52,7 @@ export const exportNotebookAsHtml = Effect.fn("command.exportNotebookAsHtml")(
         title: "Exporting notebook as HTML",
         cancellable: false,
       },
-      Effect.fnUntraced(function* () {
+      Effect.fn(function* () {
         // Call the LSP API to export the notebook
         const result = yield* client
           .executeCommand({

--- a/extension/src/commands/newMarimoNotebook.ts
+++ b/extension/src/commands/newMarimoNotebook.ts
@@ -50,7 +50,7 @@ def _():
   flow(
     Effect.catchTag(
       "FileSystemError",
-      Effect.fnUntraced(function* (error) {
+      Effect.fn(function* (error) {
         yield* Effect.logError("Failed to create notebook").pipe(
           Effect.annotateLogs({ cause: Cause.fail(error) }),
         );

--- a/extension/src/commands/restartKernel.ts
+++ b/extension/src/commands/restartKernel.ts
@@ -33,7 +33,7 @@ export const restartKernel = Effect.fn("command.restartKernel")(function* () {
       title: "Restarting kernel",
       cancellable: true,
     },
-    Effect.fnUntraced(function* (progress) {
+    Effect.fn(function* (progress) {
       progress.report({ message: "Closing session..." });
 
       const result = yield* client

--- a/extension/src/layers/MarimoFileDetector.ts
+++ b/extension/src/layers/MarimoFileDetector.ts
@@ -26,7 +26,7 @@ export const MarimoFileDetectorLive = Layer.scopedDiscard(
     };
 
     // Update context based on active editor
-    const updateContext = Effect.fnUntraced(function* (
+    const updateContext = Effect.fn(function* (
       editor: Option.Option<vscode.TextEditor>,
     ) {
       const isMarimoNotebook = Option.match(editor, {

--- a/extension/src/layers/RegisterCommands.ts
+++ b/extension/src/layers/RegisterCommands.ts
@@ -94,7 +94,7 @@ export const RegisterCommandsLive = Layer.scopedDiscard(
     yield* Effect.forkScoped(
       queue.pipe(
         Stream.runForEach(
-          Effect.fnUntraced(function* (result) {
+          Effect.fn(function* (result) {
             if (Either.isLeft(result)) {
               yield* telemetry.capture("executed_command", {
                 command: result.left,

--- a/extension/src/layers/__tests__/CellStatusBarProvider.test.ts
+++ b/extension/src/layers/__tests__/CellStatusBarProvider.test.ts
@@ -11,7 +11,7 @@ import {
 import type { CellMetadata } from "../../schemas.ts";
 import { CellStatusBarProviderLive } from "../CellStatusBarProvider.ts";
 
-const withTestCtx = Effect.fnUntraced(function* () {
+const withTestCtx = Effect.fn(function* () {
   const vscode = yield* TestVsCode.make();
   const layer = Layer.empty.pipe(
     Layer.provideMerge(CellStatusBarProviderLive),
@@ -43,7 +43,7 @@ function createMockCell(uri: vscode.Uri, metadata: Partial<CellMetadata> = {}) {
 
 it.effect(
   "should register staleness provider",
-  Effect.fnUntraced(function* () {
+  Effect.fn(function* () {
     const ctx = yield* withTestCtx();
     yield* Effect.gen(function* () {
       // Verify that registerNotebookCellStatusBarItemProvider was called
@@ -56,7 +56,7 @@ it.effect(
 
 it.effect(
   "should not show staleness for fresh cell",
-  Effect.fnUntraced(function* () {
+  Effect.fn(function* () {
     const ctx = yield* withTestCtx();
     yield* Effect.gen(function* () {
       const uri = notebookUri;
@@ -81,7 +81,7 @@ it.effect(
 
 it.effect(
   "should show staleness indicator for stale cell",
-  Effect.fnUntraced(function* () {
+  Effect.fn(function* () {
     const ctx = yield* withTestCtx();
     yield* Effect.gen(function* () {
       const uri = notebookUri;
@@ -114,7 +114,7 @@ it.effect(
 
 it.effect(
   "should not show name for default cell name",
-  Effect.fnUntraced(function* () {
+  Effect.fn(function* () {
     const ctx = yield* withTestCtx();
     yield* Effect.gen(function* () {
       const cell = createMockCell(notebookUri, {
@@ -132,7 +132,7 @@ it.effect(
 
 it.effect(
   "should show custom cell name",
-  Effect.fnUntraced(function* () {
+  Effect.fn(function* () {
     const ctx = yield* withTestCtx();
     yield* Effect.gen(function* () {
       const cell = createMockCell(notebookUri, {
@@ -157,7 +157,7 @@ it.effect(
 
 it.effect(
   "should show setup cell with gear icon",
-  Effect.fnUntraced(function* () {
+  Effect.fn(function* () {
     const ctx = yield* withTestCtx();
     yield* Effect.gen(function* () {
       const cell = createMockCell(notebookUri, {
@@ -183,7 +183,7 @@ it.effect(
 
 it.effect(
   "should handle cell with no metadata",
-  Effect.fnUntraced(function* () {
+  Effect.fn(function* () {
     const ctx = yield* withTestCtx();
     yield* Effect.gen(function* () {
       const cell = createMockCell(notebookUri);
@@ -201,7 +201,7 @@ it.effect(
 
 it.effect(
   "should provide change event emitter",
-  Effect.fnUntraced(function* () {
+  Effect.fn(function* () {
     const ctx = yield* withTestCtx();
     yield* Effect.gen(function* () {
       const providers = yield* ctx.vscode.getRegisteredStatusBarItemProviders();
@@ -217,7 +217,7 @@ it.effect(
 
 it.effect(
   "should handle both staleness and name simultaneously",
-  Effect.fnUntraced(function* () {
+  Effect.fn(function* () {
     const ctx = yield* withTestCtx();
     yield* Effect.gen(function* () {
       const cell = createMockCell(notebookUri, {

--- a/extension/src/layers/__tests__/MarimoCodeLensProvider.test.ts
+++ b/extension/src/layers/__tests__/MarimoCodeLensProvider.test.ts
@@ -97,7 +97,7 @@ describe("findMarimoAppLine", () => {
 // ============================================================================
 
 describe("MarimoCodeLensProviderLive", () => {
-  const withTestCtx = Effect.fnUntraced(function* () {
+  const withTestCtx = Effect.fn(function* () {
     const vscode = yield* TestVsCode.make();
     const layer = Layer.empty.pipe(
       Layer.provideMerge(MarimoCodeLensProviderLive),
@@ -108,7 +108,7 @@ describe("MarimoCodeLensProviderLive", () => {
 
   it.effect(
     "registers CodeLens provider successfully",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const ctx = yield* withTestCtx();
       yield* Effect.provide(Effect.void, ctx.layer);
       // If we get here without errors, the provider was registered successfully
@@ -118,7 +118,7 @@ describe("MarimoCodeLensProviderLive", () => {
 
   it.effect(
     "happy path: provides CodeLens for valid marimo file",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const ctx = yield* withTestCtx();
       const pythonCode = `import marimo
 

--- a/extension/src/layers/__tests__/MarimoFileDetector.test.ts
+++ b/extension/src/layers/__tests__/MarimoFileDetector.test.ts
@@ -8,7 +8,7 @@ import {
 } from "../../__mocks__/TestVsCode.ts";
 import { MarimoFileDetectorLive } from "../MarimoFileDetector.ts";
 
-const withTestCtx = Effect.fnUntraced(function* () {
+const withTestCtx = Effect.fn(function* () {
   const vscode = yield* TestVsCode.make();
   const layer = Layer.empty.pipe(
     Layer.provideMerge(MarimoFileDetectorLive),
@@ -19,7 +19,7 @@ const withTestCtx = Effect.fnUntraced(function* () {
 
 it.effect(
   "should be false on initialization without active editor",
-  Effect.fnUntraced(function* () {
+  Effect.fn(function* () {
     const ctx = yield* withTestCtx();
     // build the layer
     yield* Effect.provide(Effect.void, ctx.layer);
@@ -93,7 +93,7 @@ if __name__ == "__main__":
   ],
 ] as const)(
   "should be true on initialization with active editor: %s",
-  Effect.fnUntraced(function* ([_, pythonCode]) {
+  Effect.fn(function* ([_, pythonCode]) {
     const ctx = yield* withTestCtx();
 
     const editor = createTestTextEditor(
@@ -116,7 +116,7 @@ if __name__ == "__main__":
 
 it.effect(
   "should set context to true for valid marimo notebook",
-  Effect.fnUntraced(function* () {
+  Effect.fn(function* () {
     const ctx = yield* withTestCtx();
     const pythonCode = `import marimo
 
@@ -227,7 +227,7 @@ my_app = marimo.App()
   ],
 ] as const)(
   "should set context to false for non-marimo Python files: %s",
-  Effect.fnUntraced(function* ([_, pythonCode]) {
+  Effect.fn(function* ([_, pythonCode]) {
     const ctx = yield* withTestCtx();
     const editor = createTestTextEditor(
       createTestTextDocument("/test/notebook.py", "python", pythonCode),

--- a/extension/src/operations.ts
+++ b/extension/src/operations.ts
@@ -10,108 +10,110 @@ import type { NotificationOf } from "./types.ts";
 import { findVenvPath } from "./utils/findVenvPath.ts";
 import { installPackages } from "./utils/installPackages.ts";
 
-export const handleMissingPackageAlert = Effect.fnUntraced(function* (
-  operation: NotificationOf<"missing-package-alert">,
-  notebook: MarimoNotebookDocument,
-  controller: PythonController | SandboxController,
-) {
-  const code = yield* VsCode;
-  const config = yield* Config;
-  const tyLsp = yield* TyLanguageServer;
+export const handleMissingPackageAlert = Effect.fn("handleMissingPackageAlert")(
+  function* (
+    operation: NotificationOf<"missing-package-alert">,
+    notebook: MarimoNotebookDocument,
+    controller: PythonController | SandboxController,
+  ) {
+    const code = yield* VsCode;
+    const config = yield* Config;
+    const tyLsp = yield* TyLanguageServer;
 
-  if (operation.packages.length === 0) {
-    // Nothing to do
-    return;
-  }
+    if (operation.packages.length === 0) {
+      // Nothing to do
+      return;
+    }
 
-  if (!config.uv.enabled) {
-    // User has uv disabled
-    yield* Effect.logDebug("uv integration disabled. Skipping install.").pipe(
-      Effect.annotateLogs({
-        packages: operation.packages,
-      }),
-    );
-
-    return;
-  }
-
-  let options: { script: MarimoNotebookDocument } | { venvPath: string };
-
-  if ("executable" in controller) {
-    // Only venv environments (with pyvenv.cfg) support uv package installation
-    // Non-venv environments (pixi, conda, bazel, global) are skipped
-    const venvPath = findVenvPath(controller.executable);
-
-    if (Option.isNone(venvPath)) {
-      yield* Effect.logDebug(
-        "No venv found for environment. Skipping uv install.",
-      ).pipe(
+    if (!config.uv.enabled) {
+      // User has uv disabled
+      yield* Effect.logDebug("uv integration disabled. Skipping install.").pipe(
         Effect.annotateLogs({
           packages: operation.packages,
-          executable: controller.executable,
         }),
       );
+
       return;
     }
 
-    options = { venvPath: venvPath.value };
-  } else {
-    options = { script: notebook };
-  }
+    let options: { script: MarimoNotebookDocument } | { venvPath: string };
 
-  const choice = yield* code.window.showInformationMessage(
-    operation.packages.length === 1
-      ? `Missing package: ${operation.packages[0]}. Install with uv?`
-      : `Missing packages: ${operation.packages.join(", ")}. Install with uv?`,
-    {
-      items: ["Install All", "Customize..."],
-    },
-  );
+    if ("executable" in controller) {
+      // Only venv environments (with pyvenv.cfg) support uv package installation
+      // Non-venv environments (pixi, conda, bazel, global) are skipped
+      const venvPath = findVenvPath(controller.executable);
 
-  if (Option.isNone(choice)) {
-    // dismissed
-    return;
-  }
+      if (Option.isNone(venvPath)) {
+        yield* Effect.logDebug(
+          "No venv found for environment. Skipping uv install.",
+        ).pipe(
+          Effect.annotateLogs({
+            packages: operation.packages,
+            executable: controller.executable,
+          }),
+        );
+        return;
+      }
 
-  if (choice.value === "Install All") {
-    yield* Effect.logInfo("Install packages").pipe(
-      Effect.annotateLogs("packages", operation.packages),
-    );
-
-    if ("venvPath" in options) {
-      yield* installPackages(operation.packages, options);
+      options = { venvPath: venvPath.value };
     } else {
-      yield* installPackages(operation.packages, options);
+      options = { script: notebook };
     }
 
-    // Restart ty to pick up newly installed packages
-    yield* tyLsp.restart("packages installed via missing-package-alert");
-    return;
-  }
+    const choice = yield* code.window.showInformationMessage(
+      operation.packages.length === 1
+        ? `Missing package: ${operation.packages[0]}. Install with uv?`
+        : `Missing packages: ${operation.packages.join(", ")}. Install with uv?`,
+      {
+        items: ["Install All", "Customize..."],
+      },
+    );
 
-  if (choice.value === "Customize...") {
-    const response = yield* code.window.showInputBox({
-      prompt: "Add packages",
-      value: operation.packages.join(" "),
-      placeHolder: "package1 package2 package3",
-    });
-
-    if (Option.isNone(response)) {
+    if (Option.isNone(choice)) {
+      // dismissed
       return;
     }
 
-    const newPackages = response.value.split(" ");
-    yield* Effect.logInfo("Install packages").pipe(
-      Effect.annotateLogs("packages", newPackages),
-    );
+    if (choice.value === "Install All") {
+      yield* Effect.logInfo("Install packages").pipe(
+        Effect.annotateLogs("packages", operation.packages),
+      );
 
-    if ("venvPath" in options) {
-      yield* installPackages(newPackages, options);
-    } else {
-      yield* installPackages(newPackages, options);
+      if ("venvPath" in options) {
+        yield* installPackages(operation.packages, options);
+      } else {
+        yield* installPackages(operation.packages, options);
+      }
+
+      // Restart ty to pick up newly installed packages
+      yield* tyLsp.restart("packages installed via missing-package-alert");
+      return;
     }
 
-    // Restart ty to pick up newly installed packages
-    yield* tyLsp.restart("packages installed via missing-package-alert");
-  }
-});
+    if (choice.value === "Customize...") {
+      const response = yield* code.window.showInputBox({
+        prompt: "Add packages",
+        value: operation.packages.join(" "),
+        placeHolder: "package1 package2 package3",
+      });
+
+      if (Option.isNone(response)) {
+        return;
+      }
+
+      const newPackages = response.value.split(" ");
+      yield* Effect.logInfo("Install packages").pipe(
+        Effect.annotateLogs("packages", newPackages),
+      );
+
+      if ("venvPath" in options) {
+        yield* installPackages(newPackages, options);
+      } else {
+        yield* installPackages(newPackages, options);
+      }
+
+      // Restart ty to pick up newly installed packages
+      yield* tyLsp.restart("packages installed via missing-package-alert");
+    }
+  },
+);

--- a/extension/src/services/CellStateManager.ts
+++ b/extension/src/services/CellStateManager.ts
@@ -42,7 +42,7 @@ export class CellStateManager extends Effect.Service<CellStateManager>()(
       );
 
       // Helper to update context based on current state
-      const updateContext = Effect.fnUntraced(function* () {
+      const updateContext = Effect.fn(function* () {
         const [staleMap, activeMarimoNotebook] = yield* Effect.all([
           SubscriptionRef.get(staleStateRef),
           editorRegistry.getActiveNotebookUri(),
@@ -91,7 +91,7 @@ export class CellStateManager extends Effect.Service<CellStateManager>()(
             ),
           ),
           Stream.runForEach(
-            Effect.fnUntraced(function* (event) {
+            Effect.fn(function* (event) {
               // Process cell deletions
               // When a cell is moved, VSCode reports it as removed AND added
               // We need to filter out moved cells to find truly deleted cells

--- a/extension/src/services/ControllerRegistry.ts
+++ b/extension/src/services/ControllerRegistry.ts
@@ -75,7 +75,7 @@ export class ControllerRegistry extends Effect.Service<ControllerRegistry>()(
       yield* Effect.addFinalizer(() =>
         SynchronizedRef.updateEffect(
           handlesRef,
-          Effect.fnUntraced(function* (map) {
+          Effect.fn(function* (map) {
             yield* Effect.forEach(
               HashMap.values(map),
               ({ scope }) => Scope.close(scope, Exit.void),
@@ -179,69 +179,72 @@ export class ControllerRegistry extends Effect.Service<ControllerRegistry>()(
   },
 ) {}
 
-const updateNotebookAffinityEffect = Effect.fnUntraced(function* (options: {
-  notebook: MarimoNotebookDocument;
-  sandboxController: SandboxController;
-  handlesRef: SynchronizedRef.SynchronizedRef<
-    HashMap.HashMap<NotebookControllerId, NotebookControllerHandle>
-  >;
-  code: VsCode;
-}) {
-  const { notebook, sandboxController, handlesRef, code } = options;
-  const handles = yield* SynchronizedRef.get(handlesRef);
+const updateNotebookAffinityEffect = Effect.fn("updateNotebookAffinity")(
+  function* (options: {
+    notebook: MarimoNotebookDocument;
+    sandboxController: SandboxController;
+    handlesRef: SynchronizedRef.SynchronizedRef<
+      HashMap.HashMap<NotebookControllerId, NotebookControllerHandle>
+    >;
+    code: VsCode;
+  }) {
+    const { notebook, sandboxController, handlesRef, code } = options;
+    const handles = yield* SynchronizedRef.get(handlesRef);
 
-  // Check if header includes "/// script"
-  if (notebook.header.includes("/// script")) {
-    yield* Effect.logDebug(
-      "Setting affinity to sandbox controller (script header detected)",
-    ).pipe(Effect.annotateLogs({ notebookUri: notebook.id }));
+    // Check if header includes "/// script"
+    if (notebook.header.includes("/// script")) {
+      yield* Effect.logDebug(
+        "Setting affinity to sandbox controller (script header detected)",
+      ).pipe(Effect.annotateLogs({ notebookUri: notebook.uri.toString() }));
 
-    // Prefer sandbox controller
-    yield* sandboxController.updateNotebookAffinity(
-      notebook.rawNotebookDocument,
-      code.NotebookControllerAffinity.Preferred,
-    );
-
-    return;
-  }
-
-  // Check for venv next to notebook
-  const notebookDir = NodePath.dirname(notebook.uri.fsPath);
-  const venvPath = findVenvPath(NodePath.join(notebookDir, ".venv"));
-
-  if (Option.isSome(venvPath)) {
-    yield* Effect.logDebug(
-      "Setting affinity to venv controller (venv detected)",
-    ).pipe(
-      Effect.annotateLogs({
-        notebookUri: notebook.id,
-        venvPath: venvPath.value,
-      }),
-    );
-
-    // Find controller with matching venv path
-    // The venv path should contain the Python executable
-    const venvControllers = HashMap.filter(handles, (handle) => {
-      const controllerVenv = findVenvPath(handle.controller.executable);
-      return (
-        Option.isSome(controllerVenv) && controllerVenv.value === venvPath.value
-      );
-    });
-
-    for (const handle of HashMap.values(venvControllers)) {
-      yield* handle.controller.updateNotebookAffinity(
+      // Prefer sandbox controller
+      yield* sandboxController.updateNotebookAffinity(
         notebook.rawNotebookDocument,
         code.NotebookControllerAffinity.Preferred,
       );
-    }
-    return;
-  }
 
-  // Otherwise, don't set any affinity (let VSCode use defaults)
-  yield* Effect.logDebug(
-    "No affinity preference set (no script header or venv)",
-  ).pipe(Effect.annotateLogs({ notebookUri: notebook.id }));
-});
+      return;
+    }
+
+    // Check for venv next to notebook
+    const notebookDir = NodePath.dirname(notebook.uri.fsPath);
+    const venvPath = findVenvPath(NodePath.join(notebookDir, ".venv"));
+
+    if (Option.isSome(venvPath)) {
+      yield* Effect.logDebug(
+        "Setting affinity to venv controller (venv detected)",
+      ).pipe(
+        Effect.annotateLogs({
+          notebookUri: notebook.id,
+          venvPath: venvPath.value,
+        }),
+      );
+
+      // Find controller with matching venv path
+      // The venv path should contain the Python executable
+      const venvControllers = HashMap.filter(handles, (handle) => {
+        const controllerVenv = findVenvPath(handle.controller.executable);
+        return (
+          Option.isSome(controllerVenv) &&
+          controllerVenv.value === venvPath.value
+        );
+      });
+
+      for (const handle of HashMap.values(venvControllers)) {
+        yield* handle.controller.updateNotebookAffinity(
+          notebook.rawNotebookDocument,
+          code.NotebookControllerAffinity.Preferred,
+        );
+      }
+      return;
+    }
+
+    // Otherwise, don't set any affinity (let VSCode use defaults)
+    yield* Effect.logDebug(
+      "No affinity preference set (no script header or venv)",
+    ).pipe(Effect.annotateLogs({ notebookUri: notebook.id }));
+  },
+);
 
 const trackControllerSelections = (
   controller: AnyController,
@@ -249,7 +252,7 @@ const trackControllerSelections = (
 ) =>
   controller.selectedNotebookChanges().pipe(
     Stream.mapEffect(
-      Effect.fnUntraced(function* (e) {
+      Effect.fn(function* (e) {
         if (!e.selected) {
           // NB: We don't delete from selections when deselected
           // because another controller will overwrite it when selected
@@ -286,7 +289,7 @@ const createOrUpdateController = Effect.fn("ControllerRegistry.createOrUpdate")(
 
     yield* SynchronizedRef.updateEffect(
       handlesRef,
-      Effect.fnUntraced(function* (map) {
+      Effect.fn(function* (map) {
         const existing = HashMap.get(map, controllerId);
 
         // Just update description if we already have a controller
@@ -323,68 +326,70 @@ const createOrUpdateController = Effect.fn("ControllerRegistry.createOrUpdate")(
   },
 );
 
-const pruneStaleControllers = Effect.fnUntraced(function* (options: {
-  envs: ReadonlyArray<py.Environment>;
-  handlesRef: SynchronizedRef.SynchronizedRef<
-    HashMap.HashMap<NotebookControllerId, NotebookControllerHandle>
-  >;
-  selectionsRef: Ref.Ref<HashMap.HashMap<NotebookId, AnyController>>;
-}) {
-  const { envs, handlesRef, selectionsRef } = options;
-  yield* Effect.logDebug("Checking for stale controllers");
-  const desiredControllerIds = new Set(
-    envs.map((env) => PythonController.getId(env)),
-  );
+const pruneStaleControllers = Effect.fn("pruneStaleControllers")(
+  function* (options: {
+    envs: ReadonlyArray<py.Environment>;
+    handlesRef: SynchronizedRef.SynchronizedRef<
+      HashMap.HashMap<NotebookControllerId, NotebookControllerHandle>
+    >;
+    selectionsRef: Ref.Ref<HashMap.HashMap<NotebookId, AnyController>>;
+  }) {
+    const { envs, handlesRef, selectionsRef } = options;
+    yield* Effect.logDebug("Checking for stale controllers");
+    const desiredControllerIds = new Set(
+      envs.map((env) => PythonController.getId(env)),
+    );
 
-  yield* SynchronizedRef.updateEffect(
-    handlesRef,
-    Effect.fnUntraced(function* (map) {
-      const selections = yield* Ref.get(selectionsRef);
+    yield* SynchronizedRef.updateEffect(
+      handlesRef,
+      Effect.fn(function* (map) {
+        const selections = yield* Ref.get(selectionsRef);
 
-      // Check which controllers can be disposed
-      const toRemove: Array<NotebookControllerHandle> = [];
-      for (const [controllerId, handle] of map) {
-        if (desiredControllerIds.has(controllerId)) {
-          continue;
-        }
+        // Check which controllers can be disposed
+        const toRemove: Array<NotebookControllerHandle> = [];
+        for (const [controllerId, handle] of map) {
+          if (desiredControllerIds.has(controllerId)) {
+            continue;
+          }
 
-        const inUse = HashMap.some(
-          selections,
-          (selected) => selected.id === handle.controller.id,
-        );
-        if (inUse) {
-          yield* Effect.annotateLogs(
-            Effect.logWarning("Controller in use. Skipping removal."),
-            { controllerId: handle.controller.id },
+          const inUse = HashMap.some(
+            selections,
+            (selected) => selected.id === handle.controller.id,
           );
-          continue;
+          if (inUse) {
+            yield* Effect.annotateLogs(
+              Effect.logWarning("Controller in use. Skipping removal."),
+              { controllerId: handle.controller.id },
+            );
+            continue;
+          }
+
+          toRemove.push(handle);
         }
 
-        toRemove.push(handle);
-      }
+        // Close scopes for controllers to be removed
+        yield* Effect.forEach(
+          toRemove,
+          (handle) => Scope.close(handle.scope, Exit.void),
+          { discard: true },
+        );
 
-      // Close scopes for controllers to be removed
-      yield* Effect.forEach(
-        toRemove,
-        (handle) => Scope.close(handle.scope, Exit.void),
-        { discard: true },
-      );
+        const update = toRemove.reduce(
+          (acc, handle) => HashMap.remove(acc, handle.controller.id),
+          map,
+        );
 
-      const update = toRemove.reduce(
-        (acc, handle) => HashMap.remove(acc, handle.controller.id),
-        map,
-      );
+        // Remove all disposed controllers in one update
+        yield* Effect.annotateLogs(
+          Effect.logDebug("Completed stale controller removal"),
+          { removedCount: toRemove.length },
+        );
 
-      // Remove all disposed controllers in one update
-      yield* Effect.annotateLogs(
-        Effect.logDebug("Completed stale controller removal"),
-        { removedCount: toRemove.length },
-      );
-
-      return update;
-    }),
-  );
-});
+        return update;
+      }),
+    );
+  },
+);
 
 /**
  * Determines if the given Python environment is located within the uv cache directory.

--- a/extension/src/services/DebugAdapter.ts
+++ b/extension/src/services/DebugAdapter.ts
@@ -32,7 +32,7 @@ export class DebugAdapter extends Effect.Service<DebugAdapter>()(
 
       yield* client.streamOf("marimo/dap").pipe(
         Stream.mapEffect(
-          Effect.fnUntraced(function* ({ sessionId, message }) {
+          Effect.fn(function* ({ sessionId, message }) {
             yield* Effect.logDebug("Received DAP message from LSP").pipe(
               Effect.annotateLogs({
                 sessionId,
@@ -80,7 +80,7 @@ export class DebugAdapter extends Effect.Service<DebugAdapter>()(
                 }).pipe(
                   Effect.catchTags({
                     ExecuteCommandError: Effect.logError,
-                    LanguageClientStartError: Effect.fnUntraced(function* () {
+                    LanguageClientStartError: Effect.fn(function* () {
                       yield* showErrorAndPromptLogs(
                         "marimo-lsp failed to start.",
                       );

--- a/extension/src/services/EnvironmentValidator.ts
+++ b/extension/src/services/EnvironmentValidator.ts
@@ -124,7 +124,7 @@ print(json.dumps(packages), flush=True)`,
             }),
             Effect.catchTag(
               "SystemError",
-              Effect.fnUntraced(function* (error) {
+              Effect.fn(function* (error) {
                 const exists = yield* fs.exists(env.path);
                 return yield* exists
                   ? error
@@ -133,7 +133,7 @@ print(json.dumps(packages), flush=True)`,
             ),
             Effect.catchTag(
               "BadArgument",
-              Effect.fnUntraced(function* (error) {
+              Effect.fn(function* (error) {
                 const exists = yield* fs.exists(env.path);
                 return yield* exists
                   ? error

--- a/extension/src/services/ExecutionRegistry.ts
+++ b/extension/src/services/ExecutionRegistry.ts
@@ -380,7 +380,7 @@ class CellEntry extends Data.TaggedClass("CellEntry")<{
       pendingExecution: Option.none(),
     });
   }
-  static maybeUpdateCellOutput = Effect.fnUntraced(function* (
+  static maybeUpdateCellOutput = Effect.fn(function* (
     cell: CellEntry,
     code: VsCode,
     deps?: {

--- a/extension/src/services/GitHubClient.ts
+++ b/extension/src/services/GitHubClient.ts
@@ -59,7 +59,7 @@ export class GitHubClient extends Effect.Service<GitHubClient>()(
         transformClient: flow(
           HttpClient.mapRequest(HttpClientRequest.acceptJson),
           HttpClient.mapRequestEffect(
-            Effect.fnUntraced(function* (request) {
+            Effect.fn(function* (request) {
               // lazily try to get session when making requests
               const session = yield* code.auth
                 .getSession("github", ["gist"], { createIfNone: true })

--- a/extension/src/services/KernelManager.ts
+++ b/extension/src/services/KernelManager.ts
@@ -77,7 +77,7 @@ export class KernelManager extends Effect.Service<KernelManager>()(
       yield* Effect.forkScoped(
         client.streamOf("marimo/operation").pipe(
           Stream.mapEffect(
-            Effect.fnUntraced(function* (msg) {
+            Effect.fn(function* (msg) {
               yield* Queue.offer(queue, msg);
             }),
           ),
@@ -96,7 +96,7 @@ export class KernelManager extends Effect.Service<KernelManager>()(
               }),
               Effect.withSpan("process-operation"),
               Effect.catchAllCause(
-                Effect.fnUntraced(function* (cause) {
+                Effect.fn(function* (cause) {
                   yield* Effect.logError(
                     "Failed to process marimo operation",
                   ).pipe(Effect.annotateLogs({ cause }));
@@ -116,7 +116,7 @@ export class KernelManager extends Effect.Service<KernelManager>()(
       yield* Effect.forkScoped(
         renderer.messages().pipe(
           Stream.mapEffect(
-            Effect.fnUntraced(function* ({ editor, message }) {
+            Effect.fn(function* ({ editor, message }) {
               const notebook = MarimoNotebookDocument.from(editor.notebook);
               switch (message.command) {
                 case "update-ui-element": {

--- a/extension/src/services/LanguageClient.ts
+++ b/extension/src/services/LanguageClient.ts
@@ -100,7 +100,7 @@ export class LanguageClient extends Effect.Service<LanguageClient>()(
               title: "Restarting marimo-lsp",
               cancellable: true,
             },
-            Effect.fnUntraced(function* (progress) {
+            Effect.fn(function* (progress) {
               if (client.isRunning()) {
                 progress.report({ message: "Stopping..." });
                 yield* Effect.promise(() => client.stop());
@@ -109,7 +109,7 @@ export class LanguageClient extends Effect.Service<LanguageClient>()(
               yield* startClient().pipe(
                 Effect.catchTag(
                   "LanguageClientStartError",
-                  Effect.fnUntraced(function* (error) {
+                  Effect.fn(function* (error) {
                     const msg = "Failed to restart marimo-lsp.";
                     yield* Effect.logError(msg).pipe(
                       Effect.annotateLogs({ cause: Cause.fail(error) }),
@@ -123,7 +123,7 @@ export class LanguageClient extends Effect.Service<LanguageClient>()(
               progress.report({ message: "Done." });
             }),
           ),
-        executeCommand: Effect.fnUntraced(function* (cmd: MarimoCommand) {
+        executeCommand: Effect.fn(function* (cmd: MarimoCommand) {
           if (!client.isRunning()) {
             yield* startClient();
           }
@@ -164,7 +164,7 @@ export class LanguageClient extends Effect.Service<LanguageClient>()(
   },
 ) {}
 
-export const findLspExecutable = Effect.fnUntraced(function* (
+export const findLspExecutable = Effect.fn("findLspExecutable")(function* (
   uvBinary: string,
 ) {
   // Look for bundled wheel matching marimo_lsp-* pattern

--- a/extension/src/services/NotebookControllerFactory.ts
+++ b/extension/src/services/NotebookControllerFactory.ts
@@ -106,7 +106,7 @@ export class NotebookControllerFactory extends Effect.Service<NotebookController
                 }),
                 // Known exceptions
                 Effect.catchTags({
-                  ExecuteCommandError: Effect.fnUntraced(function* (error) {
+                  ExecuteCommandError: Effect.fn(function* (error) {
                     yield* Effect.logError("Failed to execute command").pipe(
                       Effect.annotateLogs({
                         cause: Cause.fail(error),
@@ -121,101 +121,97 @@ export class NotebookControllerFactory extends Effect.Service<NotebookController
                       { modal: true },
                     );
                   }),
-                  EnvironmentInspectionError: Effect.fnUntraced(
-                    function* (error) {
-                      yield* Effect.logError("Python venv check failed").pipe(
-                        Effect.annotateLogs({
-                          cause: Cause.fail(error),
-                          pythonPath: error.env.path,
-                          stdout: error.stdout,
-                          stderr: error.stderr,
-                        }),
-                      );
+                  EnvironmentInspectionError: Effect.fn(function* (error) {
+                    yield* Effect.logError("Python venv check failed").pipe(
+                      Effect.annotateLogs({
+                        cause: Cause.fail(error),
+                        pythonPath: error.env.path,
+                        stdout: error.stdout,
+                        stderr: error.stderr,
+                      }),
+                    );
 
-                      if (error.cause?._tag === "InvalidExecutableError") {
-                        yield* code.window.showErrorMessage(
-                          `Python executable does not exist for env: ${error.env.path}.`,
-                          { modal: true },
-                        );
-                      } else {
-                        const stderrSnippet = error.stderr
-                          ? `\n\nstderr:\n${truncate(error.stderr.trim(), 500)}`
-                          : "";
-                        yield* code.window.showErrorMessage(
-                          `Failed to check dependencies in ${formatControllerLabel(code, options.env)}.\n\n` +
-                            `Python path: ${error.env.path}` +
-                            stderrSnippet,
-                          { modal: true },
-                        );
-                      }
-                    },
-                  ),
-                  EnvironmentRequirementError: Effect.fnUntraced(
-                    function* (error) {
-                      yield* Effect.logWarning(
-                        "Environment requirements not met",
-                      ).pipe(
-                        Effect.annotateLogs({
-                          pythonPath: error.env.path,
-                          diagnostics: error.diagnostics,
-                        }),
+                    if (error.cause?._tag === "InvalidExecutableError") {
+                      yield* code.window.showErrorMessage(
+                        `Python executable does not exist for env: ${error.env.path}.`,
+                        { modal: true },
                       );
-                      const messages = error.diagnostics.map((d) => {
-                        switch (d.kind) {
-                          case "missing":
-                            return `• ${d.package}: not installed`;
-                          case "outdated":
-                            return `• ${d.package}: v${semver.format(d.currentVersion)} (requires >=v${semver.format(d.requiredVersion)})`;
-                          case "unknown":
-                            return `• ${d.package}: unable to detect`;
-                          default:
-                            return unreachable(d);
-                        }
+                    } else {
+                      const stderrSnippet = error.stderr
+                        ? `\n\nstderr:\n${truncate(error.stderr.trim(), 500)}`
+                        : "";
+                      yield* code.window.showErrorMessage(
+                        `Failed to check dependencies in ${formatControllerLabel(code, options.env)}.\n\n` +
+                          `Python path: ${error.env.path}` +
+                          stderrSnippet,
+                        { modal: true },
+                      );
+                    }
+                  }),
+                  EnvironmentRequirementError: Effect.fn(function* (error) {
+                    yield* Effect.logWarning(
+                      "Environment requirements not met",
+                    ).pipe(
+                      Effect.annotateLogs({
+                        pythonPath: error.env.path,
+                        diagnostics: error.diagnostics,
+                      }),
+                    );
+                    const messages = error.diagnostics.map((d) => {
+                      switch (d.kind) {
+                        case "missing":
+                          return `• ${d.package}: not installed`;
+                        case "outdated":
+                          return `• ${d.package}: v${semver.format(d.currentVersion)} (requires >=v${semver.format(d.requiredVersion)})`;
+                        case "unknown":
+                          return `• ${d.package}: unable to detect`;
+                        default:
+                          return unreachable(d);
+                      }
+                    });
+
+                    // Only prompt to install if uv is enabled and we have a venv
+                    // Non-venv environments (pixi, conda, bazel, global) don't have pyvenv.cfg
+                    // so uv can't install packages there
+                    const venv = findVenvPath(options.env.path);
+                    const canInstallWithUv =
+                      config.uv.enabled && Option.isSome(venv);
+
+                    if (canInstallWithUv) {
+                      const msg =
+                        `${formatControllerLabel(code, options.env)} cannot run the marimo kernel:\n\n` +
+                        messages.join("\n") +
+                        `\n\nPackages are missing or outdated.\n\nInstall with uv?`;
+
+                      const choice = yield* code.window.showErrorMessage(msg, {
+                        modal: true,
+                        items: ["Yes"],
                       });
-
-                      // Only prompt to install if uv is enabled and we have a venv
-                      // Non-venv environments (pixi, conda, bazel, global) don't have pyvenv.cfg
-                      // so uv can't install packages there
-                      const venv = findVenvPath(options.env.path);
-                      const canInstallWithUv =
-                        config.uv.enabled && Option.isSome(venv);
-
-                      if (canInstallWithUv) {
-                        const msg =
-                          `${formatControllerLabel(code, options.env)} cannot run the marimo kernel:\n\n` +
-                          messages.join("\n") +
-                          `\n\nPackages are missing or outdated.\n\nInstall with uv?`;
-
-                        const choice = yield* code.window.showErrorMessage(
-                          msg,
-                          { modal: true, items: ["Yes"] },
-                        );
-                        if (!choice) {
-                          return;
-                        }
-                        const packages = error.diagnostics.map((d) =>
-                          d.kind === "outdated"
-                            ? `${d.package}>=${semver.format(d.requiredVersion)}`
-                            : d.package,
-                        );
-                        yield* installPackages(packages, {
-                          venvPath: venv.value,
-                        }).pipe(
-                          Effect.provideService(VsCode, code),
-                          Effect.provideService(Uv, uv),
-                        );
-                      } else {
-                        const msg =
-                          `${formatControllerLabel(code, options.env)} cannot run the marimo kernel:\n\n` +
-                          messages.join("\n") +
-                          `\n\nPlease install or update the missing packages.`;
-
-                        yield* code.window.showErrorMessage(msg, {
-                          modal: true,
-                        });
+                      if (!choice) {
+                        return;
                       }
-                    },
-                  ),
+                      const packages = error.diagnostics.map((d) =>
+                        d.kind === "outdated"
+                          ? `${d.package}>=${semver.format(d.requiredVersion)}`
+                          : d.package,
+                      );
+                      yield* installPackages(packages, {
+                        venvPath: venv.value,
+                      }).pipe(
+                        Effect.provideService(VsCode, code),
+                        Effect.provideService(Uv, uv),
+                      );
+                    } else {
+                      const msg =
+                        `${formatControllerLabel(code, options.env)} cannot run the marimo kernel:\n\n` +
+                        messages.join("\n") +
+                        `\n\nPlease install or update the missing packages.`;
+
+                      yield* code.window.showErrorMessage(msg, {
+                        modal: true,
+                      });
+                    }
+                  }),
                 }),
               ),
             );

--- a/extension/src/services/NotebookDataCache.ts
+++ b/extension/src/services/NotebookDataCache.ts
@@ -91,7 +91,7 @@ export class NotebookDataCache extends Effect.Service<NotebookDataCache>()(
       }
 
       return {
-        set: Effect.fnUntraced(function* (data: vscode.NotebookData) {
+        set: Effect.fn(function* (data: vscode.NotebookData) {
           const notebook = matchRecentNotebookFromData(data, recentlyEdited);
 
           if (Option.isNone(notebook)) {
@@ -104,7 +104,7 @@ export class NotebookDataCache extends Effect.Service<NotebookDataCache>()(
             Effect.annotateLogs({ notebookId: notebook.value.id }),
           );
         }),
-        get: Effect.fnUntraced(function* (bytes: Uint8Array) {
+        get: Effect.fn(function* (bytes: Uint8Array) {
           if (Option.isNone(code)) {
             yield* Effect.logDebug(
               "Cache lookup requires VsCode service, skipping",
@@ -189,30 +189,32 @@ const matchRecentNotebookFromData = (
   return Option.none();
 };
 
-const matchRecentNotebookFromBytes = Effect.fnUntraced(function* (
-  bytes: Uint8Array,
-  deps: {
-    code: VsCode;
-    recentlyEdited: MruList<NotebookId, MarimoNotebookDocument>;
+const matchRecentNotebookFromBytes = Effect.fn("matchRecentNotebookFromBytes")(
+  function* (
+    bytes: Uint8Array,
+    deps: {
+      code: VsCode;
+      recentlyEdited: MruList<NotebookId, MarimoNotebookDocument>;
+    },
+  ) {
+    const { code, recentlyEdited } = deps;
+    const incomingContent = new TextDecoder().decode(bytes);
+
+    for (const doc of recentlyEdited.take(5)) {
+      const fileBytes = yield* code.workspace.fs
+        .readFile(doc.uri)
+        .pipe(Effect.option);
+
+      if (Option.isNone(fileBytes)) {
+        continue;
+      }
+
+      const fileContent = new TextDecoder().decode(fileBytes.value);
+      if (fileContent === incomingContent) {
+        return Option.some(doc.id);
+      }
+    }
+
+    return Option.none<NotebookId>();
   },
-) {
-  const { code, recentlyEdited } = deps;
-  const incomingContent = new TextDecoder().decode(bytes);
-
-  for (const doc of recentlyEdited.take(5)) {
-    const fileBytes = yield* code.workspace.fs
-      .readFile(doc.uri)
-      .pipe(Effect.option);
-
-    if (Option.isNone(fileBytes)) {
-      continue;
-    }
-
-    const fileContent = new TextDecoder().decode(fileBytes.value);
-    if (fileContent === incomingContent) {
-      return Option.some(doc.id);
-    }
-  }
-
-  return Option.none<NotebookId>();
-});
+);

--- a/extension/src/services/NotebookEditorRegistry.ts
+++ b/extension/src/services/NotebookEditorRegistry.ts
@@ -23,7 +23,7 @@ export class NotebookEditorRegistry extends Effect.Service<NotebookEditorRegistr
       yield* Effect.forkScoped(
         code.window.activeNotebookEditorChanges().pipe(
           Stream.mapEffect(
-            Effect.fnUntraced(function* (editor) {
+            Effect.fn(function* (editor) {
               const notebook = Option.filterMap(editor, (editor) =>
                 MarimoNotebookDocument.tryFrom(editor.notebook),
               );

--- a/extension/src/services/SandboxController.ts
+++ b/extension/src/services/SandboxController.ts
@@ -182,7 +182,7 @@ export class SandboxController extends Effect.Service<SandboxController>()(
               },
             }),
             Effect.catchAllCause(
-              Effect.fnUntraced(function* (cause) {
+              Effect.fn(function* (cause) {
                 yield* Effect.logError("Failed to interrupt execution").pipe(
                   Effect.annotateLogs({ cause }),
                 );
@@ -259,7 +259,7 @@ const findRequirements = (uv: Uv, notebook: MarimoNotebookDocument) =>
   }).pipe(
     Effect.catchTag(
       "UvMissingPep723MetadataError",
-      Effect.fnUntraced(function* () {
+      Effect.fn(function* () {
         yield* Effect.logDebug("No PEP 723 metadata.");
         return ["marimo", "pyzmq"];
       }),

--- a/extension/src/services/SessionStateManager.ts
+++ b/extension/src/services/SessionStateManager.ts
@@ -21,7 +21,7 @@ export class SessionStateManager extends Effect.Service<SessionStateManager>()(
       const controllerRegistry = yield* ControllerRegistry;
 
       // Helper to update context based on current state
-      const updateContext = Effect.fnUntraced(function* () {
+      const updateContext = Effect.fn(function* () {
         const activeNotebook = Option.filterMap(
           yield* code.window.getActiveNotebookEditor(),
           (editor) => MarimoNotebookDocument.tryFrom(editor.notebook),

--- a/extension/src/services/VsCode.ts
+++ b/extension/src/services/VsCode.ts
@@ -296,7 +296,7 @@ export class Commands extends Effect.Service<Commands>()("Commands", {
                 PubSub.publish(commandPubSub, Either.right(command)),
               ),
               Effect.catchAllCause(
-                Effect.fnUntraced(function* (cause) {
+                Effect.fn(function* (cause) {
                   // Skip logging for interruptions/cancellations (e.g., user
                   // cancels a progress dialog, VS Code disposes resources
                   // during kernel restart). These are expected and not errors.

--- a/extension/src/services/__tests__/Api.test.ts
+++ b/extension/src/services/__tests__/Api.test.ts
@@ -15,7 +15,7 @@ import { ControllerRegistry } from "../ControllerRegistry.ts";
 import { LanguageClient } from "../LanguageClient.ts";
 import { VsCode } from "../VsCode.ts";
 
-const withTestCtx = Effect.fnUntraced(function* (
+const withTestCtx = Effect.fn(function* (
   options: Parameters<(typeof TestVsCode)["make"]>[0] = {},
 ) {
   const testVsCode = yield* TestVsCode.make(options);
@@ -52,7 +52,7 @@ const withTestCtx = Effect.fnUntraced(function* (
 describe("Api", () => {
   it.scoped(
     "has experimental.kernels namespace",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const ctx = yield* withTestCtx();
 
       const api = yield* Api.pipe(Effect.provide(ctx.layer));
@@ -66,7 +66,7 @@ describe("Api", () => {
 
   it.scoped(
     "getKernel returns undefined for non-existent notebook",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const ctx = yield* withTestCtx();
 
       const kernel = yield* Effect.gen(function* () {
@@ -87,7 +87,7 @@ describe("Api", () => {
 
   it.scoped(
     "getKernel returns undefined when notebook exists but no controller",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const notebookDoc = createTestNotebookDocument(
         "file:///test/notebook_mo.py",
         {

--- a/extension/src/services/__tests__/CellMetadataUIBindingService.test.ts
+++ b/extension/src/services/__tests__/CellMetadataUIBindingService.test.ts
@@ -80,7 +80,7 @@ it.effect("should register a binding and create status bar provider", () =>
 
 it.scoped(
   "should show status bar item based on shouldShow predicate",
-  Effect.fnUntraced(function* () {
+  Effect.fn(function* () {
     const ctx = yield* withTestCtx;
     yield* Effect.gen(function* () {
       const service = yield* CellMetadataUIBindingService;

--- a/extension/src/services/__tests__/CellStateManager.test.ts
+++ b/extension/src/services/__tests__/CellStateManager.test.ts
@@ -13,7 +13,7 @@ import { CellStateManager } from "../CellStateManager.ts";
 import { LanguageClient } from "../LanguageClient.ts";
 import { VsCode } from "../VsCode.ts";
 
-const withTestCtx = Effect.fnUntraced(function* () {
+const withTestCtx = Effect.fn(function* () {
   const vscode = yield* TestVsCode.make();
   const executions = yield* Ref.make<ReadonlyArray<MarimoCommand>>([]);
   const layer = Layer.empty.pipe(
@@ -45,7 +45,7 @@ const withTestCtx = Effect.fnUntraced(function* () {
 describe("CellStateManager", () => {
   it.effect(
     "getNotebookCellId returns consistent cell IDs",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const ctx = yield* withTestCtx();
 
       yield* Effect.gen(function* () {
@@ -93,7 +93,7 @@ describe("CellStateManager", () => {
 
   it.effect(
     "deleting cell from notebook sends delete_cell command",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const ctx = yield* withTestCtx();
 
       yield* Effect.gen(function* () {
@@ -167,7 +167,7 @@ describe("CellStateManager", () => {
 
   it.effect(
     "moving cell does not send delete_cell command",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const ctx = yield* withTestCtx();
 
       yield* Effect.gen(function* () {
@@ -229,7 +229,7 @@ describe("CellStateManager", () => {
 
   it.effect(
     "updates marimo.notebook.hasStaleCells context when cells become stale",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const ctx = yield* withTestCtx();
 
       yield* Effect.gen(function* () {
@@ -291,7 +291,7 @@ describe("CellStateManager", () => {
 
   it.effect(
     "does not mark cell stale when content matches last executed (undo case)",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const ctx = yield* withTestCtx();
 
       yield* Effect.gen(function* () {

--- a/extension/src/services/__tests__/Commands.test.ts
+++ b/extension/src/services/__tests__/Commands.test.ts
@@ -4,7 +4,7 @@ import { Effect, Either, PubSub, Queue } from "effect";
 describe("Commands pubsub", () => {
   it.effect(
     "should receive command events through subscription",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const result = yield* Effect.scoped(
         Effect.gen(function* () {
           const commandPubSub =
@@ -57,7 +57,7 @@ describe("Commands pubsub", () => {
 
   it.effect(
     "should support multiple subscribers",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const result = yield* Effect.scoped(
         Effect.gen(function* () {
           const commandPubSub =

--- a/extension/src/services/__tests__/Config.test.ts
+++ b/extension/src/services/__tests__/Config.test.ts
@@ -12,7 +12,7 @@ const ConfigLive = Layer.empty.pipe(
 it.layer(ConfigLive)("Config", (it) => {
   it.effect(
     "should build",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const api = yield* Config;
       expect(api).toBeDefined();
     }),

--- a/extension/src/services/__tests__/ControllerRegistry.test.ts
+++ b/extension/src/services/__tests__/ControllerRegistry.test.ts
@@ -30,7 +30,7 @@ const TestLanguageClientMock = Layer.succeed(
   }),
 );
 
-const withTestCtx = Effect.fnUntraced(function* (
+const withTestCtx = Effect.fn(function* (
   options: { initialEnvs?: Array<py.ResolvedEnvironment> } = {},
 ) {
   const { initialEnvs = [] } = options;
@@ -52,7 +52,7 @@ const withTestCtx = Effect.fnUntraced(function* (
 
 it.effect(
   "should return None for active controller when no notebook is selected",
-  Effect.fnUntraced(function* () {
+  Effect.fn(function* () {
     const { layer } = yield* withTestCtx();
 
     const controller = yield* Effect.gen(function* () {
@@ -72,7 +72,7 @@ it.effect(
 
 it.effect(
   "should create controllers for initial python environments",
-  Effect.fnUntraced(function* () {
+  Effect.fn(function* () {
     const { layer } = yield* withTestCtx({
       initialEnvs: [
         TestPythonExtension.makeVenv("/home/user/.venv/bin/python"),
@@ -105,7 +105,7 @@ it.effect(
 
 it.effect(
   "should add controller when new python environment is added",
-  Effect.fnUntraced(function* () {
+  Effect.fn(function* () {
     const { layer, py } = yield* withTestCtx({
       initialEnvs: [TestPythonExtension.makeVenv("/usr/local/bin/python3.11")],
     });
@@ -153,7 +153,7 @@ it.effect(
 
 it.effect(
   "should remove controller when python environment is removed",
-  Effect.fnUntraced(function* () {
+  Effect.fn(function* () {
     const { layer, py } = yield* withTestCtx({
       initialEnvs: [
         TestPythonExtension.makeVenv("/usr/local/bin/python3.11"),
@@ -221,7 +221,7 @@ it.effect(
 
 it.effect(
   "should track controller selections for notebooks",
-  Effect.fnUntraced(function* () {
+  Effect.fn(function* () {
     const { layer, vscode } = yield* withTestCtx({
       initialEnvs: [
         TestPythonExtension.makeVenv("/usr/local/bin/python3.11"),
@@ -286,7 +286,7 @@ it.effect(
 
 it.effect(
   "should not remove controller when it's in use by a notebook",
-  Effect.fnUntraced(function* () {
+  Effect.fn(function* () {
     const { layer, py } = yield* withTestCtx({
       initialEnvs: [
         TestPythonExtension.makeVenv("/usr/local/bin/python3.11"),
@@ -345,7 +345,7 @@ it.effect(
 
 it.effect(
   "should handle multiple environment additions and removals",
-  Effect.fnUntraced(function* () {
+  Effect.fn(function* () {
     const { layer, py } = yield* withTestCtx({
       initialEnvs: [
         TestPythonExtension.makeVenv("/usr/local/bin/python3.11"),
@@ -483,7 +483,7 @@ it.effect(
 
 it.effect(
   "should update controller description when environment changes",
-  Effect.fnUntraced(function* () {
+  Effect.fn(function* () {
     const { layer, py } = yield* withTestCtx({
       initialEnvs: [TestPythonExtension.makeVenv("/usr/local/bin/python3.11")],
     });
@@ -532,7 +532,7 @@ it.effect(
 );
 it.effect(
   "should not set affinity when notebook has no script header or venv",
-  Effect.fnUntraced(function* () {
+  Effect.fn(function* () {
     const { layer, vscode } = yield* withTestCtx({
       initialEnvs: [TestPythonExtension.makeVenv("/usr/local/bin/python3.11")],
     });
@@ -564,7 +564,7 @@ it.effect(
 
 it.effect(
   "should handle opening multiple notebooks",
-  Effect.fnUntraced(function* () {
+  Effect.fn(function* () {
     const { layer, vscode } = yield* withTestCtx({
       initialEnvs: [TestPythonExtension.makeVenv("/usr/local/bin/python3.11")],
     });

--- a/extension/src/services/__tests__/EnvironmentValidator.test.ts
+++ b/extension/src/services/__tests__/EnvironmentValidator.test.ts
@@ -47,7 +47,7 @@ it.layer(EnvironmentValidatorLive)("EnvironmentValidator", (it) => {
 
   it.effect(
     "should build",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const api = yield* EnvironmentValidator;
       expect(api).toBeDefined();
     }),
@@ -55,7 +55,7 @@ it.layer(EnvironmentValidatorLive)("EnvironmentValidator", (it) => {
 
   it.effect(
     "should fail with missing marimo",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const uv = yield* Uv;
       const validator = yield* EnvironmentValidator;
       const tmpdir = yield* TempDir;
@@ -91,7 +91,7 @@ it.layer(EnvironmentValidatorLive)("EnvironmentValidator", (it) => {
 
   it.effect(
     "should fail with missing pyzmq",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const uv = yield* Uv;
       const validator = yield* EnvironmentValidator;
       const tmpdir = yield* TempDir;
@@ -125,7 +125,7 @@ it.layer(EnvironmentValidatorLive)("EnvironmentValidator", (it) => {
 
   it.effect(
     "Should fail with outdated marimo",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const uv = yield* Uv;
       const validator = yield* EnvironmentValidator;
       const tmpdir = yield* TempDir;
@@ -169,7 +169,7 @@ it.layer(EnvironmentValidatorLive)("EnvironmentValidator", (it) => {
 
   it.effect(
     "should succeed with marimo and pyzmq installed",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const uv = yield* Uv;
       const validator = yield* EnvironmentValidator;
       const tmpdir = yield* TempDir;
@@ -192,7 +192,7 @@ it.layer(EnvironmentValidatorLive)("EnvironmentValidator", (it) => {
 
   it.effect(
     "should fail for no python interpreter",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const validator = yield* EnvironmentValidator;
       const tmpdir = yield* TempDir;
 
@@ -216,7 +216,7 @@ it.layer(EnvironmentValidatorLive)("EnvironmentValidator", (it) => {
   describe.skipIf(isWindows)("subprocess output parsing", () => {
     it.effect(
       "should fail with EnvironmentInspectionError when stdout is empty",
-      Effect.fnUntraced(function* () {
+      Effect.fn(function* () {
         const validator = yield* EnvironmentValidator;
         const tmpdir = yield* TempDir;
         const script = makeFakeExecutable(tmpdir.path, "empty-stdout", {
@@ -235,7 +235,7 @@ it.layer(EnvironmentValidatorLive)("EnvironmentValidator", (it) => {
 
     it.effect(
       "should fail with EnvironmentInspectionError when stdout is not JSON",
-      Effect.fnUntraced(function* () {
+      Effect.fn(function* () {
         const validator = yield* EnvironmentValidator;
         const tmpdir = yield* TempDir;
         const script = makeFakeExecutable(tmpdir.path, "non-json", {
@@ -258,7 +258,7 @@ it.layer(EnvironmentValidatorLive)("EnvironmentValidator", (it) => {
 
     it.effect(
       "should fail with EnvironmentInspectionError on non-zero exit code",
-      Effect.fnUntraced(function* () {
+      Effect.fn(function* () {
         const validator = yield* EnvironmentValidator;
         const tmpdir = yield* TempDir;
         const script = makeFakeExecutable(tmpdir.path, "exit-1", {
@@ -282,7 +282,7 @@ it.layer(EnvironmentValidatorLive)("EnvironmentValidator", (it) => {
 
     it.effect(
       "should fail with EnvironmentInspectionError on truncated JSON",
-      Effect.fnUntraced(function* () {
+      Effect.fn(function* () {
         const validator = yield* EnvironmentValidator;
         const tmpdir = yield* TempDir;
         const script = makeFakeExecutable(tmpdir.path, "truncated-json", {
@@ -301,7 +301,7 @@ it.layer(EnvironmentValidatorLive)("EnvironmentValidator", (it) => {
 
     it.effect(
       "should fail with EnvironmentInspectionError on wrong JSON shape",
-      Effect.fnUntraced(function* () {
+      Effect.fn(function* () {
         const validator = yield* EnvironmentValidator;
         const tmpdir = yield* TempDir;
         const script = makeFakeExecutable(tmpdir.path, "wrong-shape", {
@@ -320,7 +320,7 @@ it.layer(EnvironmentValidatorLive)("EnvironmentValidator", (it) => {
 
     it.effect(
       "should handle JSON with extra whitespace/newlines",
-      Effect.fnUntraced(function* () {
+      Effect.fn(function* () {
         const validator = yield* EnvironmentValidator;
         const tmpdir = yield* TempDir;
         const json = JSON.stringify([
@@ -343,7 +343,7 @@ it.layer(EnvironmentValidatorLive)("EnvironmentValidator", (it) => {
 
     it.effect(
       "should treat null versions as missing packages",
-      Effect.fnUntraced(function* () {
+      Effect.fn(function* () {
         const validator = yield* EnvironmentValidator;
         const tmpdir = yield* TempDir;
         const json = JSON.stringify([
@@ -373,7 +373,7 @@ it.layer(EnvironmentValidatorLive)("EnvironmentValidator", (it) => {
 
     it.effect(
       "should fail with EnvironmentInspectionError when stderr has content but exit code 0 and empty stdout",
-      Effect.fnUntraced(function* () {
+      Effect.fn(function* () {
         const validator = yield* EnvironmentValidator;
         const tmpdir = yield* TempDir;
         const script = makeFakeExecutable(tmpdir.path, "stderr-only", {
@@ -422,7 +422,7 @@ const decodeSemVer = Schema.decodeUnknownEither(SemVerFromString);
 
 it.effect(
   "SemVerFromString: parses standard semver",
-  Effect.fnUntraced(function* () {
+  Effect.fn(function* () {
     yield* Effect.void;
     const result = decodeSemVer("1.2.3");
     assert(Either.isRight(result));
@@ -432,7 +432,7 @@ it.effect(
 
 it.effect(
   "SemVerFromString: parses two-part version (PyPI style)",
-  Effect.fnUntraced(function* () {
+  Effect.fn(function* () {
     yield* Effect.void;
     const result = decodeSemVer("26.2");
     assert(Either.isRight(result));
@@ -442,7 +442,7 @@ it.effect(
 
 it.effect(
   "SemVerFromString: parses version with prerelease suffix",
-  Effect.fnUntraced(function* () {
+  Effect.fn(function* () {
     yield* Effect.void;
     const result = decodeSemVer("0.21.0-rc1");
     assert(Either.isRight(result));
@@ -452,7 +452,7 @@ it.effect(
 
 it.effect(
   "SemVerFromString: fails on garbage input",
-  Effect.fnUntraced(function* () {
+  Effect.fn(function* () {
     yield* Effect.void;
     const result = decodeSemVer("not-a-version");
     assert(Either.isLeft(result));
@@ -461,7 +461,7 @@ it.effect(
 
 it.effect(
   "SemVerFromString: fails on empty string",
-  Effect.fnUntraced(function* () {
+  Effect.fn(function* () {
     yield* Effect.void;
     const result = decodeSemVer("");
     assert(Either.isLeft(result));

--- a/extension/src/services/__tests__/ExecutionRegistry.test.ts
+++ b/extension/src/services/__tests__/ExecutionRegistry.test.ts
@@ -36,7 +36,7 @@ const TestLanguageClientMock = Layer.succeed(
   }),
 );
 
-const withTestCtx = Effect.fnUntraced(function* (
+const withTestCtx = Effect.fn(function* (
   options: Parameters<(typeof TestVsCode)["make"]>[0] = {},
 ) {
   const vscode = yield* TestVsCode.make(options);
@@ -85,7 +85,7 @@ describe("buildCellOutputs", () => {
   it.effect(
     "handles stdout output",
 
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const ctx = yield* withTestCtx();
 
       const outputs = yield* Effect.gen(function* () {
@@ -110,7 +110,7 @@ describe("buildCellOutputs", () => {
 
   it.effect(
     "handles stderr output",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const ctx = yield* withTestCtx();
 
       const outputs = yield* Effect.gen(function* () {
@@ -136,7 +136,7 @@ describe("buildCellOutputs", () => {
 
   it.effect(
     "handles multiple console outputs",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const ctx = yield* withTestCtx();
 
       const outputs = yield* Effect.gen(function* () {
@@ -174,7 +174,7 @@ describe("buildCellOutputs", () => {
 
   it.effect(
     "handles marimo error output",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const ctx = yield* withTestCtx();
 
       const outputs = yield* Effect.gen(function* () {
@@ -203,7 +203,7 @@ describe("buildCellOutputs", () => {
 
   it.effect(
     "handles HTML output",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const ctx = yield* withTestCtx();
       const outputs = yield* Effect.gen(function* () {
         const code = yield* VsCode;
@@ -226,7 +226,7 @@ describe("buildCellOutputs", () => {
 
   it.effect(
     "handles JSON output",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const ctx = yield* withTestCtx();
 
       const outputs = yield* Effect.gen(function* () {
@@ -249,7 +249,7 @@ describe("buildCellOutputs", () => {
 
   it.effect(
     "handles mixed output and console streams",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const ctx = yield* withTestCtx();
       const outputs = yield* Effect.gen(function* () {
         const code = yield* VsCode;
@@ -286,7 +286,7 @@ describe("buildCellOutputs", () => {
 
   it.effect(
     "handles stdin output",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const ctx = yield* withTestCtx();
 
       const outputs = yield* Effect.gen(function* () {
@@ -312,7 +312,7 @@ describe("buildCellOutputs", () => {
 
   it.effect(
     "handles empty state",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const ctx = yield* withTestCtx();
 
       const outputs = yield* Effect.gen(function* () {
@@ -328,7 +328,7 @@ describe("buildCellOutputs", () => {
 
   it.effect(
     "handles multiple errors in marimo error output",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const ctx = yield* withTestCtx();
 
       const outputs = yield* Effect.gen(function* () {
@@ -362,7 +362,7 @@ describe("buildCellOutputs", () => {
 
   it.effect(
     "handles multiple stderr errors",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const ctx = yield* withTestCtx();
 
       const outputs = yield* Effect.gen(function* () {
@@ -400,7 +400,7 @@ describe("buildCellOutputs", () => {
 
   it.effect(
     "handles stdout + stderr + output together",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const ctx = yield* withTestCtx();
 
       const outputs = yield* Effect.gen(function* () {
@@ -444,7 +444,7 @@ describe("buildCellOutputs", () => {
 
   it.effect(
     "handles application/vnd.marimo+traceback output",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const ctx = yield* withTestCtx();
 
       const outputs = yield* Effect.gen(function* () {
@@ -467,7 +467,7 @@ describe("buildCellOutputs", () => {
 
   it.effect(
     "filters out empty text/plain stdout output",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const ctx = yield* withTestCtx();
 
       const state: CellRuntimeState = {
@@ -493,7 +493,7 @@ describe("buildCellOutputs", () => {
 
   it.effect(
     "filters out empty text/plain stderr output",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const ctx = yield* withTestCtx();
 
       const state: CellRuntimeState = {
@@ -519,7 +519,7 @@ describe("buildCellOutputs", () => {
 
   it.effect(
     "filters out empty traceback output",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const ctx = yield* withTestCtx();
 
       const state: CellRuntimeState = {
@@ -542,7 +542,7 @@ describe("buildCellOutputs", () => {
 
   it.effect(
     "filters out null output data",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const ctx = yield* withTestCtx();
 
       const state: CellRuntimeState = {
@@ -565,7 +565,7 @@ describe("buildCellOutputs", () => {
 
   it.effect(
     "filters out undefined output data",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const ctx = yield* withTestCtx();
 
       const state: CellRuntimeState = {
@@ -588,7 +588,7 @@ describe("buildCellOutputs", () => {
 
   it.effect(
     "handles mix of empty and non-empty console outputs",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const ctx = yield* withTestCtx();
       const state: CellRuntimeState = {
         ...createCellRuntimeState(),
@@ -631,7 +631,7 @@ describe("buildCellOutputs", () => {
 
   it.effect(
     "handles null output object",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const ctx = yield* withTestCtx();
 
       const state: CellRuntimeState = {
@@ -650,7 +650,7 @@ describe("buildCellOutputs", () => {
 
   it.effect(
     "handles empty marimo error data array",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const ctx = yield* withTestCtx();
       const state: CellRuntimeState = {
         ...createCellRuntimeState(),
@@ -673,7 +673,7 @@ describe("buildCellOutputs", () => {
 
   it.effect(
     "preserves whitespace-only output",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const ctx = yield* withTestCtx();
       const state: CellRuntimeState = {
         ...createCellRuntimeState(),
@@ -698,7 +698,7 @@ describe("buildCellOutputs", () => {
 
   it.effect(
     "handles numeric zero output",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const ctx = yield* withTestCtx();
       const state: CellRuntimeState = {
         ...createCellRuntimeState(),
@@ -721,7 +721,7 @@ describe("buildCellOutputs", () => {
 
   it.effect(
     "handles boolean false output",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const ctx = yield* withTestCtx();
       const state: CellRuntimeState = {
         ...createCellRuntimeState(),
@@ -744,7 +744,7 @@ describe("buildCellOutputs", () => {
 
   it.effect(
     "handles media channel in console outputs",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const ctx = yield* withTestCtx();
       const state: CellRuntimeState = {
         ...createCellRuntimeState(),
@@ -769,7 +769,7 @@ describe("buildCellOutputs", () => {
 
   it.effect(
     "ignores output/marimo-error/pdb channels in console outputs",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const ctx = yield* withTestCtx();
       const state: CellRuntimeState = {
         ...createCellRuntimeState(),
@@ -813,7 +813,7 @@ describe("buildCellOutputs", () => {
 
   it.effect(
     "separates console outputs from main output correctly",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const ctx = yield* withTestCtx();
       const state: CellRuntimeState = {
         ...createCellRuntimeState(),
@@ -845,7 +845,7 @@ describe("buildCellOutputs", () => {
 
   it.effect(
     "handles media channel with stdout in console outputs",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const ctx = yield* withTestCtx();
       const state: CellRuntimeState = {
         ...createCellRuntimeState(),
@@ -878,7 +878,7 @@ describe("buildCellOutputs", () => {
 
 it.scoped(
   "marks cell as stale when message has staleInputs",
-  Effect.fnUntraced(function* () {
+  Effect.fn(function* () {
     const editor = TestVsCode.makeNotebookEditor(
       "file:///test/notebook_mo.py",
       {
@@ -951,7 +951,7 @@ it.scoped(
 
 it.scoped(
   "clears stale state when cell is queued for execution",
-  Effect.fnUntraced(function* () {
+  Effect.fn(function* () {
     const ctx = yield* withTestCtx();
 
     yield* Effect.gen(function* () {
@@ -1045,7 +1045,7 @@ function makeThrowingController(): PythonController {
 
 it.scoped(
   "handles InvalidCellError when createNotebookCellExecution throws on queued",
-  Effect.fnUntraced(function* () {
+  Effect.fn(function* () {
     const editor = TestVsCode.makeNotebookEditor(
       "file:///test/notebook_mo.py",
       {
@@ -1097,7 +1097,7 @@ it.scoped(
 
 it.scoped(
   "handles InvalidCellError on ephemeral execution for marimo error",
-  Effect.fnUntraced(function* () {
+  Effect.fn(function* () {
     const editor = TestVsCode.makeNotebookEditor(
       "file:///test/notebook_mo.py",
       {

--- a/extension/src/services/__tests__/NotebookDataCache.test.ts
+++ b/extension/src/services/__tests__/NotebookDataCache.test.ts
@@ -18,7 +18,7 @@ function makeCacheLayer(vscode: TestVsCode) {
 
 it.effect(
   "should gracefully handle file read errors when matching notebooks from bytes",
-  Effect.fnUntraced(function* () {
+  Effect.fn(function* () {
     const deletedFileUri = Uri.file("/test/deleted_mo.py");
     const notebookContent = "x = 1";
 
@@ -69,7 +69,7 @@ it.effect(
 
 it.effect(
   "should skip deleted files and continue checking other notebooks in MRU list",
-  Effect.fnUntraced(function* () {
+  Effect.fn(function* () {
     const deletedFileUri = Uri.file("/test/deleted_mo.py");
     const existingFileUri = Uri.file("/test/existing_mo.py");
     const notebookContent = "print('hello')";
@@ -137,7 +137,7 @@ it.effect(
 
 it.effect(
   "should return None when file exists but content does not match",
-  Effect.fnUntraced(function* () {
+  Effect.fn(function* () {
     const existingFileUri = Uri.file("/test/existing_mo.py");
     const fileContent = "x = 1";
     const differentContent = "y = 2";

--- a/extension/src/services/__tests__/NotebookEditorRegistry.test.ts
+++ b/extension/src/services/__tests__/NotebookEditorRegistry.test.ts
@@ -20,7 +20,7 @@ function makeRegistryLayer(vscode: TestVsCode) {
 
 it.effect(
   "should return None when no active notebook editor",
-  Effect.fnUntraced(function* () {
+  Effect.fn(function* () {
     const vscode = yield* TestVsCode.make();
 
     yield* Effect.provide(
@@ -40,7 +40,7 @@ it.effect(
 
 it.effect(
   "should track active notebook editor changes",
-  Effect.fnUntraced(function* () {
+  Effect.fn(function* () {
     const vscode = yield* TestVsCode.make();
 
     yield* Effect.provide(
@@ -96,7 +96,7 @@ it.effect(
 
 it.effect(
   "should track stream of active notebook editor changes",
-  Effect.fnUntraced(function* () {
+  Effect.fn(function* () {
     const vscode = yield* TestVsCode.make();
 
     yield* Effect.provide(

--- a/extension/src/services/__tests__/NotebookSerializer.test.ts
+++ b/extension/src/services/__tests__/NotebookSerializer.test.ts
@@ -28,7 +28,7 @@ it.layer(NotebookSerializerLive, { timeout: 30_000 })(
 
     it.effect(
       "serializes notebook cells to marimo format",
-      Effect.fnUntraced(function* () {
+      Effect.fn(function* () {
         const { LanguageId } = yield* Constants;
         const serializer = yield* NotebookSerializer;
         const bytes = yield* serializer.serializeEffect({
@@ -74,7 +74,7 @@ it.layer(NotebookSerializerLive, { timeout: 30_000 })(
 
     it.effect(
       "serializes markdown notebook cells to marimo format",
-      Effect.fnUntraced(function* () {
+      Effect.fn(function* () {
         const { LanguageId } = yield* Constants;
         const serializer = yield* NotebookSerializer;
         const bytes = yield* serializer.serializeEffect({
@@ -136,7 +136,7 @@ it.layer(NotebookSerializerLive, { timeout: 30_000 })(
 
     it.effect(
       "deserializes mo.md() without f-strings to markdown cells",
-      Effect.fnUntraced(function* () {
+      Effect.fn(function* () {
         const { LanguageId } = yield* Constants;
         const serializer = yield* NotebookSerializer;
         const source = `import marimo
@@ -194,7 +194,7 @@ if __name__ == "__main__":
 
     it.effect(
       "keeps mo.md() with f-strings as Python cells",
-      Effect.fnUntraced(function* () {
+      Effect.fn(function* () {
         const { LanguageId } = yield* Constants;
         const serializer = yield* NotebookSerializer;
         const source = `import marimo
@@ -240,7 +240,7 @@ if __name__ == "__main__":
 
     it.effect(
       "round-trip markdown cells maintain mo.md() format",
-      Effect.fnUntraced(function* () {
+      Effect.fn(function* () {
         const { LanguageId } = yield* Constants;
         const serializer = yield* NotebookSerializer;
         const source = `import marimo

--- a/extension/src/services/__tests__/OutputChannel.test.ts
+++ b/extension/src/services/__tests__/OutputChannel.test.ts
@@ -12,7 +12,7 @@ const OutputChannelLive = Layer.empty.pipe(
 it.layer(OutputChannelLive)("OutputChannel", (it) => {
   it.effect(
     "should build",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const api = yield* OutputChannel;
       expect(api).toBeDefined();
     }),

--- a/extension/src/services/__tests__/Storage.test.ts
+++ b/extension/src/services/__tests__/Storage.test.ts
@@ -9,7 +9,7 @@ import {
   Storage,
 } from "../../services/Storage.ts";
 
-const withTestCtx = Effect.fnUntraced(function* (
+const withTestCtx = Effect.fn(function* (
   ctx: { globalState?: Memento; workspaceState?: Memento } = {},
 ) {
   const vscode = yield* TestVsCode.make();
@@ -34,7 +34,7 @@ const withTestCtx = Effect.fnUntraced(function* (
 
 it.effect(
   "should return Option.None when no entry",
-  Effect.fnUntraced(function* () {
+  Effect.fn(function* () {
     const { key, layer } = yield* withTestCtx();
     yield* Effect.gen(function* () {
       const storage = yield* Storage;
@@ -46,7 +46,7 @@ it.effect(
 
 it.effect(
   "should fallback to default without updating storage",
-  Effect.fnUntraced(function* () {
+  Effect.fn(function* () {
     const { key, layer } = yield* withTestCtx();
     yield* Effect.gen(function* () {
       const storage = yield* Storage;
@@ -82,7 +82,7 @@ it.effect(
 
 it.effect(
   "should encode value into the underlying store",
-  Effect.fnUntraced(function* () {
+  Effect.fn(function* () {
     const { key, layer } = yield* withTestCtx();
     yield* Effect.gen(function* () {
       const storage = yield* Storage;
@@ -119,7 +119,7 @@ it.effect(
 
 it.effect(
   "should replace existing value in the underlying store",
-  Effect.fnUntraced(function* () {
+  Effect.fn(function* () {
     // initial state
     const workspaceState = new Memento();
     yield* Effect.promise(() => workspaceState.update("key", { value: 2 }));
@@ -161,7 +161,7 @@ it.effect(
 
 it.effect(
   "should throw StorageDecodeError badly encoded value",
-  Effect.fnUntraced(function* () {
+  Effect.fn(function* () {
     const workspaceState = new Memento();
     yield* Effect.promise(() => workspaceState.update("key", "blah"));
 

--- a/extension/src/services/__tests__/Uv.test.ts
+++ b/extension/src/services/__tests__/Uv.test.ts
@@ -43,7 +43,7 @@ describe("Uv", () => {
   it.layer(Layer.fresh(UvLive))((it) => {
     it.scoped(
       "should create a new python venv",
-      Effect.fnUntraced(function* () {
+      Effect.fn(function* () {
         const uv = yield* Uv;
         const tmpdir = yield* TmpDir;
         const target = NodePath.join(tmpdir.path, ".venv");
@@ -57,7 +57,7 @@ describe("Uv", () => {
   it.layer(Layer.fresh(UvLive))((it) => {
     it.scoped(
       "should fail `uv add` without pyproject.toml",
-      Effect.fnUntraced(function* () {
+      Effect.fn(function* () {
         const uv = yield* Uv;
         const tmpdir = yield* TmpDir;
         const result = yield* Effect.either(
@@ -73,7 +73,7 @@ describe("Uv", () => {
   it.layer(Layer.fresh(UvLive))((it) => {
     it.scoped(
       "should `uv pip install` into venv",
-      Effect.fnUntraced(function* () {
+      Effect.fn(function* () {
         const uv = yield* Uv;
         const tmpdir = yield* TmpDir;
         const venv = NodePath.join(tmpdir.path, ".venv");
@@ -98,7 +98,7 @@ describe("Uv", () => {
   it.layer(Layer.fresh(UvLive))((it) => {
     it.scoped(
       "should `uv init` a new project",
-      Effect.fnUntraced(function* () {
+      Effect.fn(function* () {
         const uv = yield* Uv;
         const tmpdir = yield* TmpDir;
 
@@ -126,7 +126,7 @@ describe("Uv", () => {
   it.layer(Layer.fresh(UvLive))((it) => {
     it.scoped(
       "should fail with UvResolutionError on conflicting dependencies",
-      Effect.fnUntraced(function* () {
+      Effect.fn(function* () {
         const uv = yield* Uv;
         const tmpdir = yield* TmpDir;
 
@@ -158,7 +158,7 @@ print("This should fail to sync")
   it.layer(Layer.fresh(UvLive))((it) => {
     it.scoped(
       "should fail with UvMissingPep723MetadataError when script has no metadata",
-      Effect.fnUntraced(function* () {
+      Effect.fn(function* () {
         const uv = yield* Uv;
         const tmpdir = yield* TmpDir;
 
@@ -185,7 +185,7 @@ print("This script has no PEP 723 metadata")
   it.layer(Layer.fresh(UvLive))((it) => {
     it.scoped(
       "should return absolute path from syncScript even if uv outputs relative path",
-      Effect.fnUntraced(function* () {
+      Effect.fn(function* () {
         const uv = yield* Uv;
         const tmpdir = yield* TmpDir;
 
@@ -239,7 +239,7 @@ print("hello")
     it.layer(Layer.fresh(UvLive))((it) => {
       it.scoped(
         "installs with default strategy",
-        Effect.fnUntraced(function* () {
+        Effect.fn(function* () {
           const uv = yield* Uv;
           const tmpdir = yield* TmpDir;
           const targetPath = NodePath.join(tmpdir.path, "default");
@@ -256,7 +256,7 @@ print("hello")
 
       it.scoped(
         "installs with native-tls strategy",
-        Effect.fnUntraced(function* () {
+        Effect.fn(function* () {
           const uv = yield* Uv;
           const tmpdir = yield* TmpDir;
           const targetPath = NodePath.join(tmpdir.path, "native-tls");
@@ -273,7 +273,7 @@ print("hello")
 
       it.scoped(
         "installs with offline strategy",
-        Effect.fnUntraced(function* () {
+        Effect.fn(function* () {
           const uv = yield* Uv;
           const tmpdir = yield* TmpDir;
           const targetPath = NodePath.join(tmpdir.path, "offline");
@@ -296,7 +296,7 @@ print("hello")
 
       it.scoped(
         "reinstalling with a new version replaces the binary",
-        Effect.fnUntraced(function* () {
+        Effect.fn(function* () {
           const uv = yield* Uv;
           const tmpdir = yield* TmpDir;
           const targetPath = NodePath.join(tmpdir.path, "upgrade");

--- a/extension/src/services/completions/TyLanguageServer.ts
+++ b/extension/src/services/completions/TyLanguageServer.ts
@@ -185,7 +185,7 @@ export class TyLanguageServer extends Effect.Service<TyLanguageServer>()(
                 yield* sentry.value.setTag("ty.version", serverVersion);
               }
 
-              const updateRunningStatus = Effect.fnUntraced(function* () {
+              const updateRunningStatus = Effect.fn(function* () {
                 const activePath = yield* pyExt.getActiveEnvironmentPath();
                 const resolved = yield* pyExt.resolveEnvironment(activePath);
                 const pythonEnvironment = Option.map(resolved, (env) => ({
@@ -214,7 +214,7 @@ export class TyLanguageServer extends Effect.Service<TyLanguageServer>()(
                 pyExt.activeEnvironmentPathChanges().pipe(
                   Stream.debounce(Duration.seconds(2)),
                   Stream.runForEach(
-                    Effect.fnUntraced(function* (event) {
+                    Effect.fn(function* (event) {
                       yield* client
                         .restart(`Python environment changed to: ${event.path}`)
                         .pipe(
@@ -248,7 +248,7 @@ export class TyLanguageServer extends Effect.Service<TyLanguageServer>()(
          * This is useful after installing packages, as ty doesn't support
          * workspace/didChangeConfiguration.
          */
-        restart: Effect.fnUntraced(function* (reason: string) {
+        restart: Effect.fn(function* (reason: string) {
           const status = yield* Ref.get(statusRef);
           if (!TyLanguageServerStatus.$is("Running")(status)) {
             yield* Effect.logWarning(
@@ -387,7 +387,7 @@ function createTyMiddleware(
           const enrichedResponse = await runPromise(
             Effect.all(
               params.items.map(
-                Effect.fnUntraced(function* (param, index) {
+                Effect.fn(function* (param, index) {
                   const code = yield* VsCode;
                   const pythonExtension = yield* PythonExtension;
 

--- a/extension/src/services/config/__tests__/ConfigContextManager.test.ts
+++ b/extension/src/services/config/__tests__/ConfigContextManager.test.ts
@@ -193,7 +193,7 @@ const lifecycle = Effect.gen(function* () {
 it.layer(TestLayer)("ConfigContextManager", (it) => {
   it.scoped(
     "should build",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const manager = yield* ConfigContextManager;
       yield* lifecycle;
       expect(manager).toBeDefined();
@@ -202,7 +202,7 @@ it.layer(TestLayer)("ConfigContextManager", (it) => {
 
   it.scoped(
     "should update VSCode context when config changes",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const ctx = yield* TestContext;
       const configService = yield* MarimoConfigurationService;
       const _manager = yield* ConfigContextManager;
@@ -234,7 +234,7 @@ it.layer(TestLayer)("ConfigContextManager", (it) => {
 
   it.scoped(
     "should default to autorun when config is None",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const ctx = yield* TestContext;
       const _manager = yield* ConfigContextManager;
 
@@ -253,7 +253,7 @@ it.layer(TestLayer)("ConfigContextManager", (it) => {
 
   it.scoped(
     "should stream on_cell_change mode changes",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const ctx = yield* TestContext;
       const configService = yield* MarimoConfigurationService;
       const manager = yield* ConfigContextManager;
@@ -314,7 +314,7 @@ it.layer(TestLayer)("ConfigContextManager", (it) => {
 
   it.scoped(
     "should handle switching between notebooks",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const ctx = yield* TestContext;
       const configService = yield* MarimoConfigurationService;
       const _manager = yield* ConfigContextManager;
@@ -356,7 +356,7 @@ it.layer(TestLayer)("ConfigContextManager", (it) => {
 
   it.scoped(
     "should default auto_reload to off when config is None",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const ctx = yield* TestContext;
       const _manager = yield* ConfigContextManager;
 
@@ -377,7 +377,7 @@ it.layer(TestLayer)("ConfigContextManager", (it) => {
 
   it.scoped(
     "should update auto_reload context when config changes",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const ctx = yield* TestContext;
       const configService = yield* MarimoConfigurationService;
       const _manager = yield* ConfigContextManager;
@@ -419,7 +419,7 @@ it.layer(TestLayer)("ConfigContextManager", (it) => {
 
   it.scoped(
     "should stream auto_reload mode changes",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const ctx = yield* TestContext;
       const configService = yield* MarimoConfigurationService;
       const manager = yield* ConfigContextManager;
@@ -484,7 +484,7 @@ it.layer(TestLayer)("ConfigContextManager", (it) => {
 
   it.scoped(
     "should handle switching between notebooks with different auto_reload configs",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const ctx = yield* TestContext;
       const configService = yield* MarimoConfigurationService;
       const _manager = yield* ConfigContextManager;

--- a/extension/src/services/config/__tests__/MarimoConfigurationService.test.ts
+++ b/extension/src/services/config/__tests__/MarimoConfigurationService.test.ts
@@ -30,7 +30,7 @@ const LAZY_CONFIG = {
   },
 } as MarimoConfig;
 
-const withTestCtx = Effect.fnUntraced(function* (
+const withTestCtx = Effect.fn(function* (
   options: { configStore?: Map<NotebookId, MarimoConfig> } = {},
 ) {
   const vscode = yield* TestVsCode.make();
@@ -48,7 +48,7 @@ const withTestCtx = Effect.fnUntraced(function* (
           },
           restart: () => Effect.void,
           streamOf: () => Stream.never,
-          executeCommand: Effect.fnUntraced(function* ({ command, params }) {
+          executeCommand: Effect.fn(function* ({ command, params }) {
             if (!(command === "marimo.api")) {
               return yield* Effect.die(`Unknown command: ${command}`);
             }
@@ -102,7 +102,7 @@ const withTestCtx = Effect.fnUntraced(function* (
 describe("MarimoConfigurationService", () => {
   it.effect(
     "should build",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const ctx = yield* withTestCtx();
       const service = yield* Effect.provide(
         MarimoConfigurationService,
@@ -114,7 +114,7 @@ describe("MarimoConfigurationService", () => {
 
   it.effect(
     "should fetch configuration from the language server",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const mockConfig = AUTORUN_CONFIG;
       const notebookUri = NOTEBOOK_URI;
 
@@ -133,7 +133,7 @@ describe("MarimoConfigurationService", () => {
 
   it.effect(
     "should cache configuration after first fetch",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const notebookUri = NOTEBOOK_URI;
       const mockConfig = AUTORUN_CONFIG;
       const ctx = yield* withTestCtx({
@@ -164,7 +164,7 @@ describe("MarimoConfigurationService", () => {
 
   it.effect(
     "should update configuration and cache",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const notebookUri = NOTEBOOK_URI;
       const initialConfig = AUTORUN_CONFIG;
 
@@ -198,7 +198,7 @@ describe("MarimoConfigurationService", () => {
 
   it.effect(
     "should clear notebook configuration",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const notebookUri = NOTEBOOK_URI;
       const mockConfig = AUTORUN_CONFIG;
 
@@ -231,7 +231,7 @@ describe("MarimoConfigurationService", () => {
 
   it.effect(
     "should stream configuration changes and dedupe",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const notebookUri = NOTEBOOK_URI;
       const initialConfig = AUTORUN_CONFIG;
 
@@ -319,7 +319,7 @@ describe("MarimoConfigurationService", () => {
 
   it.effect(
     "should stream configuration changes when active notebook changes",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const notebook1Uri = NOTEBOOK_URI_1;
       const notebook2Uri = NOTEBOOK_URI_2;
 
@@ -430,7 +430,7 @@ describe("MarimoConfigurationService", () => {
 
   it.effect(
     "should stream mapped configuration values",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const notebookUri = NOTEBOOK_URI;
       const mockConfig = AUTORUN_CONFIG;
       const ctx = yield* withTestCtx();
@@ -490,7 +490,7 @@ describe("MarimoConfigurationService", () => {
 
   it.effect(
     "should handle multiple notebooks independently",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const notebook1Uri = NOTEBOOK_URI_1;
       const notebook2Uri = NOTEBOOK_URI_2;
 
@@ -537,7 +537,7 @@ describe("MarimoConfigurationService", () => {
 
   it.effect(
     "should return cached config when available without LSP call",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const notebookUri = NOTEBOOK_URI;
       const mockConfig = AUTORUN_CONFIG;
 
@@ -562,7 +562,7 @@ describe("MarimoConfigurationService", () => {
 
   it.effect(
     "should stream auto_reload configuration changes and dedupe",
-    Effect.fnUntraced(function* () {
+    Effect.fn(function* () {
       const notebookUri = NOTEBOOK_URI;
       const initialConfig = {
         runtime: {

--- a/extension/src/services/variables/__tests__/VariablesService.test.ts
+++ b/extension/src/services/variables/__tests__/VariablesService.test.ts
@@ -47,7 +47,7 @@ function createMockVariableValuesOp(
 
 it.effect(
   "should return None when no variables exist for a notebook",
-  Effect.fnUntraced(function* () {
+  Effect.fn(function* () {
     const { layer } = yield* withTestCtx();
 
     const result = yield* Effect.gen(function* () {
@@ -67,7 +67,7 @@ it.effect(
 
 it.effect(
   "should update and retrieve variable declarations",
-  Effect.fnUntraced(function* () {
+  Effect.fn(function* () {
     const { layer } = yield* withTestCtx();
 
     const variables = yield* Effect.gen(function* () {
@@ -95,7 +95,7 @@ it.effect(
 
 it.effect(
   "should update and retrieve variable values",
-  Effect.fnUntraced(function* () {
+  Effect.fn(function* () {
     const { layer } = yield* withTestCtx();
 
     const values = yield* Effect.gen(function* () {
@@ -123,7 +123,7 @@ it.effect(
 
 it.effect(
   "should get all variable data for a notebook",
-  Effect.fnUntraced(function* () {
+  Effect.fn(function* () {
     const { layer } = yield* withTestCtx();
 
     const allData = yield* Effect.gen(function* () {
@@ -154,7 +154,7 @@ it.effect(
 
 it.effect(
   "should handle multiple notebooks independently",
-  Effect.fnUntraced(function* () {
+  Effect.fn(function* () {
     const { layer } = yield* withTestCtx();
 
     const result = yield* Effect.gen(function* () {
@@ -189,7 +189,7 @@ it.effect(
 
 it.effect(
   "should clear all data for a notebook",
-  Effect.fnUntraced(function* () {
+  Effect.fn(function* () {
     const { layer } = yield* withTestCtx();
 
     const result = yield* Effect.gen(function* () {
@@ -235,7 +235,7 @@ it.effect(
 
 it.effect(
   "should stream variable declaration changes",
-  Effect.fnUntraced(function* () {
+  Effect.fn(function* () {
     const { layer } = yield* withTestCtx();
 
     const count = yield* Effect.gen(function* () {
@@ -292,7 +292,7 @@ it.effect(
 
 it.effect(
   "should stream variable value changes",
-  Effect.fnUntraced(function* () {
+  Effect.fn(function* () {
     const { layer } = yield* withTestCtx();
 
     const count = yield* Effect.gen(function* () {
@@ -336,7 +336,7 @@ it.effect(
 
 it.effect(
   "should preserve variable values when updating variable declarations",
-  Effect.fnUntraced(function* () {
+  Effect.fn(function* () {
     const { layer } = yield* withTestCtx();
 
     const values = yield* Effect.gen(function* () {

--- a/extension/src/utils/installPackages.ts
+++ b/extension/src/utils/installPackages.ts
@@ -46,7 +46,7 @@ export function installPackages(
             yield* uv.addProject({ directory: venvPath, packages }).pipe(
               Effect.catchTag(
                 "UvMissingPyProjectError",
-                Effect.fnUntraced(function* () {
+                Effect.fn(function* () {
                   yield* Effect.logWarning(
                     "Failed to `uv add`, attempting `uv pip install`.",
                   );
@@ -77,7 +77,7 @@ export function installPackages(
           });
         }).pipe(
           Effect.catchAllCause(
-            Effect.fnUntraced(function* (cause) {
+            Effect.fn(function* (cause) {
               yield* Effect.logError("Failed to install").pipe(
                 Effect.annotateLogs({ cause }),
               );
@@ -91,7 +91,7 @@ export function installPackages(
   });
 }
 
-export const uvAddScriptSafe = Effect.fnUntraced(function* (
+export const uvAddScriptSafe = Effect.fn("uvAddScriptSafe")(function* (
   packages: ReadonlyArray<string>,
   notebook: MarimoNotebookDocument,
 ) {

--- a/extension/src/views/DatasourcesView.ts
+++ b/extension/src/views/DatasourcesView.ts
@@ -235,7 +235,7 @@ export const DatasourcesViewLive = Layer.scopedDiscard(
     });
 
     // Helper to rebuild the datasources list from current state
-    const refreshDatasources = Effect.fnUntraced(function* () {
+    const refreshDatasources = Effect.fn(function* () {
       const activeNotebookUri = yield* editorRegistry.getActiveNotebookUri();
 
       yield* Effect.logTrace("Refreshing datasources").pipe(
@@ -379,7 +379,7 @@ export const DatasourcesViewLive = Layer.scopedDiscard(
     yield* Effect.forkScoped(
       datasourcesService.streamConnectionsChanges().pipe(
         Stream.mapEffect(
-          Effect.fnUntraced(function* (_connectionsMap) {
+          Effect.fn(function* (_connectionsMap) {
             yield* refreshDatasources();
           }),
         ),
@@ -391,7 +391,7 @@ export const DatasourcesViewLive = Layer.scopedDiscard(
     yield* Effect.forkScoped(
       datasourcesService.streamDatasetsChanges().pipe(
         Stream.mapEffect(
-          Effect.fnUntraced(function* (_datasetsMap) {
+          Effect.fn(function* (_datasetsMap) {
             yield* refreshDatasources();
           }),
         ),

--- a/extension/src/views/MarimoStatusBar.ts
+++ b/extension/src/views/MarimoStatusBar.ts
@@ -67,7 +67,7 @@ export const MarimoStatusBarLive = Layer.scopedDiscard(
           case "tutorials": {
             yield* tutorialCommands().pipe(
               Effect.catchAll(
-                Effect.fnUntraced(function* (error) {
+                Effect.fn(function* (error) {
                   yield* Effect.logError("Failed to open tutorial").pipe(
                     Effect.annotateLogs({ cause: Cause.fail(error) }),
                   );

--- a/extension/src/views/PackagesView.ts
+++ b/extension/src/views/PackagesView.ts
@@ -82,7 +82,7 @@ export const PackagesViewLive = Layer.scopedDiscard(
     });
 
     // Helper to rebuild the package tree from current state
-    const refreshPackages = Effect.fnUntraced(function* () {
+    const refreshPackages = Effect.fn(function* () {
       const activeNotebookUri = yield* editorRegistry.getActiveNotebookUri();
 
       yield* Effect.logDebug("Refreshing packages").pipe(
@@ -154,7 +154,7 @@ export const PackagesViewLive = Layer.scopedDiscard(
     yield* Effect.forkScoped(
       packagesService.streamDependencyTreeChanges().pipe(
         Stream.mapEffect(
-          Effect.fnUntraced(function* (_treeMap) {
+          Effect.fn(function* (_treeMap) {
             yield* refreshPackages();
           }),
         ),

--- a/extension/src/views/PythonEnvironmentStatusBar.ts
+++ b/extension/src/views/PythonEnvironmentStatusBar.ts
@@ -78,7 +78,7 @@ export const PythonEnvironmentStatusBarLive = Layer.scopedDiscard(
     // Listen for environment changes and update the status bar
     yield* pythonExtension.activeEnvironmentPathChanges().pipe(
       Stream.runForEach(
-        Effect.fnUntraced(function* (event) {
+        Effect.fn(function* (event) {
           yield* updateDisplay(item, Option.some(event.path));
           yield* updateVisibility(item);
         }),

--- a/extension/src/views/RecentNotebooks.ts
+++ b/extension/src/views/RecentNotebooks.ts
@@ -42,7 +42,7 @@ export const RecentNotebooksLive = Layer.scopedDiscard(
       .pipe(
         Effect.catchTag(
           "StorageDecodeError",
-          Effect.fnUntraced(function* (error) {
+          Effect.fn(function* (error) {
             yield* Effect.logWarning(
               "Failed to decode recent notebooks from storage, using empty list",
               error.cause,
@@ -100,7 +100,7 @@ export const RecentNotebooksLive = Layer.scopedDiscard(
     });
 
     // Helper to add a notebook to recent list
-    const addRecentNotebook = Effect.fnUntraced(function* (
+    const addRecentNotebook = Effect.fn(function* (
       uri: Uri,
       document: MarimoNotebookDocument,
     ) {
@@ -141,7 +141,7 @@ export const RecentNotebooksLive = Layer.scopedDiscard(
     yield* Effect.forkScoped(
       code.window.activeNotebookEditorChanges().pipe(
         Stream.mapEffect(
-          Effect.fnUntraced(function* (maybeEditor) {
+          Effect.fn(function* (maybeEditor) {
             const notebook = maybeEditor.pipe(
               Option.flatMap((editor) =>
                 MarimoNotebookDocument.tryFrom(editor.notebook),

--- a/extension/src/views/TreeView.ts
+++ b/extension/src/views/TreeView.ts
@@ -36,7 +36,7 @@ export class TreeView extends Effect.Service<TreeView>()("TreeView", {
        *
        * @param options - Configuration for the tree view
        */
-      createTreeDataProvider: Effect.fnUntraced(function* <T>(options: {
+      createTreeDataProvider: Effect.fn(function* <T>(options: {
         viewId: MarimoView;
         getChildren: (element?: T) => Effect.Effect<T[]>;
         getTreeItem: (element: T) => Effect.Effect<TreeItem>;

--- a/extension/src/views/VariablesView.ts
+++ b/extension/src/views/VariablesView.ts
@@ -52,7 +52,7 @@ export const VariablesViewLive = Layer.scopedDiscard(
     });
 
     // Helper to rebuild the variables list from current state
-    const refreshVariables = Effect.fnUntraced(function* () {
+    const refreshVariables = Effect.fn(function* () {
       const activeNotebookUri = yield* editorRegistry.getActiveNotebookUri();
 
       yield* Effect.logDebug("Refreshing variables").pipe(
@@ -125,7 +125,7 @@ export const VariablesViewLive = Layer.scopedDiscard(
     yield* Effect.forkScoped(
       variablesService.streamVariableValuesChanges().pipe(
         Stream.mapEffect(
-          Effect.fnUntraced(function* (valuesMap) {
+          Effect.fn(function* (valuesMap) {
             const activeNotebookUri =
               yield* editorRegistry.getActiveNotebookUri();
 

--- a/extension/src/views/__tests__/PythonEnvironmentStatusBar.test.ts
+++ b/extension/src/views/__tests__/PythonEnvironmentStatusBar.test.ts
@@ -54,7 +54,7 @@ const withTestCtx = Effect.gen(function* () {
 
 it.scoped(
   "should show status bar when marimo notebook is active",
-  Effect.fnUntraced(function* () {
+  Effect.fn(function* () {
     const ctx = yield* withTestCtx;
     yield* Effect.gen(function* () {
       const marimoEditor = TestVsCode.makeNotebookEditor(
@@ -73,7 +73,7 @@ it.scoped(
 
 it.scoped(
   "should hide status bar when Jupyter notebook becomes active",
-  Effect.fnUntraced(function* () {
+  Effect.fn(function* () {
     const ctx = yield* withTestCtx;
     yield* Effect.gen(function* () {
       // Start with marimo notebook active
@@ -104,7 +104,7 @@ it.scoped(
 
 it.scoped(
   "should hide status bar when no notebook is active",
-  Effect.fnUntraced(function* () {
+  Effect.fn(function* () {
     const ctx = yield* withTestCtx;
     yield* Effect.gen(function* () {
       // Start with marimo notebook active
@@ -128,7 +128,7 @@ it.scoped(
 
 it.scoped(
   "should hide status bar initially when no marimo notebook is open",
-  Effect.fnUntraced(function* () {
+  Effect.fn(function* () {
     const ctx = yield* withTestCtx;
     yield* Effect.gen(function* () {
       yield* TestClock.adjust("10 millis");


### PR DESCRIPTION
`Effect.fnUntraced` was used throughout the codebase for both standalone functions and inline callbacks. This replaces all occurrences with `Effect.fn`, which enables lightweight tracing. 

For the six standalone production functions (handleMissingPackageAlert, findLspExecutable, uvAddScriptSafe, matchRecentNotebookFromBytes, updateNotebookAffinity, pruneStaleControllers), named spans are added via Effect.fn("name") for better observability. Inline callbacks use unnamed Effect.fn for minimal overhead while staying consistent.