### PR TITLE
Split pinned marimo from minimum kernel compatibility version

### DIFF
--- a/.github/workflows/update-marimo-version.yml
+++ b/.github/workflows/update-marimo-version.yml
@@ -1,0 +1,80 @@
+name: Update marimo version
+
+on:
+  schedule:
+    - cron: "0 17 * * *" # 1pm EST (17:00 UTC)
+  workflow_dispatch: # Allow manual triggering
+
+jobs:
+  update-version:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+        with:
+          enable-cache: true
+
+      - name: Get latest marimo version from PyPI
+        id: get_version
+        run: |
+          LATEST_VERSION=$(curl -fsSL https://pypi.org/pypi/marimo/json | jq -r .info.version)
+          echo "version=$LATEST_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Read current pinned version
+        id: current_version
+        run: |
+          CURRENT_VERSION=$(sed -n 's/^  "marimo==\([0-9.]*\)",$/\1/p' pyproject.toml)
+          echo "version=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Skip if already up to date
+        if: steps.current_version.outputs.version == steps.get_version.outputs.version
+        run: echo "Already on ${{ steps.current_version.outputs.version }} — nothing to do."
+
+      - name: Bump pyproject.toml pin
+        if: steps.current_version.outputs.version != steps.get_version.outputs.version
+        run: |
+          sed -i 's/^  "marimo==[0-9.]*",$/  "marimo==${{ steps.get_version.outputs.version }}",/' pyproject.toml
+
+      - name: Bump .marimo-version
+        if: steps.current_version.outputs.version != steps.get_version.outputs.version
+        run: |
+          echo "${{ steps.get_version.outputs.version }}" > .marimo-version
+
+      - name: Refresh uv.lock
+        if: steps.current_version.outputs.version != steps.get_version.outputs.version
+        run: uv lock --upgrade-package marimo
+
+      - name: Create Pull Request
+        if: steps.current_version.outputs.version != steps.get_version.outputs.version
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: bump marimo to ${{ steps.get_version.outputs.version }}"
+          title: "chore: bump marimo to ${{ steps.get_version.outputs.version }}"
+          body: |
+            Automated PR to bump the pinned `marimo` version from
+            `${{ steps.current_version.outputs.version }}` to
+            `${{ steps.get_version.outputs.version }}`.
+
+            Updates:
+            - `pyproject.toml` — exact pin of the `marimo` dependency
+            - `.marimo-version` — sibling-checkout ref used by CI and local dev
+            - `uv.lock` — refreshed via `uv lock --upgrade-package marimo`
+
+            Note: `[tool.marimo-lsp] minimum-kernel-version` is **not** changed
+            by this workflow. Bump it manually when intentionally dropping
+            support for an older marimo release.
+
+            Created by the
+            [`update-marimo-version`](./.github/workflows/update-marimo-version.yml)
+            workflow.
+          branch: "chore/update-marimo-version"
+          base: "main"
+          delete-branch: true

--- a/extension/scripts/codegen.mjs
+++ b/extension/scripts/codegen.mjs
@@ -38,8 +38,8 @@ const pyproject = NodeFs.readFileSync(
   NodeUrl.fileURLToPath(new URL("../../pyproject.toml", import.meta.url)),
   "utf-8",
 );
-const minimumMarimoVersion = semver.parse(
-  pyproject.match(/marimo>=([\d.]+)/)?.[1] ?? "",
+const minimumKernelVersion = semver.parse(
+  pyproject.match(/minimum-kernel-version\s*=\s*"([\d.]+)"/)?.[1] ?? "",
 );
 
 const views = Object.keys(contributes.views);
@@ -97,10 +97,10 @@ export const LanguageId = {
   Markdown: "markdown",
 } as const;
 
-export const MINIMUM_MARIMO_VERSION = {
-  major: ${minimumMarimoVersion.major},
-  minor: ${minimumMarimoVersion.minor},
-  patch: ${minimumMarimoVersion.patch},
+export const MINIMUM_MARIMO_KERNEL_VERSION = {
+  major: ${minimumKernelVersion.major},
+  minor: ${minimumKernelVersion.minor},
+  patch: ${minimumKernelVersion.patch},
 } as const;
 
 export type MarimoContextKey = ${union(contextKeys)};

--- a/extension/src/constants.ts
+++ b/extension/src/constants.ts
@@ -52,7 +52,7 @@ export const LanguageId = {
   Markdown: "markdown",
 } as const;
 
-export const MINIMUM_MARIMO_VERSION = {
+export const MINIMUM_MARIMO_KERNEL_VERSION = {
   major: 0,
   minor: 22,
   patch: 4,

--- a/extension/src/kernel/SandboxController.ts
+++ b/extension/src/kernel/SandboxController.ts
@@ -2,7 +2,7 @@ import * as semver from "@std/semver";
 import { Effect, Option, Runtime, Schema, Stream } from "effect";
 import type * as vscode from "vscode";
 
-import { MINIMUM_MARIMO_VERSION } from "../constants.ts";
+import { MINIMUM_MARIMO_KERNEL_VERSION } from "../constants.ts";
 import { SANDBOX_CONTROLLER_ID } from "../ids.ts";
 import { acquireDisposable } from "../lib/acquireDisposable.ts";
 import { extractExecuteCodeRequest } from "../lib/extractExecuteCodeRequest.ts";
@@ -236,7 +236,7 @@ const findRequirements = (uv: Uv, notebook: MarimoNotebookDocument) =>
 
         if (
           Option.isSome(version) &&
-          semver.greaterOrEqual(version.value, MINIMUM_MARIMO_VERSION)
+          semver.greaterOrEqual(version.value, MINIMUM_MARIMO_KERNEL_VERSION)
         ) {
           marimoOk = true;
         }
@@ -245,7 +245,9 @@ const findRequirements = (uv: Uv, notebook: MarimoNotebookDocument) =>
 
     const requirements = [];
     if (!marimoOk) {
-      requirements.push(`marimo>=${semver.format(MINIMUM_MARIMO_VERSION)}`);
+      requirements.push(
+        `marimo>=${semver.format(MINIMUM_MARIMO_KERNEL_VERSION)}`,
+      );
     }
 
     return requirements satisfies ReadonlyArray<string>;

--- a/extension/src/python/EnvironmentValidator.ts
+++ b/extension/src/python/EnvironmentValidator.ts
@@ -5,7 +5,7 @@ import * as semver from "@std/semver";
 import type * as py from "@vscode/python-extension";
 import { Data, Effect, type ParseResult, Schema, Stream, String } from "effect";
 
-import { MINIMUM_MARIMO_VERSION } from "../constants.ts";
+import { MINIMUM_MARIMO_KERNEL_VERSION } from "../constants.ts";
 import { SemVerFromString } from "../schemas/SemVerFromString.ts";
 
 class InvalidExecutableError extends Data.TaggedError(
@@ -148,13 +148,13 @@ print(json.dumps(packages), flush=True)`,
               diagnostics.push({ kind: "missing", package: pkg.name });
             } else if (
               pkg.name === "marimo" &&
-              !semver.greaterOrEqual(pkg.version, MINIMUM_MARIMO_VERSION)
+              !semver.greaterOrEqual(pkg.version, MINIMUM_MARIMO_KERNEL_VERSION)
             ) {
               diagnostics.push({
                 kind: "outdated",
                 package: "marimo",
                 currentVersion: pkg.version,
-                requiredVersion: MINIMUM_MARIMO_VERSION,
+                requiredVersion: MINIMUM_MARIMO_KERNEL_VERSION,
               });
             }
           }

--- a/extension/src/telemetry/HealthService.ts
+++ b/extension/src/telemetry/HealthService.ts
@@ -4,7 +4,7 @@ import * as semver from "@std/semver";
 import { Effect, Option } from "effect";
 
 import { Config } from "../config/Config.ts";
-import { MINIMUM_MARIMO_VERSION } from "../constants.ts";
+import { MINIMUM_MARIMO_KERNEL_VERSION } from "../constants.ts";
 import { BinarySource } from "../lib/binaryResolution.ts";
 import { getExtensionVersion } from "../lib/getExtensionVersion.ts";
 import {
@@ -226,7 +226,7 @@ export class HealthService extends Effect.Service<HealthService>()(
             lines.push("\t\t- Check 'marimo-lsp' output channel for errors");
             lines.push("\t2. If features are missing:");
             lines.push(
-              `\t\t - Ensure marimo version is >= ${semver.format(MINIMUM_MARIMO_VERSION)}`,
+              `\t\t - Ensure marimo version is >= ${semver.format(MINIMUM_MARIMO_KERNEL_VERSION)}`,
             );
             lines.push("\t\t- Try reloading the window");
           }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [{ name = "Trevor Manz", email = "trevor.j.manz@gmail.com" }]
 dependencies = [
   "jupytext>=1.17.2",
   "lsprotocol>=2025.0.0",
-  "marimo>=0.22.4",
+  "marimo==0.22.4",
   "pygls>=2.0.0",
 ]
 
@@ -28,6 +28,15 @@ dev = [
 [build-system]
 requires = ["uv_build>=0.8.7,<0.9.0"]
 build-backend = "uv_build"
+
+[tool.marimo-lsp]
+# Minimum marimo version allowed in the *user's* kernel environment.
+# Tracked separately from the `marimo` dependency pin above: that pin is the
+# exact version the LSP server and bundled frontend ship with (auto-bumped by
+# the update-marimo-version cron), while the value below is the compatibility
+# floor we claim to support for user kernels and is bumped manually when we
+# intentionally drop support for an older release.
+minimum-kernel-version = "0.22.4"
 
 [tool.ty.src]
 exclude = ["extension/**"]


### PR DESCRIPTION
pyproject.toml now exact-pins the marimo dependency used by the LSP server and bundled frontend. `[tool.marimo-lsp]` minimum-kernel-version is a separate value: the compatibility floor enforced against the user's kernel env.

Adds a daily cron that opens a PR bumping the pin, `.marimo-version`, and `uv.lock` when a new marimo is published to PyPI; the kernel floor is intentionally left for manual bumps.