### PR TITLE
Apply effect-ts patterns: kernel hardening and Stream cleanup

### DIFF
--- a/extension/src/features/MarimoFileDetector.ts
+++ b/extension/src/features/MarimoFileDetector.ts
@@ -57,7 +57,7 @@ export const MarimoFileDetectorLive = Layer.scopedDiscard(
     yield* Effect.forkScoped(
       code.window
         .activeTextEditorChanges()
-        .pipe(Stream.mapEffect(updateContext), Stream.runDrain),
+        .pipe(Stream.runForEach(updateContext)),
     );
   }),
 );

--- a/extension/src/features/ThemeSync.ts
+++ b/extension/src/features/ThemeSync.ts
@@ -22,7 +22,7 @@ export const ThemeSyncLive = Layer.scopedDiscard(
         code.window.colorThemeChanges().pipe(Stream.changes),
         editorRegistry.streamActiveNotebookChanges(),
       ).pipe(
-        Stream.mapEffect(
+        Stream.runForEach(
           Effect.fn("ThemeSync.sync")(function* ([theme]) {
             yield* client
               .executeCommand({
@@ -43,7 +43,6 @@ export const ThemeSyncLive = Layer.scopedDiscard(
               );
           }),
         ),
-        Stream.runDrain,
       ),
     );
   }),

--- a/extension/src/kernel/ControllerRegistry.ts
+++ b/extension/src/kernel/ControllerRegistry.ts
@@ -122,9 +122,7 @@ export class ControllerRegistry extends Effect.Service<ControllerRegistry>()(
 
       yield* refresh();
       yield* Effect.forkScoped(
-        pyExt
-          .environmentChanges()
-          .pipe(Stream.mapEffect(refresh), Stream.runDrain),
+        pyExt.environmentChanges().pipe(Stream.runForEach(refresh)),
       );
 
       // Subscribe to notebook editor changes to update affinity
@@ -252,7 +250,7 @@ const trackControllerSelections = (
   selectionsRef: Ref.Ref<HashMap.HashMap<NotebookId, AnyController>>,
 ) =>
   controller.selectedNotebookChanges().pipe(
-    Stream.mapEffect(
+    Stream.runForEach(
       Effect.fn(function* (e) {
         if (!e.selected) {
           // NB: We don't delete from selections when deselected
@@ -269,7 +267,6 @@ const trackControllerSelections = (
         );
       }),
     ),
-    Stream.runDrain,
   );
 
 const createOrUpdateController = Effect.fn("ControllerRegistry.createOrUpdate")(

--- a/extension/src/kernel/DebugAdapter.ts
+++ b/extension/src/kernel/DebugAdapter.ts
@@ -266,7 +266,10 @@ function activateDebugpy(
     yield* Stream.runForEach(ops, (op) =>
       Effect.sync(() => {
         if (result) return;
-        const consoleOutput = (op as Record<string, unknown>).console;
+        // SAFETY: `console` is an optional cell-op field whose shape isn't
+        // surfaced in the openapi-generated type for `CellOperationNotification`;
+        // the guards below validate each entry before use.
+        const consoleOutput = (op as { console?: unknown }).console;
         if (!consoleOutput) return;
 
         const outputs = Array.isArray(consoleOutput)

--- a/extension/src/kernel/ExecutionRegistry.ts
+++ b/extension/src/kernel/ExecutionRegistry.ts
@@ -119,6 +119,15 @@ export class ExecutionRegistry extends Effect.Service<ExecutionRegistry>()(
 
             switch (msg.status) {
               case "queued": {
+                const runIdOpt = extractRunId(msg);
+                if (Option.isNone(runIdOpt)) {
+                  yield* Effect.logWarning(
+                    "Queued cell-op missing run_id; cannot track execution",
+                  ).pipe(Effect.annotateLogs({ cellId, status: msg.status }));
+                  return;
+                }
+                const runId = runIdOpt.value;
+
                 // Record execution — clears stale state
                 yield* cellStateManager.recordExecution(notebookCell);
 
@@ -150,7 +159,7 @@ export class ExecutionRegistry extends Effect.Service<ExecutionRegistry>()(
                     CellEntry.withExecution(
                       cell,
                       new PendingExecutionHandle({
-                        runId: Option.getOrThrow(extractRunId(msg)),
+                        runId,
                         inner: execution,
                       }),
                     ),

--- a/extension/src/kernel/KernelManager.ts
+++ b/extension/src/kernel/KernelManager.ts
@@ -80,10 +80,9 @@ export class KernelManager extends Effect.Service<KernelManager>()(
       const scratchLock = yield* Effect.makeSemaphore(1);
 
       yield* Effect.forkScoped(
-        client.streamOf("marimo/operation").pipe(
-          Stream.mapEffect((msg) => Queue.offer(queue, msg)),
-          Stream.runDrain,
-        ),
+        client
+          .streamOf("marimo/operation")
+          .pipe(Stream.runForEach((msg) => Queue.offer(queue, msg))),
       );
 
       yield* Effect.forkScoped(
@@ -116,7 +115,7 @@ export class KernelManager extends Effect.Service<KernelManager>()(
       // renderer (i.e., front end) -> kernel
       yield* Effect.forkScoped(
         renderer.messages().pipe(
-          Stream.mapEffect(
+          Stream.runForEach(
             Effect.fn(function* ({ editor, message }) {
               const notebook = MarimoNotebookDocument.from(editor.notebook);
               switch (message.command) {
@@ -195,7 +194,6 @@ export class KernelManager extends Effect.Service<KernelManager>()(
               }
             }),
           ),
-          Stream.runDrain,
         ),
       );
 

--- a/extension/src/kernel/KernelManager.ts
+++ b/extension/src/kernel/KernelManager.ts
@@ -81,11 +81,7 @@ export class KernelManager extends Effect.Service<KernelManager>()(
 
       yield* Effect.forkScoped(
         client.streamOf("marimo/operation").pipe(
-          Stream.mapEffect(
-            Effect.fn(function* (msg) {
-              yield* Queue.offer(queue, msg);
-            }),
-          ),
+          Stream.mapEffect((msg) => Queue.offer(queue, msg)),
           Stream.runDrain,
         ),
       );

--- a/extension/src/kernel/SessionStateManager.ts
+++ b/extension/src/kernel/SessionStateManager.ts
@@ -53,7 +53,7 @@ export class SessionStateManager extends Effect.Service<SessionStateManager>()(
       yield* Effect.forkScoped(
         editorRegistry
           .streamActiveNotebookChanges()
-          .pipe(Stream.mapEffect(updateContext), Stream.runDrain),
+          .pipe(Stream.runForEach(updateContext)),
       );
 
       return {};

--- a/extension/src/kernel/__tests__/ExecutionRegistry.test.ts
+++ b/extension/src/kernel/__tests__/ExecutionRegistry.test.ts
@@ -1033,6 +1033,77 @@ it.scoped(
   }),
 );
 
+it.scoped(
+  "logs and skips when queued message has no run_id",
+  Effect.fn(function* () {
+    const ctx = yield* withTestCtx();
+
+    yield* Effect.gen(function* () {
+      const registry = yield* ExecutionRegistry;
+      const cellStateManager = yield* CellStateManager;
+
+      const cellData = {
+        kind: 1, // Code
+        value: "x = 1",
+        languageId: "python",
+        metadata: {
+          name: "test_cell",
+          state: "stale",
+          stableId: "cell-1",
+        },
+      };
+      const notebook = MarimoNotebookDocument.from(
+        createTestNotebookDocument("file:///test/notebook_mo.py", {
+          data: { cells: [cellData] },
+        }),
+      );
+      const editor = createTestNotebookEditor(notebook.rawNotebookDocument);
+      const cell = notebook.cellAt(0);
+      const cellId = Option.getOrThrow(cell.id);
+      const code = yield* VsCode;
+
+      yield* ctx.vscode.setActiveNotebookEditor(Option.some(editor));
+      yield* TestClock.adjust("10 millis");
+
+      // Mark the cell stale so we can prove the bail happens before recordExecution
+      yield* cellStateManager.invalidateCell(
+        MarimoNotebookCell.from(cell.rawNotebookCell),
+      );
+      expect(
+        yield* cellStateManager.isCellStale(
+          MarimoNotebookCell.from(cell.rawNotebookCell),
+        ),
+      ).toBe(true);
+
+      const controller = yield* code.notebooks.createNotebookController(
+        "test-controller",
+        NOTEBOOK_TYPE,
+        "test-controller",
+      );
+
+      // Pre-fix this would die via Option.getOrThrow on a None.
+      const message: CellOperationNotification = {
+        op: "cell-op",
+        cell_id: cellId,
+        status: "queued",
+        run_id: null,
+      };
+
+      yield* registry.handleCellOperation(message, {
+        editor,
+        controller: new PythonController(controller, "test-controller"),
+      });
+
+      // Stale state preserved because we bail before recordExecution
+      expect(
+        yield* cellStateManager.isCellStale(
+          MarimoNotebookCell.from(cell.rawNotebookCell),
+        ),
+      ).toBe(true);
+    }).pipe(Effect.provide(ctx.layer));
+  }),
+);
+
 /**
  * Creates a PythonController whose `createNotebookCellExecution` throws,
  * simulating VS Code's "invalid cell" error when a cell is deleted.

--- a/extension/src/notebook/CellStateManager.ts
+++ b/extension/src/notebook/CellStateManager.ts
@@ -85,17 +85,14 @@ export class CellStateManager extends Effect.Service<CellStateManager>()(
 
       // Re-derive context when execution state changes
       yield* Effect.forkScoped(
-        lastExecutedCodeRef.changes.pipe(
-          Stream.mapEffect(updateContext),
-          Stream.runDrain,
-        ),
+        lastExecutedCodeRef.changes.pipe(Stream.runForEach(updateContext)),
       );
 
       // Re-derive context when active notebook changes
       yield* Effect.forkScoped(
         editorRegistry
           .streamActiveNotebookChanges()
-          .pipe(Stream.mapEffect(updateContext), Stream.runDrain),
+          .pipe(Stream.runForEach(updateContext)),
       );
 
       // Re-derive context when cell content changes (staleness may flip)

--- a/extension/src/notebook/NotebookEditorRegistry.ts
+++ b/extension/src/notebook/NotebookEditorRegistry.ts
@@ -23,7 +23,7 @@ export class NotebookEditorRegistry extends Effect.Service<NotebookEditorRegistr
 
       yield* Effect.forkScoped(
         code.window.activeNotebookEditorChanges().pipe(
-          Stream.mapEffect(
+          Stream.runForEach(
             Effect.fn(function* (editor) {
               const notebook = Option.filterMap(editor, (editor) =>
                 MarimoNotebookDocument.tryFrom(editor.notebook),
@@ -65,7 +65,6 @@ export class NotebookEditorRegistry extends Effect.Service<NotebookEditorRegistr
               );
             }),
           ),
-          Stream.runDrain,
         ),
       );
 

--- a/extension/src/panel/RecentNotebooks.ts
+++ b/extension/src/panel/RecentNotebooks.ts
@@ -139,7 +139,7 @@ export const RecentNotebooksLive = Layer.scopedDiscard(
     // Listen for notebook open events
     yield* Effect.forkScoped(
       code.window.activeNotebookEditorChanges().pipe(
-        Stream.mapEffect(
+        Stream.runForEach(
           Effect.fn(function* (maybeEditor) {
             const notebook = maybeEditor.pipe(
               Option.flatMap((editor) =>
@@ -154,7 +154,6 @@ export const RecentNotebooksLive = Layer.scopedDiscard(
             }
           }),
         ),
-        Stream.runDrain,
       ),
     );
 

--- a/extension/src/panel/datasources/DatasourcesView.ts
+++ b/extension/src/panel/datasources/DatasourcesView.ts
@@ -368,34 +368,31 @@ export const DatasourcesViewLive = Layer.scopedDiscard(
     // Subscribe to active notebook changes
     yield* Effect.forkScoped(
       editorRegistry.streamActiveNotebookChanges().pipe(
-        Stream.mapEffect(() => {
+        Stream.runForEach(() => {
           return refreshDatasources();
         }),
-        Stream.runDrain,
       ),
     );
 
     // Subscribe to datasource connection changes
     yield* Effect.forkScoped(
       datasourcesService.streamConnectionsChanges().pipe(
-        Stream.mapEffect(
+        Stream.runForEach(
           Effect.fn(function* (_connectionsMap) {
             yield* refreshDatasources();
           }),
         ),
-        Stream.runDrain,
       ),
     );
 
     // Subscribe to dataset changes
     yield* Effect.forkScoped(
       datasourcesService.streamDatasetsChanges().pipe(
-        Stream.mapEffect(
+        Stream.runForEach(
           Effect.fn(function* (_datasetsMap) {
             yield* refreshDatasources();
           }),
         ),
-        Stream.runDrain,
       ),
     );
 

--- a/extension/src/panel/packages/PackagesView.ts
+++ b/extension/src/panel/packages/PackagesView.ts
@@ -141,22 +141,20 @@ export const PackagesViewLive = Layer.scopedDiscard(
     // Subscribe to active notebook changes
     yield* Effect.forkScoped(
       editorRegistry.streamActiveNotebookChanges().pipe(
-        Stream.mapEffect(() => {
+        Stream.runForEach(() => {
           return refreshPackages();
         }),
-        Stream.runDrain,
       ),
     );
 
     // Subscribe to dependency tree changes
     yield* Effect.forkScoped(
       packagesService.streamDependencyTreeChanges().pipe(
-        Stream.mapEffect(
+        Stream.runForEach(
           Effect.fn(function* (_treeMap) {
             yield* refreshPackages();
           }),
         ),
-        Stream.runDrain,
       ),
     );
 

--- a/extension/src/panel/variables/VariablesView.ts
+++ b/extension/src/panel/variables/VariablesView.ts
@@ -106,25 +106,23 @@ export const VariablesViewLive = Layer.scopedDiscard(
     // Subscribe to active notebook changes
     yield* Effect.forkScoped(
       editorRegistry.streamActiveNotebookChanges().pipe(
-        Stream.mapEffect(() => {
+        Stream.runForEach(() => {
           return refreshVariables();
         }),
-        Stream.runDrain,
       ),
     );
 
     // Subscribe to variable declarations changes
     yield* Effect.forkScoped(
-      variablesService.streamVariablesChanges().pipe(
-        Stream.mapEffect(() => refreshVariables()),
-        Stream.runDrain,
-      ),
+      variablesService
+        .streamVariablesChanges()
+        .pipe(Stream.runForEach(() => refreshVariables())),
     );
 
     // Subscribe to variable values changes
     yield* Effect.forkScoped(
       variablesService.streamVariableValuesChanges().pipe(
-        Stream.mapEffect(
+        Stream.runForEach(
           Effect.fn(function* (valuesMap) {
             const activeNotebookUri =
               yield* editorRegistry.getActiveNotebookUri();
@@ -162,7 +160,6 @@ export const VariablesViewLive = Layer.scopedDiscard(
             yield* provider.refresh();
           }),
         ),
-        Stream.runDrain,
       ),
     );
 


### PR DESCRIPTION
Stacked on #559. First pass through the codebase using the new `/effect-ts` skill as the rulebook.

Three real bugs in `extension/src/kernel/` — `ExecutionRegistry` called `Option.getOrThrow` on a nullable `run_id` (a malformed kernel message would die into an unhandled cause inside the cell-op stream); `DebugAdapter` cast a typed cell-op to `Record<string, unknown>` with no justification; `KernelManager` wrapped a one-line `Queue.offer` in `Effect.fn(function*)` inside the marimo/operation stream, spawning a span per message. All small, isolated fixes that route errors through the typed channel instead of dying.

On top of that, normalized `Stream.mapEffect(fn).pipe(Stream.runDrain)` → `Stream.runForEach(fn)` across 19 sites. Same behavior either way, but `runForEach` reads cleaner for one-step pipelines. Multi-stage pipelines with `filter`/`take`/`tap` left alone.

## Test plan

- [x] `just lint-ts` clean
- [x] `pnpm -C extension test -- src/` — 396 tests pass
- [ ] CI green (likely blocked on an upstream marimo lockfile issue — under investigation)
- [ ] Execute a cell in a notebook