### PR TITLE
Linkify file paths in cell tracebacks

### DIFF
--- a/extension/src/kernel/ExecutionRegistry.ts
+++ b/extension/src/kernel/ExecutionRegistry.ts
@@ -11,6 +11,7 @@ import type * as vscode from "vscode";
 import { logUnreachable } from "../assert.ts";
 import { SCRATCH_CELL_ID } from "../constants.ts";
 import { prettyErrorMessage } from "../lib/errors.ts";
+import { parseTraceback } from "../lib/tracebacks.ts";
 import { CellStateManager } from "../notebook/CellStateManager.ts";
 import { VsCode } from "../platform/VsCode.ts";
 import {
@@ -545,9 +546,10 @@ export function buildCellOutputs(
   }
 
   // Create NotebookCellOutputs for each channel with items.
-  // Order matches marimo's web frontend: rich output above console streams so
-  // reactive UI elements stay anchored when a cell also prints (#516).
-  if (errorItems.length > 0) {
+  //
+  // marimo-error and a traceback are present, the traceback already renders
+  // `<Type>: <message>` as its header, so the marimo-error item is dropped.
+  if (errorItems.length > 0 && !shouldSuppressMarimoError(state)) {
     outputs.push(
       new code.NotebookCellOutput(errorItems, {
         channel: "marimo-error",
@@ -598,6 +600,44 @@ export function buildCellOutputs(
  * @param notebook - The notebook document containing the cells
  * @returns A function that maps cell URIs to HTML link strings
  */
+const TRACEBACK_MIME = "application/vnd.marimo+traceback";
+
+function hasTraceback(state: CellRuntimeState): boolean {
+  if (state.output?.mimetype === TRACEBACK_MIME) return true;
+  return (state.consoleOutputs ?? []).some(
+    (o) => o?.mimetype === TRACEBACK_MIME,
+  );
+}
+
+function shouldSuppressMarimoError(state: CellRuntimeState): boolean {
+  const out = state.output;
+  if (!out || out.channel !== "marimo-error" || !Array.isArray(out.data)) {
+    return false;
+  }
+  const onlyExceptionLike = out.data.every(
+    (e) =>
+      e != null &&
+      typeof e === "object" &&
+      "type" in e &&
+      (e.type === "exception" || e.type === "strict-exception"),
+  );
+  return onlyExceptionLike && hasTraceback(state);
+}
+
+function createCellIdToIndex(
+  notebook: MarimoNotebookDocument,
+): (cellId: string) => number | undefined {
+  return (cellId: string) => {
+    const cellIndex = notebook.getCells().findIndex((cell) =>
+      Option.match(cell.id, {
+        onSome: (id) => id === cellId,
+        onNone: () => false,
+      }),
+    );
+    return cellIndex === -1 ? undefined : cellIndex;
+  };
+}
+
 function createCellIdMapper(
   notebook: MarimoNotebookDocument,
 ): (cellId: NotebookCellId) => string | undefined {
@@ -647,7 +687,11 @@ function buildOutputItem(
     }
   }
 
-  // Handle traceback
+  // Handle traceback — emit as a structured error so VS Code's built-in
+  // notebook error renderer applies its red-bordered styling. We rewrite
+  // each frame: cell-temp paths become `Cell cell-<N>, line <M>`, and real
+  // file paths get an inline `<a href>` anchor so VS Code's webview
+  // opener turns them into clickable links.
   if (output.mimetype === "application/vnd.marimo+traceback") {
     const text =
       typeof output.data === "object"
@@ -657,7 +701,10 @@ function buildOutputItem(
     if (!text) {
       return null;
     }
-    return code.NotebookCellOutputItem.text(text, "text/html");
+    const cellIdToIndex = notebook
+      ? createCellIdToIndex(MarimoNotebookDocument.from(notebook))
+      : undefined;
+    return code.NotebookCellOutputItem.error(parseTraceback(text, cellIdToIndex));
   }
 
   // Handle marimo errors

--- a/extension/src/kernel/ExecutionRegistry.ts
+++ b/extension/src/kernel/ExecutionRegistry.ts
@@ -588,6 +588,32 @@ export function buildCellOutputs(
   return outputs;
 }
 
+const TRACEBACK_MIME = "application/vnd.marimo+traceback";
+
+function hasTraceback(state: CellRuntimeState): boolean {
+  if (state.output?.mimetype === TRACEBACK_MIME) return true;
+  return (state.consoleOutputs ?? []).some(
+    (o) => o?.mimetype === TRACEBACK_MIME,
+  );
+}
+
+// Only suppress when every item is a plain `exception` without `raising_cell`:
+// `strict-exception` carries `ref` and `blamed_cell`, and `exception` with
+// `raising_cell` carries the "raised in cell" pointer — neither appears in the
+// Python traceback, so the marimo-error block stays in those cases.
+function shouldSuppressMarimoError(state: CellRuntimeState): boolean {
+  const out = state.output;
+  if (!out || out.channel !== "marimo-error" || !Array.isArray(out.data)) {
+    return false;
+  }
+  const everyRedundant = out.data.every((e) => {
+    if (e == null || typeof e !== "object") return false;
+    if (!("type" in e) || e.type !== "exception") return false;
+    return !("raising_cell" in e) || !e.raising_cell;
+  });
+  return everyRedundant && hasTraceback(state);
+}
+
 /**
  * Creates a mapper function that converts cell URIs to clickable HTML links.
  *
@@ -600,44 +626,6 @@ export function buildCellOutputs(
  * @param notebook - The notebook document containing the cells
  * @returns A function that maps cell URIs to HTML link strings
  */
-const TRACEBACK_MIME = "application/vnd.marimo+traceback";
-
-function hasTraceback(state: CellRuntimeState): boolean {
-  if (state.output?.mimetype === TRACEBACK_MIME) return true;
-  return (state.consoleOutputs ?? []).some(
-    (o) => o?.mimetype === TRACEBACK_MIME,
-  );
-}
-
-function shouldSuppressMarimoError(state: CellRuntimeState): boolean {
-  const out = state.output;
-  if (!out || out.channel !== "marimo-error" || !Array.isArray(out.data)) {
-    return false;
-  }
-  const onlyExceptionLike = out.data.every(
-    (e) =>
-      e != null &&
-      typeof e === "object" &&
-      "type" in e &&
-      (e.type === "exception" || e.type === "strict-exception"),
-  );
-  return onlyExceptionLike && hasTraceback(state);
-}
-
-function createCellIdToIndex(
-  notebook: MarimoNotebookDocument,
-): (cellId: string) => number | undefined {
-  return (cellId: string) => {
-    const cellIndex = notebook.getCells().findIndex((cell) =>
-      Option.match(cell.id, {
-        onSome: (id) => id === cellId,
-        onNone: () => false,
-      }),
-    );
-    return cellIndex === -1 ? undefined : cellIndex;
-  };
-}
-
 function createCellIdMapper(
   notebook: MarimoNotebookDocument,
 ): (cellId: NotebookCellId) => string | undefined {
@@ -653,6 +641,20 @@ function createCellIdMapper(
       return undefined;
     }
     return createCellNavigationLink(cellId, cellIndex + 1);
+  };
+}
+
+function createCellIdToIndex(
+  notebook: MarimoNotebookDocument,
+): (cellId: string) => number | undefined {
+  return (cellId: string) => {
+    const cellIndex = notebook.getCells().findIndex((cell) =>
+      Option.match(cell.id, {
+        onSome: (id) => id === cellId,
+        onNone: () => false,
+      }),
+    );
+    return cellIndex === -1 ? undefined : cellIndex;
   };
 }
 
@@ -704,7 +706,9 @@ function buildOutputItem(
     const cellIdToIndex = notebook
       ? createCellIdToIndex(MarimoNotebookDocument.from(notebook))
       : undefined;
-    return code.NotebookCellOutputItem.error(parseTraceback(text, cellIdToIndex));
+    return code.NotebookCellOutputItem.error(
+      parseTraceback(text, cellIdToIndex),
+    );
   }
 
   // Handle marimo errors

--- a/extension/src/kernel/__tests__/ExecutionRegistry.test.ts
+++ b/extension/src/kernel/__tests__/ExecutionRegistry.test.ts
@@ -454,7 +454,7 @@ describe("buildCellOutputs", () => {
           output: {
             mimetype: "application/vnd.marimo+traceback",
             channel: "output",
-            data: '<b>Traceback (most recent call last):</b>\n  File "<stdin>", line 1, in <module>\nTypeError: invalid value',
+            data: '<div class="highlight"><pre>Traceback (most recent call last):\n  File <span class="s">&quot;/tmp/foo.py&quot;</span>, line 1, in &lt;module&gt;\nTypeError: invalid value</pre></div>',
           },
         };
 
@@ -510,6 +510,80 @@ describe("buildCellOutputs", () => {
 
       const outputs = yield* Effect.gen(function* () {
         const code = yield* VsCode;
+        return buildCellOutputs(CELL_ID, state, code);
+      }).pipe(Effect.provide(ctx.layer));
+
+      expect(normalizeOutputsForSnapshot(outputs)).toMatchSnapshot();
+    }),
+  );
+
+  it.effect(
+    "suppresses redundant exception marimo-error when a traceback is also present",
+    Effect.fn(function* () {
+      const ctx = yield* withTestCtx();
+
+      const outputs = yield* Effect.gen(function* () {
+        const code = yield* VsCode;
+        const state: CellRuntimeState = {
+          ...createCellRuntimeState(),
+          output: {
+            mimetype: "application/vnd.marimo+error",
+            channel: "marimo-error",
+            data: [
+              {
+                type: "exception",
+                msg: "division by zero",
+                exception_type: "ZeroDivisionError",
+              },
+            ],
+            timestamp: 0,
+          },
+          consoleOutputs: [
+            {
+              mimetype: "application/vnd.marimo+traceback",
+              channel: "stderr",
+              data: "Traceback (most recent call last):\n  File &quot;/tmp/cell.py&quot;, line 1, in &lt;module&gt;\nZeroDivisionError: division by zero",
+              timestamp: 0,
+            },
+          ],
+        };
+        return buildCellOutputs(CELL_ID, state, code);
+      }).pipe(Effect.provide(ctx.layer));
+
+      expect(normalizeOutputsForSnapshot(outputs)).toMatchSnapshot();
+    }),
+  );
+
+  it.effect(
+    "keeps marimo-error rule violations even when a traceback is present",
+    Effect.fn(function* () {
+      const ctx = yield* withTestCtx();
+
+      const outputs = yield* Effect.gen(function* () {
+        const code = yield* VsCode;
+        const state: CellRuntimeState = {
+          ...createCellRuntimeState(),
+          output: {
+            mimetype: "application/vnd.marimo+error",
+            channel: "marimo-error",
+            data: [
+              {
+                type: "multiple-defs",
+                name: "x",
+                cells: [cellId("other-cell-id")],
+              },
+            ],
+            timestamp: 0,
+          },
+          consoleOutputs: [
+            {
+              mimetype: "application/vnd.marimo+traceback",
+              channel: "stderr",
+              data: "Traceback (most recent call last):\n  File &quot;/tmp/cell.py&quot;, line 1\nNameError: unused",
+              timestamp: 0,
+            },
+          ],
+        };
         return buildCellOutputs(CELL_ID, state, code);
       }).pipe(Effect.provide(ctx.layer));
 

--- a/extension/src/kernel/__tests__/ExecutionRegistry.test.ts
+++ b/extension/src/kernel/__tests__/ExecutionRegistry.test.ts
@@ -555,6 +555,82 @@ describe("buildCellOutputs", () => {
   );
 
   it.effect(
+    "keeps strict-exception marimo-error even when a traceback is present",
+    Effect.fn(function* () {
+      const ctx = yield* withTestCtx();
+
+      const outputs = yield* Effect.gen(function* () {
+        const code = yield* VsCode;
+        const state: CellRuntimeState = {
+          ...createCellRuntimeState(),
+          output: {
+            mimetype: "application/vnd.marimo+error",
+            channel: "marimo-error",
+            data: [
+              {
+                type: "strict-exception",
+                msg: "name 'x' is not defined",
+                ref: "x",
+                blamed_cell: cellId("blamed-cell-id"),
+              },
+            ],
+            timestamp: 0,
+          },
+          consoleOutputs: [
+            {
+              mimetype: "application/vnd.marimo+traceback",
+              channel: "stderr",
+              data: "Traceback (most recent call last):\n  File &quot;/tmp/cell.py&quot;, line 1, in &lt;module&gt;\nNameError: name 'x' is not defined",
+              timestamp: 0,
+            },
+          ],
+        };
+        return buildCellOutputs(CELL_ID, state, code);
+      }).pipe(Effect.provide(ctx.layer));
+
+      expect(normalizeOutputsForSnapshot(outputs)).toMatchSnapshot();
+    }),
+  );
+
+  it.effect(
+    "keeps exception marimo-error with raising_cell even when a traceback is present",
+    Effect.fn(function* () {
+      const ctx = yield* withTestCtx();
+
+      const outputs = yield* Effect.gen(function* () {
+        const code = yield* VsCode;
+        const state: CellRuntimeState = {
+          ...createCellRuntimeState(),
+          output: {
+            mimetype: "application/vnd.marimo+error",
+            channel: "marimo-error",
+            data: [
+              {
+                type: "exception",
+                msg: "division by zero",
+                exception_type: "ZeroDivisionError",
+                raising_cell: cellId("raising-cell-id"),
+              },
+            ],
+            timestamp: 0,
+          },
+          consoleOutputs: [
+            {
+              mimetype: "application/vnd.marimo+traceback",
+              channel: "stderr",
+              data: "Traceback (most recent call last):\n  File &quot;/tmp/cell.py&quot;, line 1, in &lt;module&gt;\nZeroDivisionError: division by zero",
+              timestamp: 0,
+            },
+          ],
+        };
+        return buildCellOutputs(CELL_ID, state, code);
+      }).pipe(Effect.provide(ctx.layer));
+
+      expect(normalizeOutputsForSnapshot(outputs)).toMatchSnapshot();
+    }),
+  );
+
+  it.effect(
     "keeps marimo-error rule violations even when a traceback is present",
     Effect.fn(function* () {
       const ctx = yield* withTestCtx();

--- a/extension/src/kernel/__tests__/__snapshots__/ExecutionRegistry.test.ts.snap
+++ b/extension/src/kernel/__tests__/__snapshots__/ExecutionRegistry.test.ts.snap
@@ -43,10 +43,8 @@ exports[`buildCellOutputs > handles application/vnd.marimo+traceback output 1`] 
   {
     "items": [
       {
-        "data": "<b>Traceback (most recent call last):</b>
-  File "<stdin>", line 1, in <module>
-TypeError: invalid value",
-        "mime": "text/html",
+        "data": "{"name":"TypeError","message":"invalid value","stack":"Traceback (most recent call last):\\n  File <a href=\\"/tmp/foo.py:1\\">/tmp/foo.py:1</a>\\u001b[2m, in <module>\\u001b[0m\\n\\u001b[1;31mTypeError\\u001b[0m: invalid value"}",
+        "mime": "application/vnd.code.notebook.error",
       },
     ],
     "metadata": undefined,
@@ -392,6 +390,36 @@ exports[`buildCellOutputs > ignores output/marimo-error/pdb channels in console 
 ]
 `;
 
+exports[`buildCellOutputs > keeps marimo-error rule violations even when a traceback is present 1`] = `
+[
+  {
+    "items": [
+      {
+        "data": "This cell redefines variables from other cells.
+
+'x' was also defined by:
+  • other-cell-id",
+        "mime": "application/vnd.code.notebook.stderr",
+      },
+    ],
+    "metadata": {
+      "channel": "marimo-error",
+    },
+  },
+  {
+    "items": [
+      {
+        "data": "{"name":"NameError","message":"unused","stack":"Traceback (most recent call last):\\n  File <a href=\\"/tmp/cell.py:1\\">/tmp/cell.py:1</a>\\u001b[2m\\u001b[0m\\n\\u001b[1;31mNameError\\u001b[0m: unused"}",
+        "mime": "application/vnd.code.notebook.error",
+      },
+    ],
+    "metadata": {
+      "channel": "stderr",
+    },
+  },
+]
+`;
+
 exports[`buildCellOutputs > preserves whitespace-only output 1`] = `
 [
   {
@@ -428,6 +456,22 @@ exports[`buildCellOutputs > separates console outputs from main output correctly
     ],
     "metadata": {
       "channel": "stdout",
+    },
+  },
+]
+`;
+
+exports[`buildCellOutputs > suppresses redundant exception marimo-error when a traceback is also present 1`] = `
+[
+  {
+    "items": [
+      {
+        "data": "{"name":"ZeroDivisionError","message":"division by zero","stack":"Traceback (most recent call last):\\n  File <a href=\\"/tmp/cell.py:1\\">/tmp/cell.py:1</a>\\u001b[2m, in <module>\\u001b[0m\\n\\u001b[1;31mZeroDivisionError\\u001b[0m: division by zero"}",
+        "mime": "application/vnd.code.notebook.error",
+      },
+    ],
+    "metadata": {
+      "channel": "stderr",
     },
   },
 ]

--- a/extension/src/kernel/__tests__/__snapshots__/ExecutionRegistry.test.ts.snap
+++ b/extension/src/kernel/__tests__/__snapshots__/ExecutionRegistry.test.ts.snap
@@ -390,6 +390,33 @@ exports[`buildCellOutputs > ignores output/marimo-error/pdb channels in console 
 ]
 `;
 
+exports[`buildCellOutputs > keeps exception marimo-error with raising_cell even when a traceback is present 1`] = `
+[
+  {
+    "items": [
+      {
+        "data": "ZeroDivisionError: division by zero (raised in cell: raising-cell-id)",
+        "mime": "application/vnd.code.notebook.stderr",
+      },
+    ],
+    "metadata": {
+      "channel": "marimo-error",
+    },
+  },
+  {
+    "items": [
+      {
+        "data": "{"name":"ZeroDivisionError","message":"division by zero","stack":"Traceback (most recent call last):\\n  File <a href=\\"/tmp/cell.py:1\\">/tmp/cell.py:1</a>\\u001b[2m, in <module>\\u001b[0m\\n\\u001b[1;31mZeroDivisionError\\u001b[0m: division by zero"}",
+        "mime": "application/vnd.code.notebook.error",
+      },
+    ],
+    "metadata": {
+      "channel": "stderr",
+    },
+  },
+]
+`;
+
 exports[`buildCellOutputs > keeps marimo-error rule violations even when a traceback is present 1`] = `
 [
   {
@@ -410,6 +437,33 @@ exports[`buildCellOutputs > keeps marimo-error rule violations even when a trace
     "items": [
       {
         "data": "{"name":"NameError","message":"unused","stack":"Traceback (most recent call last):\\n  File <a href=\\"/tmp/cell.py:1\\">/tmp/cell.py:1</a>\\u001b[2m\\u001b[0m\\n\\u001b[1;31mNameError\\u001b[0m: unused"}",
+        "mime": "application/vnd.code.notebook.error",
+      },
+    ],
+    "metadata": {
+      "channel": "stderr",
+    },
+  },
+]
+`;
+
+exports[`buildCellOutputs > keeps strict-exception marimo-error even when a traceback is present 1`] = `
+[
+  {
+    "items": [
+      {
+        "data": "Strict execution error: name 'x' is not defined (ref: x, cell: blamed-cell-id)",
+        "mime": "application/vnd.code.notebook.stderr",
+      },
+    ],
+    "metadata": {
+      "channel": "marimo-error",
+    },
+  },
+  {
+    "items": [
+      {
+        "data": "{"name":"NameError","message":"name 'x' is not defined","stack":"Traceback (most recent call last):\\n  File <a href=\\"/tmp/cell.py:1\\">/tmp/cell.py:1</a>\\u001b[2m, in <module>\\u001b[0m\\n\\u001b[1;31mNameError\\u001b[0m: name 'x' is not defined"}",
         "mime": "application/vnd.code.notebook.error",
       },
     ],

--- a/extension/src/lib/__tests__/tracebacks.test.ts
+++ b/extension/src/lib/__tests__/tracebacks.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+
+import { parseTraceback } from "../tracebacks.ts";
+
+const stripAnsi = (s: string) => s.replace(/\u001b\[[\d;]*m/g, "");
+
+describe("parseTraceback", () => {
+  it("strips pygments wrapper, rewrites frames to IPython shape, and extracts name/message", () => {
+    const html = `<div class="highlight"><pre><span class="gt">Traceback (most recent call last):</span>
+  File <span class="s">&quot;/Users/me/proj/foo.py&quot;</span>, line <span class="m">42</span>, in <span class="nb">&lt;module&gt;</span>
+    foo()
+<span class="ne">NameError</span>: name &#39;x&#39; is not defined
+</pre></div>`;
+    expect(parseTraceback(html)).toMatchInlineSnapshot(`
+    	{
+    	  "message": "name 'x' is not defined",
+    	  "name": "NameError",
+    	  "stack": "Traceback (most recent call last):
+    	  File <a href="/Users/me/proj/foo.py:42">/Users/me/proj/foo.py:42</a>[2m, in <module>[0m
+    	    foo()
+    	[1;31mNameError[0m: name 'x' is not defined",
+    	}
+    `);
+  });
+
+  it("handles cell-temp file frames with no mapper (cell-?)", () => {
+    const html = `Traceback (most recent call last):
+  File &quot;/var/folders/zz/abc/T/__marimo__cell_AbCd_.py&quot;, line 1, in &lt;module&gt;
+    1/0
+ZeroDivisionError: division by zero`;
+    expect(parseTraceback(html)).toMatchInlineSnapshot(`
+    	{
+    	  "message": "division by zero",
+    	  "name": "ZeroDivisionError",
+    	  "stack": "Traceback (most recent call last):
+    	  Cell [36mcell-?[0m[2m, line 1[0m
+    	    1/0
+    	[1;31mZeroDivisionError[0m: division by zero",
+    	}
+    `);
+  });
+
+  it("resolves cell-temp frames to cell-<index+1> via mapper", () => {
+    const html = `Traceback (most recent call last):
+  File &quot;/var/folders/zz/abc/T/__marimo__cell_AbCd_.py&quot;, line 3, in &lt;module&gt;
+    kaboom()
+ZeroDivisionError: division by zero`;
+    const cellIdToIndex = (id: string) => (id === "AbCd" ? 1 : undefined);
+    const out = parseTraceback(html, cellIdToIndex);
+    expect(stripAnsi(out.stack)).toContain("Cell cell-2, line 3");
+  });
+
+  it("handles chained exceptions (during handling)", () => {
+    const html = `Traceback (most recent call last):
+  File &quot;/a.py&quot;, line 3, in &lt;module&gt;
+KeyError: 'k'
+
+During handling of the above exception, another exception occurred:
+
+Traceback (most recent call last):
+  File &quot;/b.py&quot;, line 5, in &lt;module&gt;
+ValueError: bad`;
+    const out = parseTraceback(html);
+    expect(out.name).toBe("ValueError");
+    expect(out.message).toBe("bad");
+    expect(out.stack).toContain('<a href="/a.py:3">');
+    expect(out.stack).toContain('<a href="/b.py:5">');
+  });
+
+  it("handles chained exceptions (the above was the direct cause)", () => {
+    const html = `Traceback (most recent call last):
+  File &quot;/x.py&quot;, line 1
+TypeError: a
+
+The above exception was the direct cause of the following exception:
+
+Traceback (most recent call last):
+  File &quot;/y.py&quot;, line 2
+RuntimeError: b`;
+    const out = parseTraceback(html);
+    expect(out.name).toBe("RuntimeError");
+    expect(out.message).toBe("b");
+  });
+
+  it("handles exceptions with no message", () => {
+    const html = `Traceback (most recent call last):
+  File &quot;/a.py&quot;, line 1, in &lt;module&gt;
+StopIteration`;
+    expect(parseTraceback(html)).toMatchInlineSnapshot(`
+    	{
+    	  "message": "",
+    	  "name": "StopIteration",
+    	  "stack": "Traceback (most recent call last):
+    	  File <a href="/a.py:1">/a.py:1</a>[2m, in <module>[0m
+    	[1;31mStopIteration[0m",
+    	}
+    `);
+  });
+
+  it("handles dotted exception names (qualified types)", () => {
+    const html = `Traceback (most recent call last):
+  File &quot;/a.py&quot;, line 1
+my.pkg.CustomError: oops`;
+    const out = parseTraceback(html);
+    expect(out.name).toBe("my.pkg.CustomError");
+    expect(out.message).toBe("oops");
+  });
+
+  it("returns empty name/message when the input is not a traceback", () => {
+    expect(parseTraceback("<p>not a traceback</p>")).toMatchInlineSnapshot(`
+    	{
+    	  "message": "",
+    	  "name": "not a traceback",
+    	  "stack": "not a traceback",
+    	}
+    `);
+  });
+});

--- a/extension/src/lib/__tests__/tracebacks.test.ts
+++ b/extension/src/lib/__tests__/tracebacks.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { parseTraceback } from "../tracebacks.ts";
 
+// oxlint-disable-next-line no-control-regex
 const stripAnsi = (s: string) => s.replace(/\u001b\[[\d;]*m/g, "");
 
 describe("parseTraceback", () => {
@@ -104,6 +105,25 @@ my.pkg.CustomError: oops`;
     const out = parseTraceback(html);
     expect(out.name).toBe("my.pkg.CustomError");
     expect(out.message).toBe("oops");
+  });
+
+  it("escapes HTML-special characters in the anchor label and href", () => {
+    // Pygments encodes special chars in paths as HTML entities, so the input
+    // arrives with `&amp;`/`&lt;`/`&gt;` and `decodeEntities` resurrects them
+    // before the frame is rewritten. The anchor must re-escape them so the
+    // VS Code error renderer treats them as text, not markup.
+    const html = `Traceback (most recent call last):
+  File &quot;/tmp/a&amp;b&lt;c&gt;.py&quot;, line 1, in &lt;module&gt;
+ValueError: oops`;
+    expect(parseTraceback(html)).toMatchInlineSnapshot(`
+    	{
+    	  "message": "oops",
+    	  "name": "ValueError",
+    	  "stack": "Traceback (most recent call last):
+    	  File <a href="/tmp/a&amp;b&lt;c&gt;.py:1">/tmp/a&amp;b&lt;c&gt;.py:1</a>[2m, in <module>[0m
+    	[1;31mValueError[0m: oops",
+    	}
+    `);
   });
 
   it("returns empty name/message when the input is not a traceback", () => {

--- a/extension/src/lib/tracebacks.ts
+++ b/extension/src/lib/tracebacks.ts
@@ -61,9 +61,8 @@ function rewriteFrame(line: string, cellIdToIndex?: CellIdToIndex): string {
     // Keep ANSI strictly OUTSIDE the anchor — ANSI codes inside the anchor
     // text get split into separate segments by the ANSI parser before the
     // HTML-link regex runs, breaking link detection.
-    const href = `${escapeHtml(path)}:${lineNo}`;
-    const label = `${path}:${lineNo}`;
-    return `${indent}File <a href="${href}">${label}</a>${ANSI.dim}${tail}${ANSI.reset}`;
+    const escaped = escapeHtml(`${path}:${lineNo}`);
+    return `${indent}File <a href="${escaped}">${escaped}</a>${ANSI.dim}${tail}${ANSI.reset}`;
   });
 }
 

--- a/extension/src/lib/tracebacks.ts
+++ b/extension/src/lib/tracebacks.ts
@@ -1,0 +1,115 @@
+export interface ParsedTraceback {
+  name: string;
+  message: string;
+  stack: string;
+}
+
+export type CellIdToIndex = (cellId: string) => number | undefined;
+
+const HTML_ENTITIES: Record<string, string> = {
+  "&quot;": '"',
+  "&apos;": "'",
+  "&#39;": "'",
+  "&lt;": "<",
+  "&gt;": ">",
+  "&nbsp;": " ",
+  "&amp;": "&",
+};
+
+function decodeEntities(s: string): string {
+  return s.replace(
+    /&(?:quot|apos|#39|lt|gt|nbsp|amp);/g,
+    (m) => HTML_ENTITIES[m] ?? m,
+  );
+}
+
+function stripTags(html: string): string {
+  return html.replace(/<[^>]*>/g, "");
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+const ESC = "";
+const ANSI = {
+  reset: `${ESC}[0m`,
+  boldRed: `${ESC}[1;31m`,
+  cyan: `${ESC}[36m`,
+  dim: `${ESC}[2m`,
+} as const;
+
+// linecache-backed temp file path: extract the marimo cell_id encoded in it.
+function extractCellId(path: string): string | undefined {
+  return /__marimo__cell_([^/\\]+)_\.py$/.exec(path)?.[1];
+}
+
+const FRAME_RE = /^(\s*)File\s+"([^"]+)",\s+line\s+(\d+)(.*)$/;
+
+function rewriteFrame(line: string, cellIdToIndex?: CellIdToIndex): string {
+  return line.replace(FRAME_RE, (_full, indent, path, lineNo, tail) => {
+    const cellId = extractCellId(path);
+    if (cellId !== undefined) {
+      const idx = cellIdToIndex?.(cellId);
+      const label = idx !== undefined ? `cell-${idx + 1}` : "cell-?";
+      return `${indent}Cell ${ANSI.cyan}${label}${ANSI.reset}${ANSI.dim}, line ${lineNo}${ANSI.reset}`;
+    }
+    // Keep ANSI strictly OUTSIDE the anchor — ANSI codes inside the anchor
+    // text get split into separate segments by the ANSI parser before the
+    // HTML-link regex runs, breaking link detection.
+    const href = `${escapeHtml(path)}:${lineNo}`;
+    const label = `${path}:${lineNo}`;
+    return `${indent}File <a href="${href}">${label}</a>${ANSI.dim}${tail}${ANSI.reset}`;
+  });
+}
+
+const EXCEPTION_LINE_RE = /^([A-Za-z_][\w.]*)(:.*)?$/;
+
+function colorExceptionLine(line: string): string {
+  return line.replace(EXCEPTION_LINE_RE, `${ANSI.boldRed}$1${ANSI.reset}$2`);
+}
+
+function findExceptionLineIndex(lines: string[]): number {
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i];
+    if (!line || /^\s/.test(line) || line.startsWith("Traceback ")) continue;
+    if (
+      line.startsWith("The above exception") ||
+      line.startsWith("During handling")
+    ) {
+      continue;
+    }
+    return i;
+  }
+  return -1;
+}
+
+function parseNameAndMessage(line: string): { name: string; message: string } {
+  const colon = line.indexOf(":");
+  if (colon === -1) return { name: line.trim(), message: "" };
+  return {
+    name: line.slice(0, colon).trim(),
+    message: line.slice(colon + 1).trim(),
+  };
+}
+
+export function parseTraceback(
+  pygmentsHtml: string,
+  cellIdToIndex?: CellIdToIndex,
+): ParsedTraceback {
+  const raw = decodeEntities(stripTags(pygmentsHtml));
+  const lines = raw.split("\n").map((l) => rewriteFrame(l, cellIdToIndex));
+  const exceptionIdx = findExceptionLineIndex(lines);
+  let name = "";
+  let message = "";
+  if (exceptionIdx !== -1) {
+    ({ name, message } = parseNameAndMessage(lines[exceptionIdx]));
+    lines[exceptionIdx] = colorExceptionLine(lines[exceptionIdx]);
+  }
+  const stack = lines.join("\n").replace(/\n+$/, "");
+  return { name, message, stack };
+}


### PR DESCRIPTION
Fixes #566

Similar to Jupyter, we now emit `application/vnd.code.notebook.error` for user errors so VS Code's built-in error renderer can style and link the stack.