### PR TITLE
Match marimo's pnpm setup for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,10 +49,9 @@ jobs:
           doppler-project: marimo-lsp
           doppler-config: dev
 
-      - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.4.0
         with:
           package_json_file: marimo-lsp/extension/package.json
-          version: 10.28.2
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
@@ -67,12 +66,13 @@ jobs:
           TURBO_TOKEN: ${{ steps.secrets.outputs.TURBO_TOKEN }}
         run: |
           cd marimo
+          pnpm install --frozen-lockfile
           pnpm turbo run build --filter="./packages/*"
 
       - name: Check (lint + format)
         run: |
           cd marimo-lsp/extension
-          pnpm install
+          pnpm install --frozen-lockfile
           pnpm check
 
   typescript-typecheck:
@@ -108,10 +108,9 @@ jobs:
           doppler-project: marimo-lsp
           doppler-config: dev
 
-      - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.4.0
         with:
           package_json_file: marimo-lsp/extension/package.json
-          version: 10.28.2
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
@@ -126,6 +125,7 @@ jobs:
           TURBO_TOKEN: ${{ steps.secrets.outputs.TURBO_TOKEN }}
         run: |
           cd marimo
+          pnpm install --frozen-lockfile
           pnpm turbo run build --filter="./packages/*"
 
       - name: Install and typecheck extension
@@ -133,7 +133,7 @@ jobs:
           TURBO_TOKEN: ${{ steps.secrets.outputs.TURBO_TOKEN }}
         run: |
           cd marimo-lsp/extension
-          pnpm install
+          pnpm install --frozen-lockfile
           # make sure our types are up to date
           node scripts/codegen.mjs
           pnpm turbo typecheck-ci
@@ -181,10 +181,9 @@ jobs:
 
       - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
 
-      - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.4.0
         with:
           package_json_file: marimo-lsp/extension/package.json
-          version: 10.28.2
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
@@ -199,6 +198,7 @@ jobs:
           TURBO_TOKEN: ${{ steps.secrets.outputs.TURBO_TOKEN }}
         run: |
           cd marimo
+          pnpm install --frozen-lockfile
           pnpm --recursive --filter "./packages/*" codegen
           pnpm --recursive --filter "./packages/*" build
 
@@ -207,7 +207,7 @@ jobs:
         env:
           TURBO_TOKEN: ${{ steps.secrets.outputs.TURBO_TOKEN }}
         run: |
-          pnpm install
+          pnpm install --frozen-lockfile
           # make sure our types are up to date
           node scripts/codegen.mjs
           pnpm build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.4.0
         with:
           package_json_file: extension/package.json
 
@@ -184,7 +184,7 @@ jobs:
       # Install system uv for building sdist (bundled uv may be cross-compiled and not executable on the runner)
       - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
 
-      - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.4.0
         with:
           package_json_file: marimo-lsp/extension/package.json
 
@@ -199,13 +199,14 @@ jobs:
       - name: Build marimo packages
         run: |
           cd marimo
+          pnpm install --frozen-lockfile
           pnpm --recursive --filter "./packages/*" codegen
           pnpm --recursive --filter "./packages/*" build
 
       - name: Install packages and build extension
         working-directory: marimo-lsp/extension
         run: |
-          pnpm install
+          pnpm install --frozen-lockfile
           pnpm build
           pnpm embed-sdist
 
@@ -253,7 +254,7 @@ jobs:
 
       - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
 
-      - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.4.0
         with:
           package_json_file: marimo-lsp/extension/package.json
 
@@ -268,13 +269,14 @@ jobs:
       - name: Build marimo packages
         run: |
           cd marimo
+          pnpm install --frozen-lockfile
           pnpm --recursive --filter "./packages/*" codegen
           pnpm --recursive --filter "./packages/*" build
 
       - name: Install packages and build extension
         working-directory: marimo-lsp/extension
         run: |
-          pnpm install
+          pnpm install --frozen-lockfile
           pnpm build
           pnpm embed-sdist
 

--- a/extension/src/kernel/KernelManager.ts
+++ b/extension/src/kernel/KernelManager.ts
@@ -284,6 +284,7 @@ function processOperation(
       case "cache-info":
       case "completed-run":
       case "completion-result":
+      case "consumer-capabilities":
       case "focus-cell":
       case "installing-package-alert":
       case "kernel-ready":

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -801,7 +801,7 @@ x\
             },
             {
                 "notebookUri": "file:///exec_test.py",
-                "operation": {"op": "completed-run"},
+                "operation": {"op": "completed-run", "run_id": None},
             },
             {
                 "notebookUri": "file:///exec_test.py",
@@ -944,7 +944,7 @@ x\
             },
             {
                 "notebookUri": "file:///exec_test.py",
-                "operation": {"op": "completed-run"},
+                "operation": {"op": "completed-run", "run_id": None},
             },
         ]
     )
@@ -1084,7 +1084,7 @@ async def test_marimo_run_with_ancestor_cell(client: LanguageClient) -> None:
             },
             {
                 "notebookUri": "file:///exec_test.py",
-                "operation": {"op": "completed-run"},
+                "operation": {"op": "completed-run", "run_id": None},
             },
             {
                 "notebookUri": "file:///exec_test.py",
@@ -1285,7 +1285,7 @@ async def test_marimo_run_with_ancestor_cell(client: LanguageClient) -> None:
             },
             {
                 "notebookUri": "file:///exec_test.py",
-                "operation": {"op": "completed-run"},
+                "operation": {"op": "completed-run", "run_id": None},
             },
         ]
     )


### PR DESCRIPTION
CI failed building the marimo packages with `ERR_PNPM_TRUST_DOWNGRADE` for `tailwind-merge`: relying on marimo's `verifyDepsBeforeRun` auto-install re-resolved deps and grabbed a newer patch that tripped marimo's `trustPolicy`.

Match marimo's own CI instead — `pnpm/action-setup@v4` (drop the redundant `version` input) and `pnpm install --frozen-lockfile` everywhere, so deps come from the committed lockfiles.

With the build fixed, typecheck reached a latent 0.23.9 break: the new `consumer-capabilities` notification op was unhandled. Ignored like the other notifications not relevant in the VS Code context.