### PR TITLE
Forward ty's RelativePattern file watchers so external edits reload

### DIFF
--- a/extension/src/__mocks__/TestVsCode.ts
+++ b/extension/src/__mocks__/TestVsCode.ts
@@ -537,6 +537,27 @@ class Range implements vscode.Range {
   }
 }
 
+class RelativePattern implements vscode.RelativePattern {
+  baseUri: vscode.Uri;
+  base: string;
+  pattern: string;
+
+  constructor(
+    base: vscode.WorkspaceFolder | vscode.Uri | string,
+    pattern: string,
+  ) {
+    if (typeof base === "string") {
+      this.baseUri = Uri.file(base);
+    } else if ("uri" in base) {
+      this.baseUri = base.uri;
+    } else {
+      this.baseUri = base;
+    }
+    this.base = this.baseUri.fsPath;
+    this.pattern = pattern;
+  }
+}
+
 class CodeLens implements vscode.CodeLens {
   readonly range: Range;
   command?: vscode.Command;
@@ -2123,6 +2144,7 @@ export class TestVsCode extends Data.TaggedClass("TestVsCode")<{
           Right: 2,
         },
         Uri,
+        RelativePattern,
         MarkdownString,
         CompletionItem,
         CompletionList,

--- a/extension/src/lsp/__tests__/connect.test.ts
+++ b/extension/src/lsp/__tests__/connect.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Unit tests for the file-watcher glob conversion in `connect.ts`.
+ *
+ * Regression coverage for the bug where ty's external function/class
+ * definitions never reloaded: the client advertises
+ * `relativePatternSupport: true`, so ty registers its file watchers as
+ * `RelativePattern` objects (`{ baseUri, pattern }`) rather than string
+ * globs. The watcher-wiring code previously dropped every non-string
+ * pattern, so no `vscode.FileSystemWatcher` was ever created and on-disk
+ * edits never reached ty.
+ */
+
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Option } from "effect";
+
+import { TestVsCode } from "../../__mocks__/TestVsCode.ts";
+import { VsCode } from "../../platform/VsCode.ts";
+import { toVsCodeGlobPattern } from "../connect.ts";
+
+describe("toVsCodeGlobPattern", () => {
+  it.scoped("passes string globs through unchanged", () =>
+    Effect.gen(function* () {
+      const test = yield* TestVsCode.make();
+      const code = yield* VsCode.pipe(Effect.provide(test.layer));
+
+      const result = toVsCodeGlobPattern(code, "**/*.py");
+
+      expect(Option.getOrThrow(result)).toBe("**/*.py");
+    }),
+  );
+
+  it.scoped(
+    "converts a RelativePattern object into a vscode.RelativePattern",
+    () =>
+      Effect.gen(function* () {
+        const test = yield* TestVsCode.make();
+        const code = yield* VsCode.pipe(Effect.provide(test.layer));
+
+        // The exact shape ty sends when relativePatternSupport is on:
+        // a file:// baseUri pointing at a project root / search path,
+        // with the catch-all "**" pattern.
+        const result = toVsCodeGlobPattern(code, {
+          baseUri: "file:///home/me/project",
+          pattern: "**",
+        });
+
+        const pattern = Option.getOrThrow(result);
+        // Must be a structured RelativePattern, not dropped or stringified.
+        if (typeof pattern === "string") {
+          throw new Error("expected a RelativePattern, got a string glob");
+        }
+        expect(pattern.pattern).toBe("**");
+        expect(pattern.baseUri.toString()).toBe("file:///home/me/project");
+      }),
+  );
+
+  it.scoped("rejects shapes it cannot interpret", () =>
+    Effect.gen(function* () {
+      const test = yield* TestVsCode.make();
+      const code = yield* VsCode.pipe(Effect.provide(test.layer));
+
+      // A workspace-folder baseUri (object, not string) — ty never emits
+      // this, and we can't resolve it here, so it must be skipped rather
+      // than crashing the watcher loop.
+      expect(
+        Option.isNone(
+          toVsCodeGlobPattern(code, {
+            baseUri: { uri: "file:///x", name: "x", index: 0 },
+            pattern: "**",
+          }),
+        ),
+      ).toBe(true);
+      expect(Option.isNone(toVsCodeGlobPattern(code, undefined))).toBe(true);
+      expect(Option.isNone(toVsCodeGlobPattern(code, 42))).toBe(true);
+    }),
+  );
+
+  it.scoped("returns None when baseUri can't be parsed", () =>
+    Effect.gen(function* () {
+      const test = yield* TestVsCode.make();
+      const code = yield* VsCode.pipe(Effect.provide(test.layer));
+
+      // Uri.parse rejects a scheme-less baseUri by throwing; the converter
+      // must swallow that and skip the watcher, not abort registration.
+      expect(
+        Option.isNone(
+          toVsCodeGlobPattern(code, {
+            baseUri: "not-a-valid-uri",
+            pattern: "**",
+          }),
+        ),
+      ).toBe(true);
+    }),
+  );
+});

--- a/extension/src/lsp/connect.ts
+++ b/extension/src/lsp/connect.ts
@@ -10,7 +10,7 @@
 
 import { Effect, Option, Stream } from "effect";
 import type * as vscode from "vscode";
-import type * as lsp from "vscode-languageserver-protocol";
+import * as lsp from "vscode-languageserver-protocol";
 
 import { NOTEBOOK_TYPE } from "../constants.ts";
 import { acquireDisposable } from "../lib/acquireDisposable.ts";
@@ -150,10 +150,24 @@ export const connectMarimoNotebookLspClient = Effect.fn(
         }
 
         for (const watcher of watchers) {
-          if (typeof watcher.globPattern !== "string") continue;
+          const globPattern = toVsCodeGlobPattern(code, watcher.globPattern);
+          if (Option.isNone(globPattern)) continue;
+
+          // `kind` is a WatchKind bitmask; absent means watch all three
+          // (the LSP default).
+          const kind =
+            typeof watcher.kind === "number"
+              ? watcher.kind
+              : lsp.WatchKind.Create |
+                lsp.WatchKind.Change |
+                lsp.WatchKind.Delete;
 
           yield* Effect.forkScoped(
-            code.workspace.createFileSystemWatcher(watcher.globPattern).pipe(
+            code.workspace.createFileSystemWatcher(globPattern.value).pipe(
+              // Drop events the server didn't ask to watch.
+              Stream.filter(
+                ({ type }) => (kind & WATCH_KIND_FOR_CHANGE[type]) !== 0,
+              ),
               Stream.runForEach(({ uri, type }) =>
                 client
                   .sendNotification("workspace/didChangeWatchedFiles", {
@@ -188,7 +202,7 @@ export type MarimoNotebookLspClient = Effect.Effect.Success<
  */
 function getFileWatchers(
   options: unknown,
-): Array<{ globPattern: unknown }> | undefined {
+): Array<{ globPattern: unknown; kind?: unknown }> | undefined {
   if (
     typeof options === "object" &&
     options !== null &&
@@ -198,6 +212,69 @@ function getFileWatchers(
     return options.watchers;
   }
   return undefined;
+}
+
+/**
+ * The `WatchKind` bit that enables each `FileChangeType`, so a change
+ * event can be tested against a watcher's `kind` bitmask. Typing it as a
+ * `Record` over `FileChangeType` forces every change type to be mapped.
+ */
+const WATCH_KIND_FOR_CHANGE: Record<lsp.FileChangeType, lsp.WatchKind> = {
+  [lsp.FileChangeType.Created]: lsp.WatchKind.Create,
+  [lsp.FileChangeType.Changed]: lsp.WatchKind.Change,
+  [lsp.FileChangeType.Deleted]: lsp.WatchKind.Delete,
+};
+
+/**
+ * The wire shape of an LSP `RelativePattern` with a string `baseUri` —
+ * the form ty emits. (The spec also allows a workspace-folder `baseUri`,
+ * which ty never sends and we can't resolve here.)
+ */
+function isRelativePattern(
+  value: unknown,
+): value is { baseUri: string; pattern: string } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "baseUri" in value &&
+    "pattern" in value &&
+    typeof value.baseUri === "string" &&
+    typeof value.pattern === "string"
+  );
+}
+
+/**
+ * Convert an LSP `GlobPattern` to a VS Code glob pattern.
+ *
+ * The server may send either a plain string glob or a `RelativePattern`
+ * object (`{ baseUri, pattern }`) when the client advertises
+ * `relativePatternSupport`. ty uses the latter to watch module search
+ * paths *outside* the workspace root, so we must handle both — mirroring
+ * vscode-languageclient's `protocolConverter.asGlobPattern`.
+ *
+ * Returns `None` for shapes we can't interpret — a workspace-folder
+ * baseUri (which ty never emits) or a `baseUri` that `Uri.parse` rejects.
+ * A malformed pattern is skipped rather than aborting watcher setup.
+ *
+ * @internal exported for testing.
+ */
+export function toVsCodeGlobPattern(
+  code: VsCode,
+  globPattern: unknown,
+): Option.Option<vscode.GlobPattern> {
+  if (typeof globPattern === "string") {
+    return Option.some(globPattern);
+  }
+  if (isRelativePattern(globPattern)) {
+    // Uri.parse throws on a malformed baseUri; treat that as a shape we
+    // can't interpret instead of letting it abort watcher registration.
+    const parseRelativePattern = Option.liftThrowable(
+      (uri: string) =>
+        new code.RelativePattern(code.Uri.parse(uri), globPattern.pattern),
+    );
+    return parseRelativePattern(globPattern.baseUri);
+  }
+  return Option.none();
 }
 
 /**

--- a/extension/src/platform/VsCode.ts
+++ b/extension/src/platform/VsCode.ts
@@ -454,7 +454,7 @@ export class Workspace extends Effect.Service<Workspace>()("Workspace", {
       }) {
         return Effect.promise(() => api.openTextDocument(options));
       },
-      createFileSystemWatcher(globPattern: string) {
+      createFileSystemWatcher(globPattern: vscode.GlobPattern) {
         return Stream.asyncPush<{ uri: vscode.Uri; type: 1 | 2 | 3 }>((emit) =>
           acquireDisposable(() => {
             const watcher = api.createFileSystemWatcher(globPattern);
@@ -1193,6 +1193,7 @@ export class VsCode extends Effect.Service<VsCode>()("VsCode", {
       Location: vscode.Location,
       Uri: vscode.Uri,
       Range: vscode.Range,
+      RelativePattern: vscode.RelativePattern,
       version: vscode.version,
       extensions: {
         getExtension<T = unknown>(extensionId: string) {


### PR DESCRIPTION
Fixes #594

ty registers workspace/didChangeWatchedFiles watchers as `vscode.RelativePattern` objects (because we advertise `relativePatternSupport`), but `connect.ts` dropped every non-string glob, so external file edits never reached ty.

These changes convert `vscode.RelativePattern` globs and honor the watcher kind bitmask.
