### PR TITLE
chore(ci): add --ignore-scripts to pnpm install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Check (lint + format)
         run: |
           cd marimo-lsp/extension
-          pnpm install
+          pnpm install --ignore-scripts
           pnpm check
 
   typescript-typecheck:
@@ -131,7 +131,7 @@ jobs:
           TURBO_TOKEN: ${{ steps.secrets.outputs.TURBO_TOKEN }}
         run: |
           cd marimo-lsp/extension
-          pnpm install
+          pnpm install --ignore-scripts
           # make sure our types are up to date
           node scripts/codegen.mjs
           pnpm turbo typecheck-ci
@@ -204,7 +204,7 @@ jobs:
         env:
           TURBO_TOKEN: ${{ steps.secrets.outputs.TURBO_TOKEN }}
         run: |
-          pnpm install
+          pnpm install --ignore-scripts
           # make sure our types are up to date
           node scripts/codegen.mjs
           pnpm build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -205,7 +205,7 @@ jobs:
       - name: Install packages and build extension
         working-directory: marimo-lsp/extension
         run: |
-          pnpm install
+          pnpm install --ignore-scripts
           pnpm build
           pnpm embed-sdist
 
@@ -274,7 +274,7 @@ jobs:
       - name: Install packages and build extension
         working-directory: marimo-lsp/extension
         run: |
-          pnpm install
+          pnpm install --ignore-scripts
           pnpm build
           pnpm embed-sdist
 


### PR DESCRIPTION
Defense-in-depth against compromised transitive deps executing postinstall/prepare in CI. Motivated by the TanStack npm supply-chain compromise (May 2026).

No functional change — these workflows do not depend on lifecycle scripts (lint/typecheck/test only).