### PR TITLE
Add copy/save image toolbar on hover for notebook outputs

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -48,6 +48,7 @@
     "@vscode/test-electron": "^2.5.2",
     "effect": "^3.19.19",
     "esbuild": "^0.25.11",
+    "happy-dom": "^20.8.9",
     "jest-mock-vscode": "^4.7.0",
     "mocha": "^11.7.4",
     "oxfmt": "^0.35.0",

--- a/extension/package.json
+++ b/extension/package.json
@@ -49,6 +49,7 @@
     "@vscode/test-electron": "^2.5.2",
     "effect": "^3.19.19",
     "esbuild": "^0.28.0",
+    "happy-dom": "^20.8.9",
     "jest-mock-vscode": "^4.7.0",
     "jotai": "2.17.0",
     "mocha": "^11.7.4",

--- a/extension/pnpm-lock.yaml
+++ b/extension/pnpm-lock.yaml
@@ -24,7 +24,7 @@ importers:
         version: 0.98.3(@effect/cluster@0.50.4(@effect/platform@0.92.1(effect@3.19.19))(@effect/rpc@0.71.0(@effect/platform@0.92.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.46.0(@effect/experimental@0.56.0(@effect/platform@0.92.1(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.92.1(effect@3.19.19))(effect@3.19.19))(@effect/workflow@0.11.3(@effect/platform@0.92.1(effect@3.19.19))(@effect/rpc@0.71.0(@effect/platform@0.92.1(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.92.1(effect@3.19.19))(@effect/rpc@0.71.0(@effect/platform@0.92.1(effect@3.19.19))(effect@3.19.19))(@effect/sql@0.46.0(@effect/experimental@0.56.0(@effect/platform@0.92.1(effect@3.19.19))(effect@3.19.19))(@effect/platform@0.92.1(effect@3.19.19))(effect@3.19.19))(effect@3.19.19)
       '@effect/vitest':
         specifier: ^0.27.0
-        version: 0.27.0(effect@3.19.19)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.7.2)(jiti@2.6.1)(lightningcss@1.30.2))
+        version: 0.27.0(effect@3.19.19)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.7.2)(happy-dom@20.8.9)(jiti@2.6.1)(lightningcss@1.30.2))
       '@marimo-team/frontend':
         specifier: link:../../marimo/frontend
         version: link:../../marimo/frontend
@@ -82,6 +82,9 @@ importers:
       esbuild:
         specifier: ^0.25.11
         version: 0.25.11
+      happy-dom:
+        specifier: ^20.8.9
+        version: 20.8.9
       jest-mock-vscode:
         specifier: ^4.7.0
         version: 4.7.0(@types/vscode@1.105.0)
@@ -123,7 +126,7 @@ importers:
         version: rolldown-vite@7.2.2(@types/node@24.7.2)(esbuild@0.25.11)(jiti@2.6.1)
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.7.2)(jiti@2.6.1)(lightningcss@1.30.2)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.7.2)(happy-dom@20.8.9)(jiti@2.6.1)(lightningcss@1.30.2)
       vscode-jsonrpc:
         specifier: ^8.2.1
         version: 8.2.1
@@ -1371,6 +1374,12 @@ packages:
   '@types/vscode@1.105.0':
     resolution: {integrity: sha512-Lotk3CTFlGZN8ray4VxJE7axIyLZZETQJVWi/lYoUVQuqfRxlQhVOfoejsD2V3dVXPSbS15ov5ZyowMAzgUqcw==}
 
+  '@types/whatwg-mimetype@3.0.2':
+    resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
   '@typescript/native-preview-darwin-arm64@7.0.0-dev.20251015.1':
     resolution: {integrity: sha512-nX3IvW3zVZItG6BWkSmQlyNiq23obmSU+S+Yp0bN6elR+S+yLWssutb1f8mmjOVx8zZVIB0PHuzeiTb3a89aEA==}
     cpu: [arm64]
@@ -1627,6 +1636,10 @@ packages:
     resolution: {integrity: sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww==}
     engines: {node: '>=10.13.0'}
 
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
+
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
@@ -1711,6 +1724,10 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  happy-dom@20.8.9:
+    resolution: {integrity: sha512-Tz23LR9T9jOGVZm2x1EPdXqwA37G/owYMxRwU0E4miurAtFsPMQ1d2Jc2okUaSjZqAFz2oEn3FLXC5a0a+siyA==}
+    engines: {node: '>=20.0.0'}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -2564,6 +2581,10 @@ packages:
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
 
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -2694,10 +2715,10 @@ snapshots:
       effect: 3.19.19
       uuid: 11.1.0
 
-  '@effect/vitest@0.27.0(effect@3.19.19)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.7.2)(jiti@2.6.1)(lightningcss@1.30.2))':
+  '@effect/vitest@0.27.0(effect@3.19.19)(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.7.2)(happy-dom@20.8.9)(jiti@2.6.1)(lightningcss@1.30.2))':
     dependencies:
       effect: 3.19.19
-      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.7.2)(jiti@2.6.1)(lightningcss@1.30.2)
+      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.7.2)(happy-dom@20.8.9)(jiti@2.6.1)(lightningcss@1.30.2)
 
   '@effect/workflow@0.11.3(@effect/platform@0.92.1(effect@3.19.19))(@effect/rpc@0.71.0(@effect/platform@0.92.1(effect@3.19.19))(effect@3.19.19))(effect@3.19.19)':
     dependencies:
@@ -3622,6 +3643,12 @@ snapshots:
 
   '@types/vscode@1.105.0': {}
 
+  '@types/whatwg-mimetype@3.0.2': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 24.7.2
+
   '@typescript/native-preview-darwin-arm64@7.0.0-dev.20251015.1':
     optional: true
 
@@ -3866,6 +3893,8 @@ snapshots:
       graceful-fs: 4.2.11
       tapable: 2.3.0
 
+  entities@7.0.1: {}
+
   es-module-lexer@1.7.0: {}
 
   esbuild@0.25.11:
@@ -3958,6 +3987,18 @@ snapshots:
       path-scurry: 1.11.1
 
   graceful-fs@4.2.11: {}
+
+  happy-dom@20.8.9:
+    dependencies:
+      '@types/node': 24.7.2
+      '@types/whatwg-mimetype': 3.0.2
+      '@types/ws': 8.18.1
+      entities: 7.0.1
+      whatwg-mimetype: 3.0.0
+      ws: 8.18.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   has-flag@4.0.0: {}
 
@@ -4698,7 +4739,7 @@ snapshots:
       jiti: 2.6.1
       lightningcss: 1.30.2
 
-  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.7.2)(jiti@2.6.1)(lightningcss@1.30.2):
+  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.7.2)(happy-dom@20.8.9)(jiti@2.6.1)(lightningcss@1.30.2):
     dependencies:
       '@vitest/expect': 4.0.18
       '@vitest/mocker': 4.0.18(vite@7.1.10(@types/node@24.7.2)(jiti@2.6.1)(lightningcss@1.30.2))
@@ -4723,6 +4764,7 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
       '@types/node': 24.7.2
+      happy-dom: 20.8.9
     transitivePeerDependencies:
       - jiti
       - less
@@ -4763,6 +4805,8 @@ snapshots:
   vscode-languageserver-types@3.17.6-next.6: {}
 
   vscode-uri@3.1.0: {}
+
+  whatwg-mimetype@3.0.0: {}
 
   which@2.0.2:
     dependencies:

--- a/extension/pnpm-lock.yaml
+++ b/extension/pnpm-lock.yaml
@@ -87,6 +87,9 @@ importers:
       esbuild:
         specifier: ^0.28.0
         version: 0.28.0
+      happy-dom:
+        specifier: ^20.8.9
+        version: 20.10.2
       jest-mock-vscode:
         specifier: ^4.7.0
         version: 4.7.0(@types/vscode@1.105.0)
@@ -122,10 +125,10 @@ importers:
         version: '@voidzero-dev/vite-plus-core@0.1.18(@types/node@24.7.2)(esbuild@0.28.0)(jiti@2.6.1)(typescript@6.0.2)'
       vite-plus:
         specifier: 0.1.18
-        version: 0.1.18(@opentelemetry/api@1.9.0)(@types/node@24.7.2)(@vitest/coverage-v8@4.1.4)(@voidzero-dev/vite-plus-core@0.1.18(@types/node@24.7.2)(esbuild@0.28.0)(jiti@2.6.1)(typescript@6.0.2))(esbuild@0.28.0)(jiti@2.6.1)(typescript@6.0.2)
+        version: 0.1.18(@opentelemetry/api@1.9.0)(@types/node@24.7.2)(@vitest/coverage-v8@4.1.4)(@voidzero-dev/vite-plus-core@0.1.18(@types/node@24.7.2)(esbuild@0.28.0)(jiti@2.6.1)(typescript@6.0.2))(esbuild@0.28.0)(happy-dom@20.10.2)(jiti@2.6.1)(typescript@6.0.2)
       vitest:
         specifier: npm:@voidzero-dev/vite-plus-test@0.1.18
-        version: '@voidzero-dev/vite-plus-test@0.1.18(@opentelemetry/api@1.9.0)(@types/node@24.7.2)(@vitest/coverage-v8@4.1.4)(@voidzero-dev/vite-plus-core@0.1.18(@types/node@24.7.2)(esbuild@0.28.0)(jiti@2.6.1)(typescript@6.0.2))(esbuild@0.28.0)(jiti@2.6.1)(typescript@6.0.2)'
+        version: '@voidzero-dev/vite-plus-test@0.1.18(@opentelemetry/api@1.9.0)(@types/node@24.7.2)(@vitest/coverage-v8@4.1.4)(@voidzero-dev/vite-plus-core@0.1.18(@types/node@24.7.2)(esbuild@0.28.0)(jiti@2.6.1)(typescript@6.0.2))(esbuild@0.28.0)(happy-dom@20.10.2)(jiti@2.6.1)(typescript@6.0.2)'
       vscode-jsonrpc:
         specifier: ^8.2.1
         version: 8.2.1
@@ -1207,6 +1210,12 @@ packages:
   '@types/vscode@1.105.0':
     resolution: {integrity: sha512-Lotk3CTFlGZN8ray4VxJE7axIyLZZETQJVWi/lYoUVQuqfRxlQhVOfoejsD2V3dVXPSbS15ov5ZyowMAzgUqcw==}
 
+  '@types/whatwg-mimetype@3.0.2':
+    resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
   '@typescript/native-preview-darwin-arm64@7.0.0-dev.20251015.1':
     resolution: {integrity: sha512-nX3IvW3zVZItG6BWkSmQlyNiq23obmSU+S+Yp0bN6elR+S+yLWssutb1f8mmjOVx8zZVIB0PHuzeiTb3a89aEA==}
     cpu: [arm64]
@@ -1489,6 +1498,10 @@ packages:
   browser-stdout@1.3.1:
     resolution: {integrity: sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==}
 
+  buffer-image-size@0.6.4:
+    resolution: {integrity: sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==}
+    engines: {node: '>=4.0'}
+
   c8@10.1.3:
     resolution: {integrity: sha512-LvcyrOAaOnrrlMpW22n690PUvxiq4Uf9WMhQwNJ9vgagkL/ph1+D4uvjvDA5XCbykrc0sx+ay6pVi9YZ1GnhyA==}
     engines: {node: '>=18'}
@@ -1603,6 +1616,10 @@ packages:
     resolution: {integrity: sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww==}
     engines: {node: '>=10.13.0'}
 
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
+
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
@@ -1683,6 +1700,10 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  happy-dom@20.10.2:
+    resolution: {integrity: sha512-5p9Sxis3eowDJKqx90QCsgbNA02XXqJ59NOHvD4V6cxp+rP4d/xOyVx7uY3hS8hiUbY1VeiFH8lbJ81AyuDVLQ==}
+    engines: {node: '>=20.0.0'}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -2457,6 +2478,10 @@ packages:
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
 
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -2487,6 +2512,18 @@ packages:
 
   ws@8.20.0:
     resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -2610,7 +2647,7 @@ snapshots:
   '@effect/vitest@0.27.0(@voidzero-dev/vite-plus-test@0.1.18)(effect@3.19.19)':
     dependencies:
       effect: 3.19.19
-      vitest: '@voidzero-dev/vite-plus-test@0.1.18(@opentelemetry/api@1.9.0)(@types/node@24.7.2)(@vitest/coverage-v8@4.1.4)(@voidzero-dev/vite-plus-core@0.1.18(@types/node@24.7.2)(esbuild@0.28.0)(jiti@2.6.1)(typescript@6.0.2))(esbuild@0.28.0)(jiti@2.6.1)(typescript@6.0.2)'
+      vitest: '@voidzero-dev/vite-plus-test@0.1.18(@opentelemetry/api@1.9.0)(@types/node@24.7.2)(@vitest/coverage-v8@4.1.4)(@voidzero-dev/vite-plus-core@0.1.18(@types/node@24.7.2)(esbuild@0.28.0)(jiti@2.6.1)(typescript@6.0.2))(esbuild@0.28.0)(happy-dom@20.10.2)(jiti@2.6.1)(typescript@6.0.2)'
 
   '@effect/workflow@0.11.3(@effect/platform@0.92.1(effect@3.19.19))(@effect/rpc@0.71.0(@effect/platform@0.92.1(effect@3.19.19))(effect@3.19.19))(effect@3.19.19)':
     dependencies:
@@ -3396,6 +3433,12 @@ snapshots:
 
   '@types/vscode@1.105.0': {}
 
+  '@types/whatwg-mimetype@3.0.2': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 24.7.2
+
   '@typescript/native-preview-darwin-arm64@7.0.0-dev.20251015.1':
     optional: true
 
@@ -3439,7 +3482,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: '@voidzero-dev/vite-plus-test@0.1.18(@opentelemetry/api@1.9.0)(@types/node@24.7.2)(@vitest/coverage-v8@4.1.4)(@voidzero-dev/vite-plus-core@0.1.18(@types/node@24.7.2)(esbuild@0.28.0)(jiti@2.6.1)(typescript@6.0.2))(esbuild@0.28.0)(jiti@2.6.1)(typescript@6.0.2)'
+      vitest: '@voidzero-dev/vite-plus-test@0.1.18(@opentelemetry/api@1.9.0)(@types/node@24.7.2)(@vitest/coverage-v8@4.1.4)(@voidzero-dev/vite-plus-core@0.1.18(@types/node@24.7.2)(esbuild@0.28.0)(jiti@2.6.1)(typescript@6.0.2))(esbuild@0.28.0)(happy-dom@20.10.2)(jiti@2.6.1)(typescript@6.0.2)'
 
   '@vitest/pretty-format@4.1.4':
     dependencies:
@@ -3482,7 +3525,7 @@ snapshots:
   '@voidzero-dev/vite-plus-linux-x64-musl@0.1.18':
     optional: true
 
-  '@voidzero-dev/vite-plus-test@0.1.18(@opentelemetry/api@1.9.0)(@types/node@24.7.2)(@vitest/coverage-v8@4.1.4)(@voidzero-dev/vite-plus-core@0.1.18(@types/node@24.7.2)(esbuild@0.28.0)(jiti@2.6.1)(typescript@6.0.2))(esbuild@0.28.0)(jiti@2.6.1)(typescript@6.0.2)':
+  '@voidzero-dev/vite-plus-test@0.1.18(@opentelemetry/api@1.9.0)(@types/node@24.7.2)(@vitest/coverage-v8@4.1.4)(@voidzero-dev/vite-plus-core@0.1.18(@types/node@24.7.2)(esbuild@0.28.0)(jiti@2.6.1)(typescript@6.0.2))(esbuild@0.28.0)(happy-dom@20.10.2)(jiti@2.6.1)(typescript@6.0.2)':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
@@ -3502,6 +3545,7 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@types/node': 24.7.2
       '@vitest/coverage-v8': 4.1.4(@voidzero-dev/vite-plus-test@0.1.18)
+      happy-dom: 20.10.2
     transitivePeerDependencies:
       - '@arethetypeswrong/core'
       - '@tsdown/css'
@@ -3610,6 +3654,10 @@ snapshots:
 
   browser-stdout@1.3.1: {}
 
+  buffer-image-size@0.6.4:
+    dependencies:
+      '@types/node': 24.7.2
+
   c8@10.1.3:
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
@@ -3715,6 +3763,8 @@ snapshots:
       graceful-fs: 4.2.11
       tapable: 2.3.0
 
+  entities@7.0.1: {}
+
   es-module-lexer@1.7.0: {}
 
   esbuild@0.28.0:
@@ -3805,6 +3855,19 @@ snapshots:
       path-scurry: 1.11.1
 
   graceful-fs@4.2.11: {}
+
+  happy-dom@20.10.2:
+    dependencies:
+      '@types/node': 24.7.2
+      '@types/whatwg-mimetype': 3.0.2
+      '@types/ws': 8.18.1
+      buffer-image-size: 0.6.4
+      entities: 7.0.1
+      whatwg-mimetype: 3.0.0
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   has-flag@4.0.0: {}
 
@@ -4488,11 +4551,11 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
 
-  vite-plus@0.1.18(@opentelemetry/api@1.9.0)(@types/node@24.7.2)(@vitest/coverage-v8@4.1.4)(@voidzero-dev/vite-plus-core@0.1.18(@types/node@24.7.2)(esbuild@0.28.0)(jiti@2.6.1)(typescript@6.0.2))(esbuild@0.28.0)(jiti@2.6.1)(typescript@6.0.2):
+  vite-plus@0.1.18(@opentelemetry/api@1.9.0)(@types/node@24.7.2)(@vitest/coverage-v8@4.1.4)(@voidzero-dev/vite-plus-core@0.1.18(@types/node@24.7.2)(esbuild@0.28.0)(jiti@2.6.1)(typescript@6.0.2))(esbuild@0.28.0)(happy-dom@20.10.2)(jiti@2.6.1)(typescript@6.0.2):
     dependencies:
       '@oxc-project/types': 0.124.0
       '@voidzero-dev/vite-plus-core': 0.1.18(@types/node@24.7.2)(esbuild@0.28.0)(jiti@2.6.1)(typescript@6.0.2)
-      '@voidzero-dev/vite-plus-test': 0.1.18(@opentelemetry/api@1.9.0)(@types/node@24.7.2)(@vitest/coverage-v8@4.1.4)(@voidzero-dev/vite-plus-core@0.1.18(@types/node@24.7.2)(esbuild@0.28.0)(jiti@2.6.1)(typescript@6.0.2))(esbuild@0.28.0)(jiti@2.6.1)(typescript@6.0.2)
+      '@voidzero-dev/vite-plus-test': 0.1.18(@opentelemetry/api@1.9.0)(@types/node@24.7.2)(@vitest/coverage-v8@4.1.4)(@voidzero-dev/vite-plus-core@0.1.18(@types/node@24.7.2)(esbuild@0.28.0)(jiti@2.6.1)(typescript@6.0.2))(esbuild@0.28.0)(happy-dom@20.10.2)(jiti@2.6.1)(typescript@6.0.2)
       oxfmt: 0.45.0
       oxlint: 1.60.0(oxlint-tsgolint@0.20.0)
       oxlint-tsgolint: 0.20.0
@@ -4563,6 +4626,8 @@ snapshots:
 
   vscode-uri@3.1.0: {}
 
+  whatwg-mimetype@3.0.0: {}
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
@@ -4584,6 +4649,8 @@ snapshots:
   ws@8.18.3: {}
 
   ws@8.20.0: {}
+
+  ws@8.21.0: {}
 
   xtend@4.0.2: {}
 

--- a/extension/src/kernel/KernelManager.ts
+++ b/extension/src/kernel/KernelManager.ts
@@ -34,6 +34,7 @@ import type {
 } from "../types.ts";
 import { ControllerRegistry } from "./ControllerRegistry.ts";
 import { ExecutionRegistry } from "./ExecutionRegistry.ts";
+import { resolveImageDataUri, saveImageToDisk } from "./imageResolver.ts";
 import { handleMissingPackageAlert } from "./operations.ts";
 
 interface MarimoOperation {
@@ -185,6 +186,35 @@ export class KernelManager extends Effect.Service<KernelManager>()(
                       code.NotebookEditorRevealType.InCenter,
                     );
                   }
+                  return;
+                }
+                case "save-image": {
+                  yield* saveImageToDisk(
+                    message.params.src,
+                    message.params.suggestedName,
+                    editor.notebook.uri,
+                  ).pipe(
+                    Effect.catchAll((cause) =>
+                      Effect.logError("Failed to save image").pipe(
+                        Effect.annotateLogs({ cause }),
+                      ),
+                    ),
+                  );
+                  return;
+                }
+                case "copy-image": {
+                  const { src, requestId } = message.params;
+                  const dataUri = yield* resolveImageDataUri(src).pipe(
+                    Effect.option,
+                  );
+                  yield* renderer.postMessage(
+                    {
+                      op: "image-data-result",
+                      requestId,
+                      dataUri: Option.getOrNull(dataUri),
+                    },
+                    editor,
+                  );
                   return;
                 }
                 default: {

--- a/extension/src/kernel/__tests__/imageResolver.test.ts
+++ b/extension/src/kernel/__tests__/imageResolver.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { decodeDataUri } from "../imageResolver.ts";
+
+describe("decodeDataUri", () => {
+  it("decodes a base64 data URI", () => {
+    // "hi" base64-encoded
+    const result = decodeDataUri("data:image/png;base64,aGk=");
+    expect(result).not.toBeNull();
+    expect(result?.mime).toBe("image/png");
+    expect(new TextDecoder().decode(result?.bytes)).toBe("hi");
+  });
+
+  it("decodes a non-base64 (url-encoded) data URI", () => {
+    const result = decodeDataUri("data:image/svg+xml,%3Csvg%2F%3E");
+    expect(result?.mime).toBe("image/svg+xml");
+    expect(new TextDecoder().decode(result?.bytes)).toBe("<svg/>");
+  });
+
+  it("returns null for a non-data URL", () => {
+    expect(decodeDataUri("https://example.com/a.svg")).toBeNull();
+  });
+});

--- a/extension/src/kernel/__tests__/imageResolver.test.ts
+++ b/extension/src/kernel/__tests__/imageResolver.test.ts
@@ -1,6 +1,11 @@
-import { describe, expect, it } from "vitest";
+import { Effect } from "effect";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { decodeDataUri } from "../imageResolver.ts";
+import {
+  decodeDataUri,
+  ImageFetchError,
+  resolveImageBytes,
+} from "../imageResolver.ts";
 
 describe("decodeDataUri", () => {
   it("decodes a base64 data URI", () => {
@@ -19,5 +24,76 @@ describe("decodeDataUri", () => {
 
   it("returns null for a non-data URL", () => {
     expect(decodeDataUri("https://example.com/a.svg")).toBeNull();
+  });
+
+  it("returns null for malformed percent-encoding", () => {
+    expect(decodeDataUri("data:image/svg+xml,%")).toBeNull();
+  });
+});
+
+describe("resolveImageBytes", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  // Effect.flip moves the error onto the success channel so we can assert on it;
+  // if the effect unexpectedly succeeds, flip fails the run and the test fails.
+  const expectError = (src: string) =>
+    Effect.runPromise(Effect.flip(resolveImageBytes(src)));
+
+  it("rejects unsupported URL schemes before fetching", async () => {
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+    const error = await expectError("file:///etc/passwd");
+    expect(error).toBeInstanceOf(ImageFetchError);
+    expect(String(error.cause)).toContain("unsupported URL scheme");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-OK responses without reading the body", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response("not found", { status: 404, statusText: "Not Found" }),
+      ),
+    );
+    const error = await expectError("https://example.com/missing.png");
+    expect(error).toBeInstanceOf(ImageFetchError);
+    expect(String(error.cause)).toContain("404");
+  });
+
+  it("rejects non-image content types", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response("<html></html>", {
+            status: 200,
+            headers: { "content-type": "text/html" },
+          }),
+      ),
+    );
+    const error = await expectError("https://example.com/page.html");
+    expect(error).toBeInstanceOf(ImageFetchError);
+    expect(String(error.cause)).toContain("text/html");
+  });
+
+  it("returns bytes and mime for an image response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(new Uint8Array([1, 2, 3]), {
+            status: 200,
+            headers: { "content-type": "image/png" },
+          }),
+      ),
+    );
+    const result = await Effect.runPromise(
+      resolveImageBytes("https://example.com/a.png"),
+    );
+    expect(result.mime).toBe("image/png");
+    expect([...result.bytes]).toEqual([1, 2, 3]);
   });
 });

--- a/extension/src/kernel/imageResolver.ts
+++ b/extension/src/kernel/imageResolver.ts
@@ -1,0 +1,78 @@
+import { Data, Effect, Option } from "effect";
+import type * as vscode from "vscode";
+
+import { VsCode } from "../platform/VsCode.ts";
+
+export class ImageFetchError extends Data.TaggedError("ImageFetchError")<{
+  cause: unknown;
+}> {}
+
+interface ImageBytes {
+  bytes: Uint8Array;
+  mime: string;
+}
+
+const DATA_URI = /^data:([^;,]+)(;base64)?,(.*)$/s;
+
+export function decodeDataUri(src: string): ImageBytes | null {
+  const match = DATA_URI.exec(src);
+  if (!match) {
+    return null;
+  }
+  const [, mime, base64, data] = match;
+  const bytes = base64
+    ? new Uint8Array(Buffer.from(data, "base64"))
+    : new TextEncoder().encode(decodeURIComponent(data));
+  return { bytes, mime };
+}
+
+/**
+ * Read an image the renderer references. Data URIs are decoded locally;
+ * anything else is fetched. The extension host has no CORS restriction, so this
+ * reaches the remote URLs that the sandboxed renderer iframe can't read itself.
+ */
+export const resolveImageBytes = Effect.fn("resolveImageBytes")(function* (
+  src: string,
+) {
+  const decoded = decodeDataUri(src);
+  if (decoded) {
+    return decoded;
+  }
+  const response = yield* Effect.tryPromise({
+    try: (signal) => fetch(src, { signal }),
+    catch: (cause) => new ImageFetchError({ cause }),
+  });
+  const buffer = yield* Effect.tryPromise({
+    try: () => response.arrayBuffer(),
+    catch: (cause) => new ImageFetchError({ cause }),
+  });
+  return {
+    bytes: new Uint8Array(buffer),
+    mime: response.headers.get("content-type") ?? "application/octet-stream",
+  } satisfies ImageBytes;
+});
+
+export const resolveImageDataUri = Effect.fn("resolveImageDataUri")(function* (
+  src: string,
+) {
+  const { bytes, mime } = yield* resolveImageBytes(src);
+  return `data:${mime};base64,${Buffer.from(bytes).toString("base64")}`;
+});
+
+export const saveImageToDisk = Effect.fn("saveImageToDisk")(function* (
+  src: string,
+  suggestedName: string,
+  notebookUri: vscode.Uri,
+) {
+  const code = yield* VsCode;
+  const { bytes } = yield* resolveImageBytes(src);
+  const saveUri = yield* code.window.showSaveDialog({
+    title: "Save image",
+    defaultUri: code.Uri.joinPath(notebookUri, "..", suggestedName),
+    filters: { Images: ["png", "jpg", "jpeg", "gif", "svg", "webp"] },
+  });
+  if (Option.isNone(saveUri)) {
+    return;
+  }
+  yield* code.workspace.fs.writeFile(saveUri.value, bytes);
+});

--- a/extension/src/kernel/imageResolver.ts
+++ b/extension/src/kernel/imageResolver.ts
@@ -20,10 +20,16 @@ export function decodeDataUri(src: string): ImageBytes | null {
     return null;
   }
   const [, mime, base64, data] = match;
-  const bytes = base64
-    ? new Uint8Array(Buffer.from(data, "base64"))
-    : new TextEncoder().encode(decodeURIComponent(data));
-  return { bytes, mime };
+  try {
+    const bytes = base64
+      ? new Uint8Array(Buffer.from(data, "base64"))
+      : new TextEncoder().encode(decodeURIComponent(data));
+    return { bytes, mime };
+  } catch {
+    // decodeURIComponent throws on malformed percent-encoding; treat such a
+    // data URI as unreadable rather than letting it break copy/save.
+    return null;
+  }
 }
 
 /**
@@ -38,17 +44,39 @@ export const resolveImageBytes = Effect.fn("resolveImageBytes")(function* (
   if (decoded) {
     return decoded;
   }
+  const url = yield* Effect.try({
+    try: () => new URL(src),
+    catch: (cause) => new ImageFetchError({ cause }),
+  });
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    return yield* Effect.fail(
+      new ImageFetchError({ cause: `unsupported URL scheme: ${url.protocol}` }),
+    );
+  }
   const response = yield* Effect.tryPromise({
     try: (signal) => fetch(src, { signal }),
     catch: (cause) => new ImageFetchError({ cause }),
   });
+  if (!response.ok) {
+    return yield* Effect.fail(
+      new ImageFetchError({
+        cause: `fetch returned ${response.status} ${response.statusText}`,
+      }),
+    );
+  }
+  const contentType = response.headers.get("content-type");
+  if (contentType && !contentType.startsWith("image/")) {
+    return yield* Effect.fail(
+      new ImageFetchError({ cause: `non-image content-type: ${contentType}` }),
+    );
+  }
   const buffer = yield* Effect.tryPromise({
     try: () => response.arrayBuffer(),
     catch: (cause) => new ImageFetchError({ cause }),
   });
   return {
     bytes: new Uint8Array(buffer),
-    mime: response.headers.get("content-type") ?? "application/octet-stream",
+    mime: contentType ?? "application/octet-stream",
   } satisfies ImageBytes;
 });
 

--- a/extension/src/renderer/CellOutput.tsx
+++ b/extension/src/renderer/CellOutput.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 
+import { ImageToolbar } from "./ImageToolbar.tsx";
 import {
   type CellId,
   type CellRuntimeState,
@@ -8,6 +9,7 @@ import {
   TooltipProvider,
   useTheme,
 } from "./marimo-frontend.ts";
+import { useEventListener } from "./useEventListener.ts";
 
 interface CellOutputProps {
   cellId: CellId;
@@ -20,6 +22,7 @@ interface CellOutputProps {
 export function CellOutput({ cellId, state }: CellOutputProps) {
   const { theme } = useTheme();
   const container = React.useRef<HTMLDivElement>(null);
+  const { target: hoveredImage, clear: clearHover } = useImageHover(container);
 
   useStopInputKeyboardPropagation(container);
 
@@ -44,8 +47,39 @@ export function CellOutput({ cellId, state }: CellOutputProps) {
           />
         )}
       </TooltipProvider>
+      {hoveredImage && (
+        <ImageToolbar target={hoveredImage} onMouseLeave={clearHover} />
+      )}
     </div>
   );
+}
+
+/**
+ * Detect when the user hovers over an <img> inside the container.
+ * Uses native DOM events via useEventListener so we can call stopPropagation.
+ */
+function useImageHover(ref: React.RefObject<HTMLDivElement | null>) {
+  const [target, setTarget] = React.useState<HTMLImageElement | null>(null);
+  const clear = React.useCallback(() => setTarget(null), []);
+
+  useEventListener(ref, "mouseover", (e) => {
+    const img = (e.target as HTMLElement).closest?.("img");
+    if (img instanceof HTMLImageElement) {
+      e.stopPropagation();
+      setTarget(img);
+    }
+  });
+
+  useEventListener(ref, "mouseout", (e) => {
+    const related = e.relatedTarget as HTMLElement | null;
+    if (related?.closest?.(".image-toolbar")) return;
+    if ((e.target as HTMLElement).closest?.("img")) {
+      e.stopPropagation();
+      setTarget(null);
+    }
+  });
+
+  return { target, clear };
 }
 
 /**
@@ -56,29 +90,16 @@ export function CellOutput({ cellId, state }: CellOutputProps) {
  * then stops propagation to VS Code.
  */
 function useStopInputKeyboardPropagation(
-  containerRef: React.RefObject<HTMLDivElement | null>,
+  ref: React.RefObject<HTMLDivElement | null>,
 ) {
-  React.useEffect(() => {
-    if (!containerRef.current) {
-      return;
+  const handler = React.useCallback((e: KeyboardEvent) => {
+    if (isFromInput(e)) {
+      e.stopPropagation();
     }
+  }, []);
 
-    const controller = new AbortController();
-    const handler = (e: KeyboardEvent) => {
-      if (isFromInput(e)) {
-        e.stopPropagation();
-      }
-    };
-
-    containerRef.current.addEventListener("keydown", handler, {
-      signal: controller.signal,
-    });
-    containerRef.current.addEventListener("keyup", handler, {
-      signal: controller.signal,
-    });
-
-    return () => controller.abort();
-  }, [containerRef]);
+  useEventListener(ref, "keydown", handler);
+  useEventListener(ref, "keyup", handler);
 }
 
 /**

--- a/extension/src/renderer/CellOutput.tsx
+++ b/extension/src/renderer/CellOutput.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 
+import { ImageToolbar } from "./ImageToolbar.tsx";
 import {
   type CellId,
   type CellRuntimeState,
@@ -8,6 +9,7 @@ import {
   TooltipProvider,
   useTheme,
 } from "./marimo-frontend.ts";
+import { useEventListener } from "./useEventListener.ts";
 
 interface CellOutputProps {
   cellId: CellId;
@@ -20,6 +22,7 @@ interface CellOutputProps {
 export function CellOutput({ cellId, state }: CellOutputProps) {
   const { theme } = useTheme();
   const container = React.useRef<HTMLDivElement>(null);
+  const { target: hoveredImage, clear: clearHover } = useImageHover(container);
 
   useStopUnmodifiedInputKeys(container);
 
@@ -44,8 +47,40 @@ export function CellOutput({ cellId, state }: CellOutputProps) {
           />
         )}
       </TooltipProvider>
+      {hoveredImage && (
+        <ImageToolbar target={hoveredImage} onMouseLeave={clearHover} />
+      )}
     </div>
   );
+}
+
+/**
+ * Detect when the user hovers over an <img> inside the container.
+ * Uses native DOM events via useEventListener so we can call stopPropagation.
+ */
+function useImageHover(ref: React.RefObject<HTMLDivElement | null>) {
+  const [target, setTarget] = React.useState<HTMLImageElement | null>(null);
+  const clear = React.useCallback(() => setTarget(null), []);
+
+  useEventListener(ref, "mouseover", (e) => {
+    if (!(e.target instanceof Element)) return;
+    const img = e.target.closest("img");
+    if (img instanceof HTMLImageElement) {
+      e.stopPropagation();
+      setTarget(img);
+    }
+  });
+
+  useEventListener(ref, "mouseout", (e) => {
+    const related = e.relatedTarget;
+    if (related instanceof Element && related.closest(".image-toolbar")) return;
+    if (e.target instanceof Element && e.target.closest("img")) {
+      e.stopPropagation();
+      setTarget(null);
+    }
+  });
+
+  return { target, clear };
 }
 
 /**
@@ -77,36 +112,22 @@ export function CellOutput({ cellId, state }: CellOutputProps) {
  *     `delegatesFocus: true` on the shadow root.
  */
 function useStopUnmodifiedInputKeys(
-  containerRef: React.RefObject<HTMLDivElement | null>,
+  ref: React.RefObject<HTMLDivElement | null>,
 ) {
-  React.useEffect(() => {
-    const container = containerRef.current;
-    if (!container) {
-      return undefined;
+  const handler = React.useCallback((e: KeyboardEvent) => {
+    if (isModifierKey(e.key)) {
+      return;
     }
+    if ((e.ctrlKey || e.metaKey) && !e.getModifierState("AltGraph")) {
+      return;
+    }
+    if (isFromInput(e)) {
+      e.stopPropagation();
+    }
+  }, []);
 
-    const controller = new AbortController();
-    const handler = (e: KeyboardEvent) => {
-      if (isModifierKey(e.key)) {
-        return;
-      }
-      if ((e.ctrlKey || e.metaKey) && !e.getModifierState("AltGraph")) {
-        return;
-      }
-      if (isFromInput(e)) {
-        e.stopPropagation();
-      }
-    };
-
-    container.addEventListener("keydown", handler, {
-      signal: controller.signal,
-    });
-    container.addEventListener("keyup", handler, {
-      signal: controller.signal,
-    });
-
-    return () => controller.abort();
-  }, [containerRef]);
+  useEventListener(ref, "keydown", handler);
+  useEventListener(ref, "keyup", handler);
 }
 
 function isModifierKey(key: string): boolean {

--- a/extension/src/renderer/ImageToolbar.tsx
+++ b/extension/src/renderer/ImageToolbar.tsx
@@ -1,0 +1,187 @@
+/// <reference lib="dom" />
+
+import * as React from "react";
+
+interface ImageToolbarProps {
+  /** The <img> element currently being hovered */
+  target: HTMLImageElement;
+  /** Called when the mouse leaves the toolbar itself */
+  onMouseLeave: () => void;
+}
+
+/**
+ * Floating toolbar that appears over images with Copy and Save actions.
+ * Positioned at the top-right corner of the hovered image.
+ */
+export function ImageToolbar({ target, onMouseLeave }: ImageToolbarProps) {
+  const [copied, setCopied] = React.useState(false);
+
+  const rect = target.getBoundingClientRect();
+  // Position relative to the nearest positioned ancestor (the output container)
+  const parentRect = target
+    .closest<HTMLElement>(".marimo-cell-output")
+    ?.getBoundingClientRect();
+  if (!parentRect) {
+    return null;
+  }
+
+  const top = rect.top - parentRect.top + 4;
+  const right = parentRect.right - rect.right + 4;
+
+  return (
+    <div
+      className="image-toolbar"
+      style={{ top, right }}
+      onMouseLeave={onMouseLeave}
+    >
+      <button
+        type="button"
+        title="Copy image to clipboard"
+        onClick={async () => {
+          await copyImageToClipboard(target);
+          setCopied(true);
+          setTimeout(() => setCopied(false), 1500);
+        }}
+      >
+        {copied ? checkIcon : copyIcon}
+      </button>
+      <button
+        type="button"
+        title="Save image"
+        onClick={() => saveImage(target)}
+      >
+        {downloadIcon}
+      </button>
+    </div>
+  );
+}
+
+async function copyImageToClipboard(img: HTMLImageElement): Promise<void> {
+  const src = img.src;
+
+  // Try the modern Clipboard API with blob
+  try {
+    const blob = await imgSrcToBlob(src, "image/png");
+    await navigator.clipboard.write([new ClipboardItem({ "image/png": blob })]);
+    return;
+  } catch {
+    // Fall back: copy the data URI as text
+    await navigator.clipboard.writeText(src);
+  }
+}
+
+function saveImage(img: HTMLImageElement): void {
+  const src = img.src;
+  const ext = guessExtension(src);
+  const filename = `image.${ext}`;
+
+  // Convert data URI to blob URL for reliable download
+  imgSrcToBlob(src, `image/${ext}`)
+    .then((blob) => {
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    })
+    .catch(() => {
+      // Fallback: open in new tab
+      const a = document.createElement("a");
+      a.href = src;
+      a.download = filename;
+      a.click();
+    });
+}
+
+/**
+ * Convert an image src (data URI or URL) to a Blob.
+ * Uses canvas to ensure we get the requested format.
+ */
+function imgSrcToBlob(src: string, mimeType: string): Promise<Blob> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.crossOrigin = "anonymous";
+    img.onload = () => {
+      const canvas = document.createElement("canvas");
+      canvas.width = img.naturalWidth;
+      canvas.height = img.naturalHeight;
+      const ctx = canvas.getContext("2d");
+      if (!ctx) {
+        reject(new Error("Could not get canvas context"));
+        return;
+      }
+      ctx.drawImage(img, 0, 0);
+      canvas.toBlob((blob) => {
+        if (blob) {
+          resolve(blob);
+        } else {
+          reject(new Error("Could not create blob from canvas"));
+        }
+      }, mimeType);
+    };
+    img.onerror = () => reject(new Error("Could not load image"));
+    img.src = src;
+  });
+}
+
+function guessExtension(src: string): string {
+  if (src.startsWith("data:image/")) {
+    const mime = src.slice(11, src.indexOf(";"));
+    if (mime === "svg+xml") return "svg";
+    if (mime === "jpeg") return "jpg";
+    return mime;
+  }
+  return "png";
+}
+
+// Inline SVG icons (16x16, stroke-based) to avoid dependencies
+const copyIcon = (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+    <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1" />
+  </svg>
+);
+
+const checkIcon = (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <polyline points="20 6 9 17 4 12" />
+  </svg>
+);
+
+const downloadIcon = (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4" />
+    <polyline points="7 10 12 15 17 10" />
+    <line x1="12" y1="15" x2="12" y2="3" />
+  </svg>
+);

--- a/extension/src/renderer/ImageToolbar.tsx
+++ b/extension/src/renderer/ImageToolbar.tsx
@@ -2,6 +2,8 @@
 
 import * as React from "react";
 
+import { requestImageDataUri, requestImageSave } from "./imageTransport.ts";
+
 interface ImageToolbarProps {
   /** The <img> element currently being hovered */
   target: HTMLImageElement;
@@ -37,10 +39,18 @@ export function ImageToolbar({ target, onMouseLeave }: ImageToolbarProps) {
       <button
         type="button"
         title="Copy image to clipboard"
-        onClick={async () => {
-          await copyImageToClipboard(target);
-          setCopied(true);
-          setTimeout(() => setCopied(false), 1500);
+        onClick={() => {
+          // Call clipboard.write synchronously so the click's user activation
+          // is still live; the blob is resolved (possibly via a host round-trip)
+          // inside the ClipboardItem promise.
+          copyImageToClipboard(target.src)
+            .then(() => {
+              setCopied(true);
+              setTimeout(() => setCopied(false), 1500);
+            })
+            .catch(() => {
+              void navigator.clipboard.writeText(target.src).catch(() => {});
+            });
         }}
       >
         {copied ? checkIcon : copyIcon}
@@ -48,7 +58,9 @@ export function ImageToolbar({ target, onMouseLeave }: ImageToolbarProps) {
       <button
         type="button"
         title="Save image"
-        onClick={() => saveImage(target)}
+        onClick={() =>
+          requestImageSave(target.src, suggestedFilename(target.src))
+        }
       >
         {downloadIcon}
       </button>
@@ -56,47 +68,37 @@ export function ImageToolbar({ target, onMouseLeave }: ImageToolbarProps) {
   );
 }
 
-async function copyImageToClipboard(img: HTMLImageElement): Promise<void> {
-  const src = img.src;
-
-  // Try the modern Clipboard API with blob
-  try {
-    const blob = await imgSrcToBlob(src, "image/png");
-    await navigator.clipboard.write([new ClipboardItem({ "image/png": blob })]);
-    return;
-  } catch {
-    // Fall back: copy the data URI as text
-    await navigator.clipboard.writeText(src);
-  }
+function copyImageToClipboard(src: string): Promise<void> {
+  return navigator.clipboard.write([
+    new ClipboardItem({ "image/png": imageToPngBlob(src) }),
+  ]);
 }
 
-async function saveImage(img: HTMLImageElement): Promise<void> {
-  const src = img.src;
-
-  // Download the original bytes so the format is preserved exactly. Going
-  // through a canvas (as the clipboard path does) would rasterize vector
-  // outputs, saving an SVG as PNG under a misleading `.svg` name.
-  try {
-    const blob = await fetch(src).then((r) => r.blob());
-    const ext = extensionForMime(blob.type) ?? guessExtension(src);
-    triggerDownload(blob, `image.${ext}`);
-  } catch {
-    const a = document.createElement("a");
-    a.href = src;
-    a.download = `image.${guessExtension(src)}`;
-    a.click();
-  }
+/**
+ * Rasterize an image to a PNG blob for the clipboard. Reads the pixels locally
+ * when possible; for cross-origin images (whose canvas would taint) it asks the
+ * host for the bytes as a same-origin data URI, then rasterizes that.
+ */
+function imageToPngBlob(src: string): Promise<Blob> {
+  return imgSrcToBlob(src, "image/png").catch(() =>
+    requestImageDataUri(src).then((dataUri) =>
+      imgSrcToBlob(dataUri, "image/png"),
+    ),
+  );
 }
 
-function triggerDownload(blob: Blob, filename: string): void {
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement("a");
-  a.href = url;
-  a.download = filename;
-  document.body.appendChild(a);
-  a.click();
-  document.body.removeChild(a);
-  URL.revokeObjectURL(url);
+function suggestedFilename(src: string): string {
+  if (!src.startsWith("data:")) {
+    try {
+      const base = new URL(src).pathname.split("/").pop();
+      if (base && /\.[^.]+$/.test(base)) {
+        return decodeURIComponent(base);
+      }
+    } catch {
+      // Not a parseable URL; fall through to a mime-derived name.
+    }
+  }
+  return `image.${guessExtension(src)}`;
 }
 
 /**

--- a/extension/src/renderer/ImageToolbar.tsx
+++ b/extension/src/renderer/ImageToolbar.tsx
@@ -34,7 +34,15 @@ export function ImageToolbar({ target, onMouseLeave }: ImageToolbarProps) {
     <div
       className="image-toolbar"
       style={{ top, right }}
-      onMouseLeave={onMouseLeave}
+      onMouseLeave={(e) => {
+        // Moving back onto the image it decorates isn't "leaving"; closing here
+        // would make the toolbar flicker as the image's mouseover re-opens it.
+        const next = e.relatedTarget;
+        if (next instanceof Node && target.contains(next)) {
+          return;
+        }
+        onMouseLeave();
+      }}
     >
       <button
         type="button"

--- a/extension/src/renderer/ImageToolbar.tsx
+++ b/extension/src/renderer/ImageToolbar.tsx
@@ -1,0 +1,194 @@
+/// <reference lib="dom" />
+
+import * as React from "react";
+
+interface ImageToolbarProps {
+  /** The <img> element currently being hovered */
+  target: HTMLImageElement;
+  /** Called when the mouse leaves the toolbar itself */
+  onMouseLeave: () => void;
+}
+
+/**
+ * Floating toolbar that appears over images with Copy and Save actions.
+ * Positioned at the top-right corner of the hovered image.
+ */
+export function ImageToolbar({ target, onMouseLeave }: ImageToolbarProps) {
+  const [copied, setCopied] = React.useState(false);
+
+  const rect = target.getBoundingClientRect();
+  // Position relative to the nearest positioned ancestor (the output container)
+  const parentRect = target
+    .closest<HTMLElement>(".marimo-cell-output")
+    ?.getBoundingClientRect();
+  if (!parentRect) {
+    return null;
+  }
+
+  const top = rect.top - parentRect.top + 4;
+  const right = parentRect.right - rect.right + 4;
+
+  return (
+    <div
+      className="image-toolbar"
+      style={{ top, right }}
+      onMouseLeave={onMouseLeave}
+    >
+      <button
+        type="button"
+        title="Copy image to clipboard"
+        onClick={async () => {
+          await copyImageToClipboard(target);
+          setCopied(true);
+          setTimeout(() => setCopied(false), 1500);
+        }}
+      >
+        {copied ? checkIcon : copyIcon}
+      </button>
+      <button
+        type="button"
+        title="Save image"
+        onClick={() => saveImage(target)}
+      >
+        {downloadIcon}
+      </button>
+    </div>
+  );
+}
+
+async function copyImageToClipboard(img: HTMLImageElement): Promise<void> {
+  const src = img.src;
+
+  // Try the modern Clipboard API with blob
+  try {
+    const blob = await imgSrcToBlob(src, "image/png");
+    await navigator.clipboard.write([new ClipboardItem({ "image/png": blob })]);
+    return;
+  } catch {
+    // Fall back: copy the data URI as text
+    await navigator.clipboard.writeText(src);
+  }
+}
+
+async function saveImage(img: HTMLImageElement): Promise<void> {
+  const src = img.src;
+
+  // Download the original bytes so the format is preserved exactly. Going
+  // through a canvas (as the clipboard path does) would rasterize vector
+  // outputs, saving an SVG as PNG under a misleading `.svg` name.
+  try {
+    const blob = await fetch(src).then((r) => r.blob());
+    const ext = extensionForMime(blob.type) ?? guessExtension(src);
+    triggerDownload(blob, `image.${ext}`);
+  } catch {
+    const a = document.createElement("a");
+    a.href = src;
+    a.download = `image.${guessExtension(src)}`;
+    a.click();
+  }
+}
+
+function triggerDownload(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+/**
+ * Convert an image src (data URI or URL) to a Blob.
+ * Uses canvas to ensure we get the requested format.
+ */
+function imgSrcToBlob(src: string, mimeType: string): Promise<Blob> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.crossOrigin = "anonymous";
+    img.onload = () => {
+      const canvas = document.createElement("canvas");
+      canvas.width = img.naturalWidth;
+      canvas.height = img.naturalHeight;
+      const ctx = canvas.getContext("2d");
+      if (!ctx) {
+        reject(new Error("Could not get canvas context"));
+        return;
+      }
+      ctx.drawImage(img, 0, 0);
+      canvas.toBlob((blob) => {
+        if (blob) {
+          resolve(blob);
+        } else {
+          reject(new Error("Could not create blob from canvas"));
+        }
+      }, mimeType);
+    };
+    img.onerror = () => reject(new Error("Could not load image"));
+    img.src = src;
+  });
+}
+
+function guessExtension(src: string): string {
+  const match = /^data:(image\/[^;,]+)/.exec(src);
+  return (match && extensionForMime(match[1])) || "png";
+}
+
+function extensionForMime(mime: string): string | undefined {
+  const match = /^image\/(.+)$/.exec(mime);
+  if (!match) return undefined;
+  const subtype = match[1];
+  if (subtype === "svg+xml") return "svg";
+  if (subtype === "jpeg") return "jpg";
+  return subtype;
+}
+
+// Inline SVG icons (16x16, stroke-based) to avoid dependencies
+const copyIcon = (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+    <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1" />
+  </svg>
+);
+
+const checkIcon = (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <polyline points="20 6 9 17 4 12" />
+  </svg>
+);
+
+const downloadIcon = (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4" />
+    <polyline points="7 10 12 15 17 10" />
+    <line x1="12" y1="15" x2="12" y2="3" />
+  </svg>
+);

--- a/extension/src/renderer/__tests__/useEventListener.test.ts
+++ b/extension/src/renderer/__tests__/useEventListener.test.ts
@@ -1,0 +1,103 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { useEventListener } from "../useEventListener.ts";
+
+// Track the most recent useEffect cleanup so tests can invoke it.
+let cleanupFn: (() => void) | undefined;
+
+// Minimal React shim — just enough to exercise the hook synchronously in Node.
+vi.mock("react", () => ({
+  useRef: (init: unknown) => ({ current: init }),
+  useEffect: (fn: () => (() => void) | void) => {
+    cleanupFn = fn() ?? undefined;
+  },
+}));
+
+function cleanup() {
+  cleanupFn?.();
+  cleanupFn = undefined;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useEventListener", () => {
+  it("adds an event listener to the element", () => {
+    const el = document.createElement("div");
+    const spy = vi.spyOn(el, "addEventListener");
+    const ref = { current: el };
+
+    useEventListener(ref, "click", vi.fn());
+
+    expect(spy).toHaveBeenCalledOnce();
+    expect(spy).toHaveBeenCalledWith(
+      "click",
+      expect.any(Function),
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+  });
+
+  it("invokes the handler when the event fires", () => {
+    const el = document.createElement("div");
+    const ref = { current: el };
+    const handler = vi.fn();
+
+    useEventListener(ref, "click", handler);
+
+    el.click();
+
+    expect(handler).toHaveBeenCalledOnce();
+    expect(handler).toHaveBeenCalledWith(expect.any(MouseEvent));
+  });
+
+  it("aborts the listener on cleanup", () => {
+    const el = document.createElement("div");
+    const ref = { current: el };
+    const handler = vi.fn();
+
+    useEventListener(ref, "click", handler);
+
+    cleanup();
+    el.click();
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when ref is null", () => {
+    const ref = { current: null };
+    // Should not throw
+    expect(() => useEventListener(ref, "click", vi.fn())).not.toThrow();
+  });
+
+  it("passes capture: true when options is a boolean", () => {
+    const el = document.createElement("div");
+    const spy = vi.spyOn(el, "addEventListener");
+    const ref = { current: el };
+
+    useEventListener(ref, "keydown", vi.fn(), true);
+
+    expect(spy).toHaveBeenCalledWith(
+      "keydown",
+      expect.any(Function),
+      expect.objectContaining({ capture: true }),
+    );
+  });
+
+  it("only subscribes once even when handler identity changes", () => {
+    const el = document.createElement("div");
+    const spy = vi.spyOn(el, "addEventListener");
+    const ref = { current: el };
+
+    useEventListener(ref, "click", vi.fn());
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    // A second call with a different handler should not add another listener
+    // (in a real React render, useEffect deps haven't changed)
+    el.click();
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/extension/src/renderer/__tests__/useEventListener.test.ts
+++ b/extension/src/renderer/__tests__/useEventListener.test.ts
@@ -1,0 +1,143 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { act } from "react";
+import * as React from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useEventListener } from "../useEventListener.ts";
+
+declare global {
+  var IS_REACT_ACT_ENVIRONMENT: boolean | undefined;
+}
+
+// Required by React 19's `act` to confirm it runs in a test environment.
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+interface ProbeProps {
+  targetRef: React.RefObject<HTMLElement | null>;
+  event: keyof HTMLElementEventMap;
+  handler: (e: Event) => void;
+  options?: boolean | AddEventListenerOptions;
+}
+
+function Probe({ targetRef, event, handler, options }: ProbeProps) {
+  useEventListener(targetRef, event, handler, options);
+  return null;
+}
+
+let root: Root;
+let mount: HTMLElement;
+
+beforeEach(() => {
+  mount = document.createElement("div");
+  document.body.appendChild(mount);
+  root = createRoot(mount);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  mount.remove();
+});
+
+function render(props: ProbeProps) {
+  act(() => root.render(React.createElement(Probe, props)));
+}
+
+describe("useEventListener", () => {
+  it("attaches the listener to the ref'd element", () => {
+    const el = document.createElement("div");
+    const spy = vi.spyOn(el, "addEventListener");
+
+    render({ targetRef: { current: el }, event: "click", handler: vi.fn() });
+
+    expect(spy).toHaveBeenCalledOnce();
+    expect(spy).toHaveBeenCalledWith(
+      "click",
+      expect.any(Function),
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+  });
+
+  it("invokes the handler when the event fires", () => {
+    const el = document.createElement("div");
+    const handler = vi.fn();
+
+    render({ targetRef: { current: el }, event: "click", handler });
+    el.click();
+
+    expect(handler).toHaveBeenCalledOnce();
+  });
+
+  it("removes the listener on unmount", () => {
+    const el = document.createElement("div");
+    const handler = vi.fn();
+
+    render({ targetRef: { current: el }, event: "click", handler });
+    act(() => root.unmount());
+    el.click();
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("does not throw when the ref is null", () => {
+    expect(() =>
+      render({
+        targetRef: { current: null },
+        event: "click",
+        handler: vi.fn(),
+      }),
+    ).not.toThrow();
+  });
+
+  it("forwards a boolean option as capture", () => {
+    const el = document.createElement("div");
+    const spy = vi.spyOn(el, "addEventListener");
+
+    render({
+      targetRef: { current: el },
+      event: "keydown",
+      handler: vi.fn(),
+      options: true,
+    });
+
+    expect(spy).toHaveBeenCalledWith(
+      "keydown",
+      expect.any(Function),
+      expect.objectContaining({ capture: true }),
+    );
+  });
+
+  it("calls the latest handler without re-subscribing when only the handler changes", () => {
+    const el = document.createElement("div");
+    const spy = vi.spyOn(el, "addEventListener");
+    const ref = { current: el };
+    const first = vi.fn();
+    const second = vi.fn();
+
+    render({ targetRef: ref, event: "click", handler: first });
+    render({ targetRef: ref, event: "click", handler: second });
+
+    expect(spy).toHaveBeenCalledOnce();
+
+    el.click();
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledOnce();
+  });
+
+  it("re-subscribes and drops the old listener when the event type changes", () => {
+    const el = document.createElement("div");
+    const ref = { current: el };
+    const handler = vi.fn();
+
+    render({ targetRef: ref, event: "mouseover", handler });
+    render({ targetRef: ref, event: "click", handler });
+
+    el.dispatchEvent(new Event("mouseover"));
+    expect(handler).not.toHaveBeenCalled();
+
+    el.click();
+    expect(handler).toHaveBeenCalledOnce();
+  });
+});

--- a/extension/src/renderer/css/image-toolbar.css
+++ b/extension/src/renderer/css/image-toolbar.css
@@ -1,0 +1,40 @@
+/**
+ * Image toolbar: floating copy/save buttons shown on hover over images.
+ */
+.image-toolbar {
+  position: absolute;
+  z-index: 10;
+  display: flex;
+  gap: 2px;
+  padding: 2px;
+  border-radius: 4px;
+  background: var(--vscode-editor-background, #1e1e1e);
+  border: 1px solid var(--vscode-editorWidget-border, #454545);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+  opacity: 0;
+  animation: image-toolbar-fade-in 0.15s ease-out forwards;
+}
+
+@keyframes image-toolbar-fade-in {
+  to {
+    opacity: 1;
+  }
+}
+
+.image-toolbar button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: none;
+  border-radius: 3px;
+  background: transparent;
+  color: var(--vscode-editor-foreground, #cccccc);
+  cursor: pointer;
+}
+
+.image-toolbar button:hover {
+  background: var(--vscode-list-hoverBackground, #2a2d2e);
+}

--- a/extension/src/renderer/imageTransport.ts
+++ b/extension/src/renderer/imageTransport.ts
@@ -1,0 +1,68 @@
+import type { RendererCommand } from "../types.ts";
+
+/**
+ * Bridge between the image toolbar (a React component deep in the output tree)
+ * and the extension host. The renderer iframe is sandboxed and can't read
+ * cross-origin image bytes, so saving and copying are delegated to the host
+ * over the renderer messaging channel.
+ *
+ * `save-image` is fire-and-forget. `copy-image` is request/response: the host
+ * replies with an `image-data-result` carrying the bytes as a data URI, matched
+ * back to the caller by `requestId`.
+ */
+
+type PostMessage = (message: RendererCommand) => void;
+
+let postMessage: PostMessage | undefined;
+let nextRequestId = 0;
+
+const pending = new Map<
+  string,
+  { resolve: (dataUri: string) => void; reject: (reason: Error) => void }
+>();
+
+const REQUEST_TIMEOUT_MS = 15_000;
+
+export function initImageTransport(post: PostMessage): void {
+  postMessage = post;
+}
+
+/** Route an `image-data-result` reply back to its pending `requestImageDataUri`. */
+export function resolveImageDataResult(
+  requestId: string,
+  dataUri: string | null,
+): void {
+  const entry = pending.get(requestId);
+  if (!entry) {
+    return;
+  }
+  pending.delete(requestId);
+  if (dataUri === null) {
+    entry.reject(new Error("The extension host could not load the image"));
+  } else {
+    entry.resolve(dataUri);
+  }
+}
+
+/** Ask the host to fetch `src` and return its bytes as a data URI. */
+export function requestImageDataUri(src: string): Promise<string> {
+  if (!postMessage) {
+    return Promise.reject(new Error("Image transport is not initialized"));
+  }
+  const requestId = `image-${nextRequestId++}`;
+  postMessage({ command: "copy-image", params: { src, requestId } });
+
+  return new Promise((resolve, reject) => {
+    pending.set(requestId, { resolve, reject });
+    setTimeout(() => {
+      if (pending.delete(requestId)) {
+        reject(new Error("Timed out waiting for image data from the host"));
+      }
+    }, REQUEST_TIMEOUT_MS);
+  });
+}
+
+/** Ask the host to save `src` to disk via a native save dialog. */
+export function requestImageSave(src: string, suggestedName: string): void {
+  postMessage?.({ command: "save-image", params: { src, suggestedName } });
+}

--- a/extension/src/renderer/renderer.tsx
+++ b/extension/src/renderer/renderer.tsx
@@ -9,6 +9,10 @@ import { assert, unreachable } from "../assert.ts";
 import type { MarimoHtmlPublishMessage } from "../types.ts";
 import { CellOutput } from "./CellOutput.tsx";
 import {
+  initImageTransport,
+  resolveImageDataResult,
+} from "./imageTransport.ts";
+import {
   type CellId,
   type CellRuntimeState,
   handleFunctionCallResult,
@@ -32,6 +36,7 @@ export const activate: vscode.ActivationFunction = (context) => {
     limitBytes: TABLE_EXPORT_LIMIT_BYTES,
     unavailableMessage: `This table is too large to download from a VS Code notebook output (limit: ${TABLE_EXPORT_LIMIT_MB}MB). Open the notebook in a browser to export it, or filter the data first.`,
   });
+  initImageTransport((message) => context.postMessage(message));
 
   /**
    * Bridge for HTML output interactions.
@@ -80,6 +85,10 @@ export const activate: vscode.ActivationFunction = (context) => {
       }
       case "model-lifecycle": {
         handleModelLifecycle(msg);
+        return;
+      }
+      case "image-data-result": {
+        resolveImageDataResult(msg.requestId, msg.dataUri);
         return;
       }
       default: {

--- a/extension/src/renderer/styles.css
+++ b/extension/src/renderer/styles.css
@@ -1,3 +1,5 @@
+@import "./css/image-toolbar.css";
+
 /**
  * VSCode theme variable mappings to marimo's CSS variables
  * Maps VSCode's theme colors to the CSS variables used by marimo
@@ -49,6 +51,13 @@
   /* Links */
   --link: var(--vscode-textLink-foreground);
   --link-visited: var(--vscode-textLink-activeForeground);
+}
+
+/**
+ * Ensure the output container is a positioning context for the image toolbar
+ */
+.marimo-cell-output {
+  position: relative;
 }
 
 /**

--- a/extension/src/renderer/styles.css
+++ b/extension/src/renderer/styles.css
@@ -52,6 +52,54 @@
 }
 
 /**
+ * Ensure the output container is a positioning context for the image toolbar
+ */
+.marimo-cell-output {
+  position: relative;
+}
+
+/**
+ * Image toolbar: floating copy/save buttons shown on hover over images.
+ */
+.image-toolbar {
+  position: absolute;
+  z-index: 10;
+  display: flex;
+  gap: 2px;
+  padding: 2px;
+  border-radius: 4px;
+  background: var(--vscode-editor-background, #1e1e1e);
+  border: 1px solid var(--vscode-editorWidget-border, #454545);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+  opacity: 0;
+  animation: image-toolbar-fade-in 0.15s ease-out forwards;
+}
+
+@keyframes image-toolbar-fade-in {
+  to {
+    opacity: 1;
+  }
+}
+
+.image-toolbar button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: none;
+  border-radius: 3px;
+  background: transparent;
+  color: var(--vscode-editor-foreground, #cccccc);
+  cursor: pointer;
+}
+
+.image-toolbar button:hover {
+  background: var(--vscode-list-hoverBackground, #2a2d2e);
+}
+
+/**
  * Set minimum height for cell outputs containing elements with large popovers
  * This prevents popovers from being cut off in VS Code's output rendering
  */

--- a/extension/src/renderer/useEventListener.ts
+++ b/extension/src/renderer/useEventListener.ts
@@ -1,0 +1,38 @@
+/// <reference lib="dom" />
+
+import * as React from "react";
+
+/**
+ * Attach a DOM event listener to a ref'd element with automatic cleanup.
+ *
+ * - Re-attaches when the element, event type, or options change.
+ * - Always sees the latest handler without re-subscribing (via ref).
+ * - Cleans up with AbortController on unmount or dependency change.
+ */
+export function useEventListener<
+  K extends keyof HTMLElementEventMap,
+  T extends HTMLElement = HTMLElement,
+>(
+  ref: React.RefObject<T | null>,
+  event: K,
+  handler: (e: HTMLElementEventMap[K]) => void,
+  options?: boolean | AddEventListenerOptions,
+) {
+  const handlerRef = React.useRef(handler);
+  handlerRef.current = handler;
+
+  React.useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    const controller = new AbortController();
+    const opts =
+      typeof options === "boolean"
+        ? { capture: options, signal: controller.signal }
+        : { ...options, signal: controller.signal };
+
+    el.addEventListener(event, (e) => handlerRef.current(e), opts);
+
+    return () => controller.abort();
+  }, [ref, event, options]);
+}

--- a/extension/src/renderer/useEventListener.ts
+++ b/extension/src/renderer/useEventListener.ts
@@ -1,0 +1,38 @@
+/// <reference lib="dom" />
+
+import * as React from "react";
+
+/**
+ * Attach a DOM event listener to a ref'd element with automatic cleanup.
+ *
+ * - Re-attaches when the element, event type, or options change.
+ * - Always sees the latest handler without re-subscribing (via ref).
+ * - Cleans up with AbortController on unmount or dependency change.
+ */
+export function useEventListener<
+  K extends keyof HTMLElementEventMap,
+  T extends HTMLElement = HTMLElement,
+>(
+  ref: React.RefObject<T | null>,
+  event: K,
+  handler: (e: HTMLElementEventMap[K]) => void,
+  options?: boolean | AddEventListenerOptions,
+) {
+  const handlerRef = React.useRef(handler);
+  handlerRef.current = handler;
+
+  React.useEffect(() => {
+    const el = ref.current;
+    if (!el) return undefined;
+
+    const controller = new AbortController();
+    const opts =
+      typeof options === "boolean"
+        ? { capture: options, signal: controller.signal }
+        : { ...options, signal: controller.signal };
+
+    el.addEventListener(event, (e) => handlerRef.current(e), opts);
+
+    return () => controller.abort();
+  }, [ref, event, options]);
+}

--- a/extension/src/types.ts
+++ b/extension/src/types.ts
@@ -154,6 +154,12 @@ type RendererCommandMap = {
   "invoke-function": MarimoApiMethodMap["invoke-function"]["inner"];
   // Custom
   "navigate-to-cell": { cellId: NotebookCellId };
+  // Image toolbar: the sandboxed renderer can't read cross-origin image bytes,
+  // so it asks the host to fetch them. `save-image` writes to disk; `copy-image`
+  // returns the bytes (as a data URI, keyed by `requestId`) for the renderer to
+  // place on the clipboard.
+  "save-image": { src: string; suggestedName: string };
+  "copy-image": { src: string; requestId: string };
 };
 type RendererCommandMessageOf<K extends keyof RendererCommandMap> = {
   [C in keyof RendererCommandMap]: {
@@ -169,12 +175,23 @@ export type RendererCommand = RendererCommandMessageOf<
   keyof RendererCommandMap
 >;
 
+/**
+ * Reply to a renderer `copy-image` request. `dataUri` is null when the host
+ * could not fetch/decode the image, so the renderer can fall back gracefully.
+ */
+export type ImageDataResult = {
+  op: "image-data-result";
+  requestId: string;
+  dataUri: string | null;
+};
+
 // extension -> renderer
 export type RendererReceiveMessage =
   | NotificationOf<"remove-ui-elements">
   | NotificationOf<"send-ui-element-message">
   | NotificationOf<"function-call-result">
-  | NotificationOf<"model-lifecycle">;
+  | NotificationOf<"model-lifecycle">
+  | ImageDataResult;
 
 // Language server -> client
 type MarimoLspNotificationMap = {


### PR DESCRIPTION
Closes #294

Adds a floating toolbar with **Copy** and **Save** buttons that appears when hovering over images in marimo notebook outputs, similar to Jupyter's behavior in VS Code.

The toolbar is attached via native DOM event listeners (a reusable `useEventListener` hook) on the cell output container, detecting `<img>` hovers without modifying the upstream marimo `ImageOutput` component.

The notebook output renderer runs in a sandboxed iframe that can display a cross-origin image but can't read its bytes (CORS-blocked `fetch`, tainted canvas). So both actions route through the extension host, which has no such restriction, over the renderer messaging channel:

- **Save**: the host fetches/decodes the image and writes it via a native save dialog (`showSaveDialog` + `workspace.fs.writeFile`), preserving the original format (e.g. SVG is saved as SVG, not a rasterized PNG).
- **Copy**: rasterizes the image to PNG and writes it to the clipboard. Same-origin images (data URIs) are read locally; for cross-origin images the host returns the bytes as a data URI that the renderer rasterizes. The `ClipboardItem` receives its blob as a promise synchronously, so the click's user activation survives the host round-trip.