### PR TITLE
Replace per-keystroke graph compilation with debounced workspace reads

### DIFF
--- a/extension/src/services/completions/NotebookSyncService.ts
+++ b/extension/src/services/completions/NotebookSyncService.ts
@@ -355,6 +355,11 @@ function buildResyncNotification(
         reorderedCells.length,
       );
 
+      // Send all cells in didOpen so the server refreshes its TextDocuments
+      // and re-lints. This is idempotent in Ruff/ty — the server just replaces
+      // the TextDocument even if the content is identical. Without didOpen,
+      // the server reuses saved content but may skip re-linting repositioned
+      // cells (the order changed but the documents weren't "touched").
       const transformedCells = adapter.cellsEvent({
         structure: {
           array: {
@@ -499,8 +504,10 @@ function buildCellReplacement(
     return Effect.succeed(cells);
   }
 
-  // Delete all old cells, insert all in new order.
-  // We must provide ALL cells in didOpen so the server gets their text content.
+  // Replace the structural array with topologically-sorted cells and send
+  // all cells in didOpen so the server refreshes TextDocuments and re-lints.
+  // This is idempotent — Ruff/ty just replace the TextDocument even for
+  // cells that already existed with identical content.
   return SynchronizedRef.modifyEffect(cellCountsRef, (cellCounts) =>
     Effect.map(getTopologicalCells(doc), (reorderedCells) => {
       const prevCount = Option.getOrElse(

--- a/src/marimo_lsp/diagnostics.py
+++ b/src/marimo_lsp/diagnostics.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from collections import OrderedDict
-from typing import TYPE_CHECKING, Generic, NewType, TypeVar
+import asyncio
+from typing import TYPE_CHECKING
 
 from marimo._ast.compiler import compile_cell
 from marimo._messaging.msgspec_encoder import asdict
@@ -22,218 +22,143 @@ if TYPE_CHECKING:
     import lsprotocol.types as lsp
     from marimo._types.ids import CellId_t
     from pygls.lsp.server import LanguageServer
-    from pygls.workspace import Workspace
+
+# Lightweight snapshot of the variable dependency structure.
+# Maps variable_name → (frozenset of declaring cells, frozenset of using cells).
+_VariablesSnapshot = dict[str, tuple[frozenset["CellId_t"], frozenset["CellId_t"]]]
+
+_DEBOUNCE_SECONDS = 0.15
 
 
-T = TypeVar("T")
-U = TypeVar("U")
-
-CellDocumentUri = NewType("CellDocumentUri", str)
-
-
-class LRUCache(Generic[T, U]):
-    """A simple LRU (Least Recently Used) cache implementation."""
-
-    def __init__(self, capacity: int) -> None:
-        self.cache: OrderedDict[T, U] = OrderedDict()
-        self.capacity = capacity
-
-    def get(self, key: T) -> U | None:
-        """Retrieve item from cache and mark as recently used."""
-        if key not in self.cache:
-            return None
-        # Move the accessed item to the end (most recently used)
-        value = self.cache.pop(key)
-        self.cache[key] = value
-        return value
-
-    def put(self, key: T, value: U) -> None:
-        """Add item to cache, evicting least recently used if necessary."""
-        if key in self.cache:
-            self.cache.pop(key)  # Remove existing item to update its position
-        elif len(self.cache) >= self.capacity:
-            # Evict the least recently used item (first item in OrderedDict)
-            self.cache.popitem(last=False)
-        self.cache[key] = value
+def _snapshot_variables(graph: DirectedGraph) -> _VariablesSnapshot:
+    """Create a snapshot of the variable dependency structure for cheap comparison."""
+    return {
+        variable: (
+            frozenset(declared_by),
+            frozenset(graph.get_referring_cells(variable, language="python")),
+        )
+        for variable, declared_by in graph.definitions.items()
+    }
 
 
-class NotebookGraphManager:
-    """Manages incremental compilation and graph building for a notebook.
+class NotebookGraphUpdater:
+    """Debounced graph compilation for a single notebook.
 
-    This class tracks cells and only recompiles when their source text changes,
-    avoiding redundant compilation of unchanged cells.
+    Rather than compiling on every keystroke, this class schedules compilation
+    after a quiet period. When the timer fires (or ``flush()`` is called), it
+    reads the latest cell text from the pygls workspace, compiles any cells
+    whose source changed, and publishes a ``marimo/operation`` notification if
+    the variable dependency structure changed.
+
+    Parameters
+    ----------
+    server
+        The pygls language server, used to read workspace state and send
+        notifications.
+    notebook_uri
+        The URI of the notebook this updater manages.
     """
 
-    def __init__(self) -> None:
-        """Initialize the manager with empty state."""
+    def __init__(self, server: LanguageServer, notebook_uri: str) -> None:
+        self._server = server
+        self._notebook_uri = notebook_uri
         self._cell_sources: dict[CellId_t, str] = {}
         self._graph: DirectedGraph = DirectedGraph()
-        self._stale = False
-        self.uri_to_cell_id_cache: LRUCache[CellDocumentUri, CellId_t] = LRUCache(
-            capacity=1000  # We shouldn't have notebooks larger than this
+        self._last_published: _VariablesSnapshot | None = None
+        self._debounce_handle: asyncio.TimerHandle | None = None
+
+    def schedule(self) -> None:
+        """Schedule a debounced recompilation.
+
+        Each call resets the timer. The recompilation runs after
+        ``_DEBOUNCE_SECONDS`` of quiet.
+        """
+        if self._debounce_handle is not None:
+            self._debounce_handle.cancel()
+        loop = asyncio.get_event_loop()
+        self._debounce_handle = loop.call_later(_DEBOUNCE_SECONDS, self._recompile)
+
+    def cancel(self) -> None:
+        """Cancel any pending debounce timer without recompiling."""
+        if self._debounce_handle is not None:
+            self._debounce_handle.cancel()
+            self._debounce_handle = None
+
+    def flush(self) -> None:
+        """Cancel any pending debounce and recompile immediately."""
+        self.cancel()
+        self._recompile()
+
+    # -- internal helpers -----------------------------------------------
+
+    def _recompile(self) -> None:
+        """Read all cells from workspace, compile changed ones, publish if needed."""
+        self._debounce_handle = None
+        notebook = self._server.workspace.get_notebook_document(
+            notebook_uri=self._notebook_uri
         )
+        if not notebook:
+            return
 
-    def initialize(
-        self, server: LanguageServer, notebook: lsp.NotebookDocument
-    ) -> None:
-        """Build initial graph from all cells in the notebook."""
+        current_ids: set[CellId_t] = set()
         for cell in notebook.cells:
-            document = server.workspace.text_documents.get(cell.document)
-            source = document.source if document else ""
             cell_id = get_stable_id(cell)
-            if cell_id:
-                self.update_cell(cell_id, source)
-            else:
-                logger.warning("Could not find cell ID for cell; skipping.")
+            if not cell_id:
+                continue
+            current_ids.add(cell_id)
 
-        # Mark as stale so diagnostics are published on first request
-        self._stale = True
+            doc = self._server.workspace.text_documents.get(cell.document)
+            source = doc.source if doc else ""
 
-    def update_cell(self, cell_id: CellId_t, source: str) -> None:
-        """Update a single cell, recompiling only if source changed."""
-        # Only recompile if source actually changed
-        if self._cell_sources.get(cell_id) == source:
-            return
+            # Skip unchanged cells
+            if self._cell_sources.get(cell_id) == source:
+                continue
 
-        self._cell_sources[cell_id] = source
+            self._cell_sources[cell_id] = source
 
-        # If cell already exists in graph, remove it first
-        if cell_id in self._graph.cells:
-            self._graph.delete_cell(cell_id)
+            if cell_id in self._graph.cells:
+                self._graph.delete_cell(cell_id)
 
-        try:
-            compiled = compile_cell(cell_id=cell_id, code=source)
-            self._graph.register_cell(cell_id=cell_id, cell=compiled)
-        except SyntaxError:
-            # Cell has syntax error, don't add to graph
-            pass
+            try:
+                compiled = compile_cell(cell_id=cell_id, code=source)
+                self._graph.register_cell(cell_id=cell_id, cell=compiled)
+            except SyntaxError:
+                # Cell has syntax error — don't add to graph
+                pass
 
-        self._stale = True
+        # Remove cells no longer in the notebook
+        for removed_id in set(self._cell_sources) - current_ids:
+            self._cell_sources.pop(removed_id)
+            if removed_id in self._graph.cells:
+                self._graph.delete_cell(removed_id)
 
-    def remove_cell(self, cell_id: CellId_t) -> None:
-        """Remove a cell from tracking."""
-        self._cell_sources.pop(cell_id, None)
-        if cell_id in self._graph.cells:
-            self._graph.delete_cell(cell_id)
-        self._stale = True
+        # Publish only if the variable structure changed
+        snapshot = _snapshot_variables(self._graph)
+        if snapshot != self._last_published:
+            self._last_published = snapshot
+            _publish_variables(self._server, notebook, self._graph)
 
-    def get_graph(self) -> DirectedGraph:
-        """Get the current dependency graph."""
-        return self._graph
 
-    def is_stale(self) -> bool:
-        """Check if the graph has changed since last publish."""
-        return self._stale
+class GraphUpdaterRegistry:
+    """Registry of ``NotebookGraphUpdater`` instances, one per open notebook."""
 
-    def mark_clean(self) -> None:
-        """Mark the graph as clean after publishing."""
-        self._stale = False
+    def __init__(self, server: LanguageServer) -> None:
+        self._server = server
+        self._updaters: dict[str, NotebookGraphUpdater] = {}
 
-    def _remove_cell_document(self, cell: lsp.TextDocumentIdentifier) -> None:
-        """Remove a cell from tracking."""
-        cell_id = self.uri_to_cell_id_cache.get(CellDocumentUri(cell.uri))
-        if not cell_id:
-            # Debug instead of warning since can happen during normal operation
-            logger.debug(f"Could not find cell ID for URI {cell.uri} (on close)")
-        else:
-            self.remove_cell(cell_id)
-
-    def _update_cell_document(
-        self,
-        cell: lsp.VersionedTextDocumentIdentifier | lsp.TextDocumentItem,
-        source: str,
-    ) -> None:
-        """Update a cell from its notebook cell representation."""
-        cell_id = self.uri_to_cell_id_cache.get(CellDocumentUri(cell.uri))
-        if not cell_id:
-            logger.warning(
-                f"Could not find cell ID for URI {cell.uri} (on open/update)"
+    def get_or_create(self, notebook_uri: str) -> NotebookGraphUpdater:
+        """Return the updater for *notebook_uri*, creating one if needed."""
+        if notebook_uri not in self._updaters:
+            self._updaters[notebook_uri] = NotebookGraphUpdater(
+                self._server, notebook_uri
             )
-            return
-        self.update_cell(cell_id, source)
-
-    def sync_with_notebook_document_change_event(
-        self,
-        workspace: Workspace,
-        change: lsp.NotebookDocumentChangeEvent,
-    ) -> None:
-        """Sync the graph manager with changes from a notebook document change event."""
-        if change.cells is None:
-            return
-
-        # Handle cell removals
-        self._persist_mapping(change)
-
-        if change.cells.structure and change.cells.structure.did_close:
-            for closed_cell in change.cells.structure.did_close:
-                self._remove_cell_document(closed_cell)
-
-        # Handle cell additions
-        if change.cells.structure and change.cells.structure.did_open:
-            for opened_cell in change.cells.structure.did_open:
-                self._update_cell_document(opened_cell, opened_cell.text)
-
-        # Handle text content changes
-        if change.cells.text_content:
-            for text_change in change.cells.text_content:
-                document = workspace.text_documents.get(text_change.document.uri)
-                if document:
-                    self._update_cell_document(text_change.document, document.source)
-
-    def _persist_mapping(self, change: lsp.NotebookDocumentChangeEvent) -> None:
-        """Persist mapping from cell URIs to stable IDs for quick lookup."""
-        if change.cells is None:
-            return
-
-        if change.cells.data:
-            for cell in change.cells.data:
-                cell_id = get_stable_id(cell)
-                if cell_id:
-                    self.uri_to_cell_id_cache.put(
-                        CellDocumentUri(cell.document), cell_id
-                    )
-                else:
-                    logger.warning(
-                        f"Opened cell {cell.document} missing stable ID; cannot map URI."
-                    )
-        if change.cells.structure and change.cells.structure.array.cells:
-            for cell in change.cells.structure.array.cells:
-                cell_id = get_stable_id(cell)
-                if cell_id:
-                    self.uri_to_cell_id_cache.put(
-                        CellDocumentUri(cell.document), cell_id
-                    )
-                else:
-                    logger.warning(
-                        f"Opened cell {cell.document} missing stable ID; cannot map URI."
-                    )
-
-
-class GraphManagerRegistry:
-    """Registry to track NotebookGraphManager instances per notebook URI."""
-
-    def __init__(self) -> None:
-        """Initialize the registry with empty state."""
-        self._managers: dict[str, NotebookGraphManager] = {}
-
-    def init(
-        self,
-        notebook: lsp.NotebookDocument,
-        server: LanguageServer,
-    ) -> NotebookGraphManager:
-        """Create and initialize a new graph manager for the given notebook."""
-        manager = NotebookGraphManager()
-        manager.initialize(server, notebook)
-        self._managers[notebook.uri] = manager
-        return manager
-
-    def get(self, notebook_uri: str) -> NotebookGraphManager | None:
-        """Get the graph manager for the given notebook URI, or None if not found."""
-        return self._managers.get(notebook_uri)
+        return self._updaters[notebook_uri]
 
     def remove(self, notebook_uri: str) -> None:
-        """Remove the graph manager for the given notebook URI."""
-        self._managers.pop(notebook_uri, None)
+        """Remove the updater for *notebook_uri*, cancelling any pending timer."""
+        updater = self._updaters.pop(notebook_uri, None)
+        if updater is not None:
+            updater.cancel()
 
 
 def extract_variables(graph: DirectedGraph) -> VariablesNotification:
@@ -250,14 +175,12 @@ def extract_variables(graph: DirectedGraph) -> VariablesNotification:
     )
 
 
-def publish_diagnostics(
+def _publish_variables(
     server: LanguageServer,
     notebook: lsp.NotebookDocument,
     graph: DirectedGraph,
 ) -> None:
-    """Extract and publish various diagnostics from the directed graph."""
-    # Not an actual LSP diagnostic, but a custom notification we use to determine ordering
-    # of cells in our extension.
+    """Send a ``marimo/operation`` notification with the current variable state."""
     variables = extract_variables(graph)
     server.protocol.notify(
         "marimo/operation",

--- a/src/marimo_lsp/server.py
+++ b/src/marimo_lsp/server.py
@@ -15,7 +15,7 @@ from pygls.uris import to_fs_path, uri_scheme
 from marimo_lsp.api import handle_api_command
 from marimo_lsp.app_file_manager import sync_app_with_workspace
 from marimo_lsp.completions import get_completions
-from marimo_lsp.diagnostics import GraphManagerRegistry, publish_diagnostics
+from marimo_lsp.diagnostics import GraphUpdaterRegistry
 from marimo_lsp.loggers import get_logger
 from marimo_lsp.models import ApiRequest, ConvertRequest
 from marimo_lsp.session_manager import LspSessionManager
@@ -43,7 +43,7 @@ def create_server() -> LanguageServer:  # noqa: C901, PLR0915
         ),
     )
     manager = LspSessionManager()
-    graph_registry = GraphManagerRegistry()
+    graph_registry = GraphUpdaterRegistry(server)
 
     # Register atexit handler to ensure kernel processes are cleaned up
     # when the LSP server exits (e.g., extension host restart, VS Code close).
@@ -67,15 +67,9 @@ def create_server() -> LanguageServer:  # noqa: C901, PLR0915
             )
             logger.info(f"Synced session {params.notebook_document.uri}")
 
-        # Initialize graph manager (or reinitialize if already exists)
-        existing_manager = graph_registry.get(params.notebook_document.uri)
-        if existing_manager:
-            # Notebook already open, reinitialize
-            logger.debug(f"Reinitializing graph for {params.notebook_document.uri}")
-            graph_registry.remove(params.notebook_document.uri)
-
-        graph_manager = graph_registry.init(params.notebook_document, server)
-        publish_diagnostics(server, params.notebook_document, graph_manager.get_graph())
+        # Immediate compile + publish — needed for initial cell ordering
+        updater = graph_registry.get_or_create(params.notebook_document.uri)
+        updater.flush()
 
     @server.feature(lsp.NOTEBOOK_DOCUMENT_DID_CHANGE)
     async def did_change(params: lsp.DidChangeNotebookDocumentParams) -> None:
@@ -89,16 +83,9 @@ def create_server() -> LanguageServer:  # noqa: C901, PLR0915
             )
         logger.info(f"Synced session {params.notebook_document.uri}")
 
-        # Update graph incrementally based on changes
-        graph_manager = graph_registry.get(params.notebook_document.uri)
-        if graph_manager is None:
-            logger.debug(f"No graph manager for {params.notebook_document.uri}")
-            return
-
-        graph_manager.sync_with_notebook_document_change_event(
-            workspace=server.workspace,
-            change=params.change,
-        )
+        # Schedule debounced recompilation — compiles after 150ms of quiet
+        updater = graph_registry.get_or_create(params.notebook_document.uri)
+        updater.schedule()
 
     @server.feature(lsp.NOTEBOOK_DOCUMENT_DID_SAVE)
     async def did_save(params: lsp.DidSaveNotebookDocumentParams) -> None:
@@ -116,7 +103,7 @@ def create_server() -> LanguageServer:  # noqa: C901, PLR0915
     async def did_close(params: lsp.DidCloseNotebookDocumentParams) -> None:
         logger.info(f"notebookDocument/didClose {params.notebook_document.uri}")
 
-        # Clean up graph manager
+        # Clean up graph updater (cancels pending debounce timer)
         graph_registry.remove(params.notebook_document.uri)
 
         # Only close untitled sessions, when closing documents...
@@ -129,9 +116,9 @@ def create_server() -> LanguageServer:  # noqa: C901, PLR0915
     def diagnostics(params: lsp.DocumentDiagnosticParams):
         """Provide diagnostics for marimo notebooks.
 
-        The `textDocument/diagnostic` request is sent by the client to request
-        diagnostics for a specific text document. It is PULL-based, meaning the
-        server only sends diagnostics when requested by the client.
+        The ``textDocument/diagnostic`` request is pull-based.  We flush any
+        pending debounced recompilation so that the response reflects the
+        latest cell state.
         """
         logger.info(f"textDocument/diagnostic {params.text_document.uri}")
 
@@ -143,14 +130,9 @@ def create_server() -> LanguageServer:  # noqa: C901, PLR0915
             logger.debug("No target notebook found for diagnostics")
             return lsp.RelatedFullDocumentDiagnosticReport(kind="full", items=[])
 
-        # Get graph manager and publish only if stale
-        graph_manager = graph_registry.get(notebook.uri)
-        if graph_manager and graph_manager.is_stale():
-            logger.info("Graph is stale; recomputing diagnostics")
-            publish_diagnostics(server, notebook, graph_manager.get_graph())
-            graph_manager.mark_clean()
-        else:
-            logger.debug("Diagnostics are up-to-date; no action taken")
+        # Ensure the graph is up-to-date before responding
+        updater = graph_registry.get_or_create(notebook.uri)
+        updater.flush()
 
         # Return empty diagnostics report (we use custom notifications instead)
         return lsp.RelatedFullDocumentDiagnosticReport(kind="full", items=[])

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,270 +1,327 @@
-"""Tests for incremental graph management and diagnostics."""
+"""Tests for debounced graph compilation and variable publishing."""
 
 from __future__ import annotations
 
 from typing import cast
+from unittest.mock import MagicMock, patch
 
 import lsprotocol.types as lsp
 from marimo._types.ids import CellId_t
 
 from marimo_lsp.diagnostics import (
-    CellDocumentUri,
-    GraphManagerRegistry,
-    LRUCache,
-    NotebookGraphManager,
+    GraphUpdaterRegistry,
+    NotebookGraphUpdater,
+    _snapshot_variables,
 )
 from marimo_lsp.utils import decode_marimo_cell_metadata, get_stable_id
 
 
-class TestNotebookGraphManager:
-    """Unit tests for NotebookGraphManager."""
+def _make_server(
+    cells: list[tuple[str, str]],
+    notebook_uri: str = "file:///test.py",
+) -> MagicMock:
+    """Create a mock server whose workspace contains the given cells.
 
-    def test_only_recompiles_on_change(self) -> None:
-        """Test that cells aren't recompiled when source hasn't changed."""
-        manager = NotebookGraphManager()
-        cell_id = CellId_t("cell1")
+    Parameters
+    ----------
+    cells
+        List of (stable_id, source) tuples.
+    notebook_uri
+        URI of the notebook.
+    """
+    server = MagicMock()
 
-        # First update - should compile and mark stale
-        manager.update_cell(cell_id, "x = 1")
-        assert manager.is_stale()
-        assert cell_id in manager.get_graph().cells
-        manager.mark_clean()
+    lsp_cells = []
+    text_docs: dict[str, MagicMock] = {}
 
-        # Second update with same source - should not mark stale
-        manager.update_cell(cell_id, "x = 1")
-        assert not manager.is_stale()  # Should still be clean!
+    for stable_id, source in cells:
+        cell_uri = f"{notebook_uri}#cell-{stable_id}"
+        lsp_cells.append(
+            lsp.NotebookCell(
+                kind=lsp.NotebookCellKind.Code,
+                document=cell_uri,
+                metadata=cast("lsp.LSPObject", {"stableId": stable_id}),
+            )
+        )
+        doc_mock = MagicMock()
+        doc_mock.source = source
+        text_docs[cell_uri] = doc_mock
 
-        # Third update with different source - should recompile and mark stale
-        manager.update_cell(cell_id, "x = 2")
-        assert manager.is_stale()
+    notebook = lsp.NotebookDocument(
+        uri=notebook_uri,
+        notebook_type="marimo-notebook",
+        version=1,
+        cells=lsp_cells,
+    )
+    server.workspace.get_notebook_document.return_value = notebook
+    server.workspace.text_documents = text_docs
+    return server
+
+
+class TestNotebookGraphUpdater:
+    """Tests for NotebookGraphUpdater."""
+
+    def test_flush_compiles_and_publishes(self) -> None:
+        """flush() should compile all cells and publish variables."""
+        server = _make_server(
+            [
+                ("cell1", "x = 1"),
+                ("cell2", "y = x + 1"),
+            ]
+        )
+        updater = NotebookGraphUpdater(server, "file:///test.py")
+
+        updater.flush()
+
+        server.protocol.notify.assert_called_once()
+        call_args = server.protocol.notify.call_args
+        assert call_args[0][0] == "marimo/operation"
+
+    def test_flush_skips_publish_when_variables_unchanged(self) -> None:
+        """Second flush with same sources should not publish again."""
+        server = _make_server([("cell1", "x = 1")])
+        updater = NotebookGraphUpdater(server, "file:///test.py")
+
+        updater.flush()
+        assert server.protocol.notify.call_count == 1
+
+        # Same sources — should not publish again
+        updater.flush()
+        assert server.protocol.notify.call_count == 1
+
+    def test_flush_publishes_when_variables_change(self) -> None:
+        """Changing a cell's source to alter variables should trigger publish."""
+        server = _make_server([("cell1", "x = 1")])
+        updater = NotebookGraphUpdater(server, "file:///test.py")
+        updater.flush()
+        assert server.protocol.notify.call_count == 1
+
+        # Change cell source to introduce a new variable
+        server.workspace.text_documents[
+            "file:///test.py#cell-cell1"
+        ].source = "x = 1\ny = 2"
+        updater.flush()
+        assert server.protocol.notify.call_count == 2
+
+    def test_flush_skips_publish_when_source_changes_but_variables_dont(self) -> None:
+        """Changing source without altering variables should not publish."""
+        server = _make_server([("cell1", "x = 1")])
+        updater = NotebookGraphUpdater(server, "file:///test.py")
+        updater.flush()
+        assert server.protocol.notify.call_count == 1
+
+        # Change value but not variable structure
+        server.workspace.text_documents["file:///test.py#cell-cell1"].source = "x = 2"
+        updater.flush()
+        assert server.protocol.notify.call_count == 1
 
     def test_handles_syntax_errors(self) -> None:
-        """Test that cells with syntax errors are handled gracefully."""
-        manager = NotebookGraphManager()
-        cell_id = CellId_t("cell1")
+        """Cells with syntax errors should not crash the updater."""
+        server = _make_server([("cell1", "x = (")])
+        updater = NotebookGraphUpdater(server, "file:///test.py")
 
-        # Add valid cell
-        manager.update_cell(cell_id, "x = 1")
-        assert cell_id in manager.get_graph().cells
+        # Should not raise
+        updater.flush()
 
-        # Update with syntax error - should be removed from graph
-        manager.update_cell(cell_id, "x = (")
-        assert cell_id not in manager.get_graph().cells
+        # Fix the syntax error
+        server.workspace.text_documents["file:///test.py#cell-cell1"].source = "x = 1"
+        updater.flush()
 
-        # Fix syntax error - should be added back
-        manager.update_cell(cell_id, "x = 2")
-        assert cell_id in manager.get_graph().cells
+        # Should have published (new variable x)
+        assert server.protocol.notify.call_count >= 1
 
-    def test_cell_removal(self) -> None:
-        """Test that removing cells works correctly."""
-        manager = NotebookGraphManager()
-        cell_id = CellId_t("cell1")
+    def test_removed_cells_cleaned_up(self) -> None:
+        """Cells removed from notebook should be cleaned from the graph."""
+        server = _make_server(
+            [
+                ("cell1", "x = 1"),
+                ("cell2", "y = x + 1"),
+            ]
+        )
+        updater = NotebookGraphUpdater(server, "file:///test.py")
+        updater.flush()
 
-        manager.update_cell(cell_id, "x = 1")
-        assert cell_id in manager.get_graph().cells
+        # Remove cell2 from the notebook
+        notebook = server.workspace.get_notebook_document.return_value
+        notebook.cells = [notebook.cells[0]]
+        del server.workspace.text_documents["file:///test.py#cell-cell2"]
 
-        manager.remove_cell(cell_id)
-        assert cell_id not in manager.get_graph().cells
-        assert manager.is_stale()
+        updater.flush()
 
-    def test_removes_before_reregistering(self) -> None:
-        """Test that cells are deleted before being re-registered."""
-        manager = NotebookGraphManager()
-        cell_id = CellId_t("cell1")
+        # Variable y should no longer be published
+        last_call = server.protocol.notify.call_args
+        operation = last_call[0][1]["operation"]
+        var_names = [v["name"] for v in operation["variables"]]
+        assert "y" not in var_names
+        assert "x" in var_names
 
-        # Add cell
-        manager.update_cell(cell_id, "x = 1")
-        assert cell_id in manager.get_graph().cells
+    def test_cells_without_stable_id_skipped(self) -> None:
+        """Cells missing stableId metadata should be silently skipped."""
+        server = MagicMock()
 
-        # Update same cell (should delete then re-add)
-        manager.update_cell(cell_id, "x = 2")
-        assert cell_id in manager.get_graph().cells
+        cell_with_id = lsp.NotebookCell(
+            kind=lsp.NotebookCellKind.Code,
+            document="file:///test.py#cell-1",
+            metadata=cast("lsp.LSPObject", {"stableId": "cell1"}),
+        )
+        cell_without_id = lsp.NotebookCell(
+            kind=lsp.NotebookCellKind.Code,
+            document="file:///test.py#cell-2",
+            metadata=cast("lsp.LSPObject", {}),
+        )
 
-        # Should not raise AssertionError
-        manager.update_cell(cell_id, "x = 3")
-        assert cell_id in manager.get_graph().cells
-
-    def test_tracks_multiple_cells(self) -> None:
-        """Test that multiple cells are tracked independently."""
-        manager = NotebookGraphManager()
-        cell1 = CellId_t("cell1")
-        cell2 = CellId_t("cell2")
-
-        manager.update_cell(cell1, "x = 1")
-        manager.update_cell(cell2, "y = x + 1")
-        manager.mark_clean()
-
-        # Update only cell1
-        manager.update_cell(cell1, "x = 2")
-        assert manager.is_stale()
-        manager.mark_clean()
-
-        # Update with same value - should not mark stale
-        manager.update_cell(cell2, "y = x + 1")
-        assert not manager.is_stale()
-
-    def test_graph_has_correct_dependencies(self) -> None:
-        """Test that the graph correctly tracks variable dependencies."""
-        manager = NotebookGraphManager()
-        cell1 = CellId_t("cell1")
-        cell2 = CellId_t("cell2")
-
-        manager.update_cell(cell1, "x = 1")
-        manager.update_cell(cell2, "y = x + 1")
-
-        graph = manager.get_graph()
-
-        # x should be declared by cell1
-        assert "x" in graph.definitions
-        assert cell1 in graph.definitions["x"]
-
-        # y should be declared by cell2
-        assert "y" in graph.definitions
-        assert cell2 in graph.definitions["y"]
-
-        # cell2 should reference x
-        assert cell2 in graph.get_referring_cells("x", language="python")
-
-
-class TestGraphManagerRegistry:
-    """Unit tests for GraphManagerRegistry."""
-
-    def test_init_creates_manager(self) -> None:
-        """Test that init creates and initializes a manager."""
-        registry = GraphManagerRegistry()
-
-        # Mock notebook and server (simplified)
-        lsp.NotebookDocument(
+        notebook = lsp.NotebookDocument(
             uri="file:///test.py",
             notebook_type="marimo-notebook",
             version=1,
-            cells=[],
+            cells=[cell_with_id, cell_without_id],
         )
+        server.workspace.get_notebook_document.return_value = notebook
 
-        # We can't easily test this without a full server mock
-        # Just verify the manager is stored
-        assert registry.get("file:///test.py") is None
+        doc1 = MagicMock()
+        doc1.source = "x = 1"
+        doc2 = MagicMock()
+        doc2.source = "# no id"
+        server.workspace.text_documents = {
+            "file:///test.py#cell-1": doc1,
+            "file:///test.py#cell-2": doc2,
+        }
 
-    def test_get_returns_none_when_not_found(self) -> None:
-        """Test that get returns None for non-existent notebooks."""
-        registry = GraphManagerRegistry()
-        assert registry.get("file:///nonexistent.py") is None
+        updater = NotebookGraphUpdater(server, "file:///test.py")
+        updater.flush()  # Should not raise
 
-    def test_remove_deletes_manager(self) -> None:
-        """Test that remove deletes a manager."""
-        registry = GraphManagerRegistry()
+    def test_missing_notebook_is_noop(self) -> None:
+        """flush() when notebook not found in workspace should be a no-op."""
+        server = MagicMock()
+        server.workspace.get_notebook_document.return_value = None
 
-        # Manually add a manager for testing
-        registry._managers["file:///test.py"] = NotebookGraphManager()
-        assert registry.get("file:///test.py") is not None
+        updater = NotebookGraphUpdater(server, "file:///missing.py")
+        updater.flush()  # Should not raise
 
-        registry.remove("file:///test.py")
-        assert registry.get("file:///test.py") is None
+        server.protocol.notify.assert_not_called()
+
+    def test_dependency_tracking(self) -> None:
+        """Variables operation should include correct declared_by and used_by."""
+        server = _make_server(
+            [
+                ("cell1", "x = 1"),
+                ("cell2", "y = x + 1"),
+            ]
+        )
+        updater = NotebookGraphUpdater(server, "file:///test.py")
+        updater.flush()
+
+        call_args = server.protocol.notify.call_args
+        operation = call_args[0][1]["operation"]
+        variables = {v["name"]: v for v in operation["variables"]}
+
+        assert "x" in variables
+        assert CellId_t("cell1") in variables["x"]["declared_by"]
+        assert CellId_t("cell2") in variables["x"]["used_by"]
+
+    def test_schedule_sets_debounce_handle(self) -> None:
+        """schedule() should set a debounce handle."""
+        server = _make_server([("cell1", "x = 1")])
+        updater = NotebookGraphUpdater(server, "file:///test.py")
+
+        with patch("marimo_lsp.diagnostics.asyncio") as mock_asyncio:
+            mock_loop = MagicMock()
+            mock_asyncio.get_event_loop.return_value = mock_loop
+
+            updater.schedule()
+
+            mock_loop.call_later.assert_called_once()
+            assert mock_loop.call_later.call_args[0][0] == 0.15
+
+    def test_flush_cancels_pending_schedule(self) -> None:
+        """flush() should cancel any pending debounce timer."""
+        server = _make_server([("cell1", "x = 1")])
+        updater = NotebookGraphUpdater(server, "file:///test.py")
+
+        # Simulate a pending timer
+        mock_handle = MagicMock()
+        updater._debounce_handle = mock_handle
+
+        updater.flush()
+
+        mock_handle.cancel.assert_called_once()
+        assert updater._debounce_handle is None
+
+
+class TestGraphUpdaterRegistry:
+    """Tests for GraphUpdaterRegistry."""
+
+    def test_get_or_create_returns_same_instance(self) -> None:
+        """get_or_create should return the same updater for the same URI."""
+        server = MagicMock()
+        registry = GraphUpdaterRegistry(server)
+
+        u1 = registry.get_or_create("file:///test.py")
+        u2 = registry.get_or_create("file:///test.py")
+        assert u1 is u2
+
+    def test_get_or_create_different_uris(self) -> None:
+        """get_or_create should return different updaters for different URIs."""
+        server = MagicMock()
+        registry = GraphUpdaterRegistry(server)
+
+        u1 = registry.get_or_create("file:///a.py")
+        u2 = registry.get_or_create("file:///b.py")
+        assert u1 is not u2
+
+    def test_remove_cancels_timer(self) -> None:
+        """remove() should cancel any pending debounce timer."""
+        server = MagicMock()
+        registry = GraphUpdaterRegistry(server)
+
+        updater = registry.get_or_create("file:///test.py")
+
+        with patch.object(updater, "cancel") as mock_cancel:
+            registry.remove("file:///test.py")
+            mock_cancel.assert_called_once()
+
+        # New get_or_create should return a fresh instance
+        assert registry.get_or_create("file:///test.py") is not updater
 
     def test_remove_nonexistent_is_safe(self) -> None:
-        """Test that removing a non-existent manager doesn't error."""
-        registry = GraphManagerRegistry()
+        """Removing a non-existent notebook should not raise."""
+        server = MagicMock()
+        registry = GraphUpdaterRegistry(server)
         registry.remove("file:///nonexistent.py")  # Should not raise
 
 
-class TestIncrementalBehavior:
-    """Tests for incremental graph updates."""
+class TestSnapshotVariables:
+    """Tests for the _snapshot_variables helper."""
 
-    def test_empty_notebook_initializes(self) -> None:
-        """Test that an empty notebook can be initialized."""
-        manager = NotebookGraphManager()
-        # Should not error with no cells
-        graph = manager.get_graph()
-        assert len(graph.cells) == 0
+    def test_empty_graph(self) -> None:
+        """Empty graph should produce empty snapshot."""
+        from marimo._runtime.dataflow import DirectedGraph
 
-    def test_multiple_changes_to_same_cell(self) -> None:
-        """Test rapidly changing the same cell multiple times."""
-        manager = NotebookGraphManager()
-        cell_id = CellId_t("cell1")
+        graph = DirectedGraph()
+        snapshot = _snapshot_variables(graph)
+        assert snapshot == {}
 
-        # Simulate rapid edits
-        for i in range(10):
-            manager.update_cell(cell_id, f"x = {i}")
-            assert manager.is_stale()
-            manager.mark_clean()
+    def test_snapshot_captures_dependencies(self) -> None:
+        """Snapshot should capture declared_by and used_by as frozensets."""
+        from marimo._ast.compiler import compile_cell
+        from marimo._runtime.dataflow import DirectedGraph
 
-        # Final state should be x = 9
-        graph = manager.get_graph()
-        assert cell_id in graph.cells
-
-    def test_cell_order_independence(self) -> None:
-        """Test that cells can be added in any order."""
-        manager = NotebookGraphManager()
+        graph = DirectedGraph()
         cell1 = CellId_t("cell1")
         cell2 = CellId_t("cell2")
 
-        # Add cell2 first (depends on cell1)
-        manager.update_cell(cell2, "y = x + 1")
-        # Add cell1 second
-        manager.update_cell(cell1, "x = 1")
+        compiled1 = compile_cell(cell_id=cell1, code="x = 1")
+        graph.register_cell(cell_id=cell1, cell=compiled1)
 
-        graph = manager.get_graph()
-        assert cell1 in graph.cells
-        assert cell2 in graph.cells
-        assert "x" in graph.definitions
-        assert "y" in graph.definitions
+        compiled2 = compile_cell(cell_id=cell2, code="y = x + 1")
+        graph.register_cell(cell_id=cell2, cell=compiled2)
 
+        snapshot = _snapshot_variables(graph)
 
-class TestLRUCache:
-    """Unit tests for LRUCache."""
-
-    def test_basic_get_put(self) -> None:
-        """Test basic get and put operations."""
-        cache: LRUCache[str, int] = LRUCache(capacity=2)
-
-        cache.put("a", 1)
-        cache.put("b", 2)
-
-        assert cache.get("a") == 1
-        assert cache.get("b") == 2
-        assert cache.get("c") is None
-
-    def test_eviction_policy(self) -> None:
-        """Test that least recently used items are evicted."""
-        cache: LRUCache[str, int] = LRUCache(capacity=2)
-
-        cache.put("a", 1)
-        cache.put("b", 2)
-        # Access "a" to make it recently used
-        cache.get("a")
-        # Add "c" - should evict "b" (least recently used)
-        cache.put("c", 3)
-
-        assert cache.get("a") == 1
-        assert cache.get("b") is None  # Evicted
-        assert cache.get("c") == 3
-
-    def test_update_existing_key(self) -> None:
-        """Test updating an existing key updates its value and position."""
-        cache: LRUCache[str, int] = LRUCache(capacity=2)
-
-        cache.put("a", 1)
-        cache.put("b", 2)
-        cache.put("a", 10)  # Update "a"
-
-        assert cache.get("a") == 10
-
-        # Add new item - should evict "b" since "a" was just updated
-        cache.put("c", 3)
-        assert cache.get("b") is None
-        assert cache.get("a") == 10
-        assert cache.get("c") == 3
-
-    def test_capacity_one(self) -> None:
-        """Test cache with capacity of one."""
-        cache: LRUCache[str, int] = LRUCache(capacity=1)
-
-        cache.put("a", 1)
-        assert cache.get("a") == 1
-
-        cache.put("b", 2)
-        assert cache.get("a") is None  # Evicted
-        assert cache.get("b") == 2
+        assert "x" in snapshot
+        declared_by, used_by = snapshot["x"]
+        assert cell1 in declared_by
+        assert cell2 in used_by
 
 
 class TestCellMetadataHelpers:
@@ -334,99 +391,3 @@ class TestCellMetadataHelpers:
         assert cell_id is None
         assert config == {}
         assert name == "_"
-
-
-class TestURIMapping:
-    """Unit tests for URI-to-cell-id mapping functionality."""
-
-    def test_uri_cache_initialization(self) -> None:
-        """Test that NotebookGraphManager initializes the URI cache."""
-        manager = NotebookGraphManager()
-        assert manager.uri_to_cell_id_cache is not None
-
-    def test_update_cell_document_with_cached_mapping(self) -> None:
-        """Test _update_cell_document uses cached URI mapping."""
-        manager = NotebookGraphManager()
-        cell_id = CellId_t("cell1")
-        uri = CellDocumentUri("file:///test.py#cell1")
-
-        # Pre-populate the cache
-        manager.uri_to_cell_id_cache.put(uri, cell_id)
-
-        # Create a text document identifier
-        doc = lsp.VersionedTextDocumentIdentifier(uri=uri, version=1)
-
-        # Update should use the cached mapping
-        manager._update_cell_document(doc, "x = 1")
-
-        # Verify the cell was updated
-        assert cell_id in manager.get_graph().cells
-
-    def test_remove_cell_document_with_cached_mapping(self) -> None:
-        """Test _remove_cell_document uses cached URI mapping."""
-        manager = NotebookGraphManager()
-        cell_id = CellId_t("cell1")
-        uri = CellDocumentUri("file:///test.py#cell1")
-
-        # Add cell and populate cache
-        manager.update_cell(cell_id, "x = 1")
-        manager.uri_to_cell_id_cache.put(uri, cell_id)
-
-        assert cell_id in manager.get_graph().cells
-
-        # Remove via URI
-        doc = lsp.TextDocumentIdentifier(uri=uri)
-        manager._remove_cell_document(doc)
-
-        # Verify the cell was removed
-        assert cell_id not in manager.get_graph().cells
-
-    def test_persist_mapping_from_data(self) -> None:
-        """Test _persist_mapping stores mappings from cell data."""
-        manager = NotebookGraphManager()
-
-        cell = lsp.NotebookCell(
-            kind=lsp.NotebookCellKind.Code,
-            document="file:///test.py#cell1",
-            metadata=cast("lsp.LSPObject", {"stableId": "abc-123"}),
-        )
-
-        change = lsp.NotebookDocumentChangeEvent(
-            cells=lsp.NotebookDocumentCellChanges(data=[cell])
-        )
-
-        manager._persist_mapping(change)
-
-        # Verify mapping was stored
-        cached_id = manager.uri_to_cell_id_cache.get(
-            CellDocumentUri("file:///test.py#cell1")
-        )
-        assert cached_id == CellId_t("abc-123")
-
-    def test_persist_mapping_from_structure(self) -> None:
-        """Test _persist_mapping stores mappings from structure array."""
-        manager = NotebookGraphManager()
-
-        cell = lsp.NotebookCell(
-            kind=lsp.NotebookCellKind.Code,
-            document="file:///test.py#cell1",
-            metadata=cast("lsp.LSPObject", {"stableId": "abc-123"}),
-        )
-
-        change = lsp.NotebookDocumentChangeEvent(
-            cells=lsp.NotebookDocumentCellChanges(
-                structure=lsp.NotebookDocumentCellChangeStructure(
-                    array=lsp.NotebookCellArrayChange(
-                        start=0, delete_count=0, cells=[cell]
-                    )
-                )
-            )
-        )
-
-        manager._persist_mapping(change)
-
-        # Verify mapping was stored
-        cached_id = manager.uri_to_cell_id_cache.get(
-            CellDocumentUri("file:///test.py#cell1")
-        )
-        assert cached_id == CellId_t("abc-123")


### PR DESCRIPTION
The LSP server's `notebookDocument/didChange` handler previously ran `compile_cell()` synchronously on every keystroke via a complex incremental update pipeline: URI-to-cellId LRU cache lookups, structural change parsing, and per-cell compilation. This blocked the pygls asyncio event loop for all other LSP messages and wasted work since only the final state after a typing burst matters for variable ordering.

The new design replaces `NotebookGraphManager`, `GraphManagerRegistry`, and `LRUCache` with `NotebookGraphUpdater`. `NotebookGraphManager` uses `asyncio.call_later` to debounce compilation. The key is that pygls already keeps `workspace.text_documents` up-to-date on every `didChange`, so the debounced task can simply re-read all cell text from the workspace when it fires. No need to track changes incrementally.

The server handlers collapse to one-liners:

    didOpen  → updater.flush()     # immediate compile for initial ordering
    didChange → updater.schedule()  # debounced, 150ms quiet period
    diagnostic → updater.flush()   # force fresh state on pull
    didClose → registry.remove()   # cancel timer, drop state

When the debounced recompile runs, it walks all notebook cells, compiles only those whose source text actually changed (via a `_cell_sources` cache), and publishes a `marimo/operation` notification only if the variable dependency structure changed. Keystrokes now result in zero compilation work.