### PR TITLE
Improve log formatting and reduce INFO noise

### DIFF
--- a/extension/src/commands/openAsMarimoNotebook.ts
+++ b/extension/src/commands/openAsMarimoNotebook.ts
@@ -27,7 +27,7 @@ export const openAsMarimoNotebook = Effect.fn("command.openAsMarimoNotebook")(
     // stale when VS Code reorganizes tabs.
     yield* code.window.closeTextEditorTab(uri);
 
-    yield* Effect.logInfo("Opened Python file as marimo notebook").pipe(
+    yield* Effect.logDebug("Opened Python file as marimo notebook").pipe(
       Effect.annotateLogs({ uri: uri.toString() }),
     );
   },

--- a/extension/src/config/ConfigContextManager.ts
+++ b/extension/src/config/ConfigContextManager.ts
@@ -32,7 +32,7 @@ export class ConfigContextManager extends Effect.Service<ConfigContextManager>()
       yield* Effect.forkScoped(
         onCellChangeModeStream.pipe(
           Stream.tap((mode) =>
-            Effect.logDebug("Updated onCellChangeMode context").pipe(
+            Effect.logTrace("Updated onCellChangeMode context").pipe(
               Effect.annotateLogs({ mode }),
             ),
           ),
@@ -50,7 +50,7 @@ export class ConfigContextManager extends Effect.Service<ConfigContextManager>()
       yield* Effect.forkScoped(
         autoReloadModeStream.pipe(
           Stream.tap((mode) =>
-            Effect.logDebug("Updated autoReloadMode context").pipe(
+            Effect.logTrace("Updated autoReloadMode context").pipe(
               Effect.annotateLogs({ mode }),
             ),
           ),

--- a/extension/src/features/Logger.ts
+++ b/extension/src/features/Logger.ts
@@ -1,7 +1,17 @@
 import * as NodeFs from "node:fs";
 import * as NodePath from "node:path";
 
-import { Effect, Layer, Logger, type LogLevel } from "effect";
+import {
+  Array as ReadonlyArray,
+  Cause,
+  Effect,
+  HashMap,
+  Inspectable,
+  Layer,
+  List,
+  Logger,
+  type LogLevel,
+} from "effect";
 
 import { OutputChannel } from "../platform/OutputChannel.ts";
 import { Sentry } from "../telemetry/Sentry.ts";
@@ -20,6 +30,27 @@ const makeFileLogger = (logFilePath: string) =>
     });
   });
 
+const structuredMessage = (u: unknown): unknown => {
+  switch (typeof u) {
+    case "bigint":
+    case "function":
+    case "symbol":
+      return String(u);
+    default:
+      return Inspectable.toJSON(u);
+  }
+};
+
+const formatValue = (value: unknown): string => {
+  if (Cause.isCause(value)) {
+    return Cause.isEmpty(value)
+      ? ""
+      : Cause.pretty(value, { renderErrorCause: true });
+  }
+  const redacted = Inspectable.redact(value);
+  return typeof redacted === "string" ? redacted : JSON.stringify(redacted);
+};
+
 const makeVsCodeLogger = (channel: OutputChannel) => {
   type Level = Exclude<LogLevel.LogLevel["label"], "OFF" | "ALL">;
   const mapping = {
@@ -30,14 +61,67 @@ const makeVsCodeLogger = (channel: OutputChannel) => {
     ERROR: channel.error.bind(channel),
     FATAL: channel.error.bind(channel),
   } as const;
-  return Logger.map(Logger.logfmtLogger, (str) => {
-    // parse out the level from the default formatter
-    const match = str.match(/level=(\w+)\s*(.*)/);
-    const [level, message] = match
-      ? [match[1] as Level, match[2].trim()]
-      : ["INFO" as Level, str];
+
+  return Logger.make((opts) => {
+    const messages = ReadonlyArray.ensure(opts.message);
+    const lines: Array<string> = [];
+
+    // First line: inline the first message if it's a string (matches prettyLogger)
+    let firstLine = "";
+    let messageIndex = 0;
+    if (messages.length > 0) {
+      const first = structuredMessage(messages[0]);
+      if (typeof first === "string") {
+        firstLine = first;
+        messageIndex = 1;
+      }
+    }
+
+    // Append spans to first line
+    if (List.isCons(opts.spans)) {
+      const now = opts.date.getTime();
+      const spanParts: Array<string> = [];
+      for (const span of opts.spans) {
+        spanParts.push(`${span.label}=${now - span.startTime}ms`);
+      }
+      if (firstLine) {
+        firstLine += ` (${spanParts.join(", ")})`;
+      } else {
+        firstLine = spanParts.join(", ");
+      }
+    }
+
+    lines.push(firstLine);
+
+    // Cause first (matches prettyLogger order)
+    if (!Cause.isEmpty(opts.cause)) {
+      lines.push(Cause.pretty(opts.cause, { renderErrorCause: true }));
+    }
+
+    // Remaining messages
+    for (; messageIndex < messages.length; messageIndex++) {
+      lines.push(`  ${formatValue(messages[messageIndex])}`);
+    }
+
+    // Annotations: inline short values on first line, multi-line values below
+    if (HashMap.size(opts.annotations) > 0) {
+      const inline: Array<string> = [];
+      for (const [key, value] of opts.annotations) {
+        const formatted = formatValue(value);
+        if (formatted.includes("\n")) {
+          lines.push(`  ${key}: ${formatted}`);
+        } else {
+          inline.push(`${key}=${formatted}`);
+        }
+      }
+      if (inline.length > 0) {
+        lines[0] += ` [${inline.join(", ")}]`;
+      }
+    }
+
+    const level = opts.logLevel.label as Level;
     const log = mapping[level] ?? channel.info.bind(channel);
-    log(message);
+    log(lines.join("\n"));
   });
 };
 

--- a/extension/src/kernel/ControllerRegistry.ts
+++ b/extension/src/kernel/ControllerRegistry.ts
@@ -261,7 +261,7 @@ const trackControllerSelections = (
         }
         const notebook = MarimoNotebookDocument.from(e.notebook);
         yield* Ref.update(selectionsRef, HashMap.set(notebook.id, controller));
-        yield* Effect.logDebug("Updated controller for notebook").pipe(
+        yield* Effect.logTrace("Updated controller for notebook").pipe(
           Effect.annotateLogs({
             controllerId: controller.id,
             notebookUri: notebook.id,
@@ -336,7 +336,7 @@ const pruneStaleControllers = Effect.fn("pruneStaleControllers")(
     selectionsRef: Ref.Ref<HashMap.HashMap<NotebookId, AnyController>>;
   }) {
     const { envs, handlesRef, selectionsRef } = options;
-    yield* Effect.logDebug("Checking for stale controllers");
+    yield* Effect.logTrace("Checking for stale controllers");
     const desiredControllerIds = new Set(
       envs.map((env) => PythonController.getId(env)),
     );
@@ -382,7 +382,7 @@ const pruneStaleControllers = Effect.fn("pruneStaleControllers")(
 
         // Remove all disposed controllers in one update
         yield* Effect.annotateLogs(
-          Effect.logDebug("Completed stale controller removal"),
+          Effect.logTrace("Completed stale controller removal"),
           { removedCount: toRemove.length },
         );
 

--- a/extension/src/kernel/KernelManager.ts
+++ b/extension/src/kernel/KernelManager.ts
@@ -66,7 +66,7 @@ export class KernelManager extends Effect.Service<KernelManager>()(
       PythonEnvInvalidation.Default,
     ],
     scoped: Effect.gen(function* () {
-      yield* Effect.logInfo("Setting up kernel manager");
+      yield* Effect.logDebug("Setting up kernel manager");
       const code = yield* VsCode;
       const client = yield* LanguageClient;
       const renderer = yield* NotebookRenderer;

--- a/extension/src/lib/__tests__/binaryResolution.test.ts
+++ b/extension/src/lib/__tests__/binaryResolution.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "@effect/vitest";
 import * as semver from "@std/semver";
-import { Effect, Logger, Option } from "effect";
+import { Effect, Logger, LogLevel, Option } from "effect";
 
 import {
   BinarySource,
@@ -212,6 +212,7 @@ describe("resolveBinary", () => {
         [emptySource("tier-1"), userSource("/bin/ty")],
         uvSource("/fallback"),
       ).pipe(
+        Logger.withMinimumLogLevel(LogLevel.Debug),
         Effect.provide(
           Logger.replace(
             Logger.defaultLogger,

--- a/extension/src/lib/binaryResolution.ts
+++ b/extension/src/lib/binaryResolution.ts
@@ -87,7 +87,7 @@ export function validateBinary(
       return Option.none<string>();
     }
 
-    yield* Effect.logInfo(
+    yield* Effect.logDebug(
       `Validated binary at ${binaryPath} (version ${semver.format(versionOption.value)})`,
     );
     return Option.some(binaryPath);
@@ -149,7 +149,7 @@ export function resolveBinary<E, R>(
       const result = yield* source.resolve;
 
       if (Option.isSome(result)) {
-        yield* Effect.logInfo("Resolved binary").pipe(
+        yield* Effect.logDebug("Resolved binary").pipe(
           Effect.annotateLogs({
             server: serverName,
             source: result.value._tag,

--- a/extension/src/lsp/LanguageClient.ts
+++ b/extension/src/lsp/LanguageClient.ts
@@ -50,7 +50,7 @@ export class LanguageClient extends Effect.Service<LanguageClient>()(
         onNone: () => findLspExecutable(uv.bin.executable),
       });
 
-      yield* Effect.logInfo("Got marimo-lsp executable").pipe(
+      yield* Effect.logDebug("Got marimo-lsp executable").pipe(
         Effect.annotateLogs({
           command: exec.command,
           args: (exec.args ?? []).join(" "),
@@ -88,7 +88,7 @@ export class LanguageClient extends Effect.Service<LanguageClient>()(
           Effect.timeout("5 seconds"),
           Effect.ignore,
         );
-        yield* Effect.logInfo("marimo-lsp client stopped");
+        yield* Effect.logDebug("marimo-lsp client stopped");
       });
 
       /**
@@ -100,7 +100,7 @@ export class LanguageClient extends Effect.Service<LanguageClient>()(
           // If the client is in a "stopping" state, wait for it to finish
           // before attempting to start again.
           if (!client.isRunning() && client.needsStop()) {
-            yield* Effect.logInfo(
+            yield* Effect.logDebug(
               "Client is still stopping, waiting before start",
             );
             yield* stopClient();
@@ -201,7 +201,7 @@ export const findLspExecutable = Effect.fn("findLspExecutable")(function* (
 
   if (sdistDir) {
     const sdist = NodePath.join(__dirname, sdistDir);
-    yield* Effect.logInfo("Using bundled marimo-lsp").pipe(
+    yield* Effect.logDebug("Using bundled marimo-lsp").pipe(
       Effect.annotateLogs({ sdist }),
     );
     return {

--- a/extension/src/lsp/RuffLanguageServer.ts
+++ b/extension/src/lsp/RuffLanguageServer.ts
@@ -83,7 +83,7 @@ export class RuffLanguageServer extends Effect.Service<RuffLanguageServer>()(
             return;
           }
 
-          yield* Effect.logInfo("Starting language server").pipe(
+          yield* Effect.logDebug("Starting language server").pipe(
             Effect.annotateLogs({
               server: RUFF_SERVER.name,
               version: RUFF_SERVER.version,

--- a/extension/src/lsp/TyLanguageServer.ts
+++ b/extension/src/lsp/TyLanguageServer.ts
@@ -95,7 +95,7 @@ export class TyLanguageServer extends Effect.Service<TyLanguageServer>()(
           // resources are cleaned up before the next cycle begins.
           const serverCycle = Effect.gen(function* () {
             yield* Ref.set(statusRef, TyLanguageServerStatus.Starting());
-            yield* Effect.logInfo("Starting language server").pipe(
+            yield* Effect.logDebug("Starting language server").pipe(
               Effect.annotateLogs({
                 server: TY_SERVER.name,
                 version: TY_SERVER.version,

--- a/extension/src/lsp/client.ts
+++ b/extension/src/lsp/client.ts
@@ -673,7 +673,7 @@ export const makeNotebookLspClient = Effect.fn("makeNotebookLspClient")(
       capabilities: initResult.capabilities,
     };
 
-    yield* Effect.logInfo("Server initialized").pipe(
+    yield* Effect.logDebug("Server initialized").pipe(
       Effect.annotateLogs({
         server: serverInfo.name,
         version: serverInfo.version,

--- a/extension/src/notebook/NotebookDataCache.ts
+++ b/extension/src/notebook/NotebookDataCache.ts
@@ -95,18 +95,31 @@ export class NotebookDataCache extends Effect.Service<NotebookDataCache>()(
           const notebook = matchRecentNotebookFromData(data, recentlyEdited);
 
           if (Option.isNone(notebook)) {
-            yield* Effect.logDebug("Could not match notebook for caching");
+            yield* Effect.logTrace("Could not match notebook for caching");
             return;
           }
 
+          // Restore transient outputs from the live document into the cached
+          // data. VS Code strips transient outputs before passing data to
+          // serializeNotebook, but we need them in the cache so that
+          // enrichNotebookFromCached can restore outputs during
+          // deserialization (e.g., after an external edit).
+          const liveCells = notebook.value.getCells();
+          for (let i = 0; i < data.cells.length && i < liveCells.length; i++) {
+            const cell = data.cells[i];
+            if (!cell.outputs || cell.outputs.length === 0) {
+              cell.outputs = [...liveCells[i].outputs];
+            }
+          }
+
           lastNotebookData.set(notebook.value.id, data);
-          yield* Effect.logDebug("Cached notebook data").pipe(
+          yield* Effect.logTrace("Cached notebook data").pipe(
             Effect.annotateLogs({ notebookId: notebook.value.id }),
           );
         }),
         get: Effect.fn(function* (bytes: Uint8Array) {
           if (Option.isNone(code)) {
-            yield* Effect.logDebug(
+            yield* Effect.logTrace(
               "Cache lookup requires VsCode service, skipping",
             );
             return Option.none<vscode.NotebookData>();
@@ -118,13 +131,13 @@ export class NotebookDataCache extends Effect.Service<NotebookDataCache>()(
           });
 
           if (Option.isNone(notebookId)) {
-            yield* Effect.logDebug("Could not match notebook from bytes");
+            yield* Effect.logTrace("Could not match notebook from bytes");
             return Option.none<vscode.NotebookData>();
           }
 
           const cachedData = lastNotebookData.get(notebookId.value);
           if (!cachedData) {
-            yield* Effect.logDebug("No cached data found for notebook").pipe(
+            yield* Effect.logTrace("No cached data found for notebook").pipe(
               Effect.annotateLogs({ notebookId: notebookId.value }),
             );
             return Option.none<vscode.NotebookData>();

--- a/extension/src/panel/RecentNotebooks.ts
+++ b/extension/src/panel/RecentNotebooks.ts
@@ -189,6 +189,6 @@ export const RecentNotebooksLive = Layer.scopedDiscard(
       }
     });
 
-    yield* Effect.logInfo("Recent notebooks view initialized");
+    yield* Effect.logDebug("Recent notebooks view initialized");
   }),
 );

--- a/extension/src/panel/datasources/DatasourcesView.ts
+++ b/extension/src/panel/datasources/DatasourcesView.ts
@@ -399,6 +399,6 @@ export const DatasourcesViewLive = Layer.scopedDiscard(
       ),
     );
 
-    yield* Effect.logInfo("Datasources view initialized");
+    yield* Effect.logDebug("Datasources view initialized");
   }),
 );

--- a/extension/src/panel/packages/PackagesView.ts
+++ b/extension/src/panel/packages/PackagesView.ts
@@ -193,6 +193,6 @@ export const PackagesViewLive = Layer.scopedDiscard(
       }),
     );
 
-    yield* Effect.logInfo("Packages view initialized");
+    yield* Effect.logDebug("Packages view initialized");
   }),
 );

--- a/extension/src/panel/variables/VariablesView.ts
+++ b/extension/src/panel/variables/VariablesView.ts
@@ -166,6 +166,6 @@ export const VariablesViewLive = Layer.scopedDiscard(
       ),
     );
 
-    yield* Effect.logInfo("Variables view initialized");
+    yield* Effect.logDebug("Variables view initialized");
   }),
 );

--- a/extension/src/statusbar/MarimoStatusBar.ts
+++ b/extension/src/statusbar/MarimoStatusBar.ts
@@ -132,7 +132,7 @@ export const MarimoStatusBarLive = Layer.scopedDiscard(
       priority: 100,
     });
 
-    yield* Effect.logInfo("marimo status bar initialized");
+    yield* Effect.logDebug("marimo status bar initialized");
   }),
 );
 

--- a/extension/src/statusbar/PythonEnvironmentStatusBar.ts
+++ b/extension/src/statusbar/PythonEnvironmentStatusBar.ts
@@ -91,7 +91,7 @@ export const PythonEnvironmentStatusBarLive = Layer.scopedDiscard(
     yield* updateDisplay(item, Option.some(initialEnv.path));
     yield* updateVisibility(item);
 
-    yield* Effect.logInfo("Python environment status bar initialized");
+    yield* Effect.logDebug("Python environment status bar initialized");
   }),
 );
 
@@ -129,7 +129,7 @@ const updateDisplay = Effect.fn(function* (
     return;
   }
 
-  yield* Effect.logInfo(`Python interpreter path: ${env.value.path}`);
+  yield* Effect.logDebug(`Python interpreter path: ${env.value.path}`);
   yield* item.setText(formatPythonStatusBarLabel(code, env.value));
   yield* item.setTooltip(env.value.path);
   yield* item.setColor("");

--- a/extension/src/telemetry/Telemetry.ts
+++ b/extension/src/telemetry/Telemetry.ts
@@ -105,7 +105,7 @@ export class Telemetry extends Effect.Service<Telemetry>()("Telemetry", {
           app_host: code.env.appHost,
         },
       });
-      yield* Effect.logInfo("Anonymous telemetry enabled");
+      yield* Effect.logDebug("Anonymous telemetry enabled");
     });
 
     // Initialize on startup if enabled


### PR DESCRIPTION
The VS Code output panel was hard to read: logfmt key=value pairs made messages hard to scan, and ~30 INFO lines on startup drowned out meaningful events.

The logger now uses `Logger.make` (matching Effect's prettyLogger conventions) instead of parsing logfmt with regex. Short annotations appear inline as `[key=val, key=val]`, multi-line values like Cause stack traces render indented below the message, and Cause objects in annotations get pretty-printed instead of dumped as raw JSON.