### PR TITLE
Fix searchable dropdown z-index in VS Code notebooks

### DIFF
--- a/extension/src/renderer/styles.css
+++ b/extension/src/renderer/styles.css
@@ -59,6 +59,7 @@
   marimo-date,
   marimo-date-range,
   marimo-datetime,
+  marimo-dropdown[data-searchable="true"],
   marimo-multiselect
 ) {
   min-height: 350px;


### PR DESCRIPTION
Fixes  #386

Add `marimo-dropdown[data-searchable="true"]` to the CSS selector that sets `min-height: 350px` on cell outputs containing elements with large popovers.

When a searchable dropdown (`searchable=True`) opens its combobox popover, it extends beyond the cell output container. VS Code's notebook renderer clips cell outputs, causing the dropdown menu to be hidden behind subsequent cells. This fix follows the same pattern already used for `marimo-date`, `marimo-date-range`, `marimo-datetime`, and `marimo-multiselect`. Only searchable dropdowns are targeted — regular dropdowns use a native `<select>` that doesn't overflow.
