### PR TITLE
fix(kernel): emit marimo-error items with NotebookCellOutputItem.error mime

### DIFF
--- a/extension/src/kernel/ExecutionRegistry.ts
+++ b/extension/src/kernel/ExecutionRegistry.ts
@@ -672,7 +672,17 @@ function buildOutputItem(
       if (errorMessage.includes("<a href=")) {
         return code.NotebookCellOutputItem.text(errorMessage, "text/html");
       }
-      return code.NotebookCellOutputItem.stderr(errorMessage);
+      // Use the canonical error mime (application/vnd.code.notebook.error) so
+      // consumers of experimental.kernels.executeCode (e.g. agent-bridge or
+      // vscode-jupyter-style consumers) can distinguish errors from stderr.
+      // The Python traceback arrives separately as a console output, so we
+      // don't synthesize a JS stack (avoids leaking absolute paths to
+      // consumers and keeps tests reproducible).
+      return code.NotebookCellOutputItem.error({
+        name:
+          error.type === "exception" ? error.exception_type : error.type,
+        message: errorMessage,
+      } as Error);
     });
     return errors[0] || null;
   }

--- a/extension/src/kernel/__tests__/ExecutionRegistry.test.ts
+++ b/extension/src/kernel/__tests__/ExecutionRegistry.test.ts
@@ -202,6 +202,52 @@ describe("buildCellOutputs", () => {
   );
 
   it.effect(
+    "marimo-error exception emits NotebookCellOutputItem.error (mime: application/vnd.code.notebook.error)",
+    Effect.fn(function* () {
+      const ctx = yield* withTestCtx();
+
+      const outputs = yield* Effect.gen(function* () {
+        const code = yield* VsCode;
+        const state: CellRuntimeState = {
+          ...createCellRuntimeState(),
+          output: {
+            mimetype: "application/vnd.marimo+error",
+            channel: "marimo-error",
+            data: [
+              {
+                type: "exception",
+                msg: "division by zero",
+                exception_type: "ZeroDivisionError",
+              },
+            ],
+            timestamp: 0,
+          },
+        };
+        return buildCellOutputs(CELL_ID, state, code);
+      }).pipe(Effect.provide(ctx.layer));
+
+      // The error item must use the canonical error mime so consumers of
+      // experimental.kernels.executeCode (e.g. agent-bridge or any
+      // vscode-jupyter-style consumer) can distinguish errors from stderr.
+      // Today this emits application/vnd.code.notebook.stderr, which makes
+      // failed scratchpad runs look indistinguishable from a successful run
+      // that printed to stderr.
+      expect(outputs).toHaveLength(1);
+      expect(outputs[0].items).toHaveLength(1);
+      expect(outputs[0].items[0].mime).toBe(
+        "application/vnd.code.notebook.error",
+      );
+      const decoded = new TextDecoder().decode(outputs[0].items[0].data);
+      const parsed = JSON.parse(decoded) as {
+        name: string;
+        message: string;
+      };
+      expect(parsed.name).toBe("ZeroDivisionError");
+      expect(parsed.message).toContain("division by zero");
+    }),
+  );
+
+  it.effect(
     "handles HTML output",
     Effect.fn(function* () {
       const ctx = yield* withTestCtx();

--- a/extension/src/kernel/__tests__/__snapshots__/ExecutionRegistry.test.ts.snap
+++ b/extension/src/kernel/__tests__/__snapshots__/ExecutionRegistry.test.ts.snap
@@ -77,8 +77,8 @@ exports[`buildCellOutputs > handles marimo error output 1`] = `
   {
     "items": [
       {
-        "data": "Syntax error: Invalid syntax",
-        "mime": "application/vnd.code.notebook.stderr",
+        "data": "{"name":"syntax","message":"Syntax error: Invalid syntax"}",
+        "mime": "application/vnd.code.notebook.error",
       },
     ],
     "metadata": {
@@ -231,8 +231,8 @@ exports[`buildCellOutputs > handles multiple errors in marimo error output 1`] =
   {
     "items": [
       {
-        "data": "ValueError: ValueError: invalid value",
-        "mime": "application/vnd.code.notebook.stderr",
+        "data": "{"name":"ValueError","message":"ValueError: ValueError: invalid value"}",
+        "mime": "application/vnd.code.notebook.error",
       },
     ],
     "metadata": {


### PR DESCRIPTION
## Summary

`experimental.kernels.executeCode()` emits `NotebookCellOutputItem.stderr(...)` (mime `application/vnd.code.notebook.stderr`) for `marimo-error` channel data. The wrapping `NotebookCellOutput` has `{channel: "marimo-error"}` metadata, but items do not, so any consumer iterating the `AsyncIterable<Output>` from the public API cannot distinguish a real failure from a successful run that printed to stderr.

The Api this is modeled after (vscode-jupyter) uses `application/vnd.code.notebook.error` mime for exactly this signal.

## Change

`extension/src/kernel/ExecutionRegistry.ts` (`buildOutputItem`): switch the marimo-error branch from `NotebookCellOutputItem.stderr(errorMessage)` to `NotebookCellOutputItem.error({name, message})`. `name` = `error.exception_type` when `type === "exception"`, else `error.type`. `message` = existing `prettyErrorMessage`.

No JS stack is synthesized (marimo's MarimoError types don't carry one; the Python traceback continues to arrive as a separate console output). This keeps snapshots reproducible across machines.

## Test

`marimo-error exception emits NotebookCellOutputItem.error (mime: application/vnd.code.notebook.error)` (new vitest in `ExecutionRegistry.test.ts`):

```ts
const state = {
  ...createCellRuntimeState(),
  output: {
    mimetype: "application/vnd.marimo+error",
    channel: "marimo-error",
    data: [{ type: "exception", msg: "division by zero",
             exception_type: "ZeroDivisionError" }],
    timestamp: 0,
  },
};
const outputs = buildCellOutputs(CELL_ID, state, code);
expect(outputs[0].items[0].mime).toBe("application/vnd.code.notebook.error");
expect(JSON.parse(...)).toMatchObject({ name: "ZeroDivisionError", message: /division by zero/ });
```

On `main`: RED — `expected '…stderr' to be '…error'`.
After patch: GREEN.

Two existing snapshots updated (they captured the previous mime — strictly demonstrate the wart). All 398 tests pass.

## UX note

Switching from `.stderr` to `.error` changes how the notebook UI renders cell errors: from inline red text to the standard red error box with `name` + `message` and a collapsible stack. The latter matches what marimo users would see in any other notebook editor. Happy to layer a `.stderr` sibling item if you'd rather keep the current inline rendering.

## Context

Filed alongside #568 which sketches the broader use case (external agents driving the editor's kernel via `experimental.kernels`) and a sibling fix for the code_mode wart (the sibling fix (see issue #568)).
