### PR TITLE
Drop pyzmq dependency and bump minimum marimo to 0.22.0

### DIFF
--- a/extension/src/constants.ts
+++ b/extension/src/constants.ts
@@ -54,8 +54,8 @@ export const LanguageId = {
 
 export const MINIMUM_MARIMO_VERSION = {
   major: 0,
-  minor: 20,
-  patch: 2,
+  minor: 22,
+  patch: 0,
 } as const;
 
 export type MarimoContextKey =

--- a/extension/src/kernel/SandboxController.ts
+++ b/extension/src/kernel/SandboxController.ts
@@ -227,7 +227,6 @@ const findRequirements = (uv: Uv, notebook: MarimoNotebookDocument) =>
     });
 
     let marimoOk = false;
-    let pyzmqOk = false;
 
     for (const pkg of packages.split("\n")) {
       if (pkg.startsWith("marimo ")) {
@@ -242,17 +241,11 @@ const findRequirements = (uv: Uv, notebook: MarimoNotebookDocument) =>
           marimoOk = true;
         }
       }
-      if (pkg.startsWith("pyzmq ")) {
-        pyzmqOk = true;
-      }
     }
 
     const requirements = [];
     if (!marimoOk) {
       requirements.push(`marimo>=${semver.format(MINIMUM_MARIMO_VERSION)}`);
-    }
-    if (!pyzmqOk) {
-      requirements.push("pyzmq");
     }
 
     return requirements satisfies ReadonlyArray<string>;
@@ -261,7 +254,7 @@ const findRequirements = (uv: Uv, notebook: MarimoNotebookDocument) =>
       "UvMissingPep723MetadataError",
       Effect.fn(function* () {
         yield* Effect.logDebug("No PEP 723 metadata.");
-        return ["marimo", "pyzmq"];
+        return ["marimo"];
       }),
     ),
   );

--- a/extension/src/python/EnvironmentValidator.ts
+++ b/extension/src/python/EnvironmentValidator.ts
@@ -39,7 +39,6 @@ class EnvironmentRequirementError extends Data.TaggedError(
  * Checks for:
  *
  *   - marimo (with version requirement)
- *   - pyzmq
  *
  * using `env.executable`.
  */
@@ -79,12 +78,6 @@ try:
     packages.append({"name":"marimo","version":marimo.__version__})
 except Exception:
     packages.append({"name":"marimo","version":None})
-
-try:
-    import zmq
-    packages.append({"name":"pyzmq","version":zmq.__version__})
-except Exception:
-    packages.append({"name":"pyzmq","version":None})
 
 # Restore stdout and emit the result
 sys.stdout = _real_stdout

--- a/extension/src/python/__tests__/EnvironmentValidator.test.ts
+++ b/extension/src/python/__tests__/EnvironmentValidator.test.ts
@@ -80,47 +80,9 @@ it.layer(EnvironmentValidatorLive)("EnvironmentValidator", (it) => {
             "kind": "missing",
             "package": "marimo",
           },
-          {
-            "kind": "missing",
-            "package": "pyzmq",
-          },
         ]
       `);
     }),
-  );
-
-  it.effect(
-    "should fail with missing pyzmq",
-    Effect.fn(function* () {
-      const uv = yield* Uv;
-      const validator = yield* EnvironmentValidator;
-      const tmpdir = yield* TempDir;
-
-      const venv = NodePath.join(tmpdir.path, ".venv");
-      yield* uv.venv(venv, { python, clear: true });
-      yield* uv.pipInstall(["marimo"], { venv });
-
-      const result = yield* Effect.either(
-        validator.validate(
-          TestPythonExtension.makeVenv(getVenvPythonPath(venv)),
-        ),
-      );
-
-      assert(Either.isLeft(result), "Expected validation to fail");
-      assert(
-        result.left._tag === "EnvironmentRequirementError",
-        `Expected EnvironmentRequirementError, got ${result.left._tag}`,
-      );
-      expect(result.left.diagnostics).toMatchInlineSnapshot(`
-        [
-          {
-            "kind": "missing",
-            "package": "pyzmq",
-          },
-        ]
-      `);
-    }),
-    { timeout: 30_000 },
   );
 
   it.effect(
@@ -132,7 +94,7 @@ it.layer(EnvironmentValidatorLive)("EnvironmentValidator", (it) => {
 
       const venv = NodePath.join(tmpdir.path, ".venv");
       yield* uv.venv(venv, { python, clear: true });
-      yield* uv.pipInstall(["marimo<0.16.0", "pyzmq"], { venv });
+      yield* uv.pipInstall(["marimo<0.16.0"], { venv });
 
       const result = yield* Effect.either(
         validator.validate(
@@ -157,8 +119,8 @@ it.layer(EnvironmentValidatorLive)("EnvironmentValidator", (it) => {
             "package": "marimo",
             "requiredVersion": {
               "major": 0,
-              "minor": 20,
-              "patch": 2,
+              "minor": 22,
+              "patch": 0,
             },
           },
         ]
@@ -168,7 +130,7 @@ it.layer(EnvironmentValidatorLive)("EnvironmentValidator", (it) => {
   );
 
   it.effect(
-    "should succeed with marimo and pyzmq installed",
+    "should succeed with marimo installed",
     Effect.fn(function* () {
       const uv = yield* Uv;
       const validator = yield* EnvironmentValidator;
@@ -176,7 +138,7 @@ it.layer(EnvironmentValidatorLive)("EnvironmentValidator", (it) => {
 
       const venv = NodePath.join(tmpdir.path, ".venv");
       yield* uv.venv(venv, { python, clear: true });
-      yield* uv.pipInstall(["marimo", "pyzmq"], { venv });
+      yield* uv.pipInstall(["marimo"], { venv });
 
       const result = yield* Effect.either(
         validator.validate(
@@ -323,10 +285,7 @@ it.layer(EnvironmentValidatorLive)("EnvironmentValidator", (it) => {
       Effect.fn(function* () {
         const validator = yield* EnvironmentValidator;
         const tmpdir = yield* TempDir;
-        const json = JSON.stringify([
-          { name: "marimo", version: "1.0.0" },
-          { name: "pyzmq", version: "26.0.0" },
-        ]);
+        const json = JSON.stringify([{ name: "marimo", version: "1.0.0" }]);
         const script = makeFakeExecutable(tmpdir.path, "extra-whitespace", {
           stdout: `\n  ${json}  \n`,
           exitCode: 0,
@@ -346,10 +305,7 @@ it.layer(EnvironmentValidatorLive)("EnvironmentValidator", (it) => {
       Effect.fn(function* () {
         const validator = yield* EnvironmentValidator;
         const tmpdir = yield* TempDir;
-        const json = JSON.stringify([
-          { name: "marimo", version: null },
-          { name: "pyzmq", version: null },
-        ]);
+        const json = JSON.stringify([{ name: "marimo", version: null }]);
         const script = makeFakeExecutable(tmpdir.path, "null-versions", {
           stdout: json,
           exitCode: 0,
@@ -366,7 +322,6 @@ it.layer(EnvironmentValidatorLive)("EnvironmentValidator", (it) => {
         );
         expect(result.left.diagnostics).toEqual([
           { kind: "missing", package: "marimo" },
-          { kind: "missing", package: "pyzmq" },
         ]);
       }),
     );

--- a/extension/src/telemetry/HealthService.ts
+++ b/extension/src/telemetry/HealthService.ts
@@ -222,7 +222,7 @@ export class HealthService extends Effect.Service<HealthService>()(
             lines.push("Common Issues:");
             lines.push("\t1. If notebooks won't open:");
             lines.push("\t\t- Check Python interpreter is selected");
-            lines.push("\t\t- Ensure marimo and pyzmq are installed");
+            lines.push("\t\t- Ensure marimo is installed");
             lines.push("\t\t- Check 'marimo-lsp' output channel for errors");
             lines.push("\t2. If features are missing:");
             lines.push(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,9 +8,8 @@ authors = [{ name = "Trevor Manz", email = "trevor.j.manz@gmail.com" }]
 dependencies = [
   "jupytext>=1.17.2",
   "lsprotocol>=2025.0.0",
-  "marimo>=0.20.2,<0.21.0",
+  "marimo>=0.22.0",
   "pygls>=2.0.0",
-  "pyzmq>=27.0.2",
 ]
 
 [project.scripts]
@@ -64,3 +63,6 @@ ignore = [
 
 [tool.typos.default.extend-words]
 somes = "somes"
+
+[tool.inline-snapshot]
+format-command="ruff format --stdin-filename {filename}"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -625,6 +625,17 @@ x\
             {
                 "notebookUri": "file:///exec_test.py",
                 "operation": {
+                    "op": "notebook-document-transaction",
+                    "transaction": {
+                        "changes": [{"type": "reorder-cells", "cellIds": ["cell1"]}],
+                        "source": "kernel",
+                        "version": None,
+                    },
+                },
+            },
+            {
+                "notebookUri": "file:///exec_test.py",
+                "operation": {
                     "op": "cell-op",
                     "cell_id": "cell1",
                     "output": None,
@@ -875,6 +886,19 @@ async def test_marimo_run_with_ancestor_cell(client: LanguageClient) -> None:
                             "used_by": ["cell2"],
                         }
                     ],
+                },
+            },
+            {
+                "notebookUri": "file:///exec_test.py",
+                "operation": {
+                    "op": "notebook-document-transaction",
+                    "transaction": {
+                        "changes": [
+                            {"type": "reorder-cells", "cellIds": ["cell1", "cell2"]}
+                        ],
+                        "source": "kernel",
+                        "version": None,
+                    },
                 },
             },
             {

--- a/uv.lock
+++ b/uv.lock
@@ -460,7 +460,7 @@ wheels = [
 
 [[package]]
 name = "marimo"
-version = "0.20.2"
+version = "0.22.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -476,15 +476,15 @@ dependencies = [
     { name = "pygments" },
     { name = "pymdown-extensions" },
     { name = "pyyaml" },
+    { name = "pyzmq", marker = "python_full_version < '3.15'" },
     { name = "starlette" },
     { name = "tomlkit" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
     { name = "uvicorn" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d4/be/84a28265e1698dbac439de8a1d428a18e07c4dd23fa72df72e8b4922e3ff/marimo-0.20.2.tar.gz", hash = "sha256:cdab009b65d58d571640ab8bb2ede68ab3b755c8f99f06b934a23f3b8aba3f34", size = 38237601, upload-time = "2026-02-22T20:19:42.198Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/93/55/6d128565bb18cb1f64707742bdbf05f7b1674e4063f70500de97b0be6a3e/marimo-0.20.2-py3-none-any.whl", hash = "sha256:f94a1bd19fa85219d0549281776e7ec4c9253d5d5849d6f2459cc3ab868abbc5", size = 38645577, upload-time = "2026-02-22T20:19:37.298Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/38/d0fbc9e7d58434bc608cb769e819053daae3ba43f4b9d819011a89276eda/marimo-0.22.0-py3-none-any.whl", hash = "sha256:b5a194e4e4f731512b8c6d82801473c502a2befbe547518717077706eabb59ba", size = 38659118, upload-time = "2026-03-31T21:07:07.076Z" },
 ]
 
 [[package]]
@@ -496,7 +496,6 @@ dependencies = [
     { name = "lsprotocol" },
     { name = "marimo" },
     { name = "pygls" },
-    { name = "pyzmq" },
 ]
 
 [package.dev-dependencies]
@@ -513,9 +512,8 @@ dev = [
 requires-dist = [
     { name = "jupytext", specifier = ">=1.17.2" },
     { name = "lsprotocol", specifier = ">=2025.0.0" },
-    { name = "marimo", specifier = ">=0.20.2,<0.21.0" },
+    { name = "marimo", specifier = ">=0.22.0" },
     { name = "pygls", specifier = ">=2.0.0" },
-    { name = "pyzmq", specifier = ">=27.0.2" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
marimo 0.22.0 pulls in pyzmq as a hard dependency, so the extension no longer needs to check for or install it separately. This removes all pyzmq validation from the environment checker, sandbox dependency resolver, health service hints, and their corresponding tests. The minimum marimo version is bumped to 0.22.0 in both `pyproject.toml` and the generated `constants.ts`, and the upper bound pin (`<0.21.0`) is dropped.