### PR TITLE
Generalize `openAsMarimoNotebook` to accept an optional resource URI string

### DIFF
--- a/extension/src/commands/defineCommand.ts
+++ b/extension/src/commands/defineCommand.ts
@@ -1,0 +1,16 @@
+import { Effect, ParseResult, Schema } from "effect";
+
+/**
+ * Ties a Schema to a command handler, returning an opaque (...args: unknown[]) => Effect
+ * that decodes args[0] before calling the handler. Keeps schema and type contract local
+ * to the command file rather than in a central registry.
+ */
+export function defineCommand<A, E, R>(
+  schema: Schema.Schema<A>,
+  handler: (arg: A) => Effect.Effect<unknown, E, R>,
+): (
+  ...args: unknown[]
+) => Effect.Effect<unknown, E | ParseResult.ParseError, R> {
+  return (...args) =>
+    Schema.decodeUnknown(schema)(args[0]).pipe(Effect.flatMap(handler));
+}

--- a/extension/src/commands/openAsMarimoNotebook.ts
+++ b/extension/src/commands/openAsMarimoNotebook.ts
@@ -1,21 +1,35 @@
-import { Effect, Option } from "effect";
+import { Effect, Either, Option, Schema } from "effect";
+import type * as vscode from "vscode";
 
 import { NOTEBOOK_TYPE } from "../constants.ts";
 import { VsCode } from "../platform/VsCode.ts";
+import { defineCommand } from "./defineCommand.ts";
 
-export const openAsMarimoNotebook = Effect.fn("command.openAsMarimoNotebook")(
-  function* () {
+export const openAsMarimoNotebook = defineCommand(
+  Schema.UndefinedOr(Schema.String),
+  Effect.fn("command.openAsMarimoNotebook")(function* (uriString) {
     const code = yield* VsCode;
-    const editor = yield* code.window.getActiveTextEditor();
 
-    if (Option.isNone(editor)) {
-      yield* code.window.showInformationMessage(
-        "No active file to open as notebook",
-      );
-      return;
+    let uri: vscode.Uri;
+    if (uriString !== undefined) {
+      const result = code.utils.parseUri(uriString);
+      if (Either.isLeft(result)) {
+        yield* code.window.showInformationMessage(
+          `Failed to parse notebook URI: ${JSON.stringify(uriString)}`,
+        );
+        return;
+      }
+      uri = result.right;
+    } else {
+      const editor = yield* code.window.getActiveTextEditor();
+      if (Option.isNone(editor)) {
+        yield* code.window.showInformationMessage(
+          "No active file to open as notebook",
+        );
+        return;
+      }
+      uri = editor.value.document.uri;
     }
-
-    const uri = editor.value.document.uri;
 
     // We open first before closing to handle multi-window scenarios correctly:
     // if we close first and it's the only editor in the window, the window
@@ -30,5 +44,5 @@ export const openAsMarimoNotebook = Effect.fn("command.openAsMarimoNotebook")(
     yield* Effect.logDebug("Opened Python file as marimo notebook").pipe(
       Effect.annotateLogs({ uri: uri.toString() }),
     );
-  },
+  }),
 );

--- a/extension/src/platform/VsCode.ts
+++ b/extension/src/platform/VsCode.ts
@@ -317,12 +317,12 @@ export class Commands extends Effect.Service<Commands>()("Commands", {
       },
       registerCommand<A, E, R>(
         command: MarimoCommand | DynamicCommand,
-        fn: () => Effect.Effect<A, E, R>,
+        fn: (...args: unknown[]) => Effect.Effect<A, E, R>,
       ) {
         return Effect.gen(function* () {
           const runPromise = Runtime.runPromise(yield* Effect.runtime<R>());
-          const callback = () =>
-            fn().pipe(
+          const callback = (...args: unknown[]) =>
+            fn(...args).pipe(
               Effect.tap(() =>
                 PubSub.publish(commandPubSub, Either.right(command)),
               ),


### PR DESCRIPTION
Adds `defineCommand(...)` helper to define typed commands.