### PR TITLE
Fix language server install failing on Windows with broken .venv

### DIFF
--- a/extension/src/python/Uv.ts
+++ b/extension/src/python/Uv.ts
@@ -6,7 +6,7 @@ import * as NodeProcess from "node:process";
 import { Command, CommandExecutor } from "@effect/platform";
 import { NodeContext } from "@effect/platform-node";
 import type { PlatformError } from "@effect/platform/Error";
-import { Data, Effect, Option, Schema, Stream, String } from "effect";
+import { Data, Effect, Function, Option, Schema, Stream, String } from "effect";
 import type * as vscode from "vscode";
 
 import { assert } from "../assert.ts";
@@ -374,6 +374,10 @@ export class Uv extends Effect.Service<Uv>()("Uv", {
               UV_DEFAULT_INDEX: "https://pypi.org/simple/",
               ...strategyToEnv[strategy],
             },
+            // Set cwd to the OS temp directory so uv doesn't walk up parent
+            // directories and discover a broken .venv (e.g., wrong-arch
+            // python.exe on Windows → OS error 193).
+            cwd: NodeOs.tmpdir(),
           });
 
         const loop = (
@@ -441,9 +445,11 @@ function createUv(
   return Effect.fn("uv")(function* (options: {
     readonly args: ReadonlyArray<string>;
     readonly env?: Record<string, string>;
+    readonly cwd?: string;
   }) {
     const command = Command.make(bin.executable, ...options.args).pipe(
       Command.env({ NO_COLOR: "1", ...options.env }),
+      options.cwd ? Command.workingDirectory(options.cwd) : Function.identity,
     );
     yield* Effect.annotateCurrentSpan("args", options.args);
     const [exitCode, stdout, stderr] = yield* command.pipe(

--- a/extension/src/python/__tests__/Uv.test.ts
+++ b/extension/src/python/__tests__/Uv.test.ts
@@ -14,6 +14,7 @@ import { Uv } from "../../python/Uv.ts";
 
 const python = "3.13";
 const timeout = 30_000;
+const isWindows = NodeProcess.platform === "win32";
 
 class TmpDir extends Effect.Service<TmpDir>()("TmpDir", {
   scoped: Effect.gen(function* () {
@@ -289,6 +290,68 @@ print("hello")
             { targetPath, policy: singleStrategy("offline") },
           );
 
+          assert(NodeFs.existsSync(binPath), `Expected binary at ${binPath}`);
+        }),
+        { timeout },
+      );
+
+      // Simulate a broken .venv in the parent directory (the scenario
+      // from VSCODE-MARIMO-2KT where a wrong-arch python.exe causes
+      // uv to fail with OS error 193 on Windows).
+      it.scoped.skipIf(isWindows)(
+        "installs even when a broken .venv exists in a parent directory (unix)",
+        Effect.fn(function* () {
+          const uv = yield* Uv;
+          const tmpdir = yield* TmpDir;
+
+          const brokenVenv = NodePath.join(tmpdir.path, ".venv");
+          NodeFs.mkdirSync(NodePath.join(brokenVenv, "bin"), {
+            recursive: true,
+          });
+          NodeFs.writeFileSync(
+            NodePath.join(brokenVenv, "bin", "python3"),
+            "not a real python",
+            { mode: 0o755 },
+          );
+          NodeFs.writeFileSync(
+            NodePath.join(brokenVenv, "pyvenv.cfg"),
+            "home = /nonexistent\n",
+          );
+
+          const targetPath = NodePath.join(tmpdir.path, "libs");
+          const binPath = yield* uv.ensureLanguageServerBinaryInstalled(
+            server,
+            { targetPath, policy: singleStrategy("default") },
+          );
+          assert(NodeFs.existsSync(binPath), `Expected binary at ${binPath}`);
+        }),
+        { timeout },
+      );
+
+      it.scoped.skipIf(!isWindows)(
+        "installs even when a broken .venv exists in a parent directory (windows)",
+        Effect.fn(function* () {
+          const uv = yield* Uv;
+          const tmpdir = yield* TmpDir;
+
+          const brokenVenv = NodePath.join(tmpdir.path, ".venv");
+          NodeFs.mkdirSync(NodePath.join(brokenVenv, "Scripts"), {
+            recursive: true,
+          });
+          NodeFs.writeFileSync(
+            NodePath.join(brokenVenv, "Scripts", "python.exe"),
+            "not a real python",
+          );
+          NodeFs.writeFileSync(
+            NodePath.join(brokenVenv, "pyvenv.cfg"),
+            "home = /nonexistent\n",
+          );
+
+          const targetPath = NodePath.join(tmpdir.path, "libs");
+          const binPath = yield* uv.ensureLanguageServerBinaryInstalled(
+            server,
+            { targetPath, policy: singleStrategy("default") },
+          );
           assert(NodeFs.existsSync(binPath), `Expected binary at ${binPath}`);
         }),
         { timeout },


### PR DESCRIPTION
Set cwd to `os.tmpdir()` for the `uv pip install` command in so uv doesn't walk up parent directories and discover a broken .venv interpreter. On Windows, OS error 193 ("not a valid Win32 application") from a wrong-arch python.exe is treated as fatal by uv, unlike on macOS/Linux.