### PR TITLE
fix(api): snapshot document on ExecuteScratchpadCommand for code_mode

### DIFF
--- a/src/marimo_lsp/api.py
+++ b/src/marimo_lsp/api.py
@@ -181,8 +181,18 @@ async def execute_scratch(
         logger.warning(f"No session found for {args.notebook_uri}")
         return
 
+    # Snapshot the document so handle_execute_scratchpad in marimo's runtime
+    # can populate the notebook_document_context ContextVar that
+    # marimo._code_mode.get_context() reads. Without this, code_mode raises
+    # RuntimeError("NotebookDocument not available"). Mirrors marimo's
+    # standalone server (marimo/_server/api/endpoints/execution.py).
     session.put_control_request(
-        ExecuteScratchpadCommand(code=args.inner.code),
+        ExecuteScratchpadCommand(
+            code=args.inner.code,
+            notebook_cells=tuple(
+                session.app_file_manager.app.cell_manager.document.cells
+            ),
+        ),
         from_consumer_id=None,
     )
     logger.info(f"Scratchpad execution request sent for {args.notebook_uri}")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1547,3 +1547,135 @@ y\
             },
         ]
     )
+
+
+@pytest.mark.asyncio
+async def test_scratchpad_code_mode_get_context(client: LanguageClient) -> None:
+    """code_mode.get_context() should resolve the notebook document when
+    invoked from scratchpad code.
+
+    handle_execute_scratchpad in marimo._runtime.runtime populates the
+    notebook_document_context ContextVar from request.notebook_cells.
+    execute_scratch in marimo_lsp.api currently sends
+    ExecuteScratchpadCommand(code=...) with no notebook_cells, so the
+    ContextVar stays None and cm.get_context() raises RuntimeError.
+
+    The fix is to snapshot the session document on send — mirroring marimo's
+    standalone /api/execute endpoint
+    (marimo/_server/api/endpoints/execution.py).
+    """
+    notebook_code = "x = 10"
+    client.notebook_document_did_open(
+        lsp.DidOpenNotebookDocumentParams(
+            notebook_document=lsp.NotebookDocument(
+                uri="file:///scratch_codemode.py",
+                notebook_type="marimo-notebook",
+                version=1,
+                cells=[
+                    NotebookCell(
+                        kind=lsp.NotebookCellKind.Code,
+                        document="file:///scratch_codemode.py#cell1",
+                    )
+                ],
+            ),
+            cell_text_documents=[
+                lsp.TextDocumentItem(
+                    uri="file:///scratch_codemode.py#cell1",
+                    language_id="python",
+                    version=1,
+                    text=notebook_code,
+                )
+            ],
+        ),
+    )
+
+    cell_completion_event = asyncio.Event()
+    scratch_messages: list[dict] = []
+    scratch_completion_event = asyncio.Event()
+    waiting_for_scratch = False
+
+    @client.feature("marimo/operation")
+    async def on_marimo_operation(params: Any) -> None:  # noqa: ANN401
+        nonlocal waiting_for_scratch
+        msg = asdict(params)
+        op = msg.get("operation", {})
+
+        if op.get("op") == "completed-run" and not waiting_for_scratch:
+            await asyncio.sleep(0.1)
+            cell_completion_event.set()
+            return
+
+        if op.get("op") == "cell-op" and op.get("cell_id") == "__scratch__":
+            scratch_messages.append(msg)
+            if op.get("status") == "idle":
+                await asyncio.sleep(0.1)
+                scratch_completion_event.set()
+
+    # Boot the kernel by running cell1.
+    await client.workspace_execute_command_async(
+        lsp.ExecuteCommandParams(
+            command="marimo.api",
+            arguments=[
+                {
+                    "method": "execute-cells",
+                    "params": {
+                        "notebookUri": "file:///scratch_codemode.py",
+                        "executable": sys.executable,
+                        "inner": {
+                            "cellIds": ["cell1"],
+                            "codes": [notebook_code],
+                        },
+                    },
+                }
+            ],
+        )
+    )
+    await asyncio.wait_for(cell_completion_event.wait(), timeout=10.0)
+    waiting_for_scratch = True
+
+    # Scratchpad code that exercises cm.get_context() and prints cell count.
+    scratchpad_code = (
+        "import marimo._code_mode as cm\n"
+        "async with cm.get_context() as ctx:\n"
+        "    print(f'cells={len(ctx.cells)}')\n"
+    )
+    await client.workspace_execute_command_async(
+        lsp.ExecuteCommandParams(
+            command="marimo.api",
+            arguments=[
+                {
+                    "method": "execute-scratchpad",
+                    "params": {
+                        "notebookUri": "file:///scratch_codemode.py",
+                        "executable": sys.executable,
+                        "inner": {"code": scratchpad_code},
+                    },
+                }
+            ],
+        )
+    )
+    await asyncio.wait_for(scratch_completion_event.wait(), timeout=5.0)
+
+    # No marimo-error must have arrived. (Without the fix, the scratchpad
+    # emits a marimo-error containing the RuntimeError from cm.get_context.)
+    error_msgs = [
+        m
+        for m in scratch_messages
+        if (m.get("operation", {}).get("output") or {}).get("channel")
+        == "marimo-error"
+    ]
+    assert error_msgs == [], (
+        "cm.get_context() raised — notebook_document_context ContextVar "
+        f"was not populated. errors: {error_msgs}"
+    )
+
+    # stdout from the scratchpad should report the cell count (1).
+    stdout_data = "".join(
+        (m["operation"].get("console") or {}).get("data") or ""
+        for m in scratch_messages
+        if isinstance(m["operation"].get("console"), dict)
+        and m["operation"]["console"].get("channel") == "stdout"
+    )
+    assert "cells=1" in stdout_data, (
+        f"expected 'cells=1' in scratchpad stdout, got: {stdout_data!r}"
+    )

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1661,8 +1661,7 @@ async def test_scratchpad_code_mode_get_context(client: LanguageClient) -> None:
     error_msgs = [
         m
         for m in scratch_messages
-        if (m.get("operation", {}).get("output") or {}).get("channel")
-        == "marimo-error"
+        if (m.get("operation", {}).get("output") or {}).get("channel") == "marimo-error"
     ]
     assert error_msgs == [], (
         "cm.get_context() raised — notebook_document_context ContextVar "


### PR DESCRIPTION
## Summary

When `cm.get_context()` is invoked from scratchpad code (e.g. via `marimo.api` `execute-scratchpad` or `experimental.kernels.executeCode`), it raises:

```
RuntimeError: NotebookDocument not available — code_mode must be invoked
via the /api/execute endpoint which sets the document context variable
```

Root cause: `execute_scratch` in `src/marimo_lsp/api.py` sends `ExecuteScratchpadCommand(code=...)` with no `notebook_cells`. `handle_execute_scratchpad` in `marimo._runtime.runtime` builds the `notebook_document_context` ContextVar from that field, so it stays None and code_mode raises.

## Change

5-LOC patch: snapshot `session.app_file_manager.app.cell_manager.document.cells` and pass it as `notebook_cells`. Mirrors marimo's standalone server (`marimo/_server/api/endpoints/execution.py:319`) literally — same source of cells, same field on the same command.

## Test

`test_scratchpad_code_mode_get_context` (new pytest in `tests/test_server.py`):

1. Opens a marimo notebook with one cell.
2. Boots the kernel by running cell1.
3. Sends `execute-scratchpad` with code that imports `marimo._code_mode` and prints `len(ctx.cells)` from inside `async with cm.get_context() as ctx`.
4. Asserts (a) no `marimo-error` operation arrives, (b) stdout reports `cells=1`.

On `main`: RED — assertion shows the exact RuntimeError surfaced as a `marimo-error` operation.
After patch: GREEN.

Existing `test_scratchpad_execution` continues to pass.

## Context

Filed alongside #568 which sketches the broader use case (external agents driving the editor's kernel via `experimental.kernels`) and a sibling fix for the error-mime wart (the sibling fix (see issue #568)).
