### PR TITLE
Fix paste in marimo UI inputs inside notebook outputs

### DIFF
--- a/extension/src/renderer/CellOutput.tsx
+++ b/extension/src/renderer/CellOutput.tsx
@@ -21,7 +21,7 @@ export function CellOutput({ cellId, state }: CellOutputProps) {
   const { theme } = useTheme();
   const container = React.useRef<HTMLDivElement>(null);
 
-  useStopInputKeyboardPropagation(container);
+  useStopUnmodifiedInputKeys(container);
 
   return (
     <div
@@ -49,31 +49,59 @@ export function CellOutput({ cellId, state }: CellOutputProps) {
 }
 
 /**
- * Prevent keyboard events from input elements from triggering VS Code
- * notebook shortcuts (like 'a' to add cell, 'x' to delete, etc.).
+ * Stop typing keystrokes inside marimo inputs from reaching VS Code's notebook
+ * keybindings (`a` insert-cell-above, `x` delete-cell, …). Ctrl/Cmd shortcuts
+ * flow through so paste (#487), user remappings, and VS Code's own clipboard
+ * handling keep working. `stopPropagation` (not `preventDefault`) leaves native
+ * typing untouched.
  *
- * Uses bubbling phase so inputs handle events first (e.g., Enter to submit),
- * then stops propagation to VS Code.
+ * Alt-only combos are treated as typing: macOS Option-character entry
+ * (Option+E → ´) and AltGr on international keyboards (reports as ctrl+alt
+ * with `AltGraph` modifier) both produce characters, not commands.
+ *
+ * Modifier keys themselves (Control/Meta/Alt/Shift) always pass through so
+ * VS Code sees their keyup and doesn't end up in a stuck-modifier state.
+ *
+ * This is a workaround. VS Code's webview preload already tracks input focus
+ * inside outputs via `hasActiveEditableElement`, which recurses into shadow
+ * roots matching `:read-write`, and sets the `notebookOutputInputFocused`
+ * context key. That works for ipywidgets and raw HTML, but not for marimo:
+ * every UI element is a custom element with `attachShadow({ mode: "open" })`
+ * and the `<input>`/`<textarea>` lives in that shadow root.
+ *
+ * Proper fix — either side removes the need for this hook:
+ *   - VS Code: make `hasActiveEditableElement` robust to editables nested in
+ *     custom-element shadow roots.
+ *   - marimo: expose a standard signal VS Code already recognizes — form-
+ *     associated custom elements (host matches `:read-write`) or
+ *     `delegatesFocus: true` on the shadow root.
  */
-function useStopInputKeyboardPropagation(
+function useStopUnmodifiedInputKeys(
   containerRef: React.RefObject<HTMLDivElement | null>,
 ) {
   React.useEffect(() => {
-    if (!containerRef.current) {
+    const container = containerRef.current;
+    if (!container) {
       return undefined;
     }
 
     const controller = new AbortController();
     const handler = (e: KeyboardEvent) => {
+      if (isModifierKey(e.key)) {
+        return;
+      }
+      if ((e.ctrlKey || e.metaKey) && !e.getModifierState("AltGraph")) {
+        return;
+      }
       if (isFromInput(e)) {
         e.stopPropagation();
       }
     };
 
-    containerRef.current.addEventListener("keydown", handler, {
+    container.addEventListener("keydown", handler, {
       signal: controller.signal,
     });
-    containerRef.current.addEventListener("keyup", handler, {
+    container.addEventListener("keyup", handler, {
       signal: controller.signal,
     });
 
@@ -81,16 +109,19 @@ function useStopInputKeyboardPropagation(
   }, [containerRef]);
 }
 
+function isModifierKey(key: string): boolean {
+  return (
+    key === "Control" || key === "Meta" || key === "Alt" || key === "Shift"
+  );
+}
+
 /**
- * Check if the keyboard event came from an input element.
- *
- * Mirrors marimo's Events.fromInput() logic, with additional handling for
- * shadow DOM since marimo UI elements are rendered as web components.
+ * Check if the keyboard event came from an input element, including across
+ * shadow DOM boundaries (marimo UI elements are web components).
  */
 function isFromInput(e: KeyboardEvent): boolean {
   const target = e.target as HTMLElement;
 
-  // Direct check (mirrors marimo's Events.fromInput)
   if (
     target.tagName === "INPUT" ||
     target.tagName === "TEXTAREA" ||
@@ -100,7 +131,6 @@ function isFromInput(e: KeyboardEvent): boolean {
     return true;
   }
 
-  // Check shadow DOM for the actual focused element
   let active: Element | null = document.activeElement;
   while (active?.shadowRoot?.activeElement) {
     active = active.shadowRoot.activeElement;


### PR DESCRIPTION
Fixes #487 

The original hook (#305) blanket-stopped every keydown from an input, which killed VS Code's paste path.

These changes narrow the renderer's keydown/keyup propagation stopper to only block plain (unmodified) keys. Modifier combos ( Cmd/Ctrl/Alt chords) now flow through to VS Code's webview preload so its clipboard routing (Cmd+V), user keymap remappings, and other modifier-based shortcuts keep working. stopPropagation (not preventDefault) still preserves native textarea typing, newlines, arrows, etc.

VS Code already tracks input focus inside outputs via h`asActiveEditableElement`, which recurses into open shadow roots matching `:read-write` and sets the `notebookOutputInputFocused` context key. That works for ipywidgets and raw HTML <textarea>, but not for marimo since our UI elements are all custom elements with their own `attachShadow({ mode: 'open' })` and the real <input>/<textarea> nested inside.