### PR TITLE
Sync and normalize markdown/SQL smart cells before snapshotting

### DIFF
--- a/extension/src/lsp/LanguageClient.ts
+++ b/extension/src/lsp/LanguageClient.ts
@@ -137,6 +137,7 @@ export class LanguageClient extends Effect.Service<LanguageClient>()(
             { notebook: NOTEBOOK_TYPE, language: "sql" },
             { notebook: NOTEBOOK_TYPE, language: "python" },
             { notebook: NOTEBOOK_TYPE, language: "mo-python" },
+            { notebook: NOTEBOOK_TYPE, language: "markdown" },
           ],
         },
       );

--- a/extension/src/schemas/CellMetadata.ts
+++ b/extension/src/schemas/CellMetadata.ts
@@ -8,6 +8,8 @@ import { CellState } from "./CellState.ts";
 export const CellLanguage = Schema.Literal("python", "sql", "markdown");
 export type CellLanguage = typeof CellLanguage.Type;
 
+// TODO: hand-mirrored by `src/marimo_lsp/models.py` (CellMetadata); nothing keeps
+// them in sync. Drive both from one source of truth (codegen / shared schema).
 const SQLMetadata = Schema.Struct({
   dataframeName: Schema.String,
   quotePrefix: Schema.Literal("", "f", "r", "fr", "rf"),

--- a/src/marimo_lsp/app_file_manager.py
+++ b/src/marimo_lsp/app_file_manager.py
@@ -11,16 +11,20 @@ from marimo._ast.app import App, InternalApp
 from marimo._ast.cell import CellConfig
 from marimo._messaging.notebook.document import NotebookCell
 from marimo._messaging.notebook.outputs import CellOutputs
+from marimo._types.ids import CellId_t
 from pygls.uris import to_fs_path
 
-from marimo_lsp.utils import decode_marimo_cell_metadata, find_text_document
+from marimo_lsp.utils import (
+    decode_cell_metadata,
+    find_text_document,
+    normalize_cell_code,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Generator
 
     import lsprotocol.types as lsp
     from lsprotocol.types import NotebookDocument
-    from marimo._types.ids import CellId_t
     from pygls.lsp.server import LanguageServer
     from pygls.workspace import Workspace
 
@@ -145,12 +149,14 @@ def _iter_notebook_cells(
 ) -> Generator[tuple[CellId_t, str, str, dict[str, Any]]]:
     """Yield (cell_id, code, name, config) for each valid cell in a notebook."""
     for cell in notebook.cells:
-        cell_id, config, name = decode_marimo_cell_metadata(cell)
-        if cell_id is None:
+        meta = decode_cell_metadata(cell)
+        if meta.stable_id is None:
             continue
         document = find_text_document(workspace, cell.document)
-        code = (document.source or "") if document else ""
-        yield cell_id, code, name, config
+        source = (document.source or "") if document else ""
+        language_id = (document.language_id if document else None) or "python"
+        code = normalize_cell_code(language_id, source, meta.language_metadata)
+        yield CellId_t(meta.stable_id), code, meta.name, meta.config
 
 
 def sync_app_with_workspace(

--- a/src/marimo_lsp/diagnostics.py
+++ b/src/marimo_lsp/diagnostics.py
@@ -13,16 +13,19 @@ from marimo._messaging.notification import (
     VariablesNotification,
 )
 from marimo._runtime.dataflow import DirectedGraph
-from marimo._types.ids import VariableName
+from marimo._types.ids import CellId_t, VariableName
 
 from marimo_lsp import _rules
 from marimo_lsp.loggers import get_logger
-from marimo_lsp.utils import decode_marimo_cell_metadata, find_text_document
+from marimo_lsp.utils import (
+    decode_cell_metadata,
+    find_text_document,
+    normalize_cell_code,
+)
 
 logger = get_logger()
 
 if TYPE_CHECKING:
-    from marimo._types.ids import CellId_t
     from pygls.lsp.server import LanguageServer
 
 # Lightweight snapshot of the variable dependency structure.
@@ -127,16 +130,20 @@ class NotebookGraphUpdater:
 
         current_ids: set[CellId_t] = set()
         for idx, cell in enumerate(notebook.cells):
-            cell_id, _config, name = decode_marimo_cell_metadata(cell)
-            if not cell_id:
+            meta = decode_cell_metadata(cell)
+            if meta.stable_id is None:
                 continue
+            cell_id = CellId_t(meta.stable_id)
             current_ids.add(cell_id)
             cell_id_to_uri[cell_id] = cell.document
-            cell_names[cell_id] = name
+            cell_names[cell_id] = meta.name
             cell_index[cell_id] = idx
 
             doc = find_text_document(self._server.workspace, cell.document)
-            source = doc.source if doc else ""
+            language_id = (doc.language_id if doc else None) or "python"
+            source = normalize_cell_code(
+                language_id, doc.source if doc else "", meta.language_metadata
+            )
 
             # Skip unchanged cells
             if self._cell_sources.get(cell_id) == source:

--- a/src/marimo_lsp/models.py
+++ b/src/marimo_lsp/models.py
@@ -6,8 +6,14 @@ import typing
 
 import marimo._server.models.models as core
 import msgspec
+from marimo._convert.common.format import DEFAULT_MARKDOWN_PREFIX
 
 T = typing.TypeVar("T", bound=msgspec.Struct)
+
+# Sentinel the frontend `@marimo-team/smart-cells` SQL parser writes into
+# `languageMetadata.sql.engine` for the implicit default engine. We must not
+# emit `engine=__marimo_duckdb` when round-tripping these cells.
+DEFAULT_SQL_ENGINE = "__marimo_duckdb"
 
 
 class NotebookCommand(msgspec.Struct, typing.Generic[T], rename="camel"):
@@ -61,6 +67,55 @@ class PackageCommand(NotebookCommand[T]):
 
     source: PackageSource
     """How to resolve the notebook's python environment."""
+
+
+# TODO: hand-mirrored from `extension/src/schemas/CellMetadata.ts`; nothing keeps
+# them in sync. Drive both from one source of truth (codegen / shared schema).
+class MarkdownCellMetadata(msgspec.Struct, rename="camel"):
+    """Smart-cell metadata for a markdown cell (mirrors the frontend shape)."""
+
+    quote_prefix: str = DEFAULT_MARKDOWN_PREFIX
+    """The string-literal prefix used to wrap the markdown (e.g. ``r``)."""
+
+
+class SqlCellMetadata(msgspec.Struct, rename="camel"):
+    """Smart-cell metadata for a SQL cell (mirrors the frontend shape)."""
+
+    dataframe_name: str = "_df"
+    """The variable the query result is bound to (``_df = mo.sql(...)``)."""
+
+    show_output: bool = True
+    """Whether the query result is displayed (``output=False`` when ``False``)."""
+
+    engine: str | None = None
+    """The SQL engine variable, or ``None`` for the implicit default."""
+
+
+class CellLanguageMetadata(msgspec.Struct, rename="camel"):
+    """Language-specific smart-cell metadata needed to re-wrap display source.
+
+    Only one of these is set, matching the cell's language. Absent when the
+    client didn't sync it, in which case the per-language defaults apply.
+    """
+
+    markdown: MarkdownCellMetadata | None = None
+    sql: SqlCellMetadata | None = None
+
+
+class CellMetadata(msgspec.Struct, rename="camel"):
+    """marimo-specific fields synced on a VS Code notebook cell's metadata."""
+
+    stable_id: str | None = None
+    """Ephemeral per-open cell identifier; the marimo `CellId_t`."""
+
+    name: str = "_"
+    """The marimo cell name."""
+
+    config: dict[str, typing.Any] = msgspec.field(default_factory=dict)
+    """The marimo `CellConfig` as a plain dict."""
+
+    language_metadata: CellLanguageMetadata | None = None
+    """Smart-cell metadata for markdown/SQL cells; absent for Python cells."""
 
 
 class SerializeRequest(msgspec.Struct, rename="camel"):

--- a/src/marimo_lsp/server.py
+++ b/src/marimo_lsp/server.py
@@ -36,6 +36,7 @@ def create_server() -> LanguageServer:  # noqa: C901, PLR0915
                         lsp.NotebookCellLanguage(language="sql"),
                         lsp.NotebookCellLanguage(language="python"),
                         lsp.NotebookCellLanguage(language="mo-python"),
+                        lsp.NotebookCellLanguage(language="markdown"),
                     ],
                 ),
             ],

--- a/src/marimo_lsp/utils.py
+++ b/src/marimo_lsp/utils.py
@@ -2,12 +2,24 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING
 from urllib.parse import unquote
 
+import msgspec
+from marimo._convert.common.format import (
+    DEFAULT_MARKDOWN_PREFIX,
+    markdown_to_marimo,
+    sql_to_marimo,
+)
 from marimo._types.ids import CellId_t
 
 from marimo_lsp.loggers import get_logger
+from marimo_lsp.models import (
+    DEFAULT_SQL_ENGINE,
+    CellLanguageMetadata,
+    CellMetadata,
+    SqlCellMetadata,
+)
 
 logger = get_logger()
 
@@ -44,22 +56,55 @@ def find_text_document(workspace: Workspace, uri: str) -> TextDocument | None:
     return None
 
 
+def decode_cell_metadata(cell: lsp.NotebookCell) -> CellMetadata:
+    """Decode marimo-specific metadata from an ``lsp.NotebookCell``.
+
+    ``cell.metadata`` is an untyped ``LSPObject`` (a dict on the wire). We
+    parse it into a typed :class:`CellMetadata` so callers earn the type
+    instead of asserting it — unknown fields (VS Code's own state, ``options``)
+    are ignored and missing fields fall back to the struct defaults.
+    """
+    return msgspec.convert(cell.metadata or {}, CellMetadata)
+
+
 def get_stable_id(cell: lsp.NotebookCell) -> CellId_t | None:
     """Get the stable ID of a marimo notebook cell."""
-    return decode_marimo_cell_metadata(cell)[0]
+    stable_id = decode_cell_metadata(cell).stable_id
+    return CellId_t(stable_id) if stable_id is not None else None
 
 
-def decode_marimo_cell_metadata(
-    cell: lsp.NotebookCell,
-) -> tuple[CellId_t | None, dict[str, Any], str]:
-    """Decode marimo-specific metadata from lsp.NotebookCell."""
-    meta = cast("dict[str, Any]", cell.metadata) if cell.metadata else {}
-    cell_id = meta.get("stableId", None)
-    config = meta.get("config", {})
-    name = meta.get("name", "_")
+def normalize_cell_code(
+    language_id: str,
+    source: str,
+    language_metadata: CellLanguageMetadata | None,
+) -> str:
+    """Normalize a smart cell's display source into marimo Python source.
 
-    return (
-        CellId_t(cell_id) if cell_id is not None else None,
-        config,
-        name,
-    )
+    Markdown and SQL cells sync their *display* form over the notebook
+    protocol — raw markdown (``# Header``) and raw SQL (``SELECT ...``) — but
+    the kernel, serializer, and dependency graph all expect Python source
+    (``mo.md(...)`` / ``_df = mo.sql(...)``). This wraps them back, mirroring
+    the frontend ``@marimo-team/smart-cells`` ``transformOut``, reading the
+    quote prefix / dataframe name / engine from ``language_metadata`` when the
+    client synced it and falling back to marimo's defaults otherwise.
+
+    Python (``python`` / ``mo-python``) cells pass through unchanged.
+    """
+    if language_id == "markdown":
+        markdown = language_metadata.markdown if language_metadata else None
+        prefix = markdown.quote_prefix if markdown else DEFAULT_MARKDOWN_PREFIX
+        return markdown_to_marimo(source, prefix=prefix)
+
+    if language_id == "sql":
+        sql = (language_metadata.sql if language_metadata else None) or (
+            SqlCellMetadata()
+        )
+        engine = sql.engine if sql.engine and sql.engine != DEFAULT_SQL_ENGINE else None
+        return sql_to_marimo(
+            source,
+            table=sql.dataframe_name,
+            hide_output=not sql.show_output,
+            engine=engine,
+        )
+
+    return source

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -6,6 +6,7 @@ from typing import cast
 from unittest.mock import MagicMock, patch
 
 import lsprotocol.types as lsp
+from inline_snapshot import snapshot
 from marimo._types.ids import CellId_t
 
 from marimo_lsp.diagnostics import (
@@ -13,7 +14,16 @@ from marimo_lsp.diagnostics import (
     NotebookGraphUpdater,
     _snapshot_variables,
 )
-from marimo_lsp.utils import decode_marimo_cell_metadata, get_stable_id
+from marimo_lsp.models import (
+    CellLanguageMetadata,
+    MarkdownCellMetadata,
+    SqlCellMetadata,
+)
+from marimo_lsp.utils import (
+    decode_cell_metadata,
+    get_stable_id,
+    normalize_cell_code,
+)
 
 
 def _make_server(
@@ -359,8 +369,8 @@ class TestCellMetadataHelpers:
         stable_id = get_stable_id(cell)
         assert stable_id is None
 
-    def test_decode_marimo_cell_metadata_complete(self) -> None:
-        """Test decode_marimo_cell_metadata with all metadata."""
+    def test_decode_cell_metadata_complete(self) -> None:
+        """Test decode_cell_metadata with all metadata."""
         cell = lsp.NotebookCell(
             kind=lsp.NotebookCellKind.Code,
             document="file:///test.py#cell1",
@@ -370,24 +380,79 @@ class TestCellMetadataHelpers:
                     "stableId": "abc-123",
                     "config": {"disabled": True},
                     "name": "my_cell",
+                    "languageMetadata": {"markdown": {"quotePrefix": "rf"}},
                 },
             ),
         )
 
-        cell_id, config, name = decode_marimo_cell_metadata(cell)
-        assert cell_id == CellId_t("abc-123")
-        assert config == {"disabled": True}
-        assert name == "my_cell"
+        meta = decode_cell_metadata(cell)
+        assert meta.stable_id == "abc-123"
+        assert meta.config == {"disabled": True}
+        assert meta.name == "my_cell"
+        assert meta.language_metadata is not None
+        assert meta.language_metadata.markdown is not None
+        assert meta.language_metadata.markdown.quote_prefix == "rf"
 
-    def test_decode_marimo_cell_metadata_defaults(self) -> None:
-        """Test decode_marimo_cell_metadata with missing fields."""
+    def test_decode_cell_metadata_defaults(self) -> None:
+        """Test decode_cell_metadata with missing fields."""
         cell = lsp.NotebookCell(
             kind=lsp.NotebookCellKind.Code,
             document="file:///test.py#cell1",
             metadata=cast("lsp.LSPObject", {}),
         )
 
-        cell_id, config, name = decode_marimo_cell_metadata(cell)
-        assert cell_id is None
-        assert config == {}
-        assert name == "_"
+        meta = decode_cell_metadata(cell)
+        assert meta.stable_id is None
+        assert meta.config == {}
+        assert meta.name == "_"
+        assert meta.language_metadata is None
+
+    def test_decode_cell_metadata_ignores_unknown_fields(self) -> None:
+        """VS Code's own cell metadata (state, options) is ignored, not fatal."""
+        cell = lsp.NotebookCell(
+            kind=lsp.NotebookCellKind.Code,
+            document="file:///test.py#cell1",
+            metadata=cast(
+                "lsp.LSPObject",
+                {"stableId": "abc-123", "state": "idle", "options": {}},
+            ),
+        )
+
+        meta = decode_cell_metadata(cell)
+        assert meta.stable_id == "abc-123"
+
+
+class TestNormalizeCellCode:
+    """Smart-cell display source → marimo Python source (the snapshot fix)."""
+
+    def test_python_passthrough(self) -> None:
+        for language_id in ("python", "mo-python"):
+            assert normalize_cell_code(language_id, "x = 1", None) == "x = 1"
+
+    def test_markdown_default_prefix(self) -> None:
+        assert normalize_cell_code("markdown", "# Header", None) == snapshot(
+            'mo.md(r"""\n# Header\n""")'
+        )
+
+    def test_markdown_respects_quote_prefix(self) -> None:
+        meta = CellLanguageMetadata(markdown=MarkdownCellMetadata(quote_prefix="rf"))
+        assert normalize_cell_code("markdown", "{x}", meta) == snapshot(
+            'mo.md(rf"""\n{x}\n""")'
+        )
+
+    def test_sql_defaults(self) -> None:
+        # No metadata → default dataframe name, output shown, default engine
+        # (which must NOT be emitted as engine=__marimo_duckdb).
+        assert normalize_cell_code("sql", "SELECT 1", None) == snapshot(
+            '_df = mo.sql(\n    f"""\n    SELECT 1\n    """\n)'
+        )
+
+    def test_sql_respects_metadata(self) -> None:
+        meta = CellLanguageMetadata(
+            sql=SqlCellMetadata(
+                dataframe_name="df2", show_output=False, engine="my_engine"
+            )
+        )
+        assert normalize_cell_code("sql", "SELECT 1", meta) == snapshot(
+            'df2 = mo.sql(\n    f"""\n    SELECT 1\n    """,\n    output=False,\n    engine=my_engine\n)'
+        )


### PR DESCRIPTION
Add 'markdown' to the notebook sync selector so markdown cells reach the LSP server, and reconstruct markdown/SQL display source into `mo.md()`/ `mo.sql()` Python before building code-mode snapshots, the InternalApp, and the dependency graph (mirrors the frontend smart-cells transformOut).