### PR TITLE
Skip cells marked disabled when building the execute-cells request (#154)

### DIFF
--- a/extension/src/lib/__tests__/extractExecuteCodeRequest.test.ts
+++ b/extension/src/lib/__tests__/extractExecuteCodeRequest.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Option } from "effect";
+import type * as vscode from "vscode";
+
+import {
+  createNotebookCell,
+  createNotebookUri,
+  createTestNotebookDocument,
+} from "../../__mocks__/TestVsCode.ts";
+import { Constants } from "../../platform/Constants.ts";
+import type { CellMetadata } from "../../schemas/CellMetadata.ts";
+import { extractExecuteCodeRequest } from "../extractExecuteCodeRequest.ts";
+
+const notebookUri = createNotebookUri("file:///test/notebook_mo.py");
+
+// Helper to create a raw vscode.NotebookCell (extractExecuteCodeRequest
+// consumes raw cells, not MarimoNotebookCell)
+function createRawCell(
+  value: string,
+  metadata: Partial<CellMetadata>,
+  index: number,
+): vscode.NotebookCell {
+  return createNotebookCell(
+    createTestNotebookDocument(notebookUri),
+    {
+      kind: 2, // Code
+      value,
+      languageId: "python",
+      metadata,
+    },
+    index,
+  );
+}
+
+describe("extractExecuteCodeRequest", () => {
+  it.effect("includes enabled cells with stable ids", () =>
+    Effect.gen(function* () {
+      const { LanguageId } = yield* Constants;
+
+      const cellA = createRawCell("x = 1", { stableId: "cell-a" }, 0);
+      const cellB = createRawCell("y = x + 1", { stableId: "cell-b" }, 1);
+
+      const request = extractExecuteCodeRequest([cellA, cellB], LanguageId);
+
+      expect(Option.isSome(request)).toBe(true);
+      const { codes, cellIds } = Option.getOrThrow(request);
+      expect(cellIds).toEqual(["cell-a", "cell-b"]);
+      expect(codes).toEqual(["x = 1", "y = x + 1"]);
+    }).pipe(Effect.provide(Constants.Default)),
+  );
+
+  it.effect("skips cells without a stable id", () =>
+    Effect.gen(function* () {
+      const { LanguageId } = yield* Constants;
+
+      const withId = createRawCell("x = 1", { stableId: "cell-a" }, 0);
+      const withoutId = createRawCell("y = 2", {}, 1);
+
+      const request = extractExecuteCodeRequest(
+        [withId, withoutId],
+        LanguageId,
+      );
+
+      expect(Option.isSome(request)).toBe(true);
+      const { cellIds } = Option.getOrThrow(request);
+      expect(cellIds).toEqual(["cell-a"]);
+    }).pipe(Effect.provide(Constants.Default)),
+  );
+
+  // Regression test for https://github.com/marimo-team/marimo-lsp/issues/154
+  // A cell authored as `@app.cell(disabled=True)` reaches the extension with
+  // metadata.options = { disabled: true } (set by NotebookSerializer from the
+  // LSP server's deserialize response). It must NOT be sent for execution.
+  it.effect(
+    "excludes cells disabled via @app.cell(disabled=True) (issue #154)",
+    () =>
+      Effect.gen(function* () {
+        const { LanguageId } = yield* Constants;
+
+        const enabled = createRawCell("x = 1", { stableId: "cell-enabled" }, 0);
+        const disabled = createRawCell(
+          'print("RAN")',
+          { stableId: "cell-disabled", options: { disabled: true } },
+          1,
+        );
+
+        const request = extractExecuteCodeRequest(
+          [enabled, disabled],
+          LanguageId,
+        );
+
+        expect(Option.isSome(request)).toBe(true);
+        const { codes, cellIds } = Option.getOrThrow(request);
+        expect(cellIds).toContain("cell-enabled");
+        expect(cellIds).not.toContain("cell-disabled");
+        expect(codes).not.toContain('print("RAN")');
+      }).pipe(Effect.provide(Constants.Default)),
+  );
+
+  // Once disabled cells are filtered, a selection of only disabled cells
+  // produces an empty request, which must be Option.none() so the controller
+  // stops instead of sending an empty execute-cells request (issue #154).
+  it.effect("returns none when every selected cell is disabled", () =>
+    Effect.gen(function* () {
+      const { LanguageId } = yield* Constants;
+
+      const disabled = createRawCell(
+        'print("RAN")',
+        { stableId: "cell-disabled", options: { disabled: true } },
+        0,
+      );
+
+      const request = extractExecuteCodeRequest([disabled], LanguageId);
+
+      expect(Option.isNone(request)).toBe(true);
+    }).pipe(Effect.provide(Constants.Default)),
+  );
+});

--- a/extension/src/lib/extractExecuteCodeRequest.ts
+++ b/extension/src/lib/extractExecuteCodeRequest.ts
@@ -22,6 +22,11 @@ export function extractExecuteCodeRequest(
       continue;
     }
 
+    // Disabled cells (`@app.cell(disabled=True)`) must not run (issue #154).
+    if (cell.isDisabled) {
+      continue;
+    }
+
     const code = getCellExecutableCode(cell, LanguageId);
     const cellId = cell.id.value;
 
@@ -30,8 +35,8 @@ export function extractExecuteCodeRequest(
   }
 
   if (codes.length === 0) {
-    // no request
-    Option.none();
+    // no request — e.g. a selection of only disabled cells (issue #154)
+    return Option.none();
   }
 
   return Option.some({ codes, cellIds });

--- a/extension/src/schemas/MarimoNotebookDocument.ts
+++ b/extension/src/schemas/MarimoNotebookDocument.ts
@@ -117,6 +117,20 @@ export class MarimoNotebookCell {
   }
 
   /**
+   * Whether the cell is disabled via `@app.cell(disabled=True)`.
+   *
+   * marimo stores the decorator's `disabled` flag in the cell's config; the
+   * LSP deserialize path surfaces it as `metadata.options.disabled`. Disabled
+   * cells must not be sent for execution (issue #154).
+   */
+  get isDisabled() {
+    return this.metadata.pipe(
+      Option.map((meta) => meta.options?.disabled === true),
+      Option.getOrElse(() => false),
+    );
+  }
+
+  /**
    * The cell's language metadata, if present.
    */
   get languageMetadata() {


### PR DESCRIPTION
## Why

Cells authored as `@app.cell(disabled=True)` are executed by the VS Code extension, even though marimo's own frontend respects the flag. @manzt confirmed in #154 that disabled cells "aren't currently supported" in the extension and welcomed a contribution.

**Root cause:** `extension/src/lib/extractExecuteCodeRequest.ts` assembles the `execute-cells` request for **both** execution paths (`NotebookControllerFactory` and `SandboxController`), but its loop only skips cells without a stable id — it never consults the disabled config. The flag *does* survive the pipeline (marimo file → LSP deserialize → `NotebookSerializer` → cell `metadata.options.disabled`); I confirmed the wire format by running the server's own deserialize path, where a disabled cell arrives as `options: { "disabled": true }`.

## What

- Add an `isDisabled` getter on `MarimoNotebookCell` (`metadata.options?.disabled === true`), mirroring the existing `isStale` getter. No schema change — `CellMetadata` already types `options` as `Record<string, unknown>`.
- Skip disabled cells in `extractExecuteCodeRequest`, fixing both call sites at the single choke point (rather than per-call-site, which would let a future call site silently reintroduce the bug).
- Fix a latent bug the filter exposes: the `if (codes.length === 0)` branch called `Option.none()` without `return`ing, so a selection of only-disabled cells would have sent an empty `execute-cells` request. It now returns `Option.none()`, which the controller already handles by stopping ("Empty execution request").

## Evidence

`extension/src/lib/__tests__/extractExecuteCodeRequest.test.ts` (4 tests):
- `excludes cells disabled via @app.cell(disabled=True) (issue #154)` — **fails before** (`expected [...'cell-disabled'] to not include 'cell-disabled'`), **passes after**.
- `returns none when every selected cell is disabled` — covers the empty-request branch.
- 2 sanity cases (enabled cells included; id-less cells skipped).

Full `just test-ts` green (466 passed / 1 skipped, +4 from this PR), `just lint` (ruff + `ty` + TS) clean, `just test-vscode` integration suite green.

**Manual (F5):** in the Extension Development Host, a notebook with a normal cell and a `@app.cell(disabled=True)` cell, run all → the disabled cell produces no output while the enabled cell runs. Matches marimo's own frontend.

## Issues

Closes #154.

## Open question

Enforce at the **extension layer** (where the request is assembled, as here) or the **LSP server layer**? I chose the extension layer since that's where the request is built and this was framed as a missing extension feature — happy to move it if you'd prefer the server side.

## Checklist
- [x] Unit tests added (regression + empty-request edge case)
- [x] `just test-ts` and `just lint` pass locally
- [x] `just test-vscode` integration suite passes
- [x] Manual end-to-end (F5) verified
