### PR TITLE
Auto-promote markdown/SQL smart cells in document transactions

### DIFF
--- a/extension/src/notebook/NotebookSerializer.ts
+++ b/extension/src/notebook/NotebookSerializer.ts
@@ -20,6 +20,7 @@ import {
   decodeCellMetadata,
 } from "../schemas/CellMetadata.ts";
 import { SerializedNotebook } from "../schemas/SerializedNotebook.ts";
+import { classifyCellCode } from "./classifyCellCode.ts";
 import { pickLiveNotebook } from "./pickLiveNotebook.ts";
 
 type BooleanMap<T> = {
@@ -76,60 +77,26 @@ export class NotebookSerializer extends Effect.Service<NotebookSerializer>()(
             },
           });
           const { cells, ...metadata } = yield* decodeDeserializeResponse(resp);
-          const sqlParser = new SQLParser();
-          const markdownParser = new MarkdownParser();
 
           const notebook = {
             metadata: metadata,
             cells: cells.map((cell) => {
-              const isNonEmpty = Boolean(cell.code.trim());
-
-              // Check if this is a markdown cell (mo.md() without f-strings)
-              if (isNonEmpty && markdownParser.isSupported(cell.code)) {
-                const result = markdownParser.transformIn(cell.code);
-                if (!result.metadata.quotePrefix.includes("f")) {
-                  return {
-                    kind: NotebookCellKind.Markup,
-                    value: result.code,
-                    languageId: constants.LanguageId.Markdown,
-                    metadata: {
-                      name: cell.name,
-                      options: cell.options,
-                      languageMetadata: {
-                        markdown: result.metadata,
-                      },
-                      stableId: crypto.randomUUID(),
-                    } satisfies CellMetadata,
-                  };
-                }
-              }
-
-              // Check if this is a SQL cell
-              if (isNonEmpty && sqlParser.isSupported(cell.code)) {
-                const result = sqlParser.transformIn(cell.code);
-                return {
-                  kind: NotebookCellKind.Code,
-                  value: result.code,
-                  languageId: constants.LanguageId.Sql,
-                  metadata: {
-                    name: cell.name,
-                    options: cell.options,
-                    languageMetadata: {
-                      sql: result.metadata,
-                    },
-                    stableId: crypto.randomUUID(),
-                  } satisfies CellMetadata,
-                };
-              }
-
-              // Default Python cell
+              // Same classification the live transaction path uses, so a file
+              // open and a code-mode commit agree on markdown/sql vs python.
+              const classified = classifyCellCode(
+                cell.code,
+                constants.LanguageId,
+              );
               return {
-                kind: NotebookCellKind.Code,
-                value: cell.code,
-                languageId: constants.LanguageId.Python,
+                kind: classified.kind,
+                value: classified.code,
+                languageId: classified.languageId,
                 metadata: {
                   name: cell.name,
                   options: cell.options,
+                  ...(classified.languageMetadata
+                    ? { languageMetadata: classified.languageMetadata }
+                    : {}),
                   stableId: crypto.randomUUID(),
                 } satisfies CellMetadata,
               };

--- a/extension/src/notebook/__tests__/transactionPlan.test.ts
+++ b/extension/src/notebook/__tests__/transactionPlan.test.ts
@@ -2,11 +2,23 @@ import { describe, expect, it } from "@effect/vitest";
 
 import { cellId as cid } from "../../lib/__tests__/branded.ts";
 import type { DocumentChange } from "../../types.ts";
+import type { LanguageIds } from "../classifyCellCode.ts";
 import {
   computeDesiredCells,
   diffToReplaceRange,
   type PlanCell,
 } from "../transactionPlan.ts";
+
+const LANGUAGE_IDS: LanguageIds = {
+  Python: "mo-python",
+  Sql: "sql",
+  Markdown: "markdown",
+};
+
+const compute = (
+  current: readonly PlanCell[],
+  changes: readonly DocumentChange[],
+) => computeDesiredCells(current, changes, LANGUAGE_IDS);
 
 function pc(
   stableId: string,
@@ -63,13 +75,13 @@ function ids(cells: readonly PlanCell[]): string[] {
 describe("computeDesiredCells", () => {
   it("appends a created cell with no anchor", () => {
     const current = [pc("a", "x = 1"), pc("b", "y = 2")];
-    const desired = computeDesiredCells(current, [createCell("c", "z = 3")]);
+    const desired = compute(current, [createCell("c", "z = 3")]);
     expect(ids(desired)).toEqual(["a", "b", "c"]);
   });
 
   it("inserts a created cell after its anchor", () => {
     const current = [pc("a", "x = 1"), pc("b", "y = 2")];
-    const desired = computeDesiredCells(current, [
+    const desired = compute(current, [
       createCell("c", "z = 3", { after: "a" }),
     ]);
     expect(ids(desired)).toEqual(["a", "c", "b"]);
@@ -77,7 +89,7 @@ describe("computeDesiredCells", () => {
 
   it("folds the create + trailing reorder-cells a code-mode batch emits", () => {
     const current = [pc("a", "x = 1")];
-    const desired = computeDesiredCells(current, [
+    const desired = compute(current, [
       createCell("c", "z = 3"),
       reorder("a", "c"),
     ]);
@@ -87,26 +99,92 @@ describe("computeDesiredCells", () => {
 
   it("edits code in place", () => {
     const current = [pc("a", "x = 1"), pc("b", "y = 2")];
-    const desired = computeDesiredCells(current, [setCode("b", "y = 99")]);
+    const desired = compute(current, [setCode("b", "y = 99")]);
     expect(desired[1]).toMatchObject({ stableId: "b", code: "y = 99" });
   });
 
   it("deletes a cell", () => {
     const current = [pc("a", "x = 1"), pc("b", "y = 2")];
-    const desired = computeDesiredCells(current, [deleteCell("a")]);
+    const desired = compute(current, [deleteCell("a")]);
     expect(ids(desired)).toEqual(["b"]);
   });
 
   it("reorders, appending cells missing from the new order", () => {
     const current = [pc("a", "1"), pc("b", "2"), pc("c", "3")];
-    const desired = computeDesiredCells(current, [reorder("c", "a")]);
+    const desired = compute(current, [reorder("c", "a")]);
     expect(ids(desired)).toEqual(["c", "a", "b"]);
   });
 
   it("ignores changes that target an unknown cell", () => {
     const current = [pc("a", "x = 1")];
-    const desired = computeDesiredCells(current, [setCode("missing", "nope")]);
+    const desired = compute(current, [setCode("missing", "nope")]);
     expect(desired).toEqual(current);
+  });
+
+  it("classifies a created mo.md cell as a markdown markup cell", () => {
+    const desired = compute([], [createCell("m", 'mo.md(r"""# Hello""")')]);
+    expect(desired[0]).toMatchObject({
+      stableId: "m",
+      // Display code, not the Python wrapper.
+      code: "# Hello",
+      languageId: "markdown",
+      // NotebookCellKind.Markup
+      kind: 1,
+    });
+    expect(desired[0].languageMetadata?.markdown).toBeDefined();
+  });
+
+  it("classifies a created mo.sql cell as a sql code cell", () => {
+    const desired = compute(
+      [],
+      [createCell("q", '_df = mo.sql(f"""SELECT 1""")')],
+    );
+    expect(desired[0]).toMatchObject({
+      stableId: "q",
+      code: "SELECT 1",
+      languageId: "sql",
+      // NotebookCellKind.Code
+      kind: 2,
+    });
+    expect(desired[0].languageMetadata?.sql).toMatchObject({
+      dataframeName: "_df",
+    });
+  });
+
+  it("keeps f-string mo.md as a Python cell (can't round-trip interpolation)", () => {
+    const desired = compute([], [createCell("m", 'mo.md(f"""# {title}""")')]);
+    expect(desired[0]).toMatchObject({ languageId: "mo-python", kind: 2 });
+    expect(desired[0].languageMetadata).toBeUndefined();
+  });
+
+  it("promotes a python cell to markdown when set-code makes it mo.md", () => {
+    const current = [pc("a", "x = 1", { languageId: "mo-python" })];
+    const desired = compute(current, [setCode("a", 'mo.md(r"""# Hi""")')]);
+    expect(desired[0]).toMatchObject({
+      stableId: "a",
+      code: "# Hi",
+      languageId: "markdown",
+      kind: 1,
+    });
+    expect(desired[0].languageMetadata?.markdown).toBeDefined();
+  });
+
+  it("demotes a markdown cell back to python when set-code makes it python", () => {
+    const current = [
+      pc("a", "# Hi", {
+        languageId: "markdown",
+        kind: 1,
+        languageMetadata: { markdown: { quotePrefix: "r" } },
+      }),
+    ];
+    const desired = compute(current, [setCode("a", "x = 1")]);
+    expect(desired[0]).toMatchObject({
+      stableId: "a",
+      code: "x = 1",
+      languageId: "mo-python",
+      kind: 2,
+    });
+    expect(desired[0].languageMetadata).toBeUndefined();
   });
 });
 

--- a/extension/src/notebook/applyDocumentTransaction.ts
+++ b/extension/src/notebook/applyDocumentTransaction.ts
@@ -11,6 +11,7 @@
 
 import { Effect, Option } from "effect";
 
+import { Constants } from "../platform/Constants.ts";
 import { VsCode } from "../platform/VsCode.ts";
 import type { CellMetadata } from "../schemas/CellMetadata.ts";
 import { encodeCellMetadata } from "../schemas/CellMetadata.ts";
@@ -35,6 +36,10 @@ function toPlanCell(cell: MarimoNotebookCell): Option.Option<PlanCell> {
     onNone: (): Record<string, unknown> => ({}),
     onSome: (meta) => meta.options ?? {},
   });
+  const languageMetadata = Option.match(cell.metadata, {
+    onNone: () => undefined,
+    onSome: (meta) => meta.languageMetadata,
+  });
   return Option.some({
     stableId,
     code: cell.document.getText(),
@@ -46,6 +51,7 @@ function toPlanCell(cell: MarimoNotebookCell): Option.Option<PlanCell> {
       disabled: options.disabled === true,
       hide_code: options.hide_code === true,
     },
+    languageMetadata,
   });
 }
 
@@ -56,6 +62,7 @@ export const applyDocumentTransaction = Effect.fn(
   transaction: DocumentTransactionNotification["transaction"],
 ) {
   const code = yield* VsCode;
+  const { LanguageId } = yield* Constants;
 
   const byId = new Map<string, MarimoNotebookCell>();
   const current: PlanCell[] = [];
@@ -67,7 +74,7 @@ export const applyDocumentTransaction = Effect.fn(
     }
   }
 
-  const desired = computeDesiredCells(current, transaction.changes);
+  const desired = computeDesiredCells(current, transaction.changes, LanguageId);
   const range = diffToReplaceRange(current, desired);
   if (range == null) return;
 
@@ -94,8 +101,9 @@ export const applyDocumentTransaction = Effect.fn(
         )
       : [];
 
-    // Preserve a surviving cell's other metadata (state, languageMetadata);
-    // override the fields the transaction owns.
+    // Preserve a surviving cell's other metadata (e.g. state); override the
+    // fields the transaction owns. `languageMetadata` is owned by the
+    // classification so a promote/demote overwrites (or clears) the prior value.
     const base = existing
       ? Option.getOrElse(existing.metadata, (): CellMetadata => ({}))
       : {};
@@ -104,6 +112,7 @@ export const applyDocumentTransaction = Effect.fn(
       stableId: cell.stableId,
       name: cell.name === "" ? undefined : cell.name,
       options: cell.config,
+      languageMetadata: cell.languageMetadata,
     });
 
     return data;

--- a/extension/src/notebook/classifyCellCode.ts
+++ b/extension/src/notebook/classifyCellCode.ts
@@ -1,0 +1,87 @@
+/**
+ * Classify a cell's Python source into a VS Code cell shape (smart-cells).
+ *
+ * A marimo markdown or SQL cell is just a Python cell whose code is a single
+ * `mo.md(...)` / `mo.sql(...)` call. The `@marimo-team/smart-cells` parsers
+ * detect that shape and `transformIn` strips the wrapper, yielding the raw
+ * markdown/SQL the user actually edits plus the metadata needed to wrap it back
+ * (`transformOut`) on save/execute.
+ *
+ * This is the single source of truth for that classification so the two paths
+ * that ingest kernel-owned Python agree: {@link NotebookSerializer} (file open)
+ * and {@link computeDesiredCells} (live document transactions). It is free of
+ * `vscode` — the parsers are pure TS — so it stays trivially unit-testable.
+ */
+
+import { MarkdownParser, SQLParser } from "@marimo-team/smart-cells";
+
+import type { CellMetadata } from "../schemas/CellMetadata.ts";
+
+/** Matches `vscode.NotebookCellKind`: 1 = Markup, 2 = Code. Kept as literals so this module stays vscode-free. */
+const MARKUP_KIND = 1;
+const CODE_KIND = 2;
+
+// Parsers are stateless; share one instance each.
+const markdownParser = new MarkdownParser();
+const sqlParser = new SQLParser();
+
+/**
+ * Resolved cell language ids. The Python id is config-dependent
+ * (`"mo-python"` vs `"python"` per `disableManagedLanguageFeatures`), so it must
+ * come from the `Constants` service rather than the static constant — the cell's
+ * `document.languageId` is the resolved value and equivalence compares against it.
+ */
+export interface LanguageIds {
+  readonly Python: string;
+  readonly Sql: string;
+  readonly Markdown: string;
+}
+
+export interface ClassifiedCell {
+  /** `vscode.NotebookCellKind`: 1 = Markup, 2 = Code. */
+  readonly kind: 1 | 2;
+  readonly languageId: string;
+  /** Display code: raw markdown/SQL for smart cells, the original Python otherwise. */
+  readonly code: string;
+  /** Smart-cell metadata needed to wrap the display code back to Python; undefined for plain Python. */
+  readonly languageMetadata: CellMetadata["languageMetadata"];
+}
+
+/**
+ * Classify kernel-owned Python source. Markdown wins over SQL (matching the
+ * serializer's order); f-string `mo.md` stays Python because we can't round-trip
+ * interpolation through a Markup cell.
+ */
+export function classifyCellCode(
+  code: string,
+  languageIds: LanguageIds,
+): ClassifiedCell {
+  if (code.trim()) {
+    if (markdownParser.isSupported(code)) {
+      const result = markdownParser.transformIn(code);
+      if (!result.metadata.quotePrefix.includes("f")) {
+        return {
+          kind: MARKUP_KIND,
+          languageId: languageIds.Markdown,
+          code: result.code,
+          languageMetadata: { markdown: result.metadata },
+        };
+      }
+    }
+    if (sqlParser.isSupported(code)) {
+      const result = sqlParser.transformIn(code);
+      return {
+        kind: CODE_KIND,
+        languageId: languageIds.Sql,
+        code: result.code,
+        languageMetadata: { sql: result.metadata },
+      };
+    }
+  }
+  return {
+    kind: CODE_KIND,
+    languageId: languageIds.Python,
+    code,
+    languageMetadata: undefined,
+  };
+}

--- a/extension/src/notebook/transactionPlan.ts
+++ b/extension/src/notebook/transactionPlan.ts
@@ -17,11 +17,9 @@
 
 import { Schema } from "effect";
 
-import { LanguageId } from "../constants.ts";
+import { LanguageMetadata } from "../schemas/CellMetadata.ts";
 import type { CellConfig, DocumentChange } from "../types.ts";
-
-/** NotebookCellKind.Code — kept as a literal so this module stays vscode-free. */
-const CODE_KIND = 2;
+import { classifyCellCode, type LanguageIds } from "./classifyCellCode.ts";
 
 /** Cell config in one normalized shape (CellConfig's documented defaults applied). */
 const PlanCellConfig = Schema.Struct({
@@ -39,6 +37,13 @@ const PlanCell = Schema.Struct({
   kind: Schema.Number,
   name: Schema.String,
   config: PlanCellConfig,
+  /**
+   * Smart-cell metadata (markdown/sql) needed to wrap the display `code` back to
+   * Python. Part of the schema so {@link cellEquivalence} re-renders a cell when
+   * a promote/demote (`set-code`) changes only its language, and so the applier
+   * carries it onto the VS Code cell.
+   */
+  languageMetadata: Schema.optional(LanguageMetadata),
 });
 export type PlanCell = typeof PlanCell.Type;
 
@@ -87,21 +92,24 @@ function insertionIndex(
 export function computeDesiredCells(
   current: readonly PlanCell[],
   changes: readonly DocumentChange[],
+  languageIds: LanguageIds,
 ): PlanCell[] {
   let cells: PlanCell[] = [...current];
 
   for (const change of changes) {
     switch (change.type) {
       case "create-cell": {
+        // Code mode can commit markdown/sql cells; classify so they land as the
+        // right VS Code cell kind instead of raw `mo.md(...)` Python.
+        const classified = classifyCellCode(change.code, languageIds);
         const cell: PlanCell = {
           stableId: change.cellId,
-          code: change.code,
-          // TODO: classify markdown/sql cells (smart-cells) — code mode can
-          // create them too; today every committed cell is treated as Python.
-          languageId: LanguageId.Python,
-          kind: CODE_KIND,
+          code: classified.code,
+          languageId: classified.languageId,
+          kind: classified.kind,
           name: change.name,
           config: normalizeConfig(change.config),
+          languageMetadata: classified.languageMetadata,
         };
         cells.splice(
           insertionIndex(cells, change.before, change.after),
@@ -117,7 +125,18 @@ export function computeDesiredCells(
       }
       case "set-code": {
         const idx = indexOfId(cells, change.cellId);
-        if (idx !== -1) cells[idx] = { ...cells[idx], code: change.code };
+        if (idx !== -1) {
+          // Re-classify on edit so a cell promotes (python → mo.md/mo.sql) or
+          // demotes (back to python) in place, mirroring the live editor.
+          const classified = classifyCellCode(change.code, languageIds);
+          cells[idx] = {
+            ...cells[idx],
+            code: classified.code,
+            languageId: classified.languageId,
+            kind: classified.kind,
+            languageMetadata: classified.languageMetadata,
+          };
+        }
         break;
       }
       case "set-name": {

--- a/extension/src/schemas/CellMetadata.ts
+++ b/extension/src/schemas/CellMetadata.ts
@@ -20,6 +20,19 @@ const MarkdownMetadata = Schema.Struct({
   quotePrefix: Schema.Literal("", "f", "r", "fr", "rf"),
 });
 
+/**
+ * Language-specific metadata (e.g. SQL engine/output flag, markdown quoting)
+ * needed to wrap a smart cell's display code back into Python. Shared with the
+ * transaction planner so its cell equivalence accounts for it.
+ */
+export const LanguageMetadata = Schema.partial(
+  Schema.Struct({
+    sql: SQLMetadata,
+    markdown: MarkdownMetadata,
+  }),
+);
+export type LanguageMetadata = typeof LanguageMetadata.Type;
+
 // TODO: passthrough unknown fields
 /**
  * VS Code notebook cell metadata (runtime state)
@@ -39,12 +52,7 @@ export const CellMetadata = Schema.partial(
     }),
 
     // Language-specific metadata (e.g., SQL engine, output flag)
-    languageMetadata: Schema.partial(
-      Schema.Struct({
-        sql: SQLMetadata,
-        markdown: MarkdownMetadata,
-      }),
-    ),
+    languageMetadata: LanguageMetadata,
 
     // Stable ID for tracking cells across re-deserializations
     // This is ephemeral (not persisted to .py file) and regenerated on file open


### PR DESCRIPTION
Code mode (and any kernel-emitted transaction) can commit cells whose code is a single `mo.md()`/`mo.sql()` call. The live transaction path treated every committed cell as Python, so smart cells only got promoted on a full save/reopen round-trip.

These changes factor the serializer's markdown/SQL classification into a shared `classifyCellCode` helper used for both create-cell (promote) and set-code (promote/demote in place). The `PlanCell` now carries `languageMetadata` so cell equivalence re-renders on a language flip and the applier carries it onto the VS Code cell.