### PR TITLE
Improve cell execution errors

### DIFF
--- a/extension/src/kernel/ExecutionRegistry.ts
+++ b/extension/src/kernel/ExecutionRegistry.ts
@@ -193,7 +193,15 @@ export class ExecutionRegistry extends Effect.Service<ExecutionRegistry>()(
                       HashMap.set(
                         map,
                         cellId,
-                        CellEntry.end(entry, true, msg.timestamp),
+                        // Report failure when the cell ended on an error so
+                        // VS Code marks the cell with the red error icon
+                        // (matches Jupyter); a marimo-error output channel is
+                        // the kernel's signal that the run raised.
+                        CellEntry.end(
+                          entry,
+                          entry.state.output?.channel !== "marimo-error",
+                          msg.timestamp,
+                        ),
                       ),
                     onNone: () => map,
                   }),

--- a/extension/src/kernel/ExecutionRegistry.ts
+++ b/extension/src/kernel/ExecutionRegistry.ts
@@ -19,12 +19,18 @@ import type * as vscode from "vscode";
 
 import { logUnreachable } from "../assert.ts";
 import { SCRATCH_CELL_ID } from "../constants.ts";
+import { acquireDisposable } from "../lib/acquireDisposable.ts";
 import { prettyErrorMessage } from "../lib/errors.ts";
-import { parseTraceback } from "../lib/tracebacks.ts";
+import {
+  extractCellFrames,
+  parseTraceback,
+  type TracebackCellFrame,
+} from "../lib/tracebacks.ts";
 import { CellStateManager } from "../notebook/CellStateManager.ts";
 import { VsCode } from "../platform/VsCode.ts";
 import {
   findNotebookCell,
+  type MarimoNotebookCell,
   MarimoNotebookDocument,
 } from "../schemas/MarimoNotebookDocument.ts";
 import {
@@ -72,6 +78,48 @@ export class ExecutionRegistry extends Effect.Service<ExecutionRegistry>()(
           return HashMap.empty();
         }),
       );
+
+      // Runtime-error diagnostics: a red squiggle on the cell line that
+      // raised, mirroring Jupyter. Kept in its own collection (separate from
+      // the LSP server's static diagnostics) so the two don't clobber each
+      // other; cleared when the cell re-runs.
+      const errorDiagnostics = yield* acquireDisposable(() =>
+        code.languages.createDiagnosticCollection("marimo-runtime"),
+      );
+
+      const clearErrorDiagnostic = (uri: vscode.Uri) =>
+        Effect.sync(() => errorDiagnostics.delete(uri));
+
+      const applyErrorDiagnostic = (
+        notebookCell: MarimoNotebookCell,
+        cellId: NotebookCellId,
+        state: CellRuntimeState,
+      ) =>
+        Effect.sync(() => {
+          const { document } = notebookCell;
+          const frame =
+            state.output?.channel === "marimo-error"
+              ? cellTracebackFrame(state, cellId)
+              : undefined;
+          if (frame === undefined) {
+            // Not an error (or no in-cell frame to point at, e.g. a syntax
+            // error already covered by the language server) — drop any stale
+            // squiggle.
+            errorDiagnostics.delete(document.uri);
+            return;
+          }
+          const lineIdx = Math.min(
+            Math.max(frame.line - 1, 0),
+            Math.max(document.lineCount - 1, 0),
+          );
+          const diagnostic = new code.Diagnostic(
+            document.lineAt(lineIdx).range,
+            diagnosticMessage(state),
+            code.DiagnosticSeverity.Error,
+          );
+          diagnostic.source = "marimo";
+          errorDiagnostics.set(document.uri, [diagnostic]);
+        });
 
       return {
         handleInterrupted(editor: vscode.NotebookEditor) {
@@ -127,6 +175,9 @@ export class ExecutionRegistry extends Effect.Service<ExecutionRegistry>()(
 
                 // Record execution — clears stale state
                 yield* cellStateManager.recordExecution(notebookCell);
+
+                // Clear any prior runtime-error squiggle before this re-run.
+                yield* clearErrorDiagnostic(notebookCell.document.uri);
 
                 // End any in-progress execution before creating a new one
                 yield* Ref.update(ref, (map) => {
@@ -187,6 +238,8 @@ export class ExecutionRegistry extends Effect.Service<ExecutionRegistry>()(
                 }
                 // MUST modify cell output before `ExecutionHandle.end`
                 yield* CellEntry.maybeUpdateCellOutput(cell, code, options);
+                // Place (or clear) the red squiggle on the raising line.
+                yield* applyErrorDiagnostic(notebookCell, cellId, cell.state);
                 yield* Ref.update(ref, (map) =>
                   Option.match(HashMap.get(map, cellId), {
                     onSome: (entry) =>
@@ -628,6 +681,38 @@ function hasTraceback(state: CellRuntimeState): boolean {
   return (state.consoleOutputs ?? []).some(
     (o) => o?.mimetype === TRACEBACK_MIME,
   );
+}
+
+/**
+ * Innermost traceback frame inside `cellId` — i.e. the line in this cell where
+ * the exception surfaced. Returns undefined when the cell has no traceback
+ * (e.g. a structural marimo error) or the exception was raised entirely in
+ * library/other-cell code, in which case there's no line here to underline.
+ */
+function cellTracebackFrame(
+  state: CellRuntimeState,
+  cellId: NotebookCellId,
+): TracebackCellFrame | undefined {
+  const traceback = (state.consoleOutputs ?? []).find(
+    (o) => o?.mimetype === TRACEBACK_MIME,
+  );
+  if (!traceback) return undefined;
+  const text =
+    typeof traceback.data === "object"
+      ? JSON.stringify(traceback.data)
+      : traceback.data;
+  return extractCellFrames(text)
+    .filter((frame) => frame.cellId === cellId)
+    .at(-1);
+}
+
+/** Human-readable message for the runtime-error diagnostic. */
+function diagnosticMessage(state: CellRuntimeState): string {
+  const data = state.output?.data;
+  if (Array.isArray(data) && data.length > 0) {
+    return prettyErrorMessage(data[0]);
+  }
+  return "Cell execution failed";
 }
 
 // Only suppress when every item is a plain `exception` without `raising_cell`:

--- a/extension/src/lib/__tests__/tracebacks.test.ts
+++ b/extension/src/lib/__tests__/tracebacks.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { parseTraceback } from "../tracebacks.ts";
+import { extractCellFrames, parseTraceback } from "../tracebacks.ts";
 
 // oxlint-disable-next-line no-control-regex
 const stripAnsi = (s: string) => s.replace(/\u001b\[[\d;]*m/g, "");
@@ -134,5 +134,37 @@ ValueError: oops`;
     	  "stack": "not a traceback",
     	}
     `);
+  });
+});
+
+describe("extractCellFrames", () => {
+  it("extracts cell id and 1-based line from a cell-temp frame", () => {
+    const html = `Traceback (most recent call last):
+  File &quot;/var/folders/zz/abc/T/__marimo__cell_AbCd_.py&quot;, line 1, in &lt;module&gt;
+    raise ValueError()
+ValueError`;
+    expect(extractCellFrames(html)).toEqual([{ cellId: "AbCd", line: 1 }]);
+  });
+
+  it("skips library frames, keeping only cell frames (innermost last)", () => {
+    const html = `Traceback (most recent call last):
+  File &quot;/var/folders/zz/abc/T/__marimo__cell_Top_.py&quot;, line 2, in &lt;module&gt;
+    helper()
+  File &quot;/usr/lib/python3.11/site-packages/lib.py&quot;, line 99, in helper
+    boom()
+  File &quot;/var/folders/zz/abc/T/__marimo__cell_Deep_.py&quot;, line 5, in boom
+    1 / 0
+ZeroDivisionError: division by zero`;
+    expect(extractCellFrames(html)).toEqual([
+      { cellId: "Top", line: 2 },
+      { cellId: "Deep", line: 5 },
+    ]);
+  });
+
+  it("returns no frames when the traceback has no cell-temp file", () => {
+    const html = `Traceback (most recent call last):
+  File &quot;/usr/lib/python3.11/json/__init__.py&quot;, line 1, in loads
+ValueError: bad`;
+    expect(extractCellFrames(html)).toEqual([]);
   });
 });

--- a/extension/src/lib/tracebacks.ts
+++ b/extension/src/lib/tracebacks.ts
@@ -96,6 +96,35 @@ function parseNameAndMessage(line: string): { name: string; message: string } {
   };
 }
 
+export interface TracebackCellFrame {
+  /** The marimo cell id the frame points into. */
+  cellId: string;
+  /** 1-based line number within the cell's source. */
+  line: number;
+}
+
+/**
+ * Extract the notebook-cell frames (cell id + 1-based line) from a raw marimo
+ * traceback (pygments HTML or plain text). Frames pointing at real files
+ * (libraries) are skipped — only frames inside `__marimo__cell_<id>_.py` temp
+ * files are returned, innermost (deepest) last, mirroring Python's traceback
+ * order. Used to place a runtime-error diagnostic on the offending line.
+ */
+export function extractCellFrames(traceback: string): TracebackCellFrame[] {
+  const raw = decodeEntities(stripTags(traceback));
+  const frames: TracebackCellFrame[] = [];
+  for (const line of raw.split("\n")) {
+    const match = FRAME_RE.exec(line);
+    if (!match) continue;
+    const cellId = extractCellId(match[2]);
+    const lineNo = Number.parseInt(match[3], 10);
+    if (cellId !== undefined && Number.isFinite(lineNo)) {
+      frames.push({ cellId, line: lineNo });
+    }
+  }
+  return frames;
+}
+
 export function parseTraceback(
   pygmentsHtml: string,
   cellIdToIndex?: CellIdToIndex,

--- a/extension/tests/diagnostics.test.cjs
+++ b/extension/tests/diagnostics.test.cjs
@@ -12,7 +12,7 @@
 const NodeAssert = require("node:assert");
 const vscode = require("vscode");
 
-const { createTestContext, selectKernel } = require("./helpers.cjs");
+const { createTestContext, selectKernel, runCell } = require("./helpers.cjs");
 
 const SCRIPT_HEADER = `# /// script
 # requires-python = ">=3.11"
@@ -145,6 +145,47 @@ suite("diagnostics", function () {
         marimoMultiDef(dB).length > 0,
         `cell 3 (a = 20) should have multi-def, got ${JSON.stringify(dB)}`,
       );
+    });
+  });
+
+  test("runtime exception marks the cell failed and squiggles the raising line", async function () {
+    this.timeout(30_000);
+    await using ctx = createTestContext();
+    const nb = await ctx.writeAndOpenNotebook(
+      makeSource(['raise ValueError("boom")']),
+    );
+    await selectKernel(nb);
+
+    const cell = nb.cellAt(0);
+    await runCell(cell);
+
+    // 1. The cell is marked failed (red error icon), matching Jupyter —
+    //    not VS Code's default green success check.
+    NodeAssert.strictEqual(
+      cell.executionSummary?.success,
+      false,
+      `expected a failed execution, got ${JSON.stringify(cell.executionSummary)}`,
+    );
+
+    // 2. A runtime-error diagnostic (red squiggle) lands on the raising line.
+    await ctx.waitUntil(() => {
+      const all = vscode.languages.getDiagnostics(cell.document.uri);
+      const runtimeErrors = all.filter(
+        (d) =>
+          d.source === "marimo" &&
+          d.severity === vscode.DiagnosticSeverity.Error &&
+          /ValueError/.test(d.message),
+      );
+      NodeAssert.ok(
+        runtimeErrors.length > 0,
+        `expected a marimo runtime-error diagnostic, got ${JSON.stringify(all)}`,
+      );
+      NodeAssert.strictEqual(
+        runtimeErrors[0].range.start.line,
+        0,
+        "diagnostic should sit on the raising line (cell line 0)",
+      );
+      NodeAssert.match(runtimeErrors[0].message, /boom/);
     });
   });
 });


### PR DESCRIPTION
Closes #570

Marks cell executions as failed (when failed) and add runtime error diagnostics inline for errors.