### PR TITLE
Sync extension/package.json to 0.13.1

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vscode-marimo",
   "displayName": "marimo",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "A marimo notebook extension for VS Code.",
   "categories": [
     "Data Science",


### PR DESCRIPTION
The last release tagged 0.13.1 but failed to push the version bump back to main (protected branch), so `extension/package.json` stayed at 0.13.0 and the next run tried to release 0.13.1 again.

Bumping to 0.13.1 so the next patch release lands on 0.13.2.