### PR TITLE
chore(ci): add --ignore-scripts to global vsce/ovsx installs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -213,7 +213,7 @@ jobs:
         working-directory: marimo-lsp/extension
         shell: bash
         run: |
-          npm install -g @vscode/vsce
+          npm install --ignore-scripts -g @vscode/vsce
           if [ "${{ inputs.pre-release }}" = "true" ]; then
             vsce package -o ./dist/marimo-${{ matrix.code-target }}.vsix --target ${{ matrix.code-target }} --pre-release
           else
@@ -283,7 +283,7 @@ jobs:
       - name: Package universal extension
         working-directory: marimo-lsp/extension
         run: |
-          npm install -g @vscode/vsce
+          npm install --ignore-scripts -g @vscode/vsce
           if [ "${{ inputs.pre-release }}" = "true" ]; then
             vsce package -o ./dist/marimo-universal.vsix --pre-release
           else
@@ -333,7 +333,7 @@ jobs:
         run: ls -al ./dist
 
       - name: Install vsce and ovsx
-        run: npm install -g @vscode/vsce ovsx
+        run: npm install --ignore-scripts -g @vscode/vsce ovsx
 
       - name: Publish to VS Code Marketplace
         env:


### PR DESCRIPTION
Defense-in-depth against compromised transitive deps executing postinstall/prepare hooks in the global install. Motivated by the TanStack npm supply-chain compromise (May 2026).

The residual `oidc-publish-fused` audit findings (Doppler-OIDC + install in the publish job, and ci.yml jobs that fetch Doppler secrets) remain by design — they're intrinsic to the current Doppler trusted-publisher architecture (the publish job needs id-token to fetch VSCE_PAT/OPEN_VSX_TOKEN, and needs vsce/ovsx CLIs on PATH to publish). pnpm installs are also flagged by the audit but are not a real risk given pnpm 10's `onlyBuiltDependencies` default-deny.

No functional change.