### PR TITLE
import proper branded type

### DIFF
--- a/src/marimo_lsp/diagnostics.py
+++ b/src/marimo_lsp/diagnostics.py
@@ -13,6 +13,7 @@ from marimo._messaging.notification import (
     VariablesNotification,
 )
 from marimo._runtime.dataflow import DirectedGraph
+from marimo._types.ids import VariableName
 
 from marimo_lsp import _rules
 from marimo_lsp.loggers import get_logger
@@ -210,7 +211,7 @@ def extract_variables(graph: DirectedGraph) -> VariablesNotification:
     return VariablesNotification(
         variables=[
             VariableDeclarationNotification(
-                name=variable,
+                name=VariableName(variable),
                 declared_by=list(declared_by),
                 used_by=list(graph.get_referring_cells(variable, language="python")),
             )


### PR DESCRIPTION
Wrap variable with VariableName() in extract_variables() to match upstream type change.

Fixes https://github.com/marimo-team/marimo/issues/8956