### PR TITLE
Pin runtime dependencies to exact versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,10 +6,10 @@ readme = "README.md"
 requires-python = ">=3.10"
 authors = [{ name = "Trevor Manz", email = "trevor.j.manz@gmail.com" }]
 dependencies = [
-  "jupytext>=1.17.2",
-  "lsprotocol>=2025.0.0",
+  "jupytext==1.19.1",
+  "lsprotocol==2025.0.0",
   "marimo==0.23.1",
-  "pygls>=2.0.0",
+  "pygls==2.1.1",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -627,10 +627,10 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "jupytext", specifier = ">=1.17.2" },
-    { name = "lsprotocol", specifier = ">=2025.0.0" },
+    { name = "jupytext", specifier = "==1.19.1" },
+    { name = "lsprotocol", specifier = "==2025.0.0" },
     { name = "marimo", specifier = "==0.23.1" },
-    { name = "pygls", specifier = ">=2.0.0" },
+    { name = "pygls", specifier = "==2.1.1" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
These deps ship bundled inside the VS Code extension, so we don't want published builds cut on different days to drift apart on `jupytext`, `lsprotocol`, or `pygls`. Pin them to `==` at their current latest versions as a first step toward deterministic builds.

This isn't a real lockfile — transitive deps still float — but a proper lock for the bundled environment will come in a followup. Dev-group deps stay on `>=` since they don't end up in the published artifact.