### PR TITLE
feat(renderer): set table download size policy at init

### DIFF
--- a/extension/src/renderer/marimo-frontend.ts
+++ b/extension/src/renderer/marimo-frontend.ts
@@ -1,3 +1,7 @@
+import {
+  type DownloadSizeLimit,
+  downloadSizeLimitAtom,
+} from "@marimo-team/frontend/unstable_internal/components/data-table/download-policy/atoms.ts";
 /**
  * @module
  *
@@ -40,13 +44,20 @@ import * as untyped from "./marimo-frontend-untyped.js";
 export { useTheme } from "@marimo-team/frontend/unstable_internal/theme/useTheme.ts";
 
 export type RequestClient = EditRequests & RunRequests;
-export type { CellRuntimeState, CellId };
+export type { CellRuntimeState, CellId, DownloadSizeLimit };
 
 /**
  * Initialize marimo UI components in the VS Code renderer environment.
  * This provides a minimal setup to hydrate web components without the full kernel.
+ *
+ * `downloadSizeLimit`, when provided, gates table exports/clipboard copies that
+ * exceed the host's limit. Applied here so all VS Code–specific store overrides
+ * stay in one place and the raw jotai `store` never escapes this module.
  */
-export function initialize(client: RequestClient) {
+export function initialize(
+  client: RequestClient,
+  downloadSizeLimit?: DownloadSizeLimit,
+) {
   store.set(initialModeAtom, "edit");
   store.set(requestClientAtom, client);
   // Trust data: URIs from plugins without waiting for a run through marimo's
@@ -59,6 +70,10 @@ export function initialize(client: RequestClient) {
   // (CodeMirror, cells state, data-table UI, etc.) blows up tsc. Once the atom
   // moves to a leaf file upstream (marimo-team/marimo#TODO), import directly.
   store.set(untyped.hasRunAnyCellAtom, true);
+
+  if (downloadSizeLimit) {
+    store.set(downloadSizeLimitAtom, downloadSizeLimit);
+  }
 
   untyped.initializePlugins();
   // Start the RuntimeState to listen for UI element value changes

--- a/extension/src/renderer/renderer.tsx
+++ b/extension/src/renderer/renderer.tsx
@@ -19,13 +19,19 @@ import {
 } from "./marimo-frontend.ts";
 import { createRequestClient, isTypedRequestContext } from "./utils.ts";
 
+const TABLE_EXPORT_LIMIT_MB = 50;
+const TABLE_EXPORT_LIMIT_BYTES = TABLE_EXPORT_LIMIT_MB * 1024 * 1024;
+
 export const activate: vscode.ActivationFunction = (context) => {
   assert(
     isTypedRequestContext(context),
     `Expected {"requiresMessaging": "always"} for marimo outputs.`,
   );
 
-  initialize(createRequestClient(context));
+  initialize(createRequestClient(context), {
+    limitBytes: TABLE_EXPORT_LIMIT_BYTES,
+    unavailableMessage: `This table is too large to download from a VS Code notebook output (limit: ${TABLE_EXPORT_LIMIT_MB}MB). Open the notebook in a browser to export it, or filter the data first.`,
+  });
 
   /**
    * Bridge for HTML output interactions.


### PR DESCRIPTION
Closes https://github.com/marimo-team/marimo-lsp/issues/542

Sets `downloadSizeLimitAtom` (introduced in marimo PR https://github.com/marimo-team/marimo/pull/9510) to a 50 MB cap with a VS Code–specific message, so the table Export button disables up-front with a tooltip instead of silently failing inside the sandboxed NotebookRenderer.

## Why 50 MB

Empirically the sandbox download path and clipboard string limit start failing below 70 MB in testing. 50 MB is the conservative safe ceiling. The size gate uses JSON-serialized size (largest format we support) so if it fits, CSV/Parquet definitely fit.

https://github.com/user-attachments/assets/51f80e8a-0ca5-4b81-836a-92c23ce5bc75



## Test plan

- [x] Big table (> 50 MB JSON) in VS Code notebook → Export button disabled, tooltip shows the message
- [x] Small table → Export button enabled, downloads work
- [x] Older marimo backend (no \`size_bytes\` in render payload) → fail-open, button enabled
- [x] \`marimo edit\` in browser unaffected (atom not set there)