### PR TITLE
Render cell outputs synchronously to fix tall-output overlap

### DIFF
--- a/extension/src/renderer/renderer.tsx
+++ b/extension/src/renderer/renderer.tsx
@@ -1,6 +1,7 @@
 /// <reference lib="dom" />
 
 import "./styles.css";
+import { flushSync } from "react-dom";
 import * as ReactDOM from "react-dom/client";
 import styleText from "virtual:stylesheet";
 import type * as vscode from "vscode-notebook-renderer";
@@ -117,7 +118,14 @@ export const activate: vscode.ActivationFunction = (context) => {
       const root = registry.get(element) ?? ReactDOM.createRoot(element);
       const { cellId, state }: { cellId: CellId; state: CellRuntimeState } =
         data.json();
-      root.render(<CellOutput cellId={cellId} state={state} />);
+      // Render synchronously so the output's real height is in the DOM before
+      // VS Code measures `element` to reserve layout space. A plain async
+      // `root.render` paints after `renderOutputItem` returns, so VS Code can
+      // reserve too little height for tall outputs (e.g. tracebacks) and the
+      // next cell overlaps them until a re-layout (#579, #598).
+      flushSync(() => {
+        root.render(<CellOutput cellId={cellId} state={state} />);
+      });
       registry.set(element, root);
       signal.addEventListener("abort", () => {
         root.unmount();


### PR DESCRIPTION
Fixes #579
Fixes #598

Cell error/traceback outputs render with too little reserved height, so the text overlaps the cell below. Moving the cell up/down forces a re-layout and fixes it. 

VS Code measures a notebook output element's height around when `renderOutputItem` returns, to reserve layout space for it. A plain `root.render(...)` paints asynchronously, so when `renderOutputItem` returns the element is still just padding. VS Code reserves too little height.

## Fix

Wrap the initial render in `flushSync` so the real content is committed to the DOM before `renderOutputItem` returns and VS Code measures the true height.

```ts
flushSync(() => {
  root.render(<CellOutput cellId={cellId} state={state} />);
});
```

### Tradeoffs

`flushSync` forces a synchronous render + reflow. That's acceptable (and probably desirable) here since outputs render once per update, are independent roots, and there's no high-frequency update loop. The synchronous reflow is exactly what gives VS Code a correct measurement.