### PR TITLE
Skip flaky outdated-marimo env validator test on Windows

### DIFF
--- a/extension/src/python/__tests__/EnvironmentValidator.test.ts
+++ b/extension/src/python/__tests__/EnvironmentValidator.test.ts
@@ -85,7 +85,10 @@ it.layer(EnvironmentValidatorLive)("EnvironmentValidator", (it) => {
     }),
   );
 
-  it.effect(
+  // Skipped on Windows: pygls intermittently hits OSError [Errno 22] on
+  // stdout flush while shutting down the server subprocess, which causes
+  // the test to hang past the 30s timeout. The non-Windows runs cover this.
+  it.effect.skipIf(isWindows)(
     "Should fail with outdated marimo",
     Effect.fn(function* () {
       const uv = yield* Uv;


### PR DESCRIPTION
## Summary

The `Should fail with outdated marimo` test in `EnvironmentValidator.test.ts` is flaky on Windows CI — it frequently times out. The hang originates in pygls, which intermittently raises `OSError: [Errno 22] Invalid argument` while flushing stdout during subprocess shutdown, leaving the test stuck until the 30s timeout fires.

Skipping just this case on Windows via `it.effect.skipIf(isWindows)`, matching the existing pattern used elsewhere in the same file (and in `Uv.test.ts`). Non-Windows runs continue to exercise the validator path.

## Test plan

- [ ] CI green on Windows (the test is skipped there)
- [ ] CI green on macOS / Linux (test still runs and passes)