### PR TITLE
Add notebook integration-test harness

### DIFF
--- a/extension/.vscode-test.cjs
+++ b/extension/.vscode-test.cjs
@@ -5,7 +5,7 @@ module.exports = defineConfig([
     label: "extension",
     files: "tests/*.test.cjs",
     version: "insiders",
-    workspaceFolder: "./sampleWorkspace",
+    workspaceFolder: "./tests/sampleWorkspace",
     installExtensions: ["ms-python.python"],
     mocha: {
       ui: "tdd",

--- a/extension/.vscode-test.cjs
+++ b/extension/.vscode-test.cjs
@@ -9,7 +9,8 @@ module.exports = defineConfig([
     installExtensions: ["ms-python.python"],
     mocha: {
       ui: "tdd",
-      timeout: 60000,
+      timeout: 30_000,
+      require: ["./tests/setup.cjs"],
     },
   },
 ]);

--- a/extension/tests/extension.test.cjs
+++ b/extension/tests/extension.test.cjs
@@ -1,7 +1,7 @@
 // @ts-check
 /// <reference types="mocha" />
 
-const assert = require("node:assert");
+const NodeAssert = require("node:assert");
 const NodeFs = require("node:fs/promises");
 const NodeOs = require("node:os");
 const NodePath = require("node:path");
@@ -10,7 +10,7 @@ const tinyspy = require("tinyspy");
 
 function getExtension() {
   const ext = vscode.extensions.getExtension("marimo-team.vscode-marimo");
-  assert.ok(ext, "Extension should be found");
+  NodeAssert.ok(ext, "Extension should be found");
   if (!ext) {
     throw new Error("Extension should be found");
   }
@@ -25,7 +25,7 @@ suite("marimo Extension Hello World Tests", () => {
   test("Extension should be present and activatable", async () => {
     const extension = getExtension();
     await extension.activate();
-    assert.strictEqual(
+    NodeAssert.strictEqual(
       extension.isActive,
       true,
       "Extension should be active after activation",
@@ -38,26 +38,26 @@ suite("marimo Extension Hello World Tests", () => {
     const commands = await vscode.commands.getCommands();
     const marimoCommands = commands.filter((cmd) => cmd.startsWith("marimo."));
     for (const { command } of packageJSON.contributes.commands) {
-      assert.ok(marimoCommands.includes(command));
+      NodeAssert.ok(marimoCommands.includes(command));
     }
   });
 
   test("Should contribute view containers", async () => {
     const packageJSON = getExtension().packageJSON;
-    assert.ok(
+    NodeAssert.ok(
       packageJSON.contributes.viewsContainers,
       "Should have viewsContainers section",
     );
-    assert.ok(
+    NodeAssert.ok(
       packageJSON.contributes.viewsContainers.panel,
       "Should have panel view containers",
     );
-    assert.strictEqual(
+    NodeAssert.strictEqual(
       packageJSON.contributes.viewsContainers.panel.length,
       1,
       "Should contribute one panel view container",
     );
-    assert.strictEqual(
+    NodeAssert.strictEqual(
       packageJSON.contributes.viewsContainers.panel[0].id,
       "marimo-explorer",
       "Should contribute marimo-explorer view container",
@@ -66,37 +66,40 @@ suite("marimo Extension Hello World Tests", () => {
 
   test("Should contribute views", async () => {
     const packageJSON = getExtension().packageJSON;
-    assert.ok(packageJSON.contributes.views, "Should have views section");
-    assert.ok(
+    NodeAssert.ok(packageJSON.contributes.views, "Should have views section");
+    NodeAssert.ok(
       packageJSON.contributes.views["marimo-explorer"],
       "Should have views in marimo-explorer container",
     );
     const marimoViews = packageJSON.contributes.views["marimo-explorer"];
-    assert.ok(marimoViews.length >= 3, "Should contribute views");
+    NodeAssert.ok(marimoViews.length >= 3, "Should contribute views");
   });
 
   test("Should have proper extension metadata", async () => {
     const extension = getExtension();
     const packageJSON = extension.packageJSON;
-    assert.strictEqual(packageJSON.name, "vscode-marimo");
-    assert.strictEqual(packageJSON.displayName, "marimo");
-    assert.strictEqual(
+    NodeAssert.strictEqual(packageJSON.name, "vscode-marimo");
+    NodeAssert.strictEqual(packageJSON.displayName, "marimo");
+    NodeAssert.strictEqual(
       packageJSON.description,
       "A marimo notebook extension for VS Code.",
     );
-    assert.strictEqual(packageJSON.publisher, "marimo-team");
+    NodeAssert.strictEqual(packageJSON.publisher, "marimo-team");
   });
 
   test("Should contribute notebook types", async () => {
     const packageJSON = getExtension().packageJSON;
-    assert.ok(packageJSON.contributes, "Should have contributes section");
-    assert.ok(packageJSON.contributes.notebooks, "Should contribute notebooks");
-    assert.strictEqual(
+    NodeAssert.ok(packageJSON.contributes, "Should have contributes section");
+    NodeAssert.ok(
+      packageJSON.contributes.notebooks,
+      "Should contribute notebooks",
+    );
+    NodeAssert.strictEqual(
       packageJSON.contributes.notebooks.length,
       1,
       "Should contribute one notebook type",
     );
-    assert.strictEqual(
+    NodeAssert.strictEqual(
       packageJSON.contributes.notebooks[0].type,
       "marimo-notebook",
       "Should contribute marimo-notebook type",
@@ -105,16 +108,16 @@ suite("marimo Extension Hello World Tests", () => {
 
   test("Should register notebook renderer", async () => {
     const packageJSON = getExtension().packageJSON;
-    assert.ok(
+    NodeAssert.ok(
       packageJSON.contributes.notebookRenderer,
       "Should contribute notebook renderer",
     );
-    assert.strictEqual(
+    NodeAssert.strictEqual(
       packageJSON.contributes.notebookRenderer.length,
       1,
       "Should contribute one renderer",
     );
-    assert.strictEqual(
+    NodeAssert.strictEqual(
       packageJSON.contributes.notebookRenderer[0].id,
       "marimo-renderer",
       "Should have marimo-renderer id",
@@ -123,7 +126,7 @@ suite("marimo Extension Hello World Tests", () => {
 
   test("marimo.newMarimoNotebook command creates Python document", async () => {
     const extension = getExtension();
-    assert.ok(extension.isActive);
+    NodeAssert.ok(extension.isActive);
 
     const initialDocCount = vscode.workspace.textDocuments.length;
     const dir = await NodeFs.mkdtemp(
@@ -141,7 +144,7 @@ suite("marimo Extension Hello World Tests", () => {
       await vscode.commands.executeCommand("marimo.newMarimoNotebook");
 
       const finalDocCount = vscode.workspace.textDocuments.length;
-      assert.strictEqual(
+      NodeAssert.strictEqual(
         finalDocCount,
         initialDocCount + 1,
         "Should have created one new document",
@@ -150,12 +153,12 @@ suite("marimo Extension Hello World Tests", () => {
         vscode.workspace.textDocuments[
           vscode.workspace.textDocuments.length - 1
         ];
-      assert.equal(
+      NodeAssert.equal(
         fakeUri.fsPath,
         doc.uri.fsPath,
         "New document should be at the save dialog path",
       );
-      assert.ok(
+      NodeAssert.ok(
         doc.uri.path.endsWith(".py"),
         "New document should be a Python file",
       );
@@ -180,13 +183,13 @@ suite("marimo Extension Experimental Kernels API", () => {
 
   test("API should have experimental.kernels namespace", async () => {
     const api = await getApi();
-    assert.ok(api, "API should be returned from extension");
-    assert.ok(api.experimental, "API should have experimental namespace");
-    assert.ok(
+    NodeAssert.ok(api, "API should be returned from extension");
+    NodeAssert.ok(api.experimental, "API should have experimental namespace");
+    NodeAssert.ok(
       api.experimental.kernels,
       "API should have experimental.kernels namespace",
     );
-    assert.ok(
+    NodeAssert.ok(
       typeof api.experimental.kernels.getKernel === "function",
       "experimental.kernels.getKernel should be a function",
     );
@@ -196,7 +199,7 @@ suite("marimo Extension Experimental Kernels API", () => {
     const api = await getApi();
     const fakeUri = vscode.Uri.parse("file:///non-existent-notebook.py");
     const kernel = await api.experimental.kernels.getKernel(fakeUri);
-    assert.strictEqual(
+    NodeAssert.strictEqual(
       kernel,
       undefined,
       "getKernel should return undefined for non-existent notebook",

--- a/extension/tests/extension.test.cjs
+++ b/extension/tests/extension.test.cjs
@@ -21,11 +21,6 @@ suite("marimo Extension Hello World Tests", () => {
 
   test("Extension should be present and activatable", async () => {
     const extension = getExtension();
-    assert.strictEqual(
-      extension.isActive,
-      false,
-      "Extension should not be active initially",
-    );
     await extension.activate();
     assert.strictEqual(
       extension.isActive,

--- a/extension/tests/extension.test.cjs
+++ b/extension/tests/extension.test.cjs
@@ -2,6 +2,9 @@
 /// <reference types="mocha" />
 
 const assert = require("node:assert");
+const NodeFs = require("node:fs/promises");
+const NodeOs = require("node:os");
+const NodePath = require("node:path");
 const vscode = require("vscode");
 const tinyspy = require("tinyspy");
 
@@ -123,104 +126,43 @@ suite("marimo Extension Hello World Tests", () => {
     assert.ok(extension.isActive);
 
     const initialDocCount = vscode.workspace.textDocuments.length;
-    const fakeUri = vscode.Uri.parse("marimo-mock:///fake/path/Notebook.py");
+    const dir = await NodeFs.mkdtemp(
+      NodePath.join(NodeOs.tmpdir(), "marimo-newtest-"),
+    );
+    const fakeUri = vscode.Uri.file(NodePath.join(dir, "Notebook.py"));
 
-    /**
-     * VS Code's test environment is read-only,
-     * so we cannot write to disk. Instead, we create
-     * an in-memory filesystem to hold our single Python
-     * file for this test.
-     */
-    {
-      /** @type {Uint8Array | undefined} */
-      let singleFileContent;
-      const disposable = vscode.workspace.registerFileSystemProvider(
-        "marimo-mock",
-        {
-          onDidChangeFile: new vscode.EventEmitter().event,
-          /** @param {vscode.Uri} uri */
-          readFile(uri) {
-            if (uri.toString() !== fakeUri.toString()) {
-              throw vscode.FileSystemError.FileNotFound(uri);
-            }
-            if (!singleFileContent) {
-              throw vscode.FileSystemError.FileNotFound(uri);
-            }
-            return singleFileContent;
-          },
-          /**
-           * @param {vscode.Uri} uri
-           * @param {Uint8Array} content
-           */
-          writeFile(uri, content) {
-            if (uri.toString() !== fakeUri.toString()) {
-              throw vscode.FileSystemError.FileNotFound(uri);
-            }
-            singleFileContent = content;
-          },
-          watch() {
-            return { dispose() {} };
-          },
-          /** @param {vscode.Uri} uri */
-          stat(uri) {
-            if (!singleFileContent) {
-              throw vscode.FileSystemError.FileNotFound(uri);
-            }
-            return {
-              type: vscode.FileType.File,
-              ctime: 0,
-              mtime: 0,
-              size: singleFileContent.length,
-            };
-          },
-          createDirectory() {},
-          readDirectory() {
-            throw vscode.FileSystemError.NoPermissions();
-          },
-          delete() {
-            throw vscode.FileSystemError.NoPermissions();
-          },
-          rename() {
-            throw vscode.FileSystemError.NoPermissions();
-          },
-          copy() {
-            throw vscode.FileSystemError.NoPermissions();
-          },
-        },
-        {
-          isCaseSensitive: true,
-        },
-      );
+    const spy = tinyspy.spyOn(
+      vscode.window,
+      "showSaveDialog",
+      async () => fakeUri,
+    );
 
-      const spy = tinyspy.spyOn(
-        vscode.window,
-        "showSaveDialog",
-        async () => fakeUri,
-      );
-
+    try {
       await vscode.commands.executeCommand("marimo.newMarimoNotebook");
 
+      const finalDocCount = vscode.workspace.textDocuments.length;
+      assert.strictEqual(
+        finalDocCount,
+        initialDocCount + 1,
+        "Should have created one new document",
+      );
+      const doc =
+        vscode.workspace.textDocuments[
+          vscode.workspace.textDocuments.length - 1
+        ];
+      assert.equal(
+        fakeUri.fsPath,
+        doc.uri.fsPath,
+        "New document should be at the save dialog path",
+      );
+      assert.ok(
+        doc.uri.path.endsWith(".py"),
+        "New document should be a Python file",
+      );
+    } finally {
       spy.restore();
-      disposable.dispose();
+      await NodeFs.rm(dir, { recursive: true, force: true }).catch(() => {});
     }
-
-    const finalDocCount = vscode.workspace.textDocuments.length;
-    assert.strictEqual(
-      finalDocCount,
-      initialDocCount + 1,
-      "Should have created one new document",
-    );
-    const doc =
-      vscode.workspace.textDocuments[vscode.workspace.textDocuments.length - 1];
-    assert.equal(
-      fakeUri.fsPath,
-      doc.uri.fsPath,
-      "New document should be untitled",
-    );
-    assert.ok(
-      doc.uri.path.endsWith(".py"),
-      "New document should be a Python file",
-    );
   });
 });
 

--- a/extension/tests/harness.test.cjs
+++ b/extension/tests/harness.test.cjs
@@ -1,7 +1,7 @@
 // @ts-check
 /// <reference types="mocha" />
 
-const assert = require("node:assert");
+const NodeAssert = require("node:assert");
 
 const {
   cellOutputText,
@@ -18,8 +18,8 @@ suite("harness: write → open → run → edit → run", () => {
     await using ctx = createTestContext({ timeoutMs: 170_000 });
     const nb = await ctx.writeAndOpenNotebook();
 
-    assert.strictEqual(nb.cellCount, 1, "should have 1 cell");
-    assert.match(
+    NodeAssert.strictEqual(nb.cellCount, 1, "should have 1 cell");
+    NodeAssert.match(
       nb.cellAt(0).document.getText(),
       /print\(10\)/,
       "initial cell should contain print(10)",
@@ -29,11 +29,11 @@ suite("harness: write → open → run → edit → run", () => {
 
     await runCell(nb.cellAt(0));
     await ctx.waitUntil(() => {
-      assert.match(cellOutputText(nb.cellAt(0)), /10/);
+      NodeAssert.match(cellOutputText(nb.cellAt(0)), /10/);
     });
 
     await editCell(nb.cellAt(0), "print(20)\n");
-    assert.match(
+    NodeAssert.match(
       nb.cellAt(0).document.getText(),
       /print\(20\)/,
       "cell text should be updated to print(20)",
@@ -41,7 +41,7 @@ suite("harness: write → open → run → edit → run", () => {
 
     await runCell(nb.cellAt(0));
     await ctx.waitUntil(() => {
-      assert.match(cellOutputText(nb.cellAt(0)), /20/);
+      NodeAssert.match(cellOutputText(nb.cellAt(0)), /20/);
     });
   });
 });

--- a/extension/tests/harness.test.cjs
+++ b/extension/tests/harness.test.cjs
@@ -4,55 +4,44 @@
 const assert = require("node:assert");
 
 const {
-  writeTempNotebook,
-  openMarimoNotebook,
-  selectSandboxController,
-  editCellText,
+  cellOutputText,
+  createTestContext,
+  editCell,
   runCell,
-  getCellOutputText,
+  selectKernel,
 } = require("./helpers.cjs");
 
 suite("harness: write → open → run → edit → run", () => {
   test("round-trips a single cell through the sandbox controller", async function () {
     // First run downloads uv cache + resolves marimo; be generous.
     this.timeout(180_000);
+    await using ctx = createTestContext({ timeoutMs: 170_000 });
+    const nb = await ctx.writeAndOpenNotebook();
 
-    const { uri, cleanup } = await writeTempNotebook();
-    try {
-      const notebook = await openMarimoNotebook(uri);
-      assert.strictEqual(notebook.cellCount, 1, "should have 1 cell");
-      assert.match(
-        notebook.cellAt(0).document.getText(),
-        /print\(10\)/,
-        "initial cell should contain print(10)",
-      );
+    assert.strictEqual(nb.cellCount, 1, "should have 1 cell");
+    assert.match(
+      nb.cellAt(0).document.getText(),
+      /print\(10\)/,
+      "initial cell should contain print(10)",
+    );
 
-      await selectSandboxController(notebook);
-      await runCell(notebook, 0);
+    await selectKernel(nb);
 
-      const firstOutput = getCellOutputText(notebook.cellAt(0));
-      assert.match(
-        firstOutput,
-        /10/,
-        `expected "10" in cell output, got: ${JSON.stringify(firstOutput)}`,
-      );
+    await runCell(nb.cellAt(0));
+    await ctx.waitUntil(() => {
+      assert.match(cellOutputText(nb.cellAt(0)), /10/);
+    });
 
-      await editCellText(notebook, 0, "print(20)\n");
-      assert.match(
-        notebook.cellAt(0).document.getText(),
-        /print\(20\)/,
-        "cell text should be updated to print(20)",
-      );
+    await editCell(nb.cellAt(0), "print(20)\n");
+    assert.match(
+      nb.cellAt(0).document.getText(),
+      /print\(20\)/,
+      "cell text should be updated to print(20)",
+    );
 
-      await runCell(notebook, 0);
-      const secondOutput = getCellOutputText(notebook.cellAt(0));
-      assert.match(
-        secondOutput,
-        /20/,
-        `expected "20" in cell output after edit, got: ${JSON.stringify(secondOutput)}`,
-      );
-    } finally {
-      await cleanup();
-    }
+    await runCell(nb.cellAt(0));
+    await ctx.waitUntil(() => {
+      assert.match(cellOutputText(nb.cellAt(0)), /20/);
+    });
   });
 });

--- a/extension/tests/harness.test.cjs
+++ b/extension/tests/harness.test.cjs
@@ -1,0 +1,58 @@
+// @ts-check
+/// <reference types="mocha" />
+
+const assert = require("node:assert");
+
+const {
+  writeTempNotebook,
+  openMarimoNotebook,
+  selectSandboxController,
+  editCellText,
+  runCell,
+  getCellOutputText,
+} = require("./helpers.cjs");
+
+suite("harness: write → open → run → edit → run", () => {
+  test("round-trips a single cell through the sandbox controller", async function () {
+    // First run downloads uv cache + resolves marimo; be generous.
+    this.timeout(180_000);
+
+    const { uri, cleanup } = await writeTempNotebook();
+    try {
+      const notebook = await openMarimoNotebook(uri);
+      assert.strictEqual(notebook.cellCount, 1, "should have 1 cell");
+      assert.match(
+        notebook.cellAt(0).document.getText(),
+        /print\(10\)/,
+        "initial cell should contain print(10)",
+      );
+
+      await selectSandboxController(notebook);
+      await runCell(notebook, 0);
+
+      const firstOutput = getCellOutputText(notebook.cellAt(0));
+      assert.match(
+        firstOutput,
+        /10/,
+        `expected "10" in cell output, got: ${JSON.stringify(firstOutput)}`,
+      );
+
+      await editCellText(notebook, 0, "print(20)\n");
+      assert.match(
+        notebook.cellAt(0).document.getText(),
+        /print\(20\)/,
+        "cell text should be updated to print(20)",
+      );
+
+      await runCell(notebook, 0);
+      const secondOutput = getCellOutputText(notebook.cellAt(0));
+      assert.match(
+        secondOutput,
+        /20/,
+        `expected "20" in cell output after edit, got: ${JSON.stringify(secondOutput)}`,
+      );
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/extension/tests/harness.test.cjs
+++ b/extension/tests/harness.test.cjs
@@ -12,8 +12,7 @@ const {
 } = require("./helpers.cjs");
 
 suite("harness: write → open → run → edit → run", () => {
-  test("round-trips a single cell through the sandbox controller", async function () {
-    this.timeout(8_000);
+  test("round-trips a single cell through the shared-venv python controller", async function () {
     await using ctx = createTestContext();
     const nb = await ctx.writeAndOpenNotebook();
 

--- a/extension/tests/harness.test.cjs
+++ b/extension/tests/harness.test.cjs
@@ -13,9 +13,8 @@ const {
 
 suite("harness: write → open → run → edit → run", () => {
   test("round-trips a single cell through the sandbox controller", async function () {
-    // First run downloads uv cache + resolves marimo; be generous.
-    this.timeout(180_000);
-    await using ctx = createTestContext({ timeoutMs: 170_000 });
+    this.timeout(8_000);
+    await using ctx = createTestContext();
     const nb = await ctx.writeAndOpenNotebook();
 
     NodeAssert.strictEqual(nb.cellCount, 1, "should have 1 cell");
@@ -28,20 +27,16 @@ suite("harness: write → open → run → edit → run", () => {
     await selectKernel(nb);
 
     await runCell(nb.cellAt(0));
-    await ctx.waitUntil(() => {
-      NodeAssert.match(cellOutputText(nb.cellAt(0)), /10/);
-    });
+    NodeAssert.match(cellOutputText(nb.cellAt(0)), /10/);
 
     await editCell(nb.cellAt(0), "print(20)\n");
     NodeAssert.match(
       nb.cellAt(0).document.getText(),
       /print\(20\)/,
-      "cell text should be updated to print(20)",
+      "cell text should reflect the edit",
     );
 
     await runCell(nb.cellAt(0));
-    await ctx.waitUntil(() => {
-      NodeAssert.match(cellOutputText(nb.cellAt(0)), /20/);
-    });
+    NodeAssert.match(cellOutputText(nb.cellAt(0)), /20/);
   });
 });

--- a/extension/tests/helpers.cjs
+++ b/extension/tests/helpers.cjs
@@ -47,42 +47,22 @@ async function activateExtension() {
   return ext;
 }
 
-async function getMarimoApi() {
-  const ext = await activateExtension();
-  return /** @type {import("../src/platform/Api.ts").MarimoApi} */ (
-    ext.exports
-  );
-}
-
 /**
- * Creates a test context with a shared AbortSignal and AsyncDisposableStack.
+ * Creates a test context with an AsyncDisposableStack for temp-file cleanup.
  *
  * Only the context itself is `AsyncDisposable`. Notebooks returned by
- * `openNotebook` / `writeAndOpenNotebook` are plain `vscode.NotebookDocument`
- * — the context owns their lifetimes (temp dirs, etc.) via its stack.
+ * `openNotebook` / `writeAndOpenNotebook` are plain `vscode.NotebookDocument`.
  *
  * Use at the top of a test:
  *
- *     await using ctx = createTestContext({ timeoutMs: 170_000 });
+ *     await using ctx = createTestContext();
  *     const nb = await ctx.writeAndOpenNotebook();
  *     await selectKernel(nb);
  *     await runCell(nb.cellAt(0));
- *     await ctx.waitUntil(() => assert.match(cellOutputText(nb.cellAt(0)), /10/));
- *
- * @param {{ timeoutMs?: number, signal?: AbortSignal }} [options]
+ *     assert.match(cellOutputText(nb.cellAt(0)), /10/);
  */
-function createTestContext(options = {}) {
+function createTestContext() {
   const stack = new AsyncDisposableStack();
-  const signals = [];
-  if (options.signal) signals.push(options.signal);
-  if (options.timeoutMs != null)
-    signals.push(AbortSignal.timeout(options.timeoutMs));
-  const signal =
-    signals.length === 0
-      ? new AbortController().signal
-      : signals.length === 1
-        ? signals[0]
-        : AbortSignal.any(signals);
 
   /**
    * Writes a source file to a fresh temp dir. Cleanup is deferred into the
@@ -133,50 +113,32 @@ function createTestContext(options = {}) {
   }
 
   /**
-   * Runs `fn` on each polling interval. If `fn` returns/resolves, `waitUntil`
-   * resolves. If `fn` throws, the error is swallowed and retried. When the
-   * context's signal aborts, the most recent thrown error is re-raised — so
-   * timeouts report the real assertion failure, not a generic "timeout".
+   * Runs `fn` on each polling tick. Resolves when `fn` doesn't throw. Loops
+   * forever — relies on mocha's `this.timeout(...)` to kill hung tests.
+   *
+   * The interval exists to yield to the event loop between polls so VS Code's
+   * I/O callbacks can fire; it's not a delay.
    *
    * Side-effect-free predicates only: the callback is called many times.
    *
    * @param {() => void | Promise<void>} fn
-   * @param {{ intervalMs?: number }} [opts]
+   * @param {number} [interval]
    */
-  async function waitUntil(fn, opts = {}) {
-    const { intervalMs = 50 } = opts;
-    /** @type {unknown} */
-    let lastError;
+  async function waitUntil(fn, interval = 50) {
     while (true) {
-      if (signal.aborted) {
-        throw lastError ?? signal.reason ?? new Error("waitUntil aborted");
-      }
       try {
         // oxlint-disable-next-line eslint/no-await-in-loop: intentional polling
         await fn();
         return;
-      } catch (err) {
-        lastError = err;
+      } catch {
+        // swallow and retry
       }
       // oxlint-disable-next-line eslint/no-await-in-loop: intentional polling
-      await new Promise((resolve) => {
-        const timer = setTimeout(resolve, intervalMs);
-        const onAbort = () => {
-          clearTimeout(timer);
-          resolve(undefined);
-        };
-        if (signal.aborted) {
-          onAbort();
-          return;
-        }
-        signal.addEventListener("abort", onAbort, { once: true });
-      });
+      await new Promise((resolve) => setTimeout(resolve, interval));
     }
   }
 
   return {
-    signal,
-    stack,
     writeTempFile,
     openNotebook,
     writeAndOpenNotebook,
@@ -205,17 +167,45 @@ async function selectKernel(notebook, id = SANDBOX_CONTROLLER_ID) {
 }
 
 /**
- * Triggers execution of a cell. Does not wait for completion — callers should
- * follow up with `ctx.waitUntil(() => assert.match(cellOutputText(cell), ...))`.
+ * Triggers execution of `cell` and resolves once this cell's execution has
+ * been finalized (`executionSummary.success !== undefined`). The subscription
+ * is established before the command dispatches so we can't miss the event.
+ *
+ * Note: marimo's reactive model may trigger additional downstream cells when
+ * this cell runs. Today we only wait for THIS cell to finalize; a future
+ * improvement could wait for all triggered executions in the cascade to
+ * settle (requires an extension-exposed "kernel idle" signal).
  *
  * @param {vscode.NotebookCell} cell
  */
 async function runCell(cell) {
   const { notebook, index } = cell;
+  const priorEndTime = cell.executionSummary?.timing?.endTime;
+
+  /** @type {Promise<void>} */
+  const finalized = new Promise((resolve) => {
+    const sub = vscode.workspace.onDidChangeNotebookDocument((event) => {
+      if (event.notebook.uri.toString() !== notebook.uri.toString()) return;
+      for (const change of event.cellChanges) {
+        if (change.cell.index !== index) continue;
+        const summary = change.executionSummary;
+        if (
+          summary?.success !== undefined &&
+          summary.timing?.endTime !== priorEndTime
+        ) {
+          sub.dispose();
+          resolve();
+          return;
+        }
+      }
+    });
+  });
+
   await vscode.commands.executeCommand("notebook.cell.execute", {
     ranges: [{ start: index, end: index + 1 }],
     document: notebook.uri,
   });
+  await finalized;
 }
 
 /**
@@ -252,13 +242,6 @@ function cellOutputText(cell) {
 }
 
 module.exports = {
-  EXTENSION_ID,
-  NOTEBOOK_TYPE,
-  SANDBOX_CONTROLLER_ID,
-  DEFAULT_SOURCE,
-  getExtension,
-  activateExtension,
-  getMarimoApi,
   createTestContext,
   selectKernel,
   runCell,

--- a/extension/tests/helpers.cjs
+++ b/extension/tests/helpers.cjs
@@ -1,0 +1,205 @@
+// @ts-check
+/// <reference types="mocha" />
+
+const assert = require("node:assert");
+const fs = require("node:fs/promises");
+const os = require("node:os");
+const path = require("node:path");
+const vscode = require("vscode");
+
+const EXTENSION_ID = "marimo-team.vscode-marimo";
+const NOTEBOOK_TYPE = "marimo-notebook";
+const SANDBOX_CONTROLLER_ID = "marimo-sandbox";
+
+const DEFAULT_SOURCE = `# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "marimo",
+# ]
+# ///
+
+import marimo
+
+app = marimo.App()
+
+
+@app.cell
+def _():
+    print(10)
+    return
+
+
+if __name__ == "__main__":
+    app.run()
+`;
+
+function getExtension() {
+  const ext = vscode.extensions.getExtension(EXTENSION_ID);
+  assert.ok(ext, `Extension ${EXTENSION_ID} should be installed`);
+  return ext;
+}
+
+async function activateExtension() {
+  const ext = getExtension();
+  if (!ext.isActive) {
+    await ext.activate();
+  }
+  return ext;
+}
+
+async function getMarimoApi() {
+  const ext = await activateExtension();
+  return /** @type {import("../src/platform/Api.ts").MarimoApi} */ (
+    ext.exports
+  );
+}
+
+/**
+ * Writes a .py source to a fresh temp directory on disk. Returns the URI and
+ * a cleanup fn that removes the directory.
+ *
+ * @param {object} [options]
+ * @param {string} [options.source]
+ * @param {string} [options.filename]
+ */
+async function writeTempNotebook(options = {}) {
+  const source = options.source ?? DEFAULT_SOURCE;
+  const filename = options.filename ?? "notebook.py";
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "marimo-it-"));
+  const filePath = path.join(dir, filename);
+  await fs.writeFile(filePath, source, "utf8");
+  const uri = vscode.Uri.file(filePath);
+  return {
+    uri,
+    dir,
+    cleanup: async () => {
+      try {
+        await fs.rm(dir, { recursive: true, force: true });
+      } catch {
+        // best effort
+      }
+    },
+  };
+}
+
+/**
+ * @param {vscode.Uri} uri
+ */
+async function openMarimoNotebook(uri) {
+  await activateExtension();
+  const notebook = await vscode.workspace.openNotebookDocument(uri);
+  assert.strictEqual(
+    notebook.notebookType,
+    NOTEBOOK_TYPE,
+    `notebook opened as ${notebook.notebookType}, expected ${NOTEBOOK_TYPE}`,
+  );
+  return notebook;
+}
+
+/**
+ * Shows the notebook and binds the sandbox controller to it.
+ *
+ * @param {vscode.NotebookDocument} notebook
+ */
+async function selectSandboxController(notebook) {
+  const editor = await vscode.window.showNotebookDocument(notebook);
+  await vscode.commands.executeCommand("notebook.selectKernel", {
+    notebookEditor: editor,
+    id: SANDBOX_CONTROLLER_ID,
+    extension: EXTENSION_ID,
+  });
+  return editor;
+}
+
+/**
+ * Replaces the entire text of a cell via WorkspaceEdit.
+ *
+ * @param {vscode.NotebookDocument} notebook
+ * @param {number} index
+ * @param {string} newText
+ */
+async function editCellText(notebook, index, newText) {
+  const cell = notebook.cellAt(index);
+  const edit = new vscode.WorkspaceEdit();
+  const fullRange = new vscode.Range(
+    cell.document.positionAt(0),
+    cell.document.positionAt(cell.document.getText().length),
+  );
+  edit.replace(cell.document.uri, fullRange, newText);
+  const applied = await vscode.workspace.applyEdit(edit);
+  assert.ok(applied, "workspace.applyEdit should return true");
+}
+
+/**
+ * Runs a single cell and resolves when execution has completed (success or
+ * failure). Rejects on timeout.
+ *
+ * @param {vscode.NotebookDocument} notebook
+ * @param {number} index
+ * @param {number} [timeoutMs]
+ * @returns {Promise<vscode.NotebookCellExecutionSummary>}
+ */
+async function runCell(notebook, index, timeoutMs = 90_000) {
+  const targetCell = notebook.cellAt(index);
+
+  /** @type {Promise<vscode.NotebookCellExecutionSummary>} */
+  const completed = new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      sub.dispose();
+      reject(new Error(`runCell(${index}) timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    const sub = vscode.workspace.onDidChangeNotebookDocument((event) => {
+      if (event.notebook.uri.toString() !== notebook.uri.toString()) return;
+      for (const change of event.cellChanges) {
+        if (change.cell !== targetCell) continue;
+        const summary = change.executionSummary;
+        if (summary && summary.success !== undefined) {
+          clearTimeout(timer);
+          sub.dispose();
+          resolve(summary);
+          return;
+        }
+      }
+    });
+  });
+
+  await vscode.commands.executeCommand("notebook.cell.execute", {
+    ranges: [{ start: index, end: index + 1 }],
+    document: notebook.uri,
+  });
+
+  return completed;
+}
+
+/**
+ * Returns the concatenated utf-8 text of all output items on a cell.
+ *
+ * @param {vscode.NotebookCell} cell
+ */
+function getCellOutputText(cell) {
+  const decoder = new TextDecoder();
+  const parts = [];
+  for (const output of cell.outputs) {
+    for (const item of output.items) {
+      parts.push(decoder.decode(item.data));
+    }
+  }
+  return parts.join("");
+}
+
+module.exports = {
+  EXTENSION_ID,
+  NOTEBOOK_TYPE,
+  SANDBOX_CONTROLLER_ID,
+  DEFAULT_SOURCE,
+  getExtension,
+  activateExtension,
+  getMarimoApi,
+  writeTempNotebook,
+  openMarimoNotebook,
+  selectSandboxController,
+  editCellText,
+  runCell,
+  getCellOutputText,
+};

--- a/extension/tests/helpers.cjs
+++ b/extension/tests/helpers.cjs
@@ -1,10 +1,10 @@
 // @ts-check
 /// <reference types="mocha" />
 
-const assert = require("node:assert");
-const fs = require("node:fs/promises");
-const os = require("node:os");
-const path = require("node:path");
+const NodeAssert = require("node:assert");
+const NodeFs = require("node:fs/promises");
+const NodeOs = require("node:os");
+const NodePath = require("node:path");
 const vscode = require("vscode");
 
 const EXTENSION_ID = "marimo-team.vscode-marimo";
@@ -35,7 +35,7 @@ if __name__ == "__main__":
 
 function getExtension() {
   const ext = vscode.extensions.getExtension(EXTENSION_ID);
-  assert.ok(ext, `Extension ${EXTENSION_ID} should be installed`);
+  NodeAssert.ok(ext, `Extension ${EXTENSION_ID} should be installed`);
   return ext;
 }
 
@@ -55,71 +55,176 @@ async function getMarimoApi() {
 }
 
 /**
- * Writes a .py source to a fresh temp directory on disk. Returns the URI and
- * a cleanup fn that removes the directory.
+ * Creates a test context with a shared AbortSignal and AsyncDisposableStack.
  *
- * @param {object} [options]
- * @param {string} [options.source]
- * @param {string} [options.filename]
+ * Only the context itself is `AsyncDisposable`. Notebooks returned by
+ * `openNotebook` / `writeAndOpenNotebook` are plain `vscode.NotebookDocument`
+ * — the context owns their lifetimes (temp dirs, etc.) via its stack.
+ *
+ * Use at the top of a test:
+ *
+ *     await using ctx = createTestContext({ timeoutMs: 170_000 });
+ *     const nb = await ctx.writeAndOpenNotebook();
+ *     await selectKernel(nb);
+ *     await runCell(nb.cellAt(0));
+ *     await ctx.waitUntil(() => assert.match(cellOutputText(nb.cellAt(0)), /10/));
+ *
+ * @param {{ timeoutMs?: number, signal?: AbortSignal }} [options]
  */
-async function writeTempNotebook(options = {}) {
-  const source = options.source ?? DEFAULT_SOURCE;
-  const filename = options.filename ?? "notebook.py";
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "marimo-it-"));
-  const filePath = path.join(dir, filename);
-  await fs.writeFile(filePath, source, "utf8");
-  const uri = vscode.Uri.file(filePath);
-  return {
-    uri,
-    dir,
-    cleanup: async () => {
-      try {
-        await fs.rm(dir, { recursive: true, force: true });
-      } catch {
-        // best effort
+function createTestContext(options = {}) {
+  const stack = new AsyncDisposableStack();
+  const signals = [];
+  if (options.signal) signals.push(options.signal);
+  if (options.timeoutMs != null)
+    signals.push(AbortSignal.timeout(options.timeoutMs));
+  const signal =
+    signals.length === 0
+      ? new AbortController().signal
+      : signals.length === 1
+        ? signals[0]
+        : AbortSignal.any(signals);
+
+  /**
+   * Writes a source file to a fresh temp dir. Cleanup is deferred into the
+   * context's stack.
+   *
+   * @param {string} [source]
+   * @param {{ filename?: string }} [opts]
+   * @returns {Promise<vscode.Uri>}
+   */
+  async function writeTempFile(source = DEFAULT_SOURCE, opts = {}) {
+    const filename = opts.filename ?? "notebook.py";
+    const dir = await NodeFs.mkdtemp(
+      NodePath.join(NodeOs.tmpdir(), "marimo-it-"),
+    );
+    const filePath = NodePath.join(dir, filename);
+    await NodeFs.writeFile(filePath, source, "utf8");
+    stack.defer(async () => {
+      await NodeFs.rm(dir, { recursive: true, force: true }).catch(() => {});
+    });
+    return vscode.Uri.file(filePath);
+  }
+
+  /**
+   * Opens an existing .py file at `uri` as a marimo notebook.
+   *
+   * @param {vscode.Uri} uri
+   * @returns {Promise<vscode.NotebookDocument>}
+   */
+  async function openNotebook(uri) {
+    await activateExtension();
+    const notebook = await vscode.workspace.openNotebookDocument(uri);
+    NodeAssert.strictEqual(
+      notebook.notebookType,
+      NOTEBOOK_TYPE,
+      `notebook opened as ${notebook.notebookType}, expected ${NOTEBOOK_TYPE}`,
+    );
+    return notebook;
+  }
+
+  /**
+   * @param {string} [source]
+   * @param {{ filename?: string }} [opts]
+   * @returns {Promise<vscode.NotebookDocument>}
+   */
+  async function writeAndOpenNotebook(source, opts) {
+    const uri = await writeTempFile(source, opts);
+    return openNotebook(uri);
+  }
+
+  /**
+   * Runs `fn` on each polling interval. If `fn` returns/resolves, `waitUntil`
+   * resolves. If `fn` throws, the error is swallowed and retried. When the
+   * context's signal aborts, the most recent thrown error is re-raised — so
+   * timeouts report the real assertion failure, not a generic "timeout".
+   *
+   * Side-effect-free predicates only: the callback is called many times.
+   *
+   * @param {() => void | Promise<void>} fn
+   * @param {{ intervalMs?: number }} [opts]
+   */
+  async function waitUntil(fn, opts = {}) {
+    const { intervalMs = 50 } = opts;
+    /** @type {unknown} */
+    let lastError;
+    while (true) {
+      if (signal.aborted) {
+        throw lastError ?? signal.reason ?? new Error("waitUntil aborted");
       }
+      try {
+        // oxlint-disable-next-line eslint/no-await-in-loop: intentional polling
+        await fn();
+        return;
+      } catch (err) {
+        lastError = err;
+      }
+      // oxlint-disable-next-line eslint/no-await-in-loop: intentional polling
+      await new Promise((resolve) => {
+        const timer = setTimeout(resolve, intervalMs);
+        const onAbort = () => {
+          clearTimeout(timer);
+          resolve(undefined);
+        };
+        if (signal.aborted) {
+          onAbort();
+          return;
+        }
+        signal.addEventListener("abort", onAbort, { once: true });
+      });
+    }
+  }
+
+  return {
+    signal,
+    stack,
+    writeTempFile,
+    openNotebook,
+    writeAndOpenNotebook,
+    waitUntil,
+    async [Symbol.asyncDispose]() {
+      await stack[Symbol.asyncDispose]();
     },
   };
 }
 
 /**
- * @param {vscode.Uri} uri
- */
-async function openMarimoNotebook(uri) {
-  await activateExtension();
-  const notebook = await vscode.workspace.openNotebookDocument(uri);
-  assert.strictEqual(
-    notebook.notebookType,
-    NOTEBOOK_TYPE,
-    `notebook opened as ${notebook.notebookType}, expected ${NOTEBOOK_TYPE}`,
-  );
-  return notebook;
-}
-
-/**
- * Shows the notebook and binds the sandbox controller to it.
+ * Binds the sandbox controller (or `id` override) to `notebook`, showing it
+ * in an editor so VS Code will pick the kernel.
  *
  * @param {vscode.NotebookDocument} notebook
+ * @param {string} [id]
  */
-async function selectSandboxController(notebook) {
+async function selectKernel(notebook, id = SANDBOX_CONTROLLER_ID) {
   const editor = await vscode.window.showNotebookDocument(notebook);
   await vscode.commands.executeCommand("notebook.selectKernel", {
     notebookEditor: editor,
-    id: SANDBOX_CONTROLLER_ID,
+    id,
     extension: EXTENSION_ID,
   });
   return editor;
 }
 
 /**
+ * Triggers execution of a cell. Does not wait for completion — callers should
+ * follow up with `ctx.waitUntil(() => assert.match(cellOutputText(cell), ...))`.
+ *
+ * @param {vscode.NotebookCell} cell
+ */
+async function runCell(cell) {
+  const { notebook, index } = cell;
+  await vscode.commands.executeCommand("notebook.cell.execute", {
+    ranges: [{ start: index, end: index + 1 }],
+    document: notebook.uri,
+  });
+}
+
+/**
  * Replaces the entire text of a cell via WorkspaceEdit.
  *
- * @param {vscode.NotebookDocument} notebook
- * @param {number} index
+ * @param {vscode.NotebookCell} cell
  * @param {string} newText
  */
-async function editCellText(notebook, index, newText) {
-  const cell = notebook.cellAt(index);
+async function editCell(cell, newText) {
   const edit = new vscode.WorkspaceEdit();
   const fullRange = new vscode.Range(
     cell.document.positionAt(0),
@@ -127,49 +232,7 @@ async function editCellText(notebook, index, newText) {
   );
   edit.replace(cell.document.uri, fullRange, newText);
   const applied = await vscode.workspace.applyEdit(edit);
-  assert.ok(applied, "workspace.applyEdit should return true");
-}
-
-/**
- * Runs a single cell and resolves when execution has completed (success or
- * failure). Rejects on timeout.
- *
- * @param {vscode.NotebookDocument} notebook
- * @param {number} index
- * @param {number} [timeoutMs]
- * @returns {Promise<vscode.NotebookCellExecutionSummary>}
- */
-async function runCell(notebook, index, timeoutMs = 90_000) {
-  const targetCell = notebook.cellAt(index);
-
-  /** @type {Promise<vscode.NotebookCellExecutionSummary>} */
-  const completed = new Promise((resolve, reject) => {
-    const timer = setTimeout(() => {
-      sub.dispose();
-      reject(new Error(`runCell(${index}) timed out after ${timeoutMs}ms`));
-    }, timeoutMs);
-
-    const sub = vscode.workspace.onDidChangeNotebookDocument((event) => {
-      if (event.notebook.uri.toString() !== notebook.uri.toString()) return;
-      for (const change of event.cellChanges) {
-        if (change.cell !== targetCell) continue;
-        const summary = change.executionSummary;
-        if (summary && summary.success !== undefined) {
-          clearTimeout(timer);
-          sub.dispose();
-          resolve(summary);
-          return;
-        }
-      }
-    });
-  });
-
-  await vscode.commands.executeCommand("notebook.cell.execute", {
-    ranges: [{ start: index, end: index + 1 }],
-    document: notebook.uri,
-  });
-
-  return completed;
+  NodeAssert.ok(applied, "workspace.applyEdit should return true");
 }
 
 /**
@@ -177,7 +240,7 @@ async function runCell(notebook, index, timeoutMs = 90_000) {
  *
  * @param {vscode.NotebookCell} cell
  */
-function getCellOutputText(cell) {
+function cellOutputText(cell) {
   const decoder = new TextDecoder();
   const parts = [];
   for (const output of cell.outputs) {
@@ -196,10 +259,9 @@ module.exports = {
   getExtension,
   activateExtension,
   getMarimoApi,
-  writeTempNotebook,
-  openMarimoNotebook,
-  selectSandboxController,
-  editCellText,
+  createTestContext,
+  selectKernel,
   runCell,
-  getCellOutputText,
+  editCell,
+  cellOutputText,
 };

--- a/extension/tests/helpers.cjs
+++ b/extension/tests/helpers.cjs
@@ -2,14 +2,63 @@
 /// <reference types="mocha" />
 
 const NodeAssert = require("node:assert");
+const NodeChildProcess = require("node:child_process");
 const NodeFs = require("node:fs/promises");
 const NodeOs = require("node:os");
 const NodePath = require("node:path");
+const NodeProcess = require("node:process");
+const NodeUtil = require("node:util");
 const vscode = require("vscode");
+
+const execFile = NodeUtil.promisify(NodeChildProcess.execFile);
 
 const EXTENSION_ID = "marimo-team.vscode-marimo";
 const NOTEBOOK_TYPE = "marimo-notebook";
-const SANDBOX_CONTROLLER_ID = "marimo-sandbox";
+
+/**
+ * Path to the Python executable inside a venv. Mirrors
+ * `extension/src/python/getVenvPythonPath.ts` — we can't share the TS helper
+ * from a CJS test file.
+ *
+ * @param {string} venv
+ */
+function venvPython(venv) {
+  return NodeProcess.platform === "win32"
+    ? NodePath.join(venv, "Scripts", "python.exe")
+    : NodePath.join(venv, "bin", "python");
+}
+
+const SHARED_VENV_DIR = NodePath.join(__dirname, "sampleWorkspace", ".venv");
+const SHARED_VENV_PYTHON = venvPython(SHARED_VENV_DIR);
+
+/**
+ * Creates (or reuses) a shared Python 3.13 venv with marimo installed under
+ * the test workspace. Memoized per test process so subsequent tests reuse
+ * the same venv — amortizing venv creation + marimo install across the
+ * whole suite.
+ *
+ * Returns the Python executable path.
+ *
+ * @type {Promise<string> | undefined}
+ */
+let sharedVenvReady;
+function ensureSharedVenv() {
+  if (sharedVenvReady) return sharedVenvReady;
+  sharedVenvReady = (async () => {
+    try {
+      await NodeFs.access(SHARED_VENV_PYTHON);
+      return SHARED_VENV_PYTHON;
+    } catch {
+      // venv doesn't exist yet; create it
+    }
+    await execFile("uv", ["venv", SHARED_VENV_DIR, "--python", "3.13"]);
+    await execFile("uv", ["pip", "install", "marimo"], {
+      env: { ...NodeProcess.env, VIRTUAL_ENV: SHARED_VENV_DIR },
+    });
+    return SHARED_VENV_PYTHON;
+  })();
+  return sharedVenvReady;
+}
 
 const DEFAULT_SOURCE = `# /// script
 # requires-python = ">=3.11"
@@ -40,6 +89,10 @@ function getExtension() {
 }
 
 async function activateExtension() {
+  // Provision the shared venv BEFORE activation so VS Code's Python
+  // extension discovers it during startup and marimo creates a Python
+  // controller for it. That controller is what `selectKernel` binds.
+  await ensureSharedVenv();
   const ext = getExtension();
   if (!ext.isActive) {
     await ext.activate();
@@ -150,13 +203,16 @@ function createTestContext() {
 }
 
 /**
- * Binds the sandbox controller (or `id` override) to `notebook`, showing it
- * in an editor so VS Code will pick the kernel.
+ * Binds the shared-venv Python controller to `notebook`, showing it in an
+ * editor so VS Code picks up the kernel. The controller id is derived from
+ * the Python executable path — see `PythonController.getId` in
+ * `src/kernel/NotebookControllerFactory.ts`.
  *
  * @param {vscode.NotebookDocument} notebook
- * @param {string} [id]
  */
-async function selectKernel(notebook, id = SANDBOX_CONTROLLER_ID) {
+async function selectKernel(notebook) {
+  const python = await ensureSharedVenv();
+  const id = `marimo-${python}`;
   const editor = await vscode.window.showNotebookDocument(notebook);
   await vscode.commands.executeCommand("notebook.selectKernel", {
     notebookEditor: editor,

--- a/extension/tests/setup.cjs
+++ b/extension/tests/setup.cjs
@@ -1,0 +1,20 @@
+// @ts-check
+/// <reference types="mocha" />
+
+// Root hook plugin. Runs once before any test. Activating the extension
+// here triggers `ensureSharedVenv` internally — the venv + `uv pip install
+// marimo` cost is borne once at startup instead of inside individual tests,
+// so tests can keep tight default timeouts.
+//
+// See https://mochajs.org/#root-hook-plugins
+
+const { activateExtension } = require("./helpers.cjs");
+
+module.exports.mochaHooks = {
+  // Cold install on a fresh CI container: `uv pip install marimo` can take
+  // 20–40s. Give it plenty of room; subsequent test timeouts stay tight.
+  beforeAll: async function () {
+    this.timeout(120_000);
+    await activateExtension();
+  },
+};


### PR DESCRIPTION
The existing `extension.test.cjs` only covers activation and contribution metadata. Bugs in the notebook lifecycle need a full Extension Host to reproduce, and there's no helper layer for driving a notebook end-to-end from a test.

This PR lands a small harness for writing tests against a real sandbox-controlled notebook. The shape:

```ts
await using ctx = createTestContext();
const nb = await ctx.writeAndOpenNotebook();
await selectKernel(nb);

await runCell(nb.cellAt(0));
assert.match(cellOutputText(nb.cellAt(0)), /10/);

await editCell(nb.cellAt(0), "print(20)\n");
await runCell(nb.cellAt(0));
assert.match(cellOutputText(nb.cellAt(0)), /20/);
```

`createTestContext` is the only `AsyncDisposable`; notebooks are raw `vscode.NotebookDocument`. Temp-file cleanup is automatic on scope exit. `runCell` waits for the cell's execution to be finalized, so test bodies read outputs synchronously instead of polling. Mocha's `this.timeout` is the sole backstop — no signal plumbing in the helpers.

For tests that need to poll non-execution state, `ctx.waitUntil(fn)` retries until `fn` stops throwing (assertions inside the callback, Testing Library-style).

A single harness test exercises the write → open → run → edit → run round-trip to prove the primitives compose. Completes in ~4s with a warm uv cache.

Two incidental changes: `sampleWorkspace` moves under `tests/` to keep fixtures co-located, and the "extension should not be active initially" precondition is dropped — it was order-dependent and any earlier test that activates the extension broke it.