### PR TITLE
ci: migrate secrets to Doppler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,13 +13,15 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   TURBO_TEAM: marimo
 
 jobs:
   typescript-lint:
     name: TypeScript / Lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # required for Doppler OIDC
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -35,6 +37,18 @@ jobs:
           ref: ${{ steps.marimo-version.outputs.ref }}
           path: marimo
 
+      - name: 🔐 Fetch Doppler secrets
+        # Skip on PRs from forks: id-token write is downgraded to read, so OIDC fails.
+        # TURBO_TOKEN is optional and tolerates empty.
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: dopplerhq/secrets-fetch-action@cd2efbf9a404504316435873eff298b82f7e0562 # v1.3.0
+        id: secrets
+        with:
+          auth-method: oidc
+          doppler-identity-id: ${{ vars.DOPPLER_IDENTITY_ID }}
+          doppler-project: marimo-lsp
+          doppler-config: dev
+
       - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
         with:
           package_json_file: marimo-lsp/extension/package.json
@@ -48,6 +62,8 @@ jobs:
             marimo-lsp/extension/pnpm-lock.yaml
 
       - name: Build marimo packages
+        env:
+          TURBO_TOKEN: ${{ steps.secrets.outputs.TURBO_TOKEN }}
         run: |
           cd marimo
           pnpm turbo run build --filter="./packages/*"
@@ -61,6 +77,9 @@ jobs:
   typescript-typecheck:
     name: TypeScript / Typecheck
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # required for Doppler OIDC
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -76,6 +95,18 @@ jobs:
           ref: ${{ steps.marimo-version.outputs.ref }}
           path: marimo
 
+      - name: 🔐 Fetch Doppler secrets
+        # Skip on PRs from forks: id-token write is downgraded to read, so OIDC fails.
+        # TURBO_TOKEN is optional and tolerates empty.
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: dopplerhq/secrets-fetch-action@cd2efbf9a404504316435873eff298b82f7e0562 # v1.3.0
+        id: secrets
+        with:
+          auth-method: oidc
+          doppler-identity-id: ${{ vars.DOPPLER_IDENTITY_ID }}
+          doppler-project: marimo-lsp
+          doppler-config: dev
+
       - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
         with:
           package_json_file: marimo-lsp/extension/package.json
@@ -89,11 +120,15 @@ jobs:
             marimo-lsp/extension/pnpm-lock.yaml
 
       - name: Build marimo packages
+        env:
+          TURBO_TOKEN: ${{ steps.secrets.outputs.TURBO_TOKEN }}
         run: |
           cd marimo
           pnpm turbo run build --filter="./packages/*"
 
       - name: Install and typecheck extension
+        env:
+          TURBO_TOKEN: ${{ steps.secrets.outputs.TURBO_TOKEN }}
         run: |
           cd marimo-lsp/extension
           pnpm install
@@ -106,6 +141,9 @@ jobs:
 
   typescript-test:
     name: TypeScript / Test / ${{ matrix.os }}
+    permissions:
+      contents: read
+      id-token: write # required for Doppler OIDC
     strategy:
       matrix:
         # TODO: more platforms
@@ -127,6 +165,18 @@ jobs:
           ref: ${{ steps.marimo-version.outputs.ref }}
           path: marimo
 
+      - name: 🔐 Fetch Doppler secrets
+        # Skip on PRs from forks: id-token write is downgraded to read, so OIDC fails.
+        # TURBO_TOKEN is optional and tolerates empty.
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: dopplerhq/secrets-fetch-action@cd2efbf9a404504316435873eff298b82f7e0562 # v1.3.0
+        id: secrets
+        with:
+          auth-method: oidc
+          doppler-identity-id: ${{ vars.DOPPLER_IDENTITY_ID }}
+          doppler-project: marimo-lsp
+          doppler-config: dev
+
       - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
 
       - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
@@ -142,6 +192,8 @@ jobs:
             marimo-lsp/extension/pnpm-lock.yaml
 
       - name: Build marimo packages
+        env:
+          TURBO_TOKEN: ${{ steps.secrets.outputs.TURBO_TOKEN }}
         run: |
           cd marimo
           pnpm --recursive --filter "./packages/*" codegen
@@ -149,6 +201,8 @@ jobs:
 
       - name: Install and build the extension
         working-directory: marimo-lsp/extension
+        env:
+          TURBO_TOKEN: ${{ steps.secrets.outputs.TURBO_TOKEN }}
         run: |
           pnpm install
           # make sure our types are up to date

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -11,19 +11,28 @@ permissions:
   contents: write
   pull-requests: write
   statuses: write
+  id-token: write # required for Doppler OIDC
 
 jobs:
   CLAAssistant:
     runs-on: ubuntu-latest
     steps:
+      - name: 🔐 Fetch Doppler secrets
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: dopplerhq/secrets-fetch-action@cd2efbf9a404504316435873eff298b82f7e0562 # v1.3.0
+        id: secrets
+        with:
+          auth-method: oidc
+          doppler-identity-id: ${{ vars.DOPPLER_IDENTITY_ID }}
+          doppler-project: marimo-lsp
+          doppler-config: dev
+
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
         uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # the below token should have repo scope and must be manually added by you in the repository's secret
-          # This token is required only if you have configured to store the signatures in a remote repository/organization
-          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ steps.secrets.outputs.PERSONAL_ACCESS_TOKEN }}
         with:
           path-to-signatures: "signatures/marimo-lsp/cla.json"
           path-to-document: "https://marimo.io/cla" # e.g. a CLA or a DCO document

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -300,12 +300,24 @@ jobs:
   publish:
     needs: [version-bump, build, build-universal]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write # required for Doppler OIDC
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           path: marimo-lsp
           fetch-depth: 0
+
+      - name: 🔐 Fetch Doppler secrets
+        uses: dopplerhq/secrets-fetch-action@cd2efbf9a404504316435873eff298b82f7e0562 # v1.3.0
+        id: secrets
+        with:
+          auth-method: oidc
+          doppler-identity-id: ${{ vars.DOPPLER_IDENTITY_ID }}
+          doppler-project: marimo-lsp
+          doppler-config: prod
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
@@ -324,19 +336,23 @@ jobs:
         run: npm install -g @vscode/vsce ovsx
 
       - name: Publish to VS Code Marketplace
+        env:
+          VSCE_PAT: ${{ steps.secrets.outputs.VSCE_PAT }}
         run: |
           if [ "${{ inputs.pre-release }}" = "true" ]; then
-            vsce publish --pat ${{ secrets.VSCE_PAT }} --packagePath ./dist/*.vsix --pre-release --skip-duplicate
+            vsce publish --pat "$VSCE_PAT" --packagePath ./dist/*.vsix --pre-release --skip-duplicate
           else
-            vsce publish --pat ${{ secrets.VSCE_PAT }} --packagePath ./dist/*.vsix --skip-duplicate
+            vsce publish --pat "$VSCE_PAT" --packagePath ./dist/*.vsix --skip-duplicate
           fi
 
       - name: Publish to Open VSX Registry
+        env:
+          OPEN_VSX_TOKEN: ${{ steps.secrets.outputs.OPEN_VSX_TOKEN }}
         run: |
           if [ "${{ inputs.pre-release }}" = "true" ]; then
-            ovsx publish --pat ${{ secrets.OPEN_VSX_TOKEN }} --packagePath ./dist/*.vsix --pre-release --skip-duplicate
+            ovsx publish --pat "$OPEN_VSX_TOKEN" --packagePath ./dist/*.vsix --pre-release --skip-duplicate
           else
-            ovsx publish --pat ${{ secrets.OPEN_VSX_TOKEN }} --packagePath ./dist/*.vsix --skip-duplicate
+            ovsx publish --pat "$OPEN_VSX_TOKEN" --packagePath ./dist/*.vsix --skip-duplicate
           fi
 
       - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
@@ -382,7 +398,7 @@ jobs:
         if: success() && github.event.pull_request.head.repo.fork == false
         uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL_RELEASES }}
+          webhook: ${{ steps.secrets.outputs.SLACK_WEBHOOK_URL_RELEASES }}
           webhook-type: incoming-webhook
           payload: |
             {
@@ -402,7 +418,7 @@ jobs:
         if: failure() && github.event.pull_request.head.repo.fork == false
         uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL_RELEASES }}
+          webhook: ${{ steps.secrets.outputs.SLACK_WEBHOOK_URL_RELEASES }}
           webhook-type: incoming-webhook
           payload: |
             {


### PR DESCRIPTION
Fetch CI secrets from Doppler via OIDC instead of GitHub Actions
secrets. 