### PR TITLE
Capture LSP stderr and split Sentry groups by cause

### DIFF
--- a/extension/src/lsp/LanguageClient.ts
+++ b/extension/src/lsp/LanguageClient.ts
@@ -73,28 +73,49 @@ export class LanguageClient extends Effect.Service<LanguageClient>()(
       const outputChannel =
         yield* code.window.createLogOutputChannel("marimo-lsp");
 
-      const stderrTail: string[] = [];
-      let lastExit: LspProcessExit | undefined;
+      interface SpawnState {
+        readonly stderrTail: string[];
+        pending: string;
+        exit?: LspProcessExit;
+      }
+      // Per-spawn state, replaced on every serverOptions() invocation so a
+      // straggler child (e.g. stopClient timed out) cannot bleed its stderr
+      // into the next spawn's LanguageClientStartError.
+      let currentSpawn: SpawnState | undefined;
 
       const serverOptions: lsp.ServerOptions = () =>
         new Promise<NodeChildProcess.ChildProcess>((resolve, reject) => {
-          stderrTail.length = 0;
-          lastExit = undefined;
+          const spawn: SpawnState = { stderrTail: [], pending: "" };
+          currentSpawn = spawn;
+
           const child = NodeChildProcess.spawn(exec.command, exec.args ?? []);
-          if (child.pid === undefined) {
-            child.once("error", reject);
-            return;
-          }
+          // Always reject on spawn failure — `pid === undefined` is a
+          // sync-detected failure path, but other failures surface
+          // asynchronously via the "error" event.
+          child.once("error", reject);
+          if (child.pid === undefined) return;
+
           child.stderr?.setEncoding("utf8");
           child.stderr?.on("data", (chunk: string) => {
-            for (const line of chunk.split(/\r?\n/)) {
+            spawn.pending += chunk;
+            let nl: number;
+            while ((nl = spawn.pending.indexOf("\n")) !== -1) {
+              let line = spawn.pending.slice(0, nl);
+              spawn.pending = spawn.pending.slice(nl + 1);
+              if (line.endsWith("\r")) line = line.slice(0, -1);
               if (line.length === 0) continue;
-              stderrTail.push(line);
-              if (stderrTail.length > MAX_STDERR_LINES) stderrTail.shift();
+              spawn.stderrTail.push(line);
+              if (spawn.stderrTail.length > MAX_STDERR_LINES) {
+                spawn.stderrTail.shift();
+              }
             }
           });
           child.once("exit", (code, signal) => {
-            lastExit = { code, signal };
+            if (spawn.pending.length > 0) {
+              spawn.stderrTail.push(spawn.pending);
+              spawn.pending = "";
+            }
+            spawn.exit = { code, signal };
           });
           resolve(child);
         });
@@ -151,8 +172,10 @@ export class LanguageClient extends Effect.Service<LanguageClient>()(
                 exec,
                 cause,
                 stderr:
-                  stderrTail.length > 0 ? stderrTail.join("\n") : undefined,
-                exit: lastExit,
+                  currentSpawn && currentSpawn.stderrTail.length > 0
+                    ? currentSpawn.stderrTail.join("\n")
+                    : undefined,
+                exit: currentSpawn?.exit,
               }),
           });
           yield* Effect.logInfo("marimo-lsp client started");

--- a/extension/src/lsp/LanguageClient.ts
+++ b/extension/src/lsp/LanguageClient.ts
@@ -78,10 +78,14 @@ export class LanguageClient extends Effect.Service<LanguageClient>()(
         pending: string;
         exit?: LspProcessExit;
       }
-      // Per-spawn state, replaced on every serverOptions() invocation so a
-      // straggler child (e.g. stopClient timed out) cannot bleed its stderr
-      // into the next spawn's LanguageClientStartError.
+      // `currentSpawn` is the most recent serverOptions() invocation;
+      // `lastExitedSpawn` is the most recent spawn whose child has exited.
+      // vscode-languageclient auto-restarts on crash, so when start() finally
+      // rejects, currentSpawn often points to a fresh child that hasn't yet
+      // produced output — the failure data lives on the previous (exited)
+      // spawn.
       let currentSpawn: SpawnState | undefined;
+      let lastExitedSpawn: SpawnState | undefined;
 
       const serverOptions: lsp.ServerOptions = () =>
         new Promise<NodeChildProcess.ChildProcess>((resolve, reject) => {
@@ -116,6 +120,7 @@ export class LanguageClient extends Effect.Service<LanguageClient>()(
               spawn.pending = "";
             }
             spawn.exit = { code, signal };
+            lastExitedSpawn = spawn;
           });
           resolve(child);
         });
@@ -167,16 +172,24 @@ export class LanguageClient extends Effect.Service<LanguageClient>()(
           }
           yield* Effect.tryPromise({
             try: () => client.start(),
-            catch: (cause) =>
-              new LanguageClientStartError({
+            catch: (cause) => {
+              // Prefer the spawn whose exit we actually observed — current
+              // may have been replaced by an auto-restart whose child hasn't
+              // produced output yet.
+              const source =
+                currentSpawn?.exit !== undefined
+                  ? currentSpawn
+                  : (lastExitedSpawn ?? currentSpawn);
+              return new LanguageClientStartError({
                 exec,
                 cause,
                 stderr:
-                  currentSpawn && currentSpawn.stderrTail.length > 0
-                    ? currentSpawn.stderrTail.join("\n")
+                  source && source.stderrTail.length > 0
+                    ? source.stderrTail.join("\n")
                     : undefined,
-                exit: currentSpawn?.exit,
-              }),
+                exit: source?.exit,
+              });
+            },
           });
           yield* Effect.logInfo("marimo-lsp client started");
         }).pipe(Effect.withSpan("lsp.start"));

--- a/extension/src/lsp/LanguageClient.ts
+++ b/extension/src/lsp/LanguageClient.ts
@@ -1,3 +1,4 @@
+import * as NodeChildProcess from "node:child_process";
 import * as NodeFs from "node:fs";
 import * as NodePath from "node:path";
 
@@ -17,11 +18,23 @@ import type {
   MarimoLspNotificationOf,
 } from "../types.ts";
 
+/** Maximum number of stderr lines retained from the LSP subprocess. */
+const MAX_STDERR_LINES = 200;
+
+export interface LspProcessExit {
+  readonly code: number | null;
+  readonly signal: NodeJS.Signals | null;
+}
+
 export class LanguageClientStartError extends Data.TaggedError(
   "LanguageClientStartError",
 )<{
   exec: lsp.Executable;
   cause: unknown;
+  /** Tail of the LSP subprocess stderr captured up to the failure, if any. */
+  stderr?: string;
+  /** Exit code/signal of the LSP subprocess if it exited before/during start. */
+  exit?: LspProcessExit;
 }> {}
 
 export class ExecuteCommandError extends Data.TaggedError(
@@ -60,10 +73,36 @@ export class LanguageClient extends Effect.Service<LanguageClient>()(
       const outputChannel =
         yield* code.window.createLogOutputChannel("marimo-lsp");
 
+      const stderrTail: string[] = [];
+      let lastExit: LspProcessExit | undefined;
+
+      const serverOptions: lsp.ServerOptions = () =>
+        new Promise<NodeChildProcess.ChildProcess>((resolve, reject) => {
+          stderrTail.length = 0;
+          lastExit = undefined;
+          const child = NodeChildProcess.spawn(exec.command, exec.args ?? []);
+          if (child.pid === undefined) {
+            child.once("error", reject);
+            return;
+          }
+          child.stderr?.setEncoding("utf8");
+          child.stderr?.on("data", (chunk: string) => {
+            for (const line of chunk.split(/\r?\n/)) {
+              if (line.length === 0) continue;
+              stderrTail.push(line);
+              if (stderrTail.length > MAX_STDERR_LINES) stderrTail.shift();
+            }
+          });
+          child.once("exit", (code, signal) => {
+            lastExit = { code, signal };
+          });
+          resolve(child);
+        });
+
       const client = new lsp.LanguageClient(
         "marimo-lsp",
         "Marimo Language Server",
-        { run: exec, debug: exec },
+        serverOptions,
         {
           // create a dedicated output channel for marimo-lsp messages
           outputChannel,
@@ -81,7 +120,7 @@ export class LanguageClient extends Effect.Service<LanguageClient>()(
        *
        * Some LSP lifecycle errors occur because `client.stop()` never
        * resolves (e.g. the server process is stuck). A bounded stop
-       * prevents the restart flow from blocking forever (VSCODE-MARIMO-2KA).
+       * prevents the restart flow from blocking forever.
        */
       const stopClient = Effect.fn(function* () {
         yield* Effect.tryPromise(() => client.stop()).pipe(
@@ -93,7 +132,7 @@ export class LanguageClient extends Effect.Service<LanguageClient>()(
 
       /**
        * Start the client. Waits until the client is fully stopped first,
-       * avoiding the "Client is currently stopping" race (VSCODE-MARIMO-2KZ).
+       * avoiding the "Client is currently stopping" race.
        */
       const startClient = () =>
         Effect.gen(function* () {
@@ -107,7 +146,14 @@ export class LanguageClient extends Effect.Service<LanguageClient>()(
           }
           yield* Effect.tryPromise({
             try: () => client.start(),
-            catch: (cause) => new LanguageClientStartError({ exec, cause }),
+            catch: (cause) =>
+              new LanguageClientStartError({
+                exec,
+                cause,
+                stderr:
+                  stderrTail.length > 0 ? stderrTail.join("\n") : undefined,
+                exit: lastExit,
+              }),
           });
           yield* Effect.logInfo("marimo-lsp client started");
         }).pipe(Effect.withSpan("lsp.start"));

--- a/extension/src/notebook/NotebookSerializer.ts
+++ b/extension/src/notebook/NotebookSerializer.ts
@@ -1,5 +1,6 @@
 import { MarkdownParser, SQLParser } from "@marimo-team/smart-cells";
 import {
+  Cause,
   Effect,
   Fiber,
   Option,
@@ -167,7 +168,10 @@ export class NotebookSerializer extends Effect.Service<NotebookSerializer>()(
                 }).pipe(
                   Effect.tapErrorCause((cause) =>
                     Effect.logError(`Notebook serialize failed`).pipe(
-                      Effect.annotateLogs({ cause }),
+                      Effect.annotateLogs({
+                        cause,
+                        "error.tag": causeTag(cause),
+                      }),
                     ),
                   ),
                   Effect.mapError(
@@ -190,7 +194,10 @@ export class NotebookSerializer extends Effect.Service<NotebookSerializer>()(
                 }).pipe(
                   Effect.tapErrorCause((cause) =>
                     Effect.logError(`Notebook deserialize failed`).pipe(
-                      Effect.annotateLogs({ cause }),
+                      Effect.annotateLogs({
+                        cause,
+                        "error.tag": causeTag(cause),
+                      }),
                     ),
                   ),
                   Effect.mapError(
@@ -250,6 +257,26 @@ const decodeDeserializeResponse = Schema.decodeUnknown(SerializedNotebook);
 const decodeSerializeResponse = Schema.decodeUnknown(
   Schema.Struct({ source: Schema.String }),
 );
+
+function hasStringTag(value: unknown): value is { _tag: string } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "_tag" in value &&
+    typeof (value as { _tag: unknown })._tag === "string"
+  );
+}
+
+function causeTag(cause: Cause.Cause<unknown>): string {
+  return Option.match(Cause.failureOption(cause), {
+    onSome: (failure) => (hasStringTag(failure) ? failure._tag : "Unknown"),
+    onNone: () => {
+      if (Cause.isDie(cause)) return "Die";
+      if (Cause.isInterruptedOnly(cause)) return "Interrupt";
+      return "Empty";
+    },
+  });
+}
 
 const DEFAULT_CELL_NAME = "_";
 

--- a/extension/src/notebook/NotebookSerializer.ts
+++ b/extension/src/notebook/NotebookSerializer.ts
@@ -263,7 +263,7 @@ function hasStringTag(value: unknown): value is { _tag: string } {
     typeof value === "object" &&
     value !== null &&
     "_tag" in value &&
-    typeof (value as { _tag: unknown })._tag === "string"
+    typeof value._tag === "string"
   );
 }
 

--- a/extension/src/telemetry/Sentry.ts
+++ b/extension/src/telemetry/Sentry.ts
@@ -170,8 +170,12 @@ export class Sentry extends Effect.Service<Sentry>()("Sentry", {
 
         // Build extra context with annotations
         const extra: Record<string, unknown> = {};
+        let errorTag: string | undefined;
         for (const [key, value] of HashMap.toEntries(opts.annotations)) {
           extra[key] = structuredMessage(value);
+          if (key === "error.tag" && typeof value === "string") {
+            errorTag = value;
+          }
           if (Cause.isCause(value) && !Cause.isEmpty(value)) {
             extra[`${key}.pretty`] = Cause.pretty(value, {
               renderErrorCause: true,
@@ -186,22 +190,39 @@ export class Sentry extends Effect.Service<Sentry>()("Sentry", {
           });
         }
 
+        // Splitting the Sentry group by inner failure tag turns coarse
+        // "Notebook deserialize failed" buckets into one group per root
+        // cause (LanguageClientStartError vs ExecuteCommandError vs ...).
+        const tags = {
+          marimo: "true",
+          ...(errorTag ? { "error.tag": errorTag } : {}),
+        };
+        const fingerprint = errorTag ? [messageStr, errorTag] : undefined;
+
         if (opts.logLevel === LogLevel.Error) {
           SentrySDK.captureMessage(messageStr, {
             extra,
             level: "error",
-            tags: { marimo: "true" },
+            tags,
+            fingerprint,
           });
         } else if (opts.logLevel === LogLevel.Fatal) {
           SentrySDK.captureMessage(messageStr, {
             extra,
             level: "fatal",
-            tags: { marimo: "true" },
+            tags,
+            fingerprint,
           });
         } else if (opts.logLevel === LogLevel.Warning) {
           SentrySDK.addBreadcrumb({
             message: messageStr,
             level: "warning",
+            data: extra,
+          });
+        } else if (opts.logLevel === LogLevel.Info) {
+          SentrySDK.addBreadcrumb({
+            message: messageStr,
+            level: "info",
             data: extra,
           });
         }


### PR DESCRIPTION
vscode-languageclient routes spawned-server stderr to the output channel but not to the start-failure surface, so distinct LSP startup failures (outdated uv, missing marimo module, AV killing the child) all surface as a generic "connection got disposed" and fingerprint identically in Sentry.

Switching to a `ServerOptions` factory lets us own the spawn, ring-buffer the last 200 stderr lines, and attach them to `LanguageClientStartError` alongside the exit code and signal.