### PR TITLE
Add CLAUDE.md and regroup just recipes

### DIFF
--- a/.claude/skills/effect-ts/SKILL.md
+++ b/.claude/skills/effect-ts/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: effect-ts
+description: "Deep reference for the Effect TypeScript library. Use this skill whenever working in a codebase that imports from 'effect' or '@effect/*', when writing Effect-based TypeScript, or when the user asks about Effect patterns, services, layers, schemas, streams, fibers, or error handling. Treat Effect as foundational infrastructure — read the relevant reference doc before writing Effect code, and go deep into the source when you need to understand a primitive."
+---
+
+# Effect
+
+Effect is not a library you call into — it is the foundation your program is built on. When you see `Effect` in a codebase, think of it the way you think of `async/await` or `Promise`: it is the core abstraction for describing what your program *does*.
+
+Every Effect program is built from a small set of primitives that compose together. Understanding these primitives deeply — not just their API, but *why* they exist and how they fit together — is what makes the difference between fighting the framework and flowing with it.
+
+## The core type
+
+```ts
+Effect<Success, Error, Requirements>
+//       A        E         R
+```
+
+- **A** — what the effect produces on success
+- **E** — what errors it can fail with (typed, not thrown)
+- **R** — what services/context it needs to run
+
+This triple is the type-level contract of every effectful computation. The compiler tracks all three, so you always know what can go wrong and what dependencies are missing.
+
+## Primitives
+
+When working with a specific primitive, read its reference doc — each one explains the concept, shows idiomatic usage, and points to where in the Effect codebase to look for deeper understanding.
+
+| Primitive | What it is | Reference |
+|-----------|-----------|-----------|
+| **Effect** | The core computation type — `gen`, `fn`, `pipe`, running | [effect-core.md](references/effect-core.md) |
+| **Services & Layers** | Typed dependency injection — `Context.Tag`, `Layer`, providing | [services-and-layers.md](references/services-and-layers.md) |
+| **Error handling** | Typed errors, `Cause`, catch/recovery patterns | [error-handling.md](references/error-handling.md) |
+| **Schema & Data** | Runtime validation, data classes, branded types | [schema-and-data.md](references/schema-and-data.md) |
+| **Concurrency** | `Fiber`, `Deferred`, `Queue`, `PubSub`, `Ref`, `Pool` | [concurrency.md](references/concurrency.md) |
+| **Streams** | Pull-based streaming — `Stream`, `Sink`, `Channel` | [streams.md](references/streams.md) |
+| **Resources** | `Scope`, `acquireRelease`, finalizers | [resource-management.md](references/resource-management.md) |
+| **Scheduling** | `Schedule` for retry, repeat, and recurrence | [scheduling.md](references/scheduling.md) |
+| **Testing** | `@effect/vitest`, `TestClock`, test layers | [testing.md](references/testing.md) |
+| **Patterns** | Idioms, anti-patterns, and common recipes | [patterns.md](references/patterns.md) |
+
+## Philosophy
+
+These principles inform every design decision in Effect:
+
+1. **Errors are values, not exceptions.** Every failure mode is tracked in the type system. You handle errors explicitly, not with try/catch.
+
+2. **Dependencies are declared, not imported.** Services are accessed through the type system (`R` parameter), wired at the edge of your program, and trivially swappable for testing.
+
+3. **Resources clean up after themselves.** Scopes and finalizers guarantee cleanup even under interruption or failure. No dangling connections.
+
+4. **Concurrency is structured.** Fibers form parent-child trees. Interruption propagates. No orphaned work.
+
+5. **Composition over configuration.** Small primitives combine into complex behaviors. `pipe` chains cross-cutting concerns (retry, timeout, tracing) without modifying business logic.
+
+## Navigating the Effect codebase
+
+The Effect source lives in `packages/effect/src/`. The codebase follows a consistent pattern:
+
+- **Public API** — `packages/effect/src/ModuleName.ts` exports types, constructors, and combinators. Read docstrings here for usage guidance.
+- **Internal implementation** — `packages/effect/src/internal/` contains the actual logic. When you need to understand *how* something works (not just *what* it does), look here.
+- **Key internal files**:
+  - `internal/core.ts` / `internal/core-effect.ts` — core Effect primitives and operators
+  - `internal/fiberRuntime.ts` — the fiber execution engine (~3800 lines, the heart of the runtime)
+  - `internal/layer/` — Layer construction and memoization
+  - `internal/stream/` — Stream implementation
+  - `internal/stm/` — Software Transactional Memory
+
+When you need to understand a primitive, start with the public module's docstrings, then follow the imports into `internal/` for the implementation.

--- a/.claude/skills/effect-ts/references/concurrency.md
+++ b/.claude/skills/effect-ts/references/concurrency.md
@@ -1,0 +1,181 @@
+# Concurrency
+
+Effect provides structured concurrency through fibers (lightweight green threads) and a set of coordination primitives. Concurrency in Effect is *structured*: fibers form parent-child trees, interruption propagates down, and resources are cleaned up automatically.
+
+## Fiber — lightweight execution
+
+A Fiber is a running Effect. Forking creates a child fiber; the parent can join, interrupt, or observe it:
+
+```ts
+import { Effect, Fiber } from "effect"
+
+const program = Effect.gen(function*() {
+  // Fork a child fiber (interrupted when parent completes):
+  const fiber = yield* Effect.fork(longRunningTask)
+
+  // Do other work concurrently...
+  yield* doSomethingElse
+
+  // Wait for the fiber to finish:
+  const result = yield* Fiber.join(fiber)
+  return result
+})
+```
+
+Fork variants:
+- `Effect.fork(effect)` — child fiber, interrupted when parent scope ends
+- `Effect.forkDaemon(effect)` — detached, runs independently of parent
+- `Effect.forkScoped(effect)` — tied to the current Scope
+- `Effect.forkIn(effect, scope)` — tied to a specific Scope
+
+## Deferred — one-time async variable
+
+A `Deferred<A, E>` is a variable that starts empty and can be set exactly once. Fibers that `await` it suspend until it's set:
+
+```ts
+import { Deferred, Effect } from "effect"
+
+const program = Effect.gen(function*() {
+  const deferred = yield* Deferred.make<string, never>()
+
+  // Consumer suspends until value is available:
+  const consumer = yield* Effect.fork(
+    Effect.gen(function*() {
+      const value = yield* Deferred.await(deferred)
+      yield* Effect.log(`Got: ${value}`)
+    })
+  )
+
+  // Producer sets the value:
+  yield* Effect.sleep("1 second")
+  yield* Deferred.succeed(deferred, "hello")
+  yield* Fiber.join(consumer)
+})
+```
+
+Use Deferred for one-shot coordination between fibers — signaling completion, passing a single result, or implementing handshakes.
+
+## Ref — shared mutable state
+
+`Ref<A>` is an atomic mutable reference, safe for concurrent access:
+
+```ts
+import { Effect, Ref } from "effect"
+
+const program = Effect.gen(function*() {
+  const counter = yield* Ref.make(0)
+
+  yield* Effect.all(
+    Array.from({ length: 10 }, () =>
+      Ref.update(counter, (n) => n + 1)
+    ),
+    { concurrency: "unbounded" }
+  )
+
+  const final = yield* Ref.get(counter)
+  // final === 10 (all updates are atomic)
+})
+```
+
+Variants:
+- `Ref` — basic atomic reference
+- `SynchronizedRef` — like Ref but `updateEffect` runs the effect atomically
+- `SubscriptionRef` — emits a Stream of changes
+
+## Queue — async message passing
+
+`Queue<A>` is a bounded or unbounded async FIFO queue:
+
+```ts
+import { Effect, Queue } from "effect"
+
+const program = Effect.gen(function*() {
+  const queue = yield* Queue.bounded<string>(100)
+
+  // Producer:
+  yield* Effect.fork(
+    Effect.forever(
+      queue.offer("tick").pipe(Effect.delay("100 millis"))
+    )
+  )
+
+  // Consumer:
+  const msg = yield* Queue.take(queue) // suspends until available
+  yield* Effect.log(`Received: ${msg}`)
+})
+```
+
+- `Queue.bounded(n)` — backpressure when full (offer suspends)
+- `Queue.unbounded()` — no limit (be careful with memory)
+- `Queue.dropping(n)` — drops new items when full
+- `Queue.sliding(n)` — drops oldest items when full
+
+## PubSub — broadcast to multiple subscribers
+
+`PubSub<A>` is a multi-subscriber broadcast hub. Each subscriber gets its own queue:
+
+```ts
+import { Effect, PubSub, Stream } from "effect"
+
+const program = Effect.gen(function*() {
+  const hub = yield* PubSub.bounded<string>(256)
+
+  // Subscribers get independent streams:
+  const stream = Stream.fromPubSub(hub)
+
+  yield* Effect.fork(
+    stream.pipe(Stream.runForEach((msg) => Effect.log(`Sub1: ${msg}`)))
+  )
+
+  yield* PubSub.publish(hub, "hello")
+})
+```
+
+## Pool — resource pooling
+
+`Pool<A, E>` manages a bounded set of reusable resources:
+
+```ts
+import { Effect, Pool } from "effect"
+
+const program = Effect.gen(function*() {
+  const pool = yield* Pool.make({
+    acquire: createConnection,
+    size: 10
+  })
+
+  // get borrows from pool, returns on scope exit:
+  const result = yield* Pool.get(pool).pipe(
+    Effect.flatMap((conn) => conn.query("SELECT 1")),
+    Effect.scoped
+  )
+})
+```
+
+## Parallel combinators
+
+```ts
+// Run effects concurrently:
+const [a, b, c] = yield* Effect.all([effectA, effectB, effectC], {
+  concurrency: "unbounded"
+})
+
+// With bounded concurrency:
+yield* Effect.forEach(items, processItem, { concurrency: 10 })
+
+// Race — first to succeed wins:
+const fastest = yield* Effect.race(effectA, effectB)
+
+// Zip concurrently:
+const [x, y] = yield* Effect.zip(effectA, effectB, { concurrent: true })
+```
+
+## Where to look in the codebase
+
+- **Fiber**: `packages/effect/src/Fiber.ts` (public), `internal/fiber.ts` and `internal/fiberRuntime.ts` (execution engine)
+- **Deferred**: `packages/effect/src/Deferred.ts` (public), `internal/deferred.ts`
+- **Ref**: `packages/effect/src/Ref.ts`, `SynchronizedRef.ts`, `SubscriptionRef.ts`
+- **Queue**: `packages/effect/src/Queue.ts`, `internal/queue.ts`
+- **PubSub**: `packages/effect/src/PubSub.ts`, `internal/pubsub.ts`
+- **Pool**: `packages/effect/src/Pool.ts`, `internal/pool.ts`
+- **Fiber runtime**: `internal/fiberRuntime.ts` — the heart of the execution engine (~3800 lines)

--- a/.claude/skills/effect-ts/references/effect-core.md
+++ b/.claude/skills/effect-ts/references/effect-core.md
@@ -1,0 +1,97 @@
+# Effect Core
+
+The `Effect<A, E, R>` type is a lazy description of a computation. Nothing runs until you explicitly execute it. This is what makes Effect composable — you build up a description of your program, then run it once at the edge.
+
+## Effect.gen — the primary coding style
+
+`Effect.gen` with `yield*` is how you write sequential Effect code. Think of it as `async/await` but with typed errors and dependency tracking:
+
+```ts
+import { Effect } from "effect"
+
+const program = Effect.gen(function*() {
+  const user = yield* fetchUser(id)
+  yield* Effect.log(`Found user: ${user.name}`)
+  const orders = yield* fetchOrders(user.id)
+  return { user, orders }
+})
+```
+
+`yield*` unwraps an Effect the way `await` unwraps a Promise — but the compiler also tracks the errors and requirements of every yielded effect, unioning them into the final type.
+
+## Effect.fn — named, traced functions
+
+For reusable effectful functions, prefer `Effect.fn` over wrapping `Effect.gen` in a function. It creates a tracing span automatically and gives better stack traces:
+
+```ts
+const processUser = Effect.fn("processUser")(function*(userId: string) {
+  const user = yield* fetchUser(userId)
+  yield* Effect.log(`Processing ${user.name}`)
+  return yield* saveUser(user)
+})
+
+// You can also apply cross-cutting concerns as additional arguments:
+const fetchWithRetry = Effect.fn("fetchWithRetry")(
+  function*(url: string) {
+    return yield* httpGet(url)
+  },
+  Effect.retry({ times: 3 }),
+  Effect.timeout("5 seconds")
+)
+```
+
+## pipe — layering on behavior
+
+`pipe` applies transformations left-to-right. Use it to add cross-cutting concerns without modifying the effect body:
+
+```ts
+const program = fetchData.pipe(
+  Effect.timeout("5 seconds"),
+  Effect.retry(Schedule.exponential("100 millis")),
+  Effect.tap((data) => Effect.log(`Fetched ${data.length} items`)),
+  Effect.withSpan("fetchData")
+)
+```
+
+## Creating effects
+
+| Constructor | Use when |
+|-------------|----------|
+| `Effect.succeed(value)` | You have a pure value |
+| `Effect.fail(error)` | You have a typed error |
+| `Effect.sync(() => ...)` | Synchronous side effect |
+| `Effect.promise((signal) => ...)` | Wrapping a Promise (no typed error) |
+| `Effect.tryPromise({ try, catch })` | Wrapping a Promise with error mapping |
+| `Effect.async(resume => ...)` | Callback-based APIs |
+| `Effect.gen(function*() { ... })` | Composing multiple effects |
+
+## Running effects
+
+Effects are descriptions — they don't execute until you run them:
+
+```ts
+// In a program entry point:
+import { NodeRuntime } from "@effect/platform-node"
+NodeRuntime.runMain(program) // handles signals, error reporting
+
+// In tests or one-off scripts:
+Effect.runPromise(program)   // returns Promise<A>, throws on failure
+Effect.runSync(program)      // synchronous, throws if async
+```
+
+## Key combinators
+
+- `Effect.map(f)` — transform the success value
+- `Effect.flatMap(f)` — chain into another effect
+- `Effect.tap(f)` — side-effect on success without changing the value
+- `Effect.all([a, b, c])` — run effects concurrently, collect results
+- `Effect.forEach(items, f)` — map over items effectfully
+- `Effect.andThen(next)` — sequence two effects
+- `Effect.provide(layer)` — satisfy requirements
+
+## Where to look in the codebase
+
+- **Public API**: `packages/effect/src/Effect.ts` — 470KB+ of exports and docstrings. The docstrings are comprehensive; read them for any combinator you're unsure about.
+- **Core primitives**: `packages/effect/src/internal/core.ts` and `core-effect.ts` — the fundamental building blocks (`succeed`, `fail`, `flatMap`, `sync`, etc.)
+- **Runtime engine**: `packages/effect/src/internal/fiberRuntime.ts` — how effects are actually executed. This is where the fiber scheduler, interruption handling, and stack-safe recursion live.
+- **Effect.fn implementation**: search for `export const fn` in `Effect.ts` (~line 14630)

--- a/.claude/skills/effect-ts/references/error-handling.md
+++ b/.claude/skills/effect-ts/references/error-handling.md
@@ -1,0 +1,130 @@
+# Error Handling
+
+Effect distinguishes between two kinds of failures:
+
+- **Expected errors** (`E`) — domain errors you model and handle. Tracked in the type system.
+- **Defects** — unexpected crashes (bugs, null pointers, OOM). Not in the `E` type. Propagate as unrecoverable unless explicitly caught.
+
+This distinction matters: you handle expected errors with combinators; defects kill the fiber unless intercepted.
+
+## Defining domain errors
+
+Use `Schema.TaggedError` for errors that need serialization (across network, logging, persistence). Use `Data.TaggedError` for lightweight internal errors.
+
+```ts
+import { Schema, Data } from "effect"
+
+// Schema-based (serializable, schema-validated):
+class NotFound extends Schema.TaggedError<NotFound>("NotFound")(
+  "NotFound",
+  { id: Schema.String }
+) {}
+
+// Data-based (lightweight, no schema overhead):
+class Timeout extends Data.TaggedError("Timeout")<{
+  readonly duration: number
+}> {}
+```
+
+Both are yieldable — you can short-circuit an `Effect.gen` by yielding them directly:
+
+```ts
+const findUser = Effect.fn("findUser")(function*(id: string) {
+  const user = yield* db.query(`SELECT * FROM users WHERE id = ?`, id)
+  if (!user) {
+    return yield* new NotFound({ id })  // short-circuits with typed error
+  }
+  return user
+})
+// findUser: (id: string) => Effect<User, NotFound, Database>
+```
+
+## Catching errors
+
+```ts
+// Catch a specific error by tag:
+program.pipe(
+  Effect.catchTag("NotFound", (err) =>
+    Effect.succeed({ fallback: true, id: err.id })
+  )
+)
+
+// Catch multiple tags at once:
+program.pipe(
+  Effect.catchTags({
+    NotFound: (err) => Effect.succeed(null),
+    Timeout: (err) => Effect.succeed(null),
+  })
+)
+
+// Catch all expected errors:
+program.pipe(
+  Effect.catchAll((err) => Effect.succeed("recovered"))
+)
+
+// Catch based on a predicate:
+program.pipe(
+  Effect.catchIf(
+    (err): err is NotFound => err._tag === "NotFound" && err.id === "admin",
+    (err) => Effect.succeed(adminFallback)
+  )
+)
+```
+
+## Converting between error types
+
+```ts
+// Expected error -> defect (you're asserting it won't happen):
+const config = yield* loadConfig.pipe(Effect.orDie)
+
+// Defect -> expected error:
+program.pipe(Effect.catchAllDefect((defect) => Effect.fail(new AppError({ cause: defect }))))
+
+// Transform an error:
+program.pipe(
+  Effect.mapError((err) => new HigherLevelError({ cause: err }))
+)
+```
+
+## Cause — the full failure picture
+
+When an effect fails, the failure is wrapped in a `Cause` that captures everything that went wrong — including parallel failures, interruption, and defects:
+
+```ts
+program.pipe(
+  Effect.catchAllCause((cause) => {
+    // cause contains the full tree of failures
+    const failures = Cause.failures(cause)  // just the E values
+    const defects = Cause.defects(cause)    // just the unexpected throws
+    return Effect.log(`Failed: ${Cause.pretty(cause)}`)
+  })
+)
+```
+
+## The error channel in practice
+
+The type system tracks your error channel through composition:
+
+```ts
+const a: Effect<string, NotFound, never> = ...
+const b: Effect<number, Timeout, never> = ...
+
+const c = Effect.gen(function*() {
+  const s = yield* a
+  const n = yield* b
+  return `${s}: ${n}`
+})
+// c: Effect<string, NotFound | Timeout, never>
+//                   ^-- union of all yielded errors
+```
+
+When you `catchTag("NotFound", ...)`, it's *removed* from the error union. When all errors are handled, `E` becomes `never`.
+
+## Where to look in the codebase
+
+- **Cause type**: `packages/effect/src/Cause.ts` — `Fail`, `Die`, `Interrupt`, `Sequential`, `Parallel`, `Empty` variants, plus `pretty`, `failures`, `defects`
+- **Exit type**: `packages/effect/src/Exit.ts` — `Exit<A, E> = Success<A> | Failure<Cause<E>>`
+- **Cause internals**: `packages/effect/src/internal/cause.ts` — rendering, folding, matching
+- **Error catching**: search `Effect.ts` for `catchTag`, `catchAll`, `catchAllCause`
+- **Data.TaggedError**: `packages/effect/src/Data.ts` — `export const TaggedError`
+- **Schema.TaggedError**: `packages/effect/src/Schema.ts` — `export const TaggedError`

--- a/.claude/skills/effect-ts/references/patterns.md
+++ b/.claude/skills/effect-ts/references/patterns.md
@@ -1,0 +1,191 @@
+# Patterns & Idioms
+
+Common recipes and anti-patterns distilled from idiomatic Effect codebases.
+
+## The service pattern — the core workflow
+
+Effect development follows a service-driven workflow:
+
+1. **Define the service interface** — what methods does it expose?
+2. **Write business logic** that uses the service (via `yield*`)
+3. **Implement the layer** — how is the service constructed?
+4. **Wire at the edge** — provide all layers at the entry point
+
+```ts
+// 1. Define the interface:
+class UserRepo extends Context.Tag("@app/UserRepo")<
+  UserRepo,
+  {
+    readonly findById: (id: UserId) => Effect.Effect<User, NotFound>
+    readonly save: (user: User) => Effect.Effect<void>
+  }
+>() {}
+
+// 2. Business logic uses the service:
+const registerUser = Effect.fn("registerUser")(function*(input: RegisterInput) {
+  const user = yield* validateInput(input)
+  const repo = yield* UserRepo
+  yield* repo.save(user)
+  return user
+})
+
+// 3. Implement the layer:
+const UserRepoLive = Layer.effect(
+  UserRepo,
+  Effect.gen(function*() {
+    const sql = yield* SqlClient
+    return {
+      findById: Effect.fn("UserRepo.findById")(function*(id) {
+        const row = yield* sql`SELECT * FROM users WHERE id = ${id}`
+        if (row.length === 0) return yield* new NotFound({ id })
+        return row[0]
+      }),
+      save: Effect.fn("UserRepo.save")(function*(user) {
+        yield* sql`INSERT INTO users ${sql.insert(user)}`
+      })
+    }
+  })
+)
+
+// 4. Wire at the entry point:
+const main = registerUser(input).pipe(
+  Effect.provide(UserRepoLive.pipe(Layer.provide(SqlLive)))
+)
+```
+
+## The "use" pattern — wrapping third-party libraries
+
+When integrating Promise-based libraries, expose a `use` callback instead of the raw client:
+
+```ts
+class PrismaClient extends Context.Tag("@app/PrismaClient")<
+  PrismaClient,
+  {
+    readonly use: <A>(
+      fn: (client: PrismaClientType, signal: AbortSignal) => Promise<A>
+    ) => Effect.Effect<A, PrismaError>
+  }
+>() {}
+
+const PrismaLive = Layer.scoped(
+  PrismaClient,
+  Effect.gen(function*() {
+    const client = new PrismaClientType()
+    yield* Effect.addFinalizer(() => Effect.promise(() => client.$disconnect()))
+    return {
+      use: (fn) => Effect.tryPromise({
+        try: (signal) => fn(client, signal),
+        catch: (cause) => new PrismaError({ cause })
+      })
+    }
+  })
+)
+
+// Usage:
+const users = yield* prisma.use((client) => client.user.findMany())
+```
+
+This gives you: automatic error wrapping, AbortSignal for interruption support, and encapsulation of the underlying client.
+
+## Config pattern
+
+```ts
+import { Config, ConfigProvider } from "effect"
+
+// Read config values:
+const port = yield* Config.number("PORT")
+const apiKey = yield* Config.redacted("API_KEY") // prevents accidental logging
+
+// Provide test config:
+const testConfig = ConfigProvider.fromJson({ PORT: 3000, API_KEY: "test" })
+program.pipe(Effect.provide(Layer.setConfigProvider(testConfig)))
+```
+
+For complex config, define a service:
+
+```ts
+class AppConfig extends Effect.Service<AppConfig>()("@app/Config", {
+  effect: Effect.gen(function*() {
+    return {
+      port: yield* Config.number("PORT"),
+      dbUrl: yield* Config.string("DATABASE_URL"),
+      apiKey: yield* Config.redacted("API_KEY")
+    }
+  })
+}) {}
+```
+
+## Naming conventions
+
+- **Service identifiers**: `"@app/ServiceName"` — namespaced, globally unique
+- **Layer properties**: `Default` (from `Effect.Service`), or `Live`/`Test` as static properties
+- **Effect.fn names**: match the function name — `Effect.fn("processUser")`
+- **Error tags**: match the class name — `Schema.TaggedError<NotFound>("NotFound")("NotFound", ...)`
+- **Branded types**: descriptive noun — `Schema.brand("UserId")`, `Schema.brand("Email")`
+
+## Anti-patterns to avoid
+
+**1. Scattering `Effect.provide` throughout business logic**
+
+Provide layers once at the entry point. Business logic should declare what it needs via `R`, not wire its own dependencies.
+
+**2. Breaking layer memoization with function calls**
+
+```ts
+// BAD — each call creates a new layer reference, so it builds twice:
+const a = serviceA.pipe(Layer.provide(makeDbLayer()))
+const b = serviceB.pipe(Layer.provide(makeDbLayer()))
+
+// GOOD — same reference, built once:
+const db = makeDbLayer()
+const a = serviceA.pipe(Layer.provide(db))
+const b = serviceB.pipe(Layer.provide(db))
+```
+
+**3. Dependencies in service method signatures**
+
+Service methods should have `R = never`. Dependencies are resolved when building the layer, not when calling methods:
+
+```ts
+// BAD — dependency leaks into every call site:
+class UserRepo {
+  findById: (id: string) => Effect.Effect<User, NotFound, Database>
+}
+
+// GOOD — dependency resolved at construction:
+class UserRepo {
+  findById: (id: string) => Effect.Effect<User, NotFound>
+}
+// Database is acquired in the Layer, not per-method
+```
+
+**4. Using `it.layer` when per-test isolation is needed**
+
+`it.layer` shares one instance across all tests in a describe block. State leaks between tests. Prefer `Effect.provide` per test unless the resource is truly expensive to create.
+
+**5. Forgetting `Effect.fn` for reusable functions**
+
+`Effect.fn` adds tracing spans with the function name. Anonymous `Effect.gen` closures lose debugging context. Always name reusable effectful functions.
+
+**6. Raw primitives instead of branded types**
+
+Use `Schema.brand` for domain primitives. A `string` that represents a UserId should be typed differently from one that represents an OrderId.
+
+**7. Using `Effect.gen` for simple single-effect transforms**
+
+```ts
+// Unnecessary ceremony:
+Effect.gen(function*() {
+  const result = yield* someEffect
+  return result.map(transform)
+})
+
+// Just pipe:
+someEffect.pipe(Effect.map(transform))
+```
+
+## Where to look for more patterns
+
+- **effect-solutions** (`github.com/kitlangton/effect-solutions`) — curated idiomatic patterns with tests
+- **effect-smol** (`github.com/Effect-TS/effect-smol`) — Effect v4 examples in `ai-docs/src/`
+- **Effect docstrings** — `packages/effect/src/Effect.ts` has comprehensive examples in JSDoc

--- a/.claude/skills/effect-ts/references/resource-management.md
+++ b/.claude/skills/effect-ts/references/resource-management.md
@@ -1,0 +1,119 @@
+# Resource Management
+
+Effect guarantees that resources are cleaned up, even when fibers are interrupted or errors occur. This is built on `Scope` — an abstraction that tracks finalizers and runs them when the scope closes.
+
+## Scope — the lifecycle container
+
+A `Scope` collects finalizers (cleanup functions) and runs them when it closes. You rarely create scopes manually — they're created by `Effect.scoped`, Layer construction, and fiber forking.
+
+The key mental model: when you acquire a resource inside a scope, you register a finalizer. When the scope ends — whether by success, failure, or interruption — all finalizers run in reverse order.
+
+## acquireRelease — the core pattern
+
+```ts
+import { Effect } from "effect"
+
+const managedConnection = Effect.acquireRelease(
+  // Acquire:
+  Effect.tryPromise(() => pool.getConnection()),
+  // Release (runs on scope close):
+  (conn) => Effect.promise(() => conn.release())
+)
+
+// Use within a scope:
+const program = Effect.scoped(
+  Effect.gen(function*() {
+    const conn = yield* managedConnection
+    return yield* conn.query("SELECT * FROM users")
+  })
+)
+// Connection is released when the scope exits
+```
+
+The release function runs regardless of how the scope ends — success, failure, or interruption. You can also inspect the exit value:
+
+```ts
+Effect.acquireRelease(
+  acquire,
+  (resource, exit) =>
+    Exit.isFailure(exit)
+      ? Effect.log("Cleaning up after failure")
+      : Effect.log("Clean exit")
+)
+```
+
+## addFinalizer — ad-hoc cleanup
+
+When you don't have a distinct acquire/release pair, use `addFinalizer` to register cleanup:
+
+```ts
+const program = Effect.gen(function*() {
+  const tmpDir = yield* createTempDir()
+  yield* Effect.addFinalizer(() => removeTempDir(tmpDir))
+  // tmpDir is cleaned up when the enclosing scope ends
+  return yield* doWorkIn(tmpDir)
+})
+```
+
+## ensuring — unconditional cleanup
+
+`Effect.ensuring` runs a finalizer after the effect completes, regardless of outcome:
+
+```ts
+const program = doWork.pipe(
+  Effect.ensuring(cleanup)
+)
+```
+
+This is simpler than `acquireRelease` but doesn't give you access to the acquired resource.
+
+## Scoped resources in Layers
+
+Layers with resources use `Layer.scoped` — the resource lives as long as the layer's scope:
+
+```ts
+const DatabaseLive = Layer.scoped(
+  Database,
+  Effect.gen(function*() {
+    const config = yield* AppConfig
+    const pool = yield* Effect.acquireRelease(
+      Effect.tryPromise(() => createPool(config.dbUrl)),
+      (pool) => Effect.promise(() => pool.end())
+    )
+    return {
+      query: (sql) => Effect.tryPromise(() => pool.query(sql)),
+      execute: (sql) => Effect.tryPromise(() => pool.execute(sql))
+    }
+  })
+)
+```
+
+The pool lives for the lifetime of the application (or test) and is properly closed when the layer is torn down.
+
+## Nested scopes
+
+Scopes nest naturally. Inner scopes finalize before outer scopes:
+
+```ts
+const program = Effect.scoped(
+  Effect.gen(function*() {
+    const outer = yield* acquireOuter
+    const result = yield* Effect.scoped(
+      Effect.gen(function*() {
+        const inner = yield* acquireInner
+        return yield* useResources(outer, inner)
+      })
+    )
+    // inner is released here, outer is still alive
+    return yield* moreWork(outer, result)
+  })
+)
+// outer is released here
+```
+
+## Where to look in the codebase
+
+- **Scope public API**: `packages/effect/src/Scope.ts` — Scope type, `addFinalizer`, `close`
+- **acquireRelease**: search `Effect.ts` for `acquireRelease` — several variants (`acquireRelease`, `acquireUseRelease`)
+- **Scope internals**: `packages/effect/src/internal/fiberScope.ts` — how scopes track and run finalizers
+- **Layer.scoped**: `packages/effect/src/Layer.ts` — search for `scoped`

--- a/.claude/skills/effect-ts/references/scheduling.md
+++ b/.claude/skills/effect-ts/references/scheduling.md
@@ -1,0 +1,92 @@
+# Scheduling
+
+`Schedule<Out, In, R>` describes a recurrence pattern — when and how many times to repeat or retry an effect. Schedules are composable: you build complex retry/repeat policies from simple building blocks.
+
+## Common schedules
+
+```ts
+import { Schedule } from "effect"
+
+Schedule.forever                          // repeat indefinitely
+Schedule.once                             // run one additional time
+Schedule.recurs(5)                        // repeat 5 times
+Schedule.spaced("1 second")              // fixed delay between runs
+Schedule.fixed("1 second")              // fixed interval (compensates for execution time)
+Schedule.exponential("100 millis")       // 100ms, 200ms, 400ms, 800ms...
+Schedule.exponential("100 millis", 1.5)  // custom growth factor
+Schedule.fibonacci("100 millis")         // fibonacci-based delays
+```
+
+## Composing schedules
+
+```ts
+// Exponential backoff, max 5 retries:
+Schedule.exponential("100 millis").pipe(
+  Schedule.compose(Schedule.recurs(5))
+)
+
+// Exponential with a ceiling:
+Schedule.exponential("100 millis").pipe(
+  Schedule.either(Schedule.spaced("10 seconds")) // cap at 10s
+)
+
+// Add jitter to avoid thundering herd:
+Schedule.exponential("100 millis").pipe(
+  Schedule.jittered
+)
+
+// Union — continue while either schedule wants to continue:
+Schedule.union(scheduleA, scheduleB)
+
+// Intersection — continue only while both want to continue:
+Schedule.intersect(scheduleA, scheduleB)
+```
+
+## Using with retry and repeat
+
+```ts
+// Retry a failing effect:
+const result = yield* fetchData.pipe(
+  Effect.retry(Schedule.exponential("100 millis").pipe(
+    Schedule.compose(Schedule.recurs(3))
+  ))
+)
+
+// Retry with a filter (only retry certain errors):
+yield* fetchData.pipe(
+  Effect.retry({
+    schedule: Schedule.recurs(3),
+    while: (err) => err._tag === "Timeout"
+  })
+)
+
+// Repeat a succeeding effect:
+yield* pollForUpdates.pipe(
+  Effect.repeat(Schedule.spaced("5 seconds"))
+)
+
+// Repeat until a condition:
+yield* pollForUpdates.pipe(
+  Effect.repeat({
+    schedule: Schedule.spaced("1 second"),
+    until: (result) => result.status === "complete"
+  })
+)
+```
+
+## Simplified retry
+
+For simple cases, `Effect.retry` accepts a plain object:
+
+```ts
+yield* fetchData.pipe(
+  Effect.retry({ times: 3 })
+)
+```
+
+## Where to look in the codebase
+
+- **Schedule public API**: `packages/effect/src/Schedule.ts` — all constructors and combinators
+- **Schedule internals**: `packages/effect/src/internal/schedule.ts`
+- **ScheduleDecision**: `packages/effect/src/ScheduleDecision.ts` — continue/done decisions
+- **retry/repeat**: search `Effect.ts` for `retry` and `repeat`

--- a/.claude/skills/effect-ts/references/schema-and-data.md
+++ b/.claude/skills/effect-ts/references/schema-and-data.md
@@ -1,0 +1,135 @@
+# Schema & Data Modeling
+
+`Schema` is the single source of truth for your domain types. One definition gives you TypeScript types, runtime validation, JSON encoding/decoding, and equality — no separate type declarations, no divergence between what you validate and what you type-check.
+
+## Schema.Class — domain models
+
+```ts
+import { Schema } from "effect"
+
+const UserId = Schema.String.pipe(Schema.brand("UserId"))
+type UserId = typeof UserId.Type
+
+class User extends Schema.Class<User>("User")({
+  id: UserId,
+  name: Schema.String,
+  email: Schema.String,
+  createdAt: Schema.DateFromSelf,
+}) {
+  // You can add computed properties and methods:
+  get displayName() {
+    return `${this.name} <${this.email}>`
+  }
+}
+```
+
+Now `User` is simultaneously:
+- A TypeScript type (`User` with `.id`, `.name`, `.email`, `.createdAt`)
+- A runtime validator (`Schema.decodeUnknown(User)(rawData)`)
+- A JSON codec (`Schema.encode(User)(user)` / `Schema.decode(User)(json)`)
+- An equality-comparable value (structural comparison via `Equal`)
+
+## Branded types
+
+Branded types prevent mixing primitives that represent different things:
+
+```ts
+const UserId = Schema.String.pipe(Schema.brand("UserId"))
+const OrderId = Schema.String.pipe(Schema.brand("OrderId"))
+
+type UserId = typeof UserId.Type   // string & Brand<"UserId">
+type OrderId = typeof OrderId.Type // string & Brand<"OrderId">
+
+// Compiler prevents: findUser(orderId) — types don't match
+```
+
+The guidance from the Effect community is that nearly all domain primitives should be branded — not just IDs, but emails, URLs, ports, amounts, etc.
+
+## Schema.TaggedError — domain errors
+
+Errors that need serialization, pattern matching, or schema validation:
+
+```ts
+class ValidationError extends Schema.TaggedError<ValidationError>("ValidationError")(
+  "ValidationError",
+  {
+    field: Schema.String,
+    message: Schema.String,
+  }
+) {
+  // Optional: custom message getter for logging
+  get message() {
+    return `${this.field}: ${this.message}`
+  }
+}
+```
+
+These are yieldable in `Effect.gen` (short-circuits with the error) and have a `_tag` field for pattern matching with `Effect.catchTag`.
+
+## Data.TaggedError — lightweight errors
+
+When you don't need schema validation/serialization:
+
+```ts
+import { Data } from "effect"
+
+class Timeout extends Data.TaggedError("Timeout")<{
+  readonly duration: number
+}> {}
+```
+
+Same yieldable behavior, same `_tag` for catchTag — just no schema overhead.
+
+## Common schema combinators
+
+```ts
+// Primitives:
+Schema.String, Schema.Number, Schema.Boolean, Schema.Date
+
+// Optional fields:
+Schema.optional(Schema.String)           // T | undefined
+Schema.optionalWith(Schema.String, { default: () => "" })
+
+// Unions and literals:
+Schema.Union(Schema.String, Schema.Number)
+Schema.Literal("admin", "user", "guest")
+
+// Arrays and records:
+Schema.Array(User)
+Schema.Record({ key: Schema.String, value: Schema.Number })
+
+// Transformations (e.g., string -> number):
+Schema.NumberFromString  // decodes "42" to 42
+
+// Filters:
+Schema.String.pipe(Schema.minLength(1), Schema.maxLength(255))
+Schema.Number.pipe(Schema.int(), Schema.between(1, 65535))
+```
+
+## Encoding and decoding
+
+```ts
+import { Schema } from "effect"
+
+// Decode unknown data (validation):
+const result = Schema.decodeUnknownSync(User)({
+  id: "usr_123",
+  name: "Alice",
+  email: "alice@example.com",
+  createdAt: new Date()
+})
+
+// As an Effect (typed errors):
+const decoded = yield* Schema.decodeUnknown(User)(rawData)
+
+// Encode to JSON-safe format:
+const json = Schema.encodeSync(User)(user)
+```
+
+## Where to look in the codebase
+
+- **Schema public API**: `packages/effect/src/Schema.ts` — all constructors, combinators, class builders
+- **Schema AST**: `packages/effect/src/SchemaAST.ts` — the abstract syntax tree that schemas compile to
+- **ParseResult**: `packages/effect/src/ParseResult.ts` — parse error representation
+- **Schema internals**: `packages/effect/src/internal/schema/` — encoding, decoding, validation logic
+- **Data module**: `packages/effect/src/Data.ts` — `TaggedError`, `TaggedClass`, `Class`, structural equality helpers

--- a/.claude/skills/effect-ts/references/services-and-layers.md
+++ b/.claude/skills/effect-ts/references/services-and-layers.md
@@ -1,0 +1,155 @@
+# Services & Layers
+
+Effect's dependency injection system makes dependencies explicit in the type system. Instead of importing singletons or using a DI container, you declare what a computation *needs* (via `R`) and satisfy those needs with `Layer`.
+
+## Defining a service
+
+A service is a typed contract with a unique identifier. Use `Context.Tag` for the basic pattern:
+
+```ts
+import { Context, Effect, Layer } from "effect"
+
+class Database extends Context.Tag("@app/Database")<
+  Database,
+  {
+    readonly query: (sql: string) => Effect.Effect<unknown[]>
+    readonly execute: (sql: string) => Effect.Effect<void>
+  }
+>() {}
+```
+
+The string `"@app/Database"` must be globally unique. The second type parameter defines the service's interface.
+
+To access a service in an Effect:
+
+```ts
+const program = Effect.gen(function*() {
+  const db = yield* Database         // pulls Database from the R context
+  const rows = yield* db.query("SELECT * FROM users")
+  return rows
+})
+// program: Effect<unknown[], never, Database>
+//                                     ^-- requires Database
+```
+
+## Effect.Tag — service with proxy accessors
+
+`Effect.Tag` extends `Context.Tag` with proxy methods, so you can call service methods directly on the tag:
+
+```ts
+class Notifications extends Effect.Tag("@app/Notifications")<
+  Notifications,
+  { readonly notify: (msg: string) => Effect.Effect<void> }
+>() {}
+
+// Instead of: yield* Notifications, then call .notify(...)
+// You can do:
+const program = Notifications.notify("hello") // Effect<void, never, Notifications>
+```
+
+## Effect.Service — service + layer in one
+
+For services where implementation and definition are co-located:
+
+```ts
+class Prefix extends Effect.Service<Prefix>()("@app/Prefix", {
+  succeed: { prefix: "PRE" }
+}) {}
+
+class Logger extends Effect.Service<Logger>()("@app/Logger", {
+  effect: Effect.gen(function*() {
+    const { prefix } = yield* Prefix
+    return {
+      info: (msg: string) => Effect.log(`[${prefix}] ${msg}`)
+    }
+  }),
+  dependencies: [Prefix.Default]
+}) {}
+```
+
+This creates both the tag and a `Logger.Default` layer automatically.
+
+## Building layers
+
+Layers describe how to construct services. They are memoized by default — a layer is only built once even if multiple services depend on it.
+
+```ts
+// From an effect (async, can use other services):
+const DatabaseLive = Layer.effect(
+  Database,
+  Effect.gen(function*() {
+    const config = yield* AppConfig
+    const pool = yield* createPool(config.dbUrl)
+    yield* Effect.addFinalizer(() => Effect.promise(() => pool.end()))
+    return {
+      query: (sql) => Effect.tryPromise(() => pool.query(sql)),
+      execute: (sql) => Effect.tryPromise(() => pool.execute(sql))
+    }
+  })
+)
+
+// From a synchronous value (no dependencies):
+const ConfigTest = Layer.succeed(AppConfig, { dbUrl: "sqlite::memory:" })
+
+// From a sync function:
+const InMemoryDb = Layer.sync(Database, () => {
+  const store = new Map()
+  return {
+    query: (sql) => Effect.succeed([...store.values()]),
+    execute: (sql) => Effect.sync(() => { store.set(sql, true) })
+  }
+})
+```
+
+## Composing layers
+
+```ts
+// provide: satisfy a layer's dependencies
+const DbWithConfig = DatabaseLive.pipe(Layer.provide(ConfigLive))
+
+// merge: combine independent layers
+const AllServices = Layer.merge(DatabaseLive, LoggerLive)
+
+// provideMerge: provide AND keep the provider in the output
+// (useful in tests — you can access both the service AND its dependencies)
+const TestStack = ServiceLive.pipe(
+  Layer.provideMerge(InMemoryDb),
+  Layer.provideMerge(ConfigTest)
+)
+```
+
+## Provide once at the entry point
+
+Wire everything at the edge of your program. Business logic should never call `Effect.provide`:
+
+```ts
+// main.ts
+const AppLive = Layer.mergeAll(DatabaseLive, LoggerLive, AuthLive).pipe(
+  Layer.provide(ConfigLive)
+)
+
+const main = program.pipe(Effect.provide(AppLive))
+NodeRuntime.runMain(main)
+```
+
+## Layer memoization
+
+Layers are memoized by reference. If two consumers depend on the same `Layer` *reference*, it's built once:
+
+```ts
+// GOOD — same reference, built once:
+const shared = DatabaseLive
+const a = ServiceA.pipe(Layer.provide(shared))
+const b = ServiceB.pipe(Layer.provide(shared))
+
+// BAD — different references from a function call, built twice:
+const a = ServiceA.pipe(Layer.provide(makeDatabaseLayer()))
+const b = ServiceB.pipe(Layer.provide(makeDatabaseLayer()))
+```
+
+## Where to look in the codebase
+
+- **Layer public API**: `packages/effect/src/Layer.ts` — constructors, combinators, docstrings
+- **Context/Tag**: `packages/effect/src/Context.ts` — Tag class, context manipulation
+- **Layer internals**: `packages/effect/src/internal/layer/` — memoization, circular dependency handling
+- **Effect.Tag/Service**: search `Effect.ts` for `export const Tag` (~line 13505) and `export const Service` (~line 13585)

--- a/.claude/skills/effect-ts/references/streams.md
+++ b/.claude/skills/effect-ts/references/streams.md
@@ -1,0 +1,106 @@
+# Streams
+
+`Stream<A, E, R>` is a pull-based streaming abstraction with built-in backpressure. Think of it as an effectful, lazy, potentially infinite sequence of values — like an async generator but with typed errors, resource safety, and composable operators.
+
+## Creating streams
+
+```ts
+import { Effect, Stream } from "effect"
+
+// From values:
+Stream.make(1, 2, 3)
+Stream.fromIterable([1, 2, 3])
+Stream.range(1, 10)
+
+// From effects:
+Stream.fromEffect(fetchUser(id))
+
+// Repeated/unfolding:
+Stream.repeat(fetchLatest, Schedule.spaced("1 second"))
+Stream.unfold(0, (n) => Option.some([n, n + 1] as const))
+
+// From async sources:
+Stream.async<string>((emit) => {
+  socket.on("message", (msg) => emit.single(msg))
+  socket.on("error", (err) => emit.fail(new SocketError({ cause: err })))
+  socket.on("close", () => emit.end())
+})
+
+// From Queue or PubSub:
+Stream.fromQueue(queue)
+Stream.fromPubSub(pubsub)
+
+// Chunked for efficiency:
+Stream.fromChunk(Chunk.make(1, 2, 3))
+```
+
+## Transforming streams
+
+```ts
+stream.pipe(
+  Stream.map((x) => x * 2),
+  Stream.filter((x) => x > 10),
+  Stream.take(100),
+  Stream.mapEffect((x) => processItem(x)),            // effectful transform
+  Stream.mapEffect((x) => processItem(x), { concurrency: 5 }), // concurrent
+  Stream.flatMap((x) => Stream.make(x, x + 1)),       // 1-to-many
+  Stream.tap((x) => Effect.log(`Processing: ${x}`)),
+  Stream.scan(0, (acc, x) => acc + x),                 // running accumulation
+  Stream.debounce("500 millis"),
+  Stream.throttle({ units: 10, duration: "1 second", strategy: "shape" }),
+  Stream.grouped(100),                                  // batch into chunks
+  Stream.groupByKey((item) => item.category),           // partition by key
+)
+```
+
+## Consuming streams
+
+```ts
+// Collect all values:
+const items = yield* Stream.runCollect(stream) // returns Chunk<A>
+
+// Process each value:
+yield* Stream.runForEach(stream, (item) => processItem(item))
+
+// Fold into a single result:
+const sum = yield* Stream.runFold(stream, 0, (acc, n) => acc + n)
+
+// Take the first value:
+const first = yield* Stream.runHead(stream)
+
+// Drain (run for side effects only):
+yield* Stream.runDrain(stream)
+
+// Into a Sink:
+yield* stream.pipe(Stream.run(mySink))
+```
+
+## Sink — stream consumers
+
+A `Sink<A, In, L, E, R>` describes how to consume stream elements and produce a result:
+
+```ts
+import { Sink, Stream } from "effect"
+
+// Built-in sinks:
+Sink.collectAll()           // collect into Chunk
+Sink.fold(0, () => true, (acc, n: number) => acc + n)  // fold
+Sink.forEach((item) => processItem(item))               // side-effect each
+Sink.take(10)               // take first 10 elements
+
+// Use with Stream.run:
+const result = yield* stream.pipe(Stream.run(Sink.collectAll()))
+```
+
+## Channel — the low-level primitive
+
+`Channel` is the underlying primitive that both `Stream` and `Sink` compile to. You rarely use it directly, but understanding it helps when you need to build custom stream operators. A Channel reads input, writes output, and can fail or succeed — it's the I/O kernel beneath the streaming abstractions.
+
+## Where to look in the codebase
+
+- **Stream public API**: `packages/effect/src/Stream.ts` — all constructors and combinators
+- **Sink public API**: `packages/effect/src/Sink.ts`
+- **Channel**: `packages/effect/src/Channel.ts` — the low-level I/O primitive
+- **Chunk**: `packages/effect/src/Chunk.ts` — efficient batch data structure used throughout streaming
+- **Stream internals**: `packages/effect/src/internal/stream/` and `internal/core-stream.ts`
+- **Channel internals**: `packages/effect/src/internal/channel/`

--- a/.claude/skills/effect-ts/references/testing.md
+++ b/.claude/skills/effect-ts/references/testing.md
@@ -1,0 +1,189 @@
+# Testing
+
+Effect provides `@effect/vitest` for testing effectful code. The core idea: tests are effects too. You get the same typed errors, dependency injection, and resource management inside your tests.
+
+## Setup
+
+```ts
+// vitest.setup.ts
+import { addEqualityTesters } from "@effect/vitest"
+addEqualityTesters() // enables Effect's structural equality in vitest matchers
+```
+
+```ts
+// vitest.config.ts
+import { defineConfig } from "vitest/config"
+export default defineConfig({
+  test: {
+    setupFiles: ["./vitest.setup.ts"]
+  }
+})
+```
+
+## Writing effect tests
+
+```ts
+import { describe, expect, it } from "@effect/vitest"
+import { Effect } from "effect"
+
+describe("UserService", () => {
+  // Test with the simulated clock (default):
+  it.effect("creates a user", () =>
+    Effect.gen(function*() {
+      const user = yield* createUser({ name: "Alice" })
+      expect(user.name).toBe("Alice")
+    })
+  )
+
+  // Test with the real clock (for actual timing):
+  it.live("measures real latency", () =>
+    Effect.gen(function*() {
+      const start = yield* Clock.currentTimeMillis
+      yield* Effect.sleep("100 millis")
+      const elapsed = (yield* Clock.currentTimeMillis) - start
+      expect(elapsed).toBeGreaterThanOrEqual(90)
+    })
+  )
+})
+```
+
+## Providing test dependencies
+
+The idiomatic pattern: define `testLayer` implementations using `Layer.sync` or `Layer.succeed`, then `Effect.provide` them in each test:
+
+```ts
+// In-memory implementation:
+const TestDatabase = Layer.sync(Database, () => {
+  const store = new Map<string, User>()
+  return {
+    query: (sql) => Effect.succeed([...store.values()]),
+    save: (user) => Effect.sync(() => { store.set(user.id, user) })
+  }
+})
+
+it.effect("saves and retrieves", () =>
+  Effect.gen(function*() {
+    const db = yield* Database
+    yield* db.save({ id: "1", name: "Alice" })
+    const users = yield* db.query("SELECT *")
+    expect(users).toHaveLength(1)
+  }).pipe(Effect.provide(TestDatabase))
+)
+```
+
+## Composing test layers with provideMerge
+
+Use `Layer.provideMerge` (not `Layer.provide`) when you need access to leaf services in your test for setup and assertions:
+
+```ts
+const TestStack = UserService.Default.pipe(
+  Layer.provideMerge(TestDatabase),  // Database is still accessible
+  Layer.provideMerge(TestConfig)
+)
+
+it.effect("user service calls database", () =>
+  Effect.gen(function*() {
+    // Can access both UserService AND the underlying Database:
+    const db = yield* Database
+    yield* db.save({ id: "1", name: "Alice" })
+
+    const userService = yield* UserService
+    const user = yield* userService.findById("1")
+    expect(user.name).toBe("Alice")
+  }).pipe(Effect.provide(TestStack))
+)
+```
+
+## TestClock — controlling time
+
+The test clock starts frozen. Advance it explicitly to trigger timeouts, delays, and schedules:
+
+```ts
+import { Effect, Fiber, TestClock } from "effect"
+
+it.effect("retries with exponential backoff", () =>
+  Effect.gen(function*() {
+    let attempts = 0
+    const task = Effect.gen(function*() {
+      attempts++
+      if (attempts < 3) {
+        return yield* Effect.fail("not yet")
+      }
+      return "done"
+    })
+
+    const fiber = yield* task.pipe(
+      Effect.retry(Schedule.exponential("1 second")),
+      Effect.fork
+    )
+
+    // Advance time to trigger retries:
+    yield* TestClock.adjust("1 second")  // first retry
+    yield* TestClock.adjust("2 seconds") // second retry (exponential)
+
+    const result = yield* Fiber.join(fiber)
+    expect(result).toBe("done")
+    expect(attempts).toBe(3)
+  })
+)
+```
+
+## withTestCtx — test context factory
+
+When a test suite needs a complex layer stack *and* access to test doubles for arrangement/assertion, extract both into an effectful factory:
+
+```ts
+const withTestCtx = Effect.fn(function*(
+  options: { initialUsers?: Array<User> } = {}
+) {
+  const testDb = yield* TestDatabase.make(options.initialUsers ?? [])
+  return {
+    db: testDb,                        // test double for arrangement/assertion
+    layer: Layer.empty.pipe(
+      Layer.merge(UserService.Default),
+      Layer.provideMerge(testDb.layer),
+      Layer.provide(TestConfigLive),
+      Layer.provide(TestLoggerLive),
+    ),
+  }
+})
+
+it.scoped("notifies on user creation", Effect.fn(function*() {
+  const ctx = yield* withTestCtx()
+
+  yield* Effect.gen(function*() {
+    const users = yield* UserService
+    yield* users.create({ name: "Alice" })
+  }).pipe(Effect.provide(ctx.layer))
+
+  // Assert against the test double directly:
+  expect(ctx.db.saved).toHaveLength(1)
+}))
+```
+
+This pattern hits a sweet spot between inline layers (repetitive) and `it.layer` (shared/leaky):
+- Each test gets a **fresh** context — no state leaks
+- The factory is **effectful** (`Effect.fn`), so it can do async setup and gets tracing for free
+- You get the composed **layer** for `Effect.provide` and direct handles to **test doubles** for assertions — in one call
+- Options let tests customize setup (seed data, feature flags) without rewriting the stack
+
+## it.layer — shared expensive resources
+
+When a resource is expensive to create (database connection, server), share it across a `describe` block:
+
+```ts
+describe.concurrent("with shared database", () => {
+  it.layer(ExpensiveDatabaseLayer)((it) => {
+    it.effect("test 1", () => Effect.gen(function*() { ... }))
+    it.effect("test 2", () => Effect.gen(function*() { ... }))
+  })
+})
+```
+
+Use `it.layer` sparingly — state leaks between tests. Prefer per-test `Effect.provide` for isolation.
+
+## Where to look in the codebase
+
+- **@effect/vitest**: `packages/vitest/src/` — `it.effect`, `it.live`, `it.layer`, equality testers
+- **TestClock**: `packages/effect/src/TestClock.ts` and `internal/testing/testClock.ts`
+- **TestContext**: `packages/effect/src/TestContext.ts` — bundles test services

--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,9 @@ tests/out/
 extension/.vscode-test/
 *.vsix
 .vscode-test/
-.claude/
-CLAUDE.md
+.claude/*
+!.claude/skills/
+.claude/settings.local.json
 
 # Coverage
 coverage/

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,251 +2,173 @@
 
 ## Overview
 
-The marimo Language Server Protocol (LSP) enables marimo notebooks to run
-natively in VS Code. It bridges VS Code's notebook interface with marimo's
-kernel runtime using both standard LSP notifications and custom LSP commands.
+marimo-lsp lets marimo notebooks run natively inside VS Code's notebook UI by
+bridging three independent runtimes. Three distinct LSP channels connect the
+extension to the server, and the server in turn proxies to the kernel:
 
 ```
-┌─────────────────┐                    ┌─────────────────┐                    ┌─────────────┐
-│    VS Code      │                    │   LSP Server    │                    │marimo kernel│
-├─────────────────┤                    │    (Python)     │                    │  (Session)  │
-│                 │  Standard LSP      │                 │                    │             │
-│ Notebook Editor │ ◄────────────────► │ Document Sync   │                    │             │
-│                 │  notifications     │                 │                    │             │
-├─────────────────┤                    ├─────────────────┤                    │             │
-│                 │  Custom LSP        │                 │     Python API     │             │
-│   Extension     │ ◄────────────────► │ Command Handler │ ◄─────────────────►│   Runtime   │
-│                 │  commands          │                 │                    │             │
-├─────────────────┤                    ├─────────────────┤                    │             │
-│                 │  marimo/operation  │                 │                    │             │
-│   UI Renderer   │ ◄──────────────────│ Session Consumer│ ◄──────────────────│   Messages  │
-│                 │  notifications     │                 │                    │             │
-└─────────────────┘                    └─────────────────┘                    └─────────────┘
+┌──────────────────┐                           ┌──────────────────┐                        ┌───────────────┐
+│     VS Code      │                           │   LSP server     │                        │ marimo kernel │
+│                  │                           │    (Python)      │                        │   (Session)   │
+├──────────────────┤  LSP notebook protocol    ├──────────────────┤                        │               │
+│  notebook editor │◄─────────────────────────►│  document sync   │                        │               │
+│  (vscode host)   │  didOpen / didChange / …  │                  │                        │               │
+├──────────────────┤  custom LSP commands      ├──────────────────┤   Session methods      │               │
+│    extension     │──────────────────────────►│ command handler  │───────────────────────►│    runtime    │
+│ (KernelManager)  │  marimo.run, interrupt, … │                  │                        │               │
+├──────────────────┤  marimo/operation push    ├──────────────────┤   SessionConsumer      │               │
+│    extension     │◄──────────────────────────│ session consumer │◄───────────────────────│   messages    │
+│ (KernelManager)  │                           │                  │                        │               │
+└──────────────────┘                           └──────────────────┘                        └───────────────┘
 ```
 
-## Protocol
+Each row is one channel with distinct semantics:
 
-The architecture uses three types of LSP communication:
+- **Top (document sync)** is standard LSP. VS Code streams notebook cell text
+  to the server; the server keeps an in-memory view so it can answer cell
+  questions without touching disk. The kernel is not involved.
+- **Middle (custom commands)** is the extension's outbound path. The
+  extension's `KernelManager` dispatches commands like `marimo.run`; the
+  server's command handler translates each into calls on the relevant
+  `Session` and its kernel subprocess.
+- **Bottom (operation push)** is the inbound path. The kernel emits messages
+  (cell state, variables, dataset previews, alerts, package install
+  progress); the server's session consumer wraps each in a `marimo/operation`
+  notification tagged with the notebook URI; the extension's `KernelManager`
+  receives them and fans them out to interested services.
 
-### 1. Standard LSP Notifications
+The kernel has no direct line to VS Code — the server is always in the
+middle, which makes the extension↔server protocol the load-bearing surface.
+The extension's `KernelManager` is the matched pair for the server's command
+handler (outbound) and session consumer (inbound).
 
-Document synchronization through LSP's notebook protocol:
+## Messaging
 
-- `notebookDocument/didOpen` - Track notebook open events and create sessions
-- `notebookDocument/didChange` - Sync cell content changes in real-time
-- `notebookDocument/didSave` - Handle save operations
-- `notebookDocument/didClose` - Clean up untitled sessions
+Three channels carry traffic between extension and server.
 
-### 2. Standard LSP Features
+**1. Document sync (standard LSP notebook protocol).** VS Code streams cell
+text to the server with `notebookDocument/didOpen`, `didChange`, `didSave`,
+`didClose`. The server uses these to keep an in-memory view of each notebook
+so it can answer questions about cells (codes, configs, names) without
+touching disk.
 
-Language features provided through standard LSP:
+**2. Language features (standard LSP).** `textDocument/completion` powers
+things like `@cell-name` cross-references; `textDocument/codeAction` offers
+conversion actions (e.g. Python / Jupyter → marimo). Normal request/response.
 
-- `textDocument/codeAction` - Provide code action to convert Python/Jupyter
-  files to marimo format
-- `textDocument/completion` - Cell code completions triggered by `@` character
-  for referencing other cell names
+**3. Custom commands and notifications.** Anything kernel-shaped rides on
+workspace commands (client → server) and server-pushed notifications. By
+category:
 
-### 3. Custom LSP Commands
+- *Lifecycle*: `marimo.run`, `marimo.interrupt`, `marimo.restart`. Creating a
+  session is a side effect of the first `marimo.run` on a given notebook URI
+  + Python executable.
+- *Interactivity*: `marimo.set_ui_element_value`, `marimo.function_call_request`.
+  UI widgets rendered inside cells bubble back through the extension and into
+  these commands.
+- *Conversion*: `marimo.serialize` / `marimo.deserialize` convert between the
+  notebook document and marimo's `.py` file format; `marimo.convert` creates a
+  new marimo file from Jupyter / plain Python input.
+- *Server push*: `marimo/operation` is the firehose. Every kernel state
+  update (cell execution transitions, variable diffs, dataset previews,
+  alerts, package-install progress, …) is tagged with a notebook URI and
+  streamed to the extension as a single notification type, carrying a
+  discriminated `operation` payload.
 
-Marimo-specific operations invoked by the extension:
+The exact request/response shapes live in the server's Python models and the
+extension's generated OpenAPI types. Treat this doc as the map, the code as
+the territory.
 
-<a name="marimo.run" href="#marimo.run">#</a> **marimo.run** ·
-[Source](src/marimo_lsp/server.py#L153)
+## A message in flight: running a cell
 
-Executes cells with specified IDs in the marimo kernel. Creates or reuses a
-session for the given notebook and Python executable.
+A concrete end-to-end flow:
 
-```typescript
-SessionCommand<RunRequest> {
-  notebookUri: string;
-  executable: string;  // Python interpreter path
-  inner: {
-    cellIds: string[];
-    codes: string[];
-  }
-}
-```
+1. **Extension** dispatches `marimo.run` with the notebook URI, the Python
+   executable, and the cells to run.
+2. **Server** looks up or creates the `Session` for that URI. On creation it
+   spins up a kernel subprocess (with `marimo` available in the user's
+   environment), wires stdio plumbing, and starts a `SessionConsumer` that
+   forwards kernel messages outward.
+3. **Kernel** receives the run request, executes the cell (and any reactively
+   dependent cells), and emits a stream of messages: queued → running →
+   outputs → idle, plus variable diffs, dataset previews, and anything else
+   touched by the execution.
+4. **Server** wraps each kernel message in a `marimo/operation` notification
+   tagged with the notebook URI and pushes it to the extension.
+5. **Extension** routes each operation to interested services in parallel —
+   cell execution state, output rendering, variables panel, datasources
+   panel, package install progress. Services subscribe by operation type, so
+   a single operation can fan out to many consumers.
 
-<a name="marimo.serialize" href="#marimo.serialize">#</a> **marimo.serialize** →
-`{source: string}` · [Source](src/marimo_lsp/server.py#L210)
+Interruption (`marimo.interrupt`) and UI interaction
+(`marimo.set_ui_element_value`) follow the same pattern: a command from the
+extension, a kernel side effect, a stream of operations back.
 
-Converts notebook document to marimo Python file format.
+## Composition
 
-```typescript
-{
-  notebook: NotebookSerialization;
-}
-```
+### Python side — adapting marimo's runtime to LSP
 
-<a name="marimo.deserialize" href="#marimo.deserialize">#</a>
-**marimo.deserialize** → `NotebookSerialization` ·
-[Source](src/marimo_lsp/server.py#L216)
+The server is a thin adapter. The heavy lifting (execution, reactivity, UI
+element state) is marimo's; the LSP layer replaces a few seams so marimo can
+drive from a live notebook document rather than a file.
 
-Converts marimo Python file to notebook document structure.
+- **Session manager** owns the notebook URI → `Session` mapping (see "Kernel
+  lifecycle" below for how that mapping is created and torn down).
+- **App file manager** adapts marimo's `AppFileManager` to read cells from
+  the in-memory LSP document state instead of a `.py` file — how a user's
+  live edits in VS Code reach the kernel's reactivity graph.
+- **Kernel manager** wraps the kernel subprocess, including interrupts and
+  cleanup.
+- **Session consumer** implements marimo's `SessionConsumer` interface and
+  forwards everything the kernel emits to the extension as `marimo/operation`
+  notifications.
 
-```typescript
-{
-  source: string;
-}
-```
+### Kernel lifecycle
 
-<a name="marimo.set_ui_element_value" href="#marimo.set_ui_element_value">#</a>
-**marimo.set_ui_element_value** · [Source](src/marimo_lsp/server.py#L173)
+Kernels live inside the server, not the extension. A few properties matter
+for debugging:
 
-Updates UI element values from frontend interactions.
-
-```typescript
-NotebookCommand<SetUIElementValueRequest> {
-  notebookUri: string;
-  inner: {
-    object_id: string;
-    value: any;
-  }
-}
-```
-
-<a name="marimo.function_call_request" href="#marimo.function_call_request">#</a>
-**marimo.function_call_request** · [Source](src/marimo_lsp/server.py#L185)
-
-Handles function call requests from UI elements (e.g., button clicks, form
-submissions).
-
-```typescript
-NotebookCommand<FunctionCallRequest> {
-  notebookUri: string;
-  inner: {
-    function_call_id: string;
-    args: Record<string, any>;
-    namespace: string;
-  }
-}
-```
-
-<a name="marimo.interrupt" href="#marimo.interrupt">#</a>
-**marimo.interrupt** · [Source](src/marimo_lsp/server.py#L197)
-
-Interrupts kernel execution for the specified notebook, stopping all running
-cells by sending SIGINT to the kernel process.
-
-```typescript
-NotebookCommand<InterruptRequest> {
-  notebookUri: string;
-  inner: {}
-}
-```
-
-<a name="marimo.convert" href="#marimo.convert">#</a> **marimo.convert** ·
-[Source](src/marimo_lsp/server.py#L237)
-
-Converts Python/Jupyter files to marimo format, creating a new `_mo.py` file
-and opening it in the editor.
-
-```typescript
-ConvertRequest {
-  uri: string; // File URI to convert
-}
-```
-
-### 4. Custom LSP Notifications
-
-Server-to-client notifications for kernel updates:
-
-<a name="marimo/operation" href="#marimo/operation">#</a> **marimo/operation** ·
-[Source](src/marimo_lsp/session_consumer.py#L48)
-
-Forwards kernel operations to the frontend. This is the primary communication
-channel for all kernel state updates.
-
-```typescript
-{
-  notebookUri: string;
-  operation: MessageOperation; // Operation with type and data
-}
-```
-
-Currently implemented operations:
-
-- `cell-op` - Cell execution state transitions (queued, running, idle)
-- `variables` - Variable state updates for the variables panel
-- `data-column-preview` - Datasource column preview data
-- `data-table-preview` - Datasource table preview data
-- `interrupted` - Kernel interrupt notification
-- `alert` - Error and info messages to display to user
-- `package-install-start` - Package installation started
-- `package-install-complete` - Package installation completed
-- And other marimo kernel operations
-
-## Components
-
-### Language Server
-
-The `pygls.LanguageServer` registers handlers for notebook lifecycle events,
-language features (code actions, completions), and custom commands. Sessions are
-lazily created on the first `marimo.run` command. The `LspSessionManager`
-maintains a mapping of notebook URI → marimo `Session`.
+- **Lazy creation.** Opening a notebook doesn't start a kernel. The first
+  `marimo.run` for a given notebook URI + Python executable creates the
+  `Session` and spawns its subprocess.
+- **Saved notebooks keep their kernel when closed.** Reopening picks up the
+  same session without losing state. Only *untitled* notebooks get cleaned
+  up on `didClose`, since there's no stable URI to come back to.
+- **Switching the Python interpreter restarts the kernel.** Creating a
+  session against a different executable closes and replaces the existing
+  one for that URI.
+- **Interrupt vs. restart.** `marimo.interrupt` sends SIGINT to the
+  subprocess (cancels the current execution, preserves state). Restarting
+  tears the session down and starts a new one.
+- **Server shutdown closes every session.** All live kernels terminate with
+  the `marimo-lsp` process.
 
 > [!IMPORTANT]
-> This mapping is tied to the file's URI, which may be unstable (e.g., renamed
-> files, untitled notebooks). As long as the document URI doesn't change during
-> a session, cell URIs remain stable, enabling reliable references to both
-> notebooks and cells.
+> The session map is keyed by notebook URI, which can be unstable across
+> rename and untitled-to-saved transitions. As long as a document's URI
+> doesn't change during a session, its cell URIs remain stable — that's what
+> the extension relies on to correlate kernel messages back to cell metadata.
 
-### Session Manager
+### TypeScript side — fanning out operations
 
-The `LspSessionManager` creates and manages marimo `Session` objects. Each
-session contains a `QueueManager`, `LspKernelManager`, `LspAppFileManager`,
-`LspSessionConsumer`, and `ConfigManager`. Sessions are closed when the notebook
-is untitled and closed, the Python executable changes, or during shutdown.
+The extension is composed as Effect services assembled into a single `Layer`.
+The notebook/kernel-shaped pieces:
 
-### App File Manager
+- **Kernel manager** owns the `marimo/operation` subscription, parses each
+  operation, and offers it to downstream services.
+- **Execution registry** translates `cell-op` operations (queued / running /
+  idle) into `NotebookCellExecution` state on VS Code's notebook API,
+  including output rendering.
+- **Cell state manager** tracks staleness (cells whose source has drifted
+  from the last executed version) and flips context keys that drive UI
+  enablement.
+- **Notebook renderer** renders marimo's custom MIME outputs inside cells and
+  routes user interactions back through the extension to
+  `marimo.set_ui_element_value` / `marimo.function_call_request`.
+- **Variables / datasources / packages** services back the corresponding
+  tree views, each subscribing to its own operation types and maintaining a
+  local cache.
 
-The `LspAppFileManager` adapts VS Code's notebook documents into marimo's
-`InternalApp` structure. Unlike marimo's standard file-based loading, it reads
-from the LSP's in-memory document state via `sync_app_with_workspace()`, which
-extracts cell IDs, codes, configs, and names from the notebook document.
-
-### Session Consumer
-
-The `LspSessionConsumer` implements marimo's `SessionConsumer` interface,
-forwarding kernel messages to VS Code via `marimo/operation` notifications.
-This enables real-time updates of cell execution status, outputs, variable
-state, UI elements, and package installation progress.
-
-### Kernel Manager (TypeScript)
-
-The `KernelManagerLive` layer (`extension/src/layers/KernelManager.ts`)
-orchestrates kernel operations by:
-
-1. Consuming `marimo/operation` notifications from the LSP server
-2. Routing operations via `routeOperation()` to appropriate handlers
-3. Forwarding renderer messages (UI interactions) back to the kernel via LSP
-   commands
-
-### Cell State Manager (TypeScript)
-
-The `CellStateManager` (`extension/src/services/CellStateManager.ts`) tracks
-cell stale state. When a cell's content changes, it's marked as stale in the
-cell metadata and the `marimo.notebook.hasStaleCells` context key is updated for UI
-enablement (e.g., "Run Stale Cells" button).
-
-### Execution Registry (TypeScript)
-
-The `ExecutionRegistry` (`extension/src/services/ExecutionRegistry.ts`) manages
-`NotebookCellExecution` objects for cells. It handles `cell-op` operations from
-the kernel, transitioning cells through queued → running → idle states, and
-manages output rendering.
-
-### Notebook Renderer (TypeScript)
-
-The `NotebookRenderer` (`extension/src/services/NotebookRenderer.ts`) provides a
-custom renderer for marimo UI elements. It renders marimo components within
-notebook cells using the `application/vnd.marimo+html` MIME type and forwards UI
-interactions (e.g., `marimo.set_ui_element_value`, `marimo.function_call_request`)
-back to the kernel.
-
-### Variables and Datasources (TypeScript)
-
-The `VariablesService` and `DatasourcesService` maintain state for their
-respective tree views. They consume `variables`, `data-column-preview`, and
-`data-table-preview` operations, updating the views in real-time as the kernel
-sends updates.
+The key property is that a single kernel operation can feed multiple services
+at once (e.g. `cell-op` drives execution state *and* updates visible output),
+and services can be added or swapped without changing the transport layer.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,135 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Repo layout
+
+This is a **dual-stack monorepo**: a Python LSP server and a TypeScript VS Code extension that talk to each other.
+
+- `src/marimo_lsp/` — Python LSP server (pygls-based). Bridges VS Code's notebook protocol to a marimo `Session`/kernel.
+- `extension/` — VS Code extension (TypeScript, Effect-TS). Consumes the LSP, renders cells, manages kernels.
+- `tests/` — pytest tests for the LSP server (uses `pytest-lsp` for in-process client).
+- `extension/src/**/__tests__/` — vitest unit tests, colocated with source.
+- `extension/tests/` — `@vscode/test-cli` integration tests that launch a real VS Code instance.
+- `scripts/` — release / maintenance Python scripts (e.g. `generate_release_notes.py`).
+
+The Python server is pinned to a specific `marimo` version (`.marimo-version`). For local dev, clone `marimo-team/marimo` as a sibling directory and check out that tag — the extension links `@marimo-team/frontend`, `@marimo-team/openapi`, and `@marimo-team/smart-cells` from `../../marimo/`. CI does this automatically.
+
+## Common commands
+
+Toolchain: **`uv`** for Python, **`pnpm`** for Node, **`just`** as task runner.
+
+**NEVER** invoke `python`/`pip` directly — use `uv run ...` / `uv pip ...`.
+
+Run `just --list` to see available recipes. They're bucketed into `lint`, `fix`, `test`, `build`, and `setup` groups; recipes that accept pytest/vitest args take them as trailing positional args (`just test-py -v -k name`, `just test-ts --watch`).
+
+To launch the extension for manual testing, open the repo in VS Code and press **F5**.
+
+## Architecture
+
+Read `ARCHITECTURE.md` first — it documents the custom LSP protocol (commands like `marimo.run`, `marimo.serialize`, `marimo.set_ui_element_value`, and the `marimo/operation` server→client notification stream). The key mental model:
+
+1. **VS Code notebook protocol** handles cell text sync (`notebookDocument/didOpen`, `didChange`, ...).
+2. **Custom LSP commands** drive kernel actions (run cells, interrupt, call UI element functions, (de)serialize).
+3. **`marimo/operation` notifications** stream kernel output/state (`cell-op`, `variables`, `data-*-preview`, `alert`, package install progress, …) from server to client.
+
+### Python side (`src/marimo_lsp/`)
+
+- `server.py` — pygls `LanguageServer` with handlers for notebook lifecycle + custom commands.
+- `session_manager.py` — `LspSessionManager`: notebook URI → marimo `Session`. Sessions are created lazily on first `marimo.run` and closed on untitled-close, executable change, or shutdown. **URIs are the session key** — they're unstable across rename, so some operations can lose track.
+- `session.py`, `session_consumer.py`, `app_file_manager.py`, `kernel_manager.py` — LSP-flavored adapters around marimo's internals (`SessionConsumer`, `AppFileManager`, `KernelManager`) that read from in-memory LSP documents instead of files.
+- `completions.py`, `diagnostics.py`, `_rules.py` — language features (trigger-char completion for `@cell_name`, diagnostics).
+- `package_manager.py`, `api.py`, `models.py` — package-install flow and shared LSP request/response schemas.
+
+### TypeScript side (`extension/src/`)
+
+Built on **Effect-TS**. Everything is wired as `Layer`s (services) assembled in `layers/Main.ts` via `makeActivate(...)` in `features/Main.ts`. Directory roles:
+
+- `features/` — top-level layers that only register side effects (commands, codelens, file detection, theme sync, debug, cell-metadata bindings).
+- `services/`, `kernel/`, `notebook/`, `config/`, `lsp/`, `platform/`, `python/`, `telemetry/` — the actual services composed into `MainLive`. E.g. `KernelManager` consumes `marimo/operation`, `ExecutionRegistry` drives `NotebookCellExecution` state, `CellStateManager` tracks stale cells and the `marimo.notebook.hasStaleCells` context key, `NotebookRenderer` renders `application/vnd.marimo+html` MIME outputs, `VariablesService`/`DatasourcesService`/`PackagesService` back the tree views.
+- `commands/` — one file per VS Code command registered in `package.json`.
+- `renderer/` — webview-side notebook renderer (`renderer.tsx`) that embeds marimo's frontend.
+- `panel/`, `views/` — tree views for recents, variables, datasources, packages.
+- `lsp/` — language-client wiring + inner servers (`RuffLanguageServer`, `TyLanguageServer`) used when managed language features are enabled.
+- `lib/`, `utils/`, `schemas/`, `vendor/`, `__mocks__/` — supporting code.
+
+Cells use a dedicated language id `mo-python` so external Python LSPs don't double up on completions/diagnostics. Users can opt out with `marimo.disableManagedLanguageFeatures`.
+
+## Philosophy
+
+Tests, types, and lints are pedantic on purpose: they're load-bearing tools, not ceremony. Opting out is rarely the right call, but is allowed only with a thoughtful and clear explanation of *why*.
+
+## Effect-TS
+
+**Treat Effect as part of this codebase, not a third-party library.** The extension is built on Effect top-to-bottom — services, layers, fibers, scopes, schemas, streams — and writing idiomatic extension code means reaching for the right Effect primitive instead of reinventing it. Before adding a new abstraction (a queue, a cache, a retry wrapper, a resource lifecycle), ask whether Effect already has it.
+
+Invoke the project-local `/effect-ts` skill ([`.claude/skills/effect-ts/SKILL.md`](.claude/skills/effect-ts/SKILL.md)) — start there; it indexes deeper references under `references/` for each primitive.
+
+When the reference doesn't cover something, reading the Effect source directly is usually the fastest way to resolve a question — the public API lives in `packages/effect/src/ModuleName.ts` and the implementation in `packages/effect/src/internal/`. One option is to clone `github.com/Effect-TS/effect` somewhere on your machine so you can grep it, but any approach that lets you read the source works.
+
+### Local Effect conventions (from `CONTRIBUTING.md`)
+
+- Use Effect's native logger primitives — no custom logging utilities.
+- Name top-level functions: `Effect.fn("namespace.operation")(function*(){...})`.
+- Put variable data in `Effect.annotateLogs({ … })` / `Effect.annotateCurrentSpan(...)`, not interpolated into the message.
+- Wrap important external calls with `Effect.withSpan("lsp.executeCommand", { attributes: {...} })`.
+
+### Prefer Schema or type guards over type assertions
+
+Think of `as T`, `!` (non-null), and `as unknown as T` the way Rust thinks of `unsafe`: the compiler's contract is off and you're staking your word that you know more than it does. Sometimes that's true — but rarely. A wrong type assertion surfaces as neither a type error nor a runtime error, just silent propagation, and that throws away the exact property we picked Effect for (`Effect<A, E, R>` making every error and dependency explicit).
+
+The convention: reach for real checks by default; assertions only in the rare case you genuinely know more than the compiler.
+
+**Use instead:**
+- **`Schema`** (Effect's `Schema`) at boundaries — once data is parsed, the type is earned.
+- **Type guards / predicates** (`function isUser(x): x is User`) for narrowing within flow.
+- **Plain narrowing** — `typeof`, `instanceof`, equality, discriminants — is often enough. In `catch`, narrow with `instanceof` or let typed Effect errors carry the shape.
+- **`assert(...)`** for runtime invariants the compiler can't see; it narrows *and* crashes loudly on violation, which is the point.
+
+**When a type assertion is warranted**, leave a `// SAFETY:` comment right above it — same convention Rust uses for every `unsafe` block. State the invariant you're staking, not what the code does, so the next reader can check your reasoning.
+
+```ts
+// SAFETY: routeOperation only forwards cell-op messages whose cellId
+// is present in `executions`; we guard the lookup on line 84.
+const execution = executions.get(cellId) as NotebookCellExecution;
+```
+
+No `// SAFETY:` comment, no type assertion.
+
+This extends to tests. Don't `{} as FooService` your way to a mock — fully `implements` the interface (see `src/__mocks__/Test*.ts`), or introduce a test-scoped branded type / helper that restricts the surface *and* gets checked. If the mock is hard to write, the seam is wrong, not the types.
+
+Background: [Be assertive](https://trevorma.nz/blog/be-assertive), [Catch errors carefully](https://trevorma.nz/blog/catch-errors-carefully).
+
+## Testing
+
+**Write tests. Not too many. Mostly integration.** ([write-tests](https://kentcdodds.com/blog/write-tests)) Integration tests are where real confidence lives — unit tests that mock out everything around the code under test give you a green bar without proving the pieces fit. For most bugfixes there's a high-value test worth adding; take a quiet moment to think about what shape of test would actually catch the bug next time, and how to make it reviewable as a diff.
+
+**`just test-vscode` (`@vscode/test-cli`)** drives the real extension inside a real VS Code instance (`extension/tests/*.test.cjs`). This is where most user-facing confidence is earned: a green test here proves the extension behaves the way a user actually uses it, end-to-end. Slower per run, but the runner is good enough to make reliable integration coverage worth the wall-clock.
+
+**`just test-py` (pytest + `pytest-lsp`)** is integration-shaped by default: it spins up a real `marimo-lsp` subprocess over stdio and drives the full protocol. The obvious place for anything that touches an LSP request/response shape.
+
+**`just test-ts` (vitest)** gives high leverage on individual services in partial isolation — the service-oriented layering means you can feed a service the events it'd normally receive from upstream and assert on what it does, without booting the whole runtime. `src/__mocks__/Test*.ts` has real `implements`-based stand-ins; `Effect.die("not implemented")` on methods the code-under-test shouldn't touch makes boundary violations loud instead of silent. Effect's `Layer` pattern makes mocking frictionless, which also makes over-mocking tempting — ask whether the test is still exercising behavior a user could observe.
+
+**Snapshot tests pull a lot of weight** — `inline-snapshot` (pytest) and `toMatchInlineSnapshot` (vitest) put the expected shape of a protocol message or serialized output right next to the test body, so PR reviewers see the expected output in the diff and regressions surface as line-by-line changes. Regen with `uv run pytest --inline-snapshot=create` (or `=fix`); pair with `dirty-equals` matchers to keep non-deterministic fields out of the recorded shape.
+
+## Other conventions
+
+### Python
+
+- Ruff is configured with `select = ["ALL"]` plus a curated ignore list in `pyproject.toml`. Tests have extra ignores (asserts allowed, no docstring requirement, etc.).
+- Type-check with `ty` (not mypy). Extension files are excluded from `ty`.
+- `inline-snapshot` is wired up with `ruff format` — regenerate with `uv run pytest --inline-snapshot=create` (or `=fix`).
+
+### Python kernel compatibility
+
+Two distinct version pins live in `pyproject.toml`:
+
+- `dependencies.marimo == <exact>` — the version the LSP server *ships with* (bundled frontend + Python API). Auto-bumped by the `update-marimo-version` cron.
+- `[tool.marimo-lsp] minimum-kernel-version` — the floor we claim to support in the *user's* kernel env. Bumped manually when intentionally dropping support.
+
+Don't conflate these when editing. The cron only touches the first.
+
+## Gotchas
+
+- **Marimo controllers leave `executionOrder` undefined.** Tests that wait for `executionOrder` to increment will hang forever — gate on cell state or output instead.
+- **`ARCHITECTURE.md` file-path references can lag the code** (services were renamed/moved from `services/` into subdirs like `kernel/`, `notebook/`, `config/`). Prefer grep over trusting a stale path.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,23 +51,24 @@ This will run linting and formatting checks automatically before each commit.
 
 ### Common Commands
 
-This project uses [just](https://just.systems/) for common development tasks:
+This project uses [just](https://just.systems/) for common development tasks.
+Run `just --list` to see all recipes, grouped into `lint`, `fix`, `test`,
+`build`, and `setup`. Highlights:
 
-| Command            | Action                                  |
-| ------------------ | --------------------------------------- |
-| `just check`       | Lint and typecheck all code             |
-| `just fix`         | Fix linting issues and format all code  |
-| `just test`        | Run all tests (pytest + vitest)         |
-| `just pytest`      | Run Python tests only                   |
-| `just vitest`      | Run TypeScript tests only               |
-| `just vscode-test` | Run VS Code extension integration tests |
+| Command              | Action                                       |
+| -------------------- | -------------------------------------------- |
+| `just lint`          | Lint + typecheck everything (py + ts)        |
+| `just fix`           | Autofix + format everything (py + ts)        |
+| `just test`          | Run all tests (`test-py` + `test-ts`)        |
+| `just test-vscode`   | VS Code extension integration tests (slow)   |
+| `just build`         | Embed the Python sdist and bundle the extension |
 
-You can pass additional arguments to test commands:
+Recipes that wrap pytest or vitest forward trailing args:
 
 ```sh
-just pytest -v                    # Run pytest with verbose output
-just pytest tests/test_foo.py     # Run specific test file
-just vitest --watch               # Run vitest in watch mode
+just test-py -v                    # pytest with verbose output
+just test-py tests/test_foo.py     # specific test file
+just test-ts --watch               # vitest in watch mode
 ```
 
 ## Architecture

--- a/justfile
+++ b/justfile
@@ -1,23 +1,64 @@
 # marimo-lsp justfile
 # Run `just` to see available recipes
 
-# Default recipe - show available commands
 default:
     @just --list
 
-# Lint and typecheck code
-check:
+# lint ---------------------------------------------------------------
+
+[group('lint')]
+lint: lint-py lint-ts
+
+[group('lint')]
+lint-py:
     uv run ruff check
     uv run ty check
+
+[group('lint')]
+lint-ts:
     pnpm -C extension check
 
-# Fix linting issues and format code
-fix:
+# fix ----------------------------------------------------------------
+
+[group('fix')]
+fix: fix-py fix-ts
+
+[group('fix')]
+fix-py:
     uv run ruff format
     uv run ruff check --fix
+
+[group('fix')]
+fix-ts:
     pnpm -C extension fix
 
-# Download tutorial files from marimo repository
+# test ---------------------------------------------------------------
+
+[group('test')]
+test: test-py test-ts
+
+[group('test')]
+test-py *args:
+    uv run pytest {{args}}
+
+[group('test')]
+test-ts *args:
+    pnpm -C extension test {{args}}
+
+[group('test')]
+test-vscode *args:
+    pnpm -C extension test:extension {{args}}
+
+# build --------------------------------------------------------------
+
+[group('build')]
+build:
+    pnpm -C extension build
+    pnpm -C extension embed-sdist
+
+# setup --------------------------------------------------------------
+
+[group('setup')]
 download-tutorials:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -29,18 +70,3 @@ download-tutorials:
         curl -fsSL "$BASE_URL/$tutorial" -o "extension/tutorials/$tutorial"
     done
     echo "All tutorials downloaded successfully!"
-
-# Run Python tests
-pytest *args:
-    uv run pytest {{args}}
-
-# Run TypeScript tests
-vitest *args:
-    pnpm -C extension test {{args}}
-
-# Run VS Code extension integration tests
-vscode-test *args:
-    pnpm -C extension test:extension {{args}}
-
-# Run all tests
-test: pytest vitest


### PR DESCRIPTION
CLAUDE.md lays out the working philosophy for agents (and humans) contributing to this repo: Effect is foundational rather than a third-party library, tests/types/lints are load-bearing and opting out needs a reason, and testing leans toward "mostly integration" with notes on where each of the three harnesses earns its keep. The companion `/effect-ts` skill is vendored under `.claude/skills/` so it ships with the repo.

The justfile rework groups recipes into `lint` / `fix` / `test` / `build` / `setup` and normalizes naming (`pytest` / `vitest` / `vscode-test` → `test-py` / `test-ts` / `test-vscode`). The new `build` recipe matches the build order CI uses.