### PR TITLE
Migrate datasources panel to the catalog children model

### DIFF
--- a/extension/src/kernel/KernelManager.ts
+++ b/extension/src/kernel/KernelManager.ts
@@ -299,8 +299,8 @@ function processOperation(
         yield* datasources.updateTablePreview(notebookUri, operation);
         break;
       }
-      case "sql-table-list-preview": {
-        yield* datasources.updateTableListPreview(notebookUri, operation);
+      case "catalog-children-preview": {
+        yield* datasources.updateCatalogChildrenPreview(notebookUri, operation);
         break;
       }
       case "data-column-preview": {
@@ -327,7 +327,6 @@ function processOperation(
       case "reconnected":
       case "reload":
       case "secret-keys-result":
-      case "sql-schema-list-preview":
       case "startup-logs":
       case "storage-download-ready":
       case "storage-entries":

--- a/extension/src/panel/datasources/DatasourcesService.ts
+++ b/extension/src/panel/datasources/DatasourcesService.ts
@@ -2,17 +2,34 @@ import { Effect, HashMap, SubscriptionRef } from "effect";
 
 import type { NotebookId } from "../../schemas/MarimoNotebookDocument.ts";
 import type {
+  CatalogChildrenPreviewNotification,
+  CatalogNode,
   DataColumnPreviewNotification,
   DataSourceConnectionsNotification,
   DatasetsNotification,
-  SqlTableListPreviewNotification,
+  DataTableNode,
   SqlTablePreviewNotification,
 } from "../../types.ts";
 
 /**
  * Maps for efficient lookups in the datasource hierarchy:
- * Connection -> Database -> Schema -> Table
+ * Connection -> Database -> CatalogTreeNode tree.
  */
+
+/**
+ * Normalized catalog tree node. Container nodes (`schema`, `namespace`) carry
+ * their resolved `children`; `data_table` leaves carry their `table` payload.
+ *
+ * Deferred buckets on the wire (`children`/`tables` === null) are normalized to
+ * an empty `children` array — the panel renders what the kernel has discovered
+ * and does not itself drive lazy catalog fetches.
+ */
+export interface CatalogTreeNode {
+  kind: "schema" | "namespace" | "data_table";
+  name: string;
+  children: CatalogTreeNode[];
+  table: DataTableNode | null;
+}
 
 interface DataSourceConnectionMap {
   // connection name -> connection data
@@ -31,13 +48,7 @@ interface DataSourceConnectionMap {
           name: string;
           dialect: string;
           engine: string | null;
-          schemas: Map<
-            string,
-            {
-              name: string;
-              tables: Map<string, DataTable>;
-            }
-          >;
+          children: CatalogTreeNode[];
         }
       >;
     }
@@ -76,7 +87,7 @@ interface DatasetsMap {
  * 1. Data source connections (data-source-connections operation)
  * 2. Datasets (datasets operation)
  * 3. SQL table previews (sql-table-preview operation)
- * 4. SQL table list previews (sql-table-list-preview operation)
+ * 4. Catalog children previews (catalog-children-preview operation)
  * 5. Data column previews (data-column-preview operation)
  *
  * Uses SubscriptionRef for reactive state management.
@@ -101,15 +112,48 @@ export class DatasourcesService extends Effect.Service<DatasourcesService>()(
         HashMap.empty<NotebookId, Map<string, DataTable | null>>(),
       );
 
-      // Track SQL table list previews: NotebookUri -> Map<request_id, tables[]>
-      const tableListPreviewsRef = yield* SubscriptionRef.make(
-        HashMap.empty<NotebookId, Map<string, DataTable[]>>(),
+      // Track catalog children previews: NotebookUri -> Map<request_id, nodes[]>
+      const catalogChildrenPreviewsRef = yield* SubscriptionRef.make(
+        HashMap.empty<NotebookId, Map<string, CatalogTreeNode[]>>(),
       );
 
       // Track column previews: NotebookUri -> Map<table_name, ColumnStats>
       const columnPreviewsRef = yield* SubscriptionRef.make(
         HashMap.empty<NotebookId, Map<string, unknown>>(),
       );
+
+      /**
+       * Normalize a wire catalog node into the panel's `CatalogTreeNode`.
+       *
+       * Recurses through `schema.tables` and `namespace.children`, flattening a
+       * deferred (`null`) bucket to an empty child list.
+       */
+      const normalizeCatalogNode = (node: CatalogNode): CatalogTreeNode => {
+        switch (node.kind) {
+          case "schema":
+            return {
+              kind: "schema",
+              name: node.name,
+              children: (node.tables ?? []).map(normalizeCatalogNode),
+              table: null,
+            };
+          case "namespace":
+            return {
+              kind: "namespace",
+              name: node.name,
+              children: (node.children ?? []).map(normalizeCatalogNode),
+              table: null,
+            };
+          default:
+            // data_table leaf
+            return {
+              kind: "data_table",
+              name: node.name,
+              children: [],
+              table: node,
+            };
+        }
+      };
 
       /**
        * Convert DataSourceConnection list to efficient map structure
@@ -123,25 +167,11 @@ export class DatasourcesService extends Effect.Service<DatasourcesService>()(
           const databasesMap = new Map();
 
           for (const db of conn.databases) {
-            const schemasMap = new Map();
-
-            for (const schema of db.schemas) {
-              const tablesMap = new Map();
-              for (const table of schema.tables) {
-                tablesMap.set(table.name, table);
-              }
-
-              schemasMap.set(schema.name, {
-                name: schema.name,
-                tables: tablesMap,
-              });
-            }
-
             databasesMap.set(db.name, {
               name: db.name,
               dialect: db.dialect,
               engine: db.engine ?? null,
-              schemas: schemasMap,
+              children: (db.children ?? []).map(normalizeCatalogNode),
             });
           }
 
@@ -254,28 +284,46 @@ export class DatasourcesService extends Effect.Service<DatasourcesService>()(
         },
 
         /**
-         * Update SQL table list preview for a notebook
+         * Update catalog children preview for a notebook.
+         *
+         * Skips updates that carry an error so a transient failure doesn't
+         * erase previously cached children.
          */
-        updateTableListPreview(
+        updateCatalogChildrenPreview(
           notebookUri: NotebookId,
-          operation: SqlTableListPreviewNotification,
+          operation: CatalogChildrenPreviewNotification,
         ) {
           return Effect.gen(function* () {
-            yield* SubscriptionRef.update(tableListPreviewsRef, (map) => {
+            if (operation.error != null) {
+              yield* Effect.logWarning("Catalog children preview failed").pipe(
+                Effect.annotateLogs({
+                  notebookUri,
+                  request_id: operation.request_id,
+                  error: operation.error,
+                }),
+              );
+              return;
+            }
+
+            const children = (operation.children ?? []).map(
+              normalizeCatalogNode,
+            );
+
+            yield* SubscriptionRef.update(catalogChildrenPreviewsRef, (map) => {
               const existing = HashMap.get(map, notebookUri);
               const previewMap =
                 existing._tag === "Some" ? existing.value : new Map();
 
-              previewMap.set(operation.request_id, operation.tables ?? []);
+              previewMap.set(operation.request_id, children);
 
               return HashMap.set(map, notebookUri, previewMap);
             });
 
-            yield* Effect.logTrace("Updated table list preview").pipe(
+            yield* Effect.logTrace("Updated catalog children preview").pipe(
               Effect.annotateLogs({
                 notebookUri,
                 request_id: operation.request_id,
-                count: operation.tables?.length ?? 0,
+                count: children.length,
               }),
             );
           });
@@ -345,11 +393,11 @@ export class DatasourcesService extends Effect.Service<DatasourcesService>()(
         },
 
         /**
-         * Get table list preview for a notebook and request ID
+         * Get catalog children preview for a notebook and request ID
          */
-        getTableListPreview(notebookUri: NotebookId, requestId: string) {
+        getCatalogChildrenPreview(notebookUri: NotebookId, requestId: string) {
           return Effect.gen(function* () {
-            const map = yield* SubscriptionRef.get(tableListPreviewsRef);
+            const map = yield* SubscriptionRef.get(catalogChildrenPreviewsRef);
             const previewMap = HashMap.get(map, notebookUri);
             if (previewMap._tag === "Some") {
               return previewMap.value.get(requestId) ?? [];
@@ -386,7 +434,7 @@ export class DatasourcesService extends Effect.Service<DatasourcesService>()(
             yield* SubscriptionRef.update(tablePreviewsRef, (map) =>
               HashMap.remove(map, notebookUri),
             );
-            yield* SubscriptionRef.update(tableListPreviewsRef, (map) =>
+            yield* SubscriptionRef.update(catalogChildrenPreviewsRef, (map) =>
               HashMap.remove(map, notebookUri),
             );
             yield* SubscriptionRef.update(columnPreviewsRef, (map) =>
@@ -427,12 +475,12 @@ export class DatasourcesService extends Effect.Service<DatasourcesService>()(
         },
 
         /**
-         * Stream of table list preview changes.
+         * Stream of catalog children preview changes.
          *
          * Emits the current value on subscription, then all subsequent changes.
          */
-        streamTableListPreviewsChanges() {
-          return tableListPreviewsRef.changes;
+        streamCatalogChildrenPreviewsChanges() {
+          return catalogChildrenPreviewsRef.changes;
         },
 
         /**

--- a/extension/src/panel/datasources/DatasourcesView.ts
+++ b/extension/src/panel/datasources/DatasourcesView.ts
@@ -3,13 +3,12 @@ import { Effect, Layer, Option, Ref, Stream } from "effect";
 import { NotebookEditorRegistry } from "../../notebook/NotebookEditorRegistry.ts";
 import type { NotebookId } from "../../schemas/MarimoNotebookDocument.ts";
 import { TreeView } from "../TreeView.ts";
-import { DatasourcesService } from "./DatasourcesService.ts";
+import {
+  type CatalogTreeNode,
+  DatasourcesService,
+} from "./DatasourcesService.ts";
 
-type DatasourceTreeItem =
-  | ConnectionItem
-  | DatabaseItem
-  | SchemaItem
-  | TableItem;
+type DatasourceTreeItem = ConnectionItem | DatabaseItem | CatalogNodeItem;
 
 interface ConnectionItem {
   type: "connection";
@@ -27,31 +26,43 @@ interface DatabaseItem {
   dialect: string;
 }
 
-interface SchemaItem {
-  type: "schema";
+/**
+ * A node in a database's recursive catalog tree: a `schema`/`namespace`
+ * container or a `data_table` leaf. `path` is the list of node names from the
+ * database root down to (and including) this node, which uniquely identifies it
+ * and lets us recover its parent/children by prefix.
+ */
+interface CatalogNodeItem {
+  type: "catalog-node";
   notebookUri: NotebookId;
   connectionName: string;
   databaseName: string;
-  schemaName: string;
-}
-
-interface TableItem {
-  type: "table";
-  notebookUri: NotebookId;
-  connectionName: string;
-  databaseName: string;
-  schemaName: string;
-  tableName: string;
-  tableType: "table" | "view";
+  path: string[];
+  kind: "schema" | "namespace" | "data_table";
+  name: string;
+  tableType: "table" | "view" | null;
   numRows: number | null;
   numColumns: number | null;
+}
+
+/** True when `child` sits directly beneath `parent` in the same db/connection. */
+function isDirectChild(
+  parent: CatalogNodeItem,
+  child: CatalogNodeItem,
+): boolean {
+  return (
+    child.connectionName === parent.connectionName &&
+    child.databaseName === parent.databaseName &&
+    child.path.length === parent.path.length + 1 &&
+    parent.path.every((segment, i) => child.path[i] === segment)
+  );
 }
 
 /**
  * Manages the datasources tree view for the active notebook.
  *
  * Displays a hierarchical view of data sources:
- * Connection → Database → Schema → Table
+ * Connection → Database → (Schema | Namespace)* → Table
  *
  * Subscribes to datasource changes and updates the tree view in real-time.
  */
@@ -69,43 +80,14 @@ export const DatasourcesViewLive = Layer.scopedDiscard(
       viewId: "marimo-explorer-datasources",
       getChildren: (element?: DatasourceTreeItem) =>
         Effect.gen(function* () {
+          const items = yield* Ref.get(datasourceItems);
+
+          // Root level: return connections
           if (!element) {
-            // Root level: return connections
-            const items = yield* Ref.get(datasourceItems);
             return items.filter((item) => item.type === "connection");
           }
 
-          const activeNotebookUri =
-            yield* editorRegistry.getActiveNotebookUri();
-          if (Option.isNone(activeNotebookUri)) {
-            return [];
-          }
-
-          const notebookUri = activeNotebookUri.value;
-          const items = yield* Ref.get(datasourceItems);
-
           if (element.type === "connection") {
-            // Get databases for this connection
-            // For in-memory connection, just filter from items (no need to query datasourcesService)
-            if (element.connectionName === "__in_memory") {
-              return items.filter(
-                (item) =>
-                  item.type === "database" &&
-                  item.connectionName === element.connectionName,
-              );
-            }
-
-            // For regular connections, filter from items
-            const connections =
-              yield* datasourcesService.getConnections(notebookUri);
-            if (Option.isNone(connections)) {
-              return [];
-            }
-
-            const connectionsMap = connections.value;
-            const conn = connectionsMap.connections.get(element.connectionName);
-            if (!conn) return [];
-
             return items.filter(
               (item) =>
                 item.type === "database" &&
@@ -114,79 +96,25 @@ export const DatasourcesViewLive = Layer.scopedDiscard(
           }
 
           if (element.type === "database") {
-            // Get schemas for this database
-            // For in-memory connection, just filter from items
-            if (element.connectionName === "__in_memory") {
-              return items.filter(
-                (item) =>
-                  item.type === "schema" &&
-                  item.connectionName === element.connectionName &&
-                  item.databaseName === element.databaseName,
-              );
-            }
-
-            // For regular connections, check if database exists
-            const connections =
-              yield* datasourcesService.getConnections(notebookUri);
-            if (Option.isNone(connections)) {
-              return [];
-            }
-
-            const connectionsMap = connections.value;
-            const conn = connectionsMap.connections.get(element.connectionName);
-            if (!conn) return [];
-
-            const db = conn.databases.get(element.databaseName);
-            if (!db) return [];
-
+            // Top-level catalog nodes for this database (path length 1).
             return items.filter(
               (item) =>
-                item.type === "schema" &&
-                item.connectionName === element.connectionName &&
-                item.databaseName === element.databaseName,
-            );
-          }
-
-          if (element.type === "schema") {
-            // Get tables for this schema
-            // For in-memory connection, just filter from items
-            if (element.connectionName === "__in_memory") {
-              return items.filter(
-                (item) =>
-                  item.type === "table" &&
-                  item.connectionName === element.connectionName &&
-                  item.databaseName === element.databaseName &&
-                  item.schemaName === element.schemaName,
-              );
-            }
-
-            // For regular connections, check if schema exists
-            const connections =
-              yield* datasourcesService.getConnections(notebookUri);
-            if (Option.isNone(connections)) {
-              return [];
-            }
-
-            const connectionsMap = connections.value;
-            const conn = connectionsMap.connections.get(element.connectionName);
-            if (!conn) return [];
-
-            const db = conn.databases.get(element.databaseName);
-            if (!db) return [];
-
-            const schema = db.schemas.get(element.schemaName);
-            if (!schema) return [];
-
-            return items.filter(
-              (item) =>
-                item.type === "table" &&
+                item.type === "catalog-node" &&
                 item.connectionName === element.connectionName &&
                 item.databaseName === element.databaseName &&
-                item.schemaName === element.schemaName,
+                item.path.length === 1,
             );
           }
 
-          return [];
+          // catalog-node: leaves have no children; containers expose their
+          // direct descendants.
+          if (element.kind === "data_table") {
+            return [];
+          }
+          return items.filter(
+            (item) =>
+              item.type === "catalog-node" && isDirectChild(element, item),
+          );
         }),
       getTreeItem: (element: DatasourceTreeItem) =>
         Effect.succeed({
@@ -195,44 +123,81 @@ export const DatasourcesViewLive = Layer.scopedDiscard(
               ? element.displayName
               : element.type === "database"
                 ? element.databaseName
-                : element.type === "schema"
-                  ? element.schemaName
-                  : element.tableName,
+                : element.name,
           description:
             element.type === "connection"
               ? element.dialect
               : element.type === "database"
                 ? element.dialect
-                : element.type === "table"
-                  ? element.numRows !== null
-                    ? `${element.numRows} rows`
-                    : undefined
+                : element.type === "catalog-node" &&
+                    element.kind === "data_table" &&
+                    element.numRows !== null
+                  ? `${element.numRows} rows`
                   : undefined,
           tooltip:
             element.type === "connection"
               ? `${element.displayName} (${element.dialect})`
               : element.type === "database"
                 ? `${element.databaseName} (${element.dialect})`
-                : element.type === "schema"
-                  ? element.schemaName
-                  : element.type === "table"
-                    ? `${element.tableName} (${element.tableType})${element.numRows !== null ? `\n${element.numRows} rows` : ""}${element.numColumns !== null ? `, ${element.numColumns} columns` : ""}`
-                    : undefined,
+                : element.kind === "data_table"
+                  ? `${element.name} (${element.tableType ?? "table"})${element.numRows !== null ? `\n${element.numRows} rows` : ""}${element.numColumns !== null ? `, ${element.numColumns} columns` : ""}`
+                  : element.name,
           iconPath: undefined,
           contextValue:
             element.type === "connection"
               ? "marimoConnection"
               : element.type === "database"
                 ? "marimoDatabase"
-                : element.type === "schema"
-                  ? "marimoSchema"
-                  : "marimoTable",
+                : element.kind === "data_table"
+                  ? "marimoTable"
+                  : element.kind === "namespace"
+                    ? "marimoNamespace"
+                    : "marimoSchema",
           collapsibleState:
-            element.type === "table"
+            element.type === "catalog-node" && element.kind === "data_table"
               ? ("None" as const)
               : ("Collapsed" as const),
         }),
     });
+
+    // Walk a database's catalog tree into flat `CatalogNodeItem`s, accumulating
+    // each node's path from the database root.
+    const collectCatalogNodes = (params: {
+      notebookUri: NotebookId;
+      connectionName: string;
+      databaseName: string;
+      nodes: readonly CatalogTreeNode[];
+      parentPath: readonly string[];
+    }): CatalogNodeItem[] => {
+      const { notebookUri, connectionName, databaseName, nodes, parentPath } =
+        params;
+      const out: CatalogNodeItem[] = [];
+      for (const node of nodes) {
+        const path = [...parentPath, node.name];
+        out.push({
+          type: "catalog-node",
+          notebookUri,
+          connectionName,
+          databaseName,
+          path,
+          kind: node.kind,
+          name: node.name,
+          tableType: node.table?.type ?? null,
+          numRows: node.table?.num_rows ?? null,
+          numColumns: node.table?.num_columns ?? null,
+        });
+        out.push(
+          ...collectCatalogNodes({
+            notebookUri,
+            connectionName,
+            databaseName,
+            nodes: node.children,
+            parentPath: path,
+          }),
+        );
+      }
+      return out;
+    };
 
     // Helper to rebuild the datasources list from current state
     const refreshDatasources = Effect.fn(function* () {
@@ -283,29 +248,15 @@ export const DatasourcesViewLive = Layer.scopedDiscard(
             dialect: db.dialect,
           });
 
-          for (const [schemaName, schema] of db.schemas) {
-            items.push({
-              type: "schema",
+          items.push(
+            ...collectCatalogNodes({
               notebookUri,
               connectionName: connName,
               databaseName: dbName,
-              schemaName: schemaName,
-            });
-
-            for (const [tableName, table] of schema.tables) {
-              items.push({
-                type: "table",
-                notebookUri,
-                connectionName: connName,
-                databaseName: dbName,
-                schemaName: schemaName,
-                tableName: tableName,
-                tableType: table.type,
-                numRows: table.num_rows,
-                numColumns: table.num_columns,
-              });
-            }
-          }
+              nodes: db.children,
+              parentPath: [],
+            }),
+          );
         }
       }
 
@@ -332,21 +283,27 @@ export const DatasourcesViewLive = Layer.scopedDiscard(
         });
 
         items.push({
-          type: "schema",
+          type: "catalog-node",
           notebookUri,
           connectionName: inMemoryConnName,
           databaseName: inMemoryDbName,
-          schemaName: inMemorySchemaName,
+          path: [inMemorySchemaName],
+          kind: "schema",
+          name: inMemorySchemaName,
+          tableType: null,
+          numRows: null,
+          numColumns: null,
         });
 
         for (const [tableName, table] of datasetsMap.tables) {
           items.push({
-            type: "table",
+            type: "catalog-node",
             notebookUri,
             connectionName: inMemoryConnName,
             databaseName: inMemoryDbName,
-            schemaName: inMemorySchemaName,
-            tableName: tableName,
+            path: [inMemorySchemaName, tableName],
+            kind: "data_table",
+            name: tableName,
             tableType: table.type,
             numRows: table.num_rows,
             numColumns: table.num_columns,

--- a/extension/src/panel/datasources/__tests__/DatasourcesService.test.ts
+++ b/extension/src/panel/datasources/__tests__/DatasourcesService.test.ts
@@ -1,0 +1,329 @@
+import { assert, expect, it } from "@effect/vitest";
+import { Effect, Layer, Option } from "effect";
+
+import { notebookId, requestId } from "../../../lib/__tests__/branded.ts";
+import type {
+  CatalogChildrenPreviewNotification,
+  CatalogNode,
+  DataSourceConnectionsNotification,
+  DataTableNode,
+  NamespaceNode,
+  SchemaNode,
+} from "../../../types.ts";
+import {
+  type CatalogTreeNode,
+  DatasourcesService,
+} from "../DatasourcesService.ts";
+
+const withTestCtx = () =>
+  Effect.sync(() => {
+    const layer = Layer.empty.pipe(
+      Layer.provideMerge(DatasourcesService.Default),
+    );
+    return { layer };
+  });
+
+const NOTEBOOK_URI = notebookId("file:///test/notebook.py");
+
+// Mock factories for the recursive `Database.children` catalog model.
+// `variable_name`/`engine` are left null and `columns` empty so the wire shape
+// typechecks without minting branded values.
+function dataTable(
+  name: string,
+  opts: { numRows?: number | null; numColumns?: number | null } = {},
+): DataTableNode {
+  return {
+    kind: "data_table",
+    name,
+    source: "test",
+    source_type: "connection",
+    num_rows: opts.numRows ?? null,
+    num_columns: opts.numColumns ?? null,
+    variable_name: null,
+    columns: [],
+    type: "table",
+  };
+}
+
+function schema(name: string, tables: DataTableNode[] | null): SchemaNode {
+  return { kind: "schema", name, tables };
+}
+
+function namespace(
+  name: string,
+  children: CatalogNode[] | null,
+): NamespaceNode {
+  return { kind: "namespace", name, children };
+}
+
+// A single connection ("conn1") with a single database ("db1") whose catalog
+// tree is `children`.
+function connectionsOp(
+  children: CatalogNode[] | null,
+): DataSourceConnectionsNotification {
+  return {
+    op: "data-source-connections",
+    connections: [
+      {
+        name: "conn1",
+        source: "postgres",
+        dialect: "postgres",
+        display_name: "Conn 1",
+        default_database: null,
+        default_schema: null,
+        databases: [
+          { name: "db1", dialect: "postgres", children, engine: null },
+        ],
+      },
+    ],
+  };
+}
+
+function catalogChildrenOp(opts: {
+  request: string;
+  children?: CatalogNode[];
+  error?: string | null;
+}): CatalogChildrenPreviewNotification {
+  return {
+    op: "catalog-children-preview",
+    request_id: requestId(opts.request),
+    metadata: { connection: "conn1", database: "db1", catalog_path: [] },
+    children: opts.children,
+    error: opts.error ?? null,
+  };
+}
+
+/** Project a catalog tree to `{ kind, name, children }` for readable snapshots. */
+function summarize(
+  nodes: readonly CatalogTreeNode[],
+): Array<{ kind: string; name: string; children: unknown }> {
+  return nodes.map((n) => ({
+    kind: n.kind,
+    name: n.name,
+    children: summarize(n.children),
+  }));
+}
+
+/** Resolve the catalog tree of conn1/db1 from a connections snapshot. */
+function db1Children(
+  map: Option.Option<{
+    connections: Map<
+      string,
+      { databases: Map<string, { children: CatalogTreeNode[] }> }
+    >;
+  }>,
+): CatalogTreeNode[] {
+  assert(Option.isSome(map), "Expected connections");
+  const db = map.value.connections.get("conn1")?.databases.get("db1");
+  assert(db !== undefined, "Expected conn1/db1");
+  return db.children;
+}
+
+it.effect(
+  "normalizes a nested catalog tree (schema, namespace, root table)",
+  Effect.fn(function* () {
+    const { layer } = yield* withTestCtx();
+
+    const children = yield* Effect.gen(function* () {
+      const service = yield* DatasourcesService;
+      yield* service.updateConnections(
+        NOTEBOOK_URI,
+        connectionsOp([
+          schema("public", [dataTable("users"), dataTable("orders")]),
+          namespace("iceberg_ns", [
+            schema("nested", [dataTable("t1")]),
+            // deferred namespace: children not yet discovered
+            namespace("deep", null),
+          ]),
+          // root-level table directly under the database
+          dataTable("root_tbl"),
+          // deferred schema: tables not yet discovered
+          schema("lazy", null),
+        ]),
+      );
+      return db1Children(yield* service.getConnections(NOTEBOOK_URI));
+    }).pipe(Effect.provide(layer));
+
+    expect(summarize(children)).toMatchInlineSnapshot(`
+    	[
+    	  {
+    	    "children": [
+    	      {
+    	        "children": [],
+    	        "kind": "data_table",
+    	        "name": "users",
+    	      },
+    	      {
+    	        "children": [],
+    	        "kind": "data_table",
+    	        "name": "orders",
+    	      },
+    	    ],
+    	    "kind": "schema",
+    	    "name": "public",
+    	  },
+    	  {
+    	    "children": [
+    	      {
+    	        "children": [
+    	          {
+    	            "children": [],
+    	            "kind": "data_table",
+    	            "name": "t1",
+    	          },
+    	        ],
+    	        "kind": "schema",
+    	        "name": "nested",
+    	      },
+    	      {
+    	        "children": [],
+    	        "kind": "namespace",
+    	        "name": "deep",
+    	      },
+    	    ],
+    	    "kind": "namespace",
+    	    "name": "iceberg_ns",
+    	  },
+    	  {
+    	    "children": [],
+    	    "kind": "data_table",
+    	    "name": "root_tbl",
+    	  },
+    	  {
+    	    "children": [],
+    	    "kind": "schema",
+    	    "name": "lazy",
+    	  },
+    	]
+    `);
+  }),
+);
+
+it.effect(
+  "flattens a deferred top-level catalog (children === null) to []",
+  Effect.fn(function* () {
+    const { layer } = yield* withTestCtx();
+
+    const children = yield* Effect.gen(function* () {
+      const service = yield* DatasourcesService;
+      yield* service.updateConnections(NOTEBOOK_URI, connectionsOp(null));
+      return db1Children(yield* service.getConnections(NOTEBOOK_URI));
+    }).pipe(Effect.provide(layer));
+
+    expect(children).toEqual([]);
+  }),
+);
+
+it.effect(
+  "preserves table metadata on data_table leaves",
+  Effect.fn(function* () {
+    const { layer } = yield* withTestCtx();
+
+    const children = yield* Effect.gen(function* () {
+      const service = yield* DatasourcesService;
+      yield* service.updateConnections(
+        NOTEBOOK_URI,
+        connectionsOp([
+          schema("public", [
+            dataTable("users", { numRows: 42, numColumns: 3 }),
+          ]),
+        ]),
+      );
+      return db1Children(yield* service.getConnections(NOTEBOOK_URI));
+    }).pipe(Effect.provide(layer));
+
+    const table = children[0]?.children[0];
+    expect(table?.kind).toBe("data_table");
+    expect(table?.table?.num_rows).toBe(42);
+    expect(table?.table?.num_columns).toBe(3);
+  }),
+);
+
+it.effect(
+  "stores catalog children previews and ignores error responses",
+  Effect.fn(function* () {
+    const { layer } = yield* withTestCtx();
+
+    const result = yield* Effect.gen(function* () {
+      const service = yield* DatasourcesService;
+
+      // Successful preview is stored.
+      yield* service.updateCatalogChildrenPreview(
+        NOTEBOOK_URI,
+        catalogChildrenOp({
+          request: "req-ok",
+          children: [schema("public", [dataTable("users")])],
+        }),
+      );
+
+      // An errored preview for a *new* request stores nothing.
+      yield* service.updateCatalogChildrenPreview(
+        NOTEBOOK_URI,
+        catalogChildrenOp({ request: "req-err", error: "boom" }),
+      );
+
+      // An errored preview must not erase a previously cached success.
+      yield* service.updateCatalogChildrenPreview(
+        NOTEBOOK_URI,
+        catalogChildrenOp({ request: "req-ok", error: "transient" }),
+      );
+
+      return {
+        ok: yield* service.getCatalogChildrenPreview(NOTEBOOK_URI, "req-ok"),
+        err: yield* service.getCatalogChildrenPreview(NOTEBOOK_URI, "req-err"),
+      };
+    }).pipe(Effect.provide(layer));
+
+    expect(summarize(result.ok)).toMatchInlineSnapshot(`
+    	[
+    	  {
+    	    "children": [
+    	      {
+    	        "children": [],
+    	        "kind": "data_table",
+    	        "name": "users",
+    	      },
+    	    ],
+    	    "kind": "schema",
+    	    "name": "public",
+    	  },
+    	]
+    `);
+    expect(result.err).toEqual([]);
+  }),
+);
+
+it.effect(
+  "clears all catalog state for a notebook",
+  Effect.fn(function* () {
+    const { layer } = yield* withTestCtx();
+
+    const after = yield* Effect.gen(function* () {
+      const service = yield* DatasourcesService;
+      yield* service.updateConnections(
+        NOTEBOOK_URI,
+        connectionsOp([schema("public", [dataTable("users")])]),
+      );
+      yield* service.updateCatalogChildrenPreview(
+        NOTEBOOK_URI,
+        catalogChildrenOp({
+          request: "req-ok",
+          children: [dataTable("root_tbl")],
+        }),
+      );
+
+      yield* service.clearNotebook(NOTEBOOK_URI);
+
+      return {
+        connections: yield* service.getConnections(NOTEBOOK_URI),
+        preview: yield* service.getCatalogChildrenPreview(
+          NOTEBOOK_URI,
+          "req-ok",
+        ),
+      };
+    }).pipe(Effect.provide(layer));
+
+    expect(Option.isNone(after.connections)).toBe(true);
+    expect(after.preview).toEqual([]);
+  }),
+);

--- a/extension/src/types.ts
+++ b/extension/src/types.ts
@@ -27,8 +27,13 @@ export type DataSourceConnectionsNotification =
   NotificationOf<"data-source-connections">;
 export type DatasetsNotification = NotificationOf<"datasets">;
 export type SqlTablePreviewNotification = NotificationOf<"sql-table-preview">;
-export type SqlTableListPreviewNotification =
-  NotificationOf<"sql-table-list-preview">;
+export type CatalogChildrenPreviewNotification =
+  NotificationOf<"catalog-children-preview">;
+
+export type CatalogNode = NonNullable<Schemas["Database"]["children"]>[number];
+export type SchemaNode = Schemas["Schema"];
+export type NamespaceNode = Schemas["Namespace"];
+export type DataTableNode = Schemas["DataTable"];
 
 export type MarimoConfig = Schemas["MarimoConfig"];
 


### PR DESCRIPTION
## Summary

Adapts the extension to [marimo-team/marimo#9874](https://github.com/marimo-team/marimo/pull/9874), which unifies catalog browsing around a recursive `Database.children` tree and one lazy-load endpoint. That PR:

- replaces the flat `Database.schemas` list with a tagged `children` tree (`schema` / `namespace` / `data_table` nodes), using `null` buckets for deferred discovery; and
- replaces the `sql-table-list-preview` + `sql-schema-list-preview` notifications with a single `catalog-children-preview`.

Since our notification/schema types are generated from `@marimo-team/openapi`, that is a **compile break** here once `.marimo-version` is bumped to the release containing #9874 (`Database.schemas`, `SqlTableListPreviewNotification`, and the old op tags all disappear). This migrates the consumers.

## Changes

- **`types.ts`** — drop `SqlTableListPreviewNotification`; add `CatalogChildrenPreviewNotification` and `CatalogNode` / `SchemaNode` / `NamespaceNode` / `DataTableNode`.
- **`KernelManager.ts`** — route `catalog-children-preview`; the now-removed `sql-schema-list-preview` no longer needs to be ignored (the exhaustive `unreachable(operation)` switch enforces full coverage).
- **`DatasourcesService.ts`** — databases now hold a recursive `CatalogTreeNode` tree instead of a flat schema map. `normalizeCatalogNode` walks `schema.tables` / `namespace.children` and flattens deferred (`null`) buckets to `[]` (the panel renders what the kernel has discovered; it does not drive lazy fetches). `updateCatalogChildrenPreview` **skips error responses** so a transient failure can't erase cached children.
- **`DatasourcesView.ts`** — generalized the fixed `Connection → Database → Schema → Table` view into a recursive `Connection → Database → (Schema | Namespace)* → Table` tree using path-prefix matching. Adds a `marimoNamespace` contextValue (no menus key on it today). In-memory datasets render unchanged.
- **Tests** — `DatasourcesService.test.ts` (the panel's first): tree normalization (nested namespaces, root-level tables), deferred-`null` flattening, the error-skip guard, and `clearNotebook`.

## Verification

Verified by checking out the #9874 commit in a sibling `marimo` checkout (so the linked `@marimo-team/openapi` + frontend are consistent):

- `tsc` — clean
- `vp test` — 5/5 pass
- `vp check` (lint + format) — clean

## ⚠️ Merge ordering

This **must land together with the `.marimo-version` bump** to the release containing #9874. Against the currently pinned openapi package the new wire types don't exist yet, so CI here will not go green until that bump is in this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)