### PR TITLE
Add debug layer for runtime inspection via Node inspector

### DIFF
--- a/extension/src/layers/DebugLayer.ts
+++ b/extension/src/layers/DebugLayer.ts
@@ -1,0 +1,33 @@
+import { Effect, Layer } from "effect";
+
+import { CellStateManager } from "../services/CellStateManager.ts";
+import { ControllerRegistry } from "../services/ControllerRegistry.ts";
+import { ExecutionRegistry } from "../services/ExecutionRegistry.ts";
+import { KernelManager } from "../services/KernelManager.ts";
+import { NotebookEditorRegistry } from "../services/NotebookEditorRegistry.ts";
+import { SessionStateManager } from "../services/SessionStateManager.ts";
+import { VariablesService } from "../services/variables/VariablesService.ts";
+
+/**
+ * Debug layer that exposes extension internals on `globalThis` when
+ * `MARIMO_DEBUG=1`. This enables runtime inspection via the Node inspector
+ * (`--inspect-extensions`) without modifying other layers.
+ *
+ * Note: `__marimoVsCode` (the raw vscode module) is set in VsCode.ts,
+ * which is the only file allowed to import "vscode" directly.
+ */
+export const DebugLayerLive = Layer.effectDiscard(
+  Effect.gen(function* () {
+    if (process.env.MARIMO_DEBUG !== "1") return;
+
+    (globalThis as any).__marimoDebug = {
+      controllerRegistry: yield* ControllerRegistry,
+      cellStateManager: yield* CellStateManager,
+      executionRegistry: yield* ExecutionRegistry,
+      variablesService: yield* VariablesService,
+      notebookEditorRegistry: yield* NotebookEditorRegistry,
+      kernelManager: yield* KernelManager,
+      sessionStateManager: yield* SessionStateManager,
+    };
+  }),
+);

--- a/extension/src/layers/Main.ts
+++ b/extension/src/layers/Main.ts
@@ -51,6 +51,7 @@ import { TreeView } from "../views/TreeView.ts";
 import { VariablesViewLive } from "../views/VariablesView.ts";
 import { CellMetadataBindingsLive } from "./CellMetadataBindings.ts";
 import { CellStatusBarProviderLive } from "./CellStatusBarProvider.ts";
+import { DebugLayerLive } from "./DebugLayer.ts";
 import { MarimoCodeLensProviderLive } from "./MarimoCodeLensProvider.ts";
 import { MarimoFileDetectorLive } from "./MarimoFileDetector.ts";
 import { RegisterCommandsLive } from "./RegisterCommands.ts";
@@ -74,6 +75,7 @@ const MainLive = Layer.empty
     Layer.merge(CellStatusBarProviderLive),
     Layer.merge(CellMetadataBindingsLive),
     Layer.merge(ReloadOnConfigChangeLive),
+    Layer.merge(DebugLayerLive),
   )
   .pipe(
     Layer.provideMerge(Api.Default),

--- a/extension/src/services/VsCode.ts
+++ b/extension/src/services/VsCode.ts
@@ -518,6 +518,12 @@ export class ParseUriError extends Data.TaggedError("ParseUriError")<{
  */
 export class VsCode extends Effect.Service<VsCode>()("VsCode", {
   effect: Effect.gen(function* () {
+    // Expose the raw vscode module for runtime inspection via --inspect-extensions.
+    // Only active when MARIMO_DEBUG=1 (set by launch-dev.sh).
+    if (process.env.MARIMO_DEBUG === "1") {
+      (globalThis as any).__marimoVsCode = vscode;
+    }
+
     return {
       // namespaces
       window: yield* Window,


### PR DESCRIPTION
When developing the extension with `--inspect-extensions`, it's useful to be able to poke at internal services from the DevTools console. This adds a `DebugLayer` that, when `MARIMO_DEBUG=1`, exposes key Effect services on `globalThis.__marimoDebug` and the raw vscode module on `globalThis.__marimoVsCode`. The vscode module is set separately in VsCode.ts since that's the only file allowed to import "vscode" directly.

The layer is a no-op when the env var is unset, so there's no cost in production.