### PR TITLE
Fix re-run output rendering and refactor the cell execution lifecycle

### DIFF
--- a/extension/src/kernel/CellOutputProjection.ts
+++ b/extension/src/kernel/CellOutputProjection.ts
@@ -1,0 +1,184 @@
+import type * as vscode from "vscode";
+
+/**
+ * A cell output tagged with the stable key of the logical slot it fills.
+ *
+ * The key is stable across a run's cell-ops, which is what lets the projection
+ * edit slots in place instead of rebuilding the list each op. There's one key
+ * per console channel and per traceback, plus a `"main"` slot shared by the
+ * cell's result, error, or suppressing traceback.
+ */
+export interface KeyedCellOutput {
+  readonly key: string;
+  readonly output: vscode.NotebookCellOutput;
+}
+
+/**
+ * The slice of `vscode.NotebookCellExecution` the projection drives.
+ *
+ * Narrowed to a port so the projection can be tested against a recording fake;
+ * a real `NotebookCellExecution` satisfies it structurally.
+ */
+export type OutputExecution = Pick<
+  vscode.NotebookCellExecution,
+  "clearOutput" | "appendOutput" | "replaceOutputItems"
+> & {
+  readonly cell: Pick<vscode.NotebookCell, "outputs">;
+};
+
+/**
+ * A slot the projection has emitted and is tracking: the `NotebookCellOutput`
+ * VS Code now owns (its identity is what `replaceOutputItems` targets) and the
+ * items we last gave it (to skip no-op edits that would re-measure it).
+ */
+interface TrackedOutput {
+  readonly output: vscode.NotebookCellOutput;
+  items: readonly vscode.NotebookCellOutputItem[];
+}
+
+/**
+ * Drives one cell run's outputs onto a `NotebookCellExecution`.
+ *
+ * Outputs are reconciled incrementally — cleared once on the run's first output,
+ * then appended and edited in place as more arrive — the way Jupyter does it,
+ * rather than rebuilt from scratch on every cell-op. The stable `"main"` key
+ * (see {@link KeyedCellOutput}) turns the common "error box, then traceback
+ * supersedes it" transition into an in-place edit.
+ *
+ * One instance backs one run and holds that run's reconcile state; the next run
+ * gets a fresh one.
+ */
+export class CellOutputProjection {
+  readonly #execution: OutputExecution;
+  // Tracked slots, in on-screen (insertion) order.
+  readonly #tracked = new Map<string, TrackedOutput>();
+  // Whether we've cleared the *previous* run's outputs and begun this run's
+  // fresh output list. Deferred until the first output arrives.
+  #cleared = false;
+
+  constructor(execution: OutputExecution) {
+    this.#execution = execution;
+  }
+
+  /** Apply a live, incremental update toward `keyed`. */
+  async project(keyed: ReadonlyArray<KeyedCellOutput>): Promise<void> {
+    await this.#applyIncremental(keyed);
+  }
+
+  /**
+   * Finish the run: leave the cell showing exactly `keyed`, every output
+   * measured.
+   *
+   * A bare `appendOutput` renders at zero height until something touches it
+   * again, so `commit` re-sets each slot's items to force a final measurement.
+   * It avoids a full `replaceOutput`, which re-collapses tall outputs and can
+   * leave a phantom empty slot when the output set shrank.
+   */
+  async commit(keyed: ReadonlyArray<KeyedCellOutput>): Promise<void> {
+    if (keyed.length === 0) {
+      // A run that produced no output must end with none.
+      if (this.#execution.cell.outputs.length > 0) await this.#clear();
+      return;
+    }
+    await this.#applyIncremental(keyed);
+    await this.#finalize(keyed);
+  }
+
+  async #clear(): Promise<void> {
+    await this.#execution.clearOutput();
+    this.#tracked.clear();
+    this.#cleared = true;
+  }
+
+  async #applyIncremental(
+    keyed: ReadonlyArray<KeyedCellOutput>,
+  ): Promise<void> {
+    const execution = this.#execution;
+
+    if (keyed.length === 0) {
+      // Nothing to show yet. If the previous run left outputs, clear them once;
+      // otherwise wait for the first output.
+      if (!this.#cleared && execution.cell.outputs.length > 0) {
+        await this.#clear();
+      }
+      return;
+    }
+
+    // First output of this run: clear the prior run's outputs so this run's are
+    // appended fresh rather than morphed onto stale ones.
+    if (!this.#cleared) {
+      await this.#clear();
+    }
+
+    // A slot we were tracking is gone — VS Code can't remove a single output,
+    // so re-clear and re-append from scratch. Uncommon within a single run.
+    const desiredKeys = new Set(keyed.map((k) => k.key));
+    if ([...this.#tracked.keys()].some((k) => !desiredKeys.has(k))) {
+      await this.#clear();
+    }
+
+    // Edit tracked slots in place, only when their items actually changed, so
+    // unchanged outputs (the traceback) are never re-measured.
+    for (const k of keyed) {
+      const slot = this.#tracked.get(k.key);
+      if (slot && !outputItemsEqual(slot.items, k.output.items)) {
+        // oxlint-disable-next-line eslint/no-await-in-loop -- ordered edits
+        await execution.replaceOutputItems(k.output.items, slot.output);
+        slot.items = k.output.items;
+      }
+    }
+
+    // Append genuinely-new slots at the end, in arrival order. Sequential by
+    // design — `appendOutput` appends at the tail, so await order is on-screen
+    // order.
+    for (const k of keyed) {
+      if (this.#tracked.has(k.key)) continue;
+      // oxlint-disable-next-line eslint/no-await-in-loop -- ordered appends
+      await execution.appendOutput(k.output);
+      this.#tracked.set(k.key, { output: k.output, items: k.output.items });
+    }
+  }
+
+  async #finalize(keyed: ReadonlyArray<KeyedCellOutput>): Promise<void> {
+    const execution = this.#execution;
+    const canonicalOrder =
+      [...this.#tracked.keys()].join(" ") === keyed.map((k) => k.key).join(" ");
+
+    if (!canonicalOrder) {
+      // Marimo can deliver cell-ops out of order (e.g. the error before the
+      // stdout that preceded it), so the appended order may not match. Rebuild
+      // from a clean slate; clearing first avoids a phantom leftover slot.
+      await execution.clearOutput();
+      this.#tracked.clear();
+      for (const k of keyed) {
+        // oxlint-disable-next-line eslint/no-await-in-loop -- ordered re-append
+        await execution.appendOutput(k.output);
+        this.#tracked.set(k.key, { output: k.output, items: k.output.items });
+      }
+    }
+
+    // Re-set each slot's items in place to force the webview to (re)measure it.
+    for (const [, slot] of this.#tracked) {
+      // oxlint-disable-next-line eslint/no-await-in-loop -- ordered re-measure
+      await execution.replaceOutputItems(slot.items, slot.output);
+    }
+  }
+}
+
+/** Structural equality for two output-item lists (mime + raw bytes). */
+function outputItemsEqual(
+  a: readonly vscode.NotebookCellOutputItem[],
+  b: readonly vscode.NotebookCellOutputItem[],
+): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    const x = a[i];
+    const y = b[i];
+    if (x.mime !== y.mime) return false;
+    if (x.data.length !== y.data.length) return false;
+    for (let j = 0; j < x.data.length; j++) {
+      if (x.data[j] !== y.data[j]) return false;
+    }
+  }
+  return true;
+}

--- a/extension/src/kernel/CellRunReducer.ts
+++ b/extension/src/kernel/CellRunReducer.ts
@@ -1,0 +1,232 @@
+// @ts-expect-error
+import { transitionCell as untypedTransitionCell } from "@marimo-team/frontend/unstable_internal/core/cells/cell.ts?nocheck";
+import { createCellRuntimeState } from "@marimo-team/frontend/unstable_internal/core/cells/types.ts";
+import { Brand, Data, Option } from "effect";
+
+import type { NotebookCellId } from "../schemas/MarimoNotebookDocument.ts";
+import type { CellOperationNotification, CellRuntimeState } from "../types.ts";
+
+export type RunId = Brand.Branded<string, "RunId">;
+export const RunId = Brand.nominal<RunId>();
+
+/**
+ * Where a cell is in its current run.
+ *
+ * Derived by the reducer, never read off the wire, and resource-free — the live
+ * execution lives in the interpreter, not here.
+ */
+export type RunPhase = Data.TaggedEnum<{
+  Idle: {};
+  Queued: { readonly runId: RunId };
+  Running: { readonly runId: RunId };
+  Completed: {};
+}>;
+export const RunPhase = Data.taggedEnum<RunPhase>();
+
+/**
+ * A `cell-op`, normalized for the reducer.
+ *
+ * {@link parseOp} folds the raw op into `CellRuntimeState` and pulls out the run
+ * id and timings, so the reducer never sees marimo's nullable wire status.
+ */
+export type Op = Data.TaggedEnum<{
+  Queue: { readonly runId: RunId; readonly next: CellRuntimeState };
+  Start: { readonly startTime: number; readonly next: CellRuntimeState };
+  Settle: {
+    readonly success: boolean;
+    readonly endTime: number | undefined;
+    readonly next: CellRuntimeState;
+  };
+  Update: { readonly next: CellRuntimeState };
+  Interrupt: {};
+}>;
+export const Op = Data.taggedEnum<Op>();
+
+/**
+ * One side effect the reducer wants done, as data. The interpreter performs it.
+ */
+export type Action = Data.TaggedEnum<{
+  CreateExecution: {};
+  StartExecution: { readonly startTime: number | undefined };
+  EmitOutputs: { readonly state: CellRuntimeState };
+  FinalizeOutputs: { readonly state: CellRuntimeState };
+  EndExecution: {
+    readonly success: boolean;
+    readonly endTime: number | undefined;
+  };
+  ApplyRuntimeError: { readonly state: CellRuntimeState };
+  ClearRuntimeError: {};
+  RecordExecution: {};
+  InvalidateCell: {};
+}>;
+export const Action = Data.taggedEnum<Action>();
+
+/** Pure, vscode-free per-cell reducer state. */
+export interface CellRunEntry {
+  readonly id: NotebookCellId;
+  readonly state: CellRuntimeState;
+  readonly phase: RunPhase;
+}
+
+export function makeCellRunEntry(id: NotebookCellId): CellRunEntry {
+  return { id, state: createCellRuntimeState(), phase: RunPhase.Idle() };
+}
+
+/** Type-safe wrapper around marimo's imported `transitionCell`. */
+export function transitionCell(
+  cell: CellRuntimeState,
+  message: CellOperationNotification,
+): CellRuntimeState {
+  return untypedTransitionCell(cell, message);
+}
+
+/**
+ * Categorize a `cell-op` into an {@link Op}.
+ *
+ * `next` is the folded state (`transitionCell(prev, msg)`); the caller folds it
+ * so it can persist the state even for an op we drop. Returns `None` only for a
+ * `queued` op with no `run_id`, which can't be tracked.
+ */
+export function parseOp(
+  next: CellRuntimeState,
+  msg: CellOperationNotification,
+): Option.Option<Op> {
+  switch (msg.status) {
+    case "queued": {
+      const runId = Option.fromNullable(msg.run_id).pipe(Option.map(RunId));
+      return Option.map(runId, (id) => Op.Queue({ runId: id, next }));
+    }
+    case "running":
+      return Option.some(
+        Op.Start({ startTime: (msg.timestamp ?? 0) * 1000, next }),
+      );
+    case "idle":
+      return Option.some(
+        Op.Settle({
+          // A marimo-error output channel is the kernel's signal that the run
+          // raised — report failure so VS Code shows the red error icon.
+          success: next.output?.channel !== "marimo-error",
+          endTime: msg.timestamp == null ? undefined : msg.timestamp * 1000,
+          next,
+        }),
+      );
+    default:
+      return Option.some(Op.Update({ next }));
+  }
+}
+
+const hasExecution = (phase: RunPhase): boolean =>
+  phase._tag === "Queued" || phase._tag === "Running";
+
+const isError = (state: CellRuntimeState): boolean =>
+  state.output?.channel === "marimo-error";
+
+/**
+ * The cell run reducer: pure, total, vscode-free. Decides the next
+ * {@link RunPhase} and the ordered {@link Action}s a single {@link Op} causes.
+ * The one place that decides what a cell-op *means*.
+ */
+export function step(
+  entry: CellRunEntry,
+  op: Op,
+): { readonly entry: CellRunEntry; readonly actions: ReadonlyArray<Action> } {
+  return Op.$match(op, {
+    Interrupt: () => {
+      if (!hasExecution(entry.phase)) return { entry, actions: [] };
+      return {
+        entry: { ...entry, phase: RunPhase.Completed() },
+        actions: [Action.EndExecution({ success: false, endTime: undefined })],
+      };
+    },
+
+    Queue: ({ runId, next }) => {
+      const actions: Action[] = [];
+      if (next.staleInputs) actions.push(Action.InvalidateCell());
+      // Record clears stale; clear any prior runtime-error squiggle.
+      actions.push(Action.RecordExecution(), Action.ClearRuntimeError());
+      // End any still-running prior execution before creating the new one.
+      if (hasExecution(entry.phase)) {
+        actions.push(
+          Action.EndExecution({ success: true, endTime: undefined }),
+        );
+      }
+      actions.push(Action.CreateExecution());
+      return {
+        entry: { ...entry, state: next, phase: RunPhase.Queued({ runId }) },
+        actions,
+      };
+    },
+
+    Start: ({ startTime, next }) => {
+      const actions: Action[] = [];
+      if (next.staleInputs) actions.push(Action.InvalidateCell());
+      let phase = entry.phase;
+      if (entry.phase._tag === "Queued") {
+        actions.push(Action.StartExecution({ startTime }));
+        phase = RunPhase.Running({ runId: entry.phase.runId });
+      }
+      if (hasExecution(phase)) {
+        actions.push(Action.EmitOutputs({ state: next }));
+      } else if (isError(next)) {
+        actions.push(...ephemeralError(next, { applyDiagnostic: false }));
+      }
+      return { entry: { ...entry, state: next, phase }, actions };
+    },
+
+    Update: ({ next }) => {
+      const actions: Action[] = [];
+      if (next.staleInputs) actions.push(Action.InvalidateCell());
+      if (hasExecution(entry.phase)) {
+        actions.push(Action.EmitOutputs({ state: next }));
+      } else if (isError(next)) {
+        actions.push(...ephemeralError(next, { applyDiagnostic: false }));
+      }
+      return { entry: { ...entry, state: next, phase: entry.phase }, actions };
+    },
+
+    Settle: ({ success, endTime, next }) => {
+      const actions: Action[] = [];
+      if (next.staleInputs) actions.push(Action.InvalidateCell());
+      if (hasExecution(entry.phase)) {
+        actions.push(
+          Action.FinalizeOutputs({ state: next }),
+          Action.ApplyRuntimeError({ state: next }),
+          Action.EndExecution({ success, endTime }),
+        );
+        return {
+          entry: { ...entry, state: next, phase: RunPhase.Completed() },
+          actions,
+        };
+      }
+      // No live execution: show a one-off execution for an error, and always
+      // reconcile the squiggle (clears it when there's no in-cell frame).
+      if (isError(next)) {
+        actions.push(...ephemeralError(next, { applyDiagnostic: true }));
+      } else {
+        actions.push(Action.ApplyRuntimeError({ state: next }));
+      }
+      return { entry: { ...entry, state: next, phase: entry.phase }, actions };
+    },
+  });
+}
+
+/**
+ * Actions to render an error from a cell that never queued (e.g. a compile
+ * error), which has no live execution: spin up a one-off execution, emit the
+ * error, end it. `applyDiagnostic` also reconciles the squiggle, which only the
+ * terminal `idle` op does.
+ */
+function ephemeralError(
+  next: CellRuntimeState,
+  opts: { readonly applyDiagnostic: boolean },
+): Action[] {
+  return [
+    Action.CreateExecution(),
+    Action.StartExecution({ startTime: undefined }),
+    Action.FinalizeOutputs({ state: next }),
+    ...(opts.applyDiagnostic
+      ? [Action.ApplyRuntimeError({ state: next })]
+      : []),
+    Action.EndExecution({ success: false, endTime: undefined }),
+  ];
+}

--- a/extension/src/kernel/ExecutionRegistry.ts
+++ b/extension/src/kernel/ExecutionRegistry.ts
@@ -1,12 +1,9 @@
-// @ts-expect-error
-import { transitionCell as untypedTransitionCell } from "@marimo-team/frontend/unstable_internal/core/cells/cell.ts?nocheck";
 import { createCellRuntimeState } from "@marimo-team/frontend/unstable_internal/core/cells/types.ts";
 import type {
   CellOutput,
   OutputMessage,
 } from "@marimo-team/frontend/unstable_internal/core/kernel/messages.ts";
 import {
-  Brand,
   Cause,
   Data,
   Effect,
@@ -17,7 +14,7 @@ import {
 } from "effect";
 import type * as vscode from "vscode";
 
-import { logUnreachable } from "../assert.ts";
+import { assert, logUnreachable } from "../assert.ts";
 import { SCRATCH_CELL_ID } from "../constants.ts";
 import { acquireDisposable } from "../lib/acquireDisposable.ts";
 import { prettyErrorMessage } from "../lib/errors.ts";
@@ -42,6 +39,19 @@ import {
   type CellRuntimeState,
   createCellNavigationLink,
 } from "../types.ts";
+import {
+  CellOutputProjection,
+  type KeyedCellOutput,
+} from "./CellOutputProjection.ts";
+import {
+  Action,
+  type CellRunEntry,
+  makeCellRunEntry,
+  Op,
+  parseOp,
+  step,
+  transitionCell,
+} from "./CellRunReducer.ts";
 import type { PythonController } from "./NotebookControllerFactory.ts";
 import type { SandboxController } from "./SandboxController.ts";
 
@@ -55,6 +65,35 @@ export class InvalidCellError extends Data.TaggedError("InvalidCellError")<{
   readonly cause: unknown;
 }> {}
 
+/** A run's live VS Code execution and the projection driving its outputs. */
+interface RunResource {
+  readonly execution: vscode.NotebookCellExecution;
+  readonly projection: CellOutputProjection;
+}
+
+/**
+ * Everything the registry tracks for one cell: the pure {@link CellRunEntry},
+ * the editor it belongs to (for interrupt fan-out), and its live execution
+ * while a run is in flight.
+ */
+interface RunRecord {
+  readonly entry: CellRunEntry;
+  readonly editor: vscode.NotebookEditor;
+  readonly resource: Option.Option<RunResource>;
+}
+
+/**
+ * What the {@link Action} interpreter needs to perform a single op's actions.
+ * `notebookCell` / `controller` are absent for interrupts (which only end
+ * executions); actions that require them assert their presence.
+ */
+interface PerformContext {
+  readonly cellId: NotebookCellId;
+  readonly notebookCell: MarimoNotebookCell | undefined;
+  readonly controller: PythonController | SandboxController | undefined;
+  readonly notebook: vscode.NotebookDocument | undefined;
+}
+
 export class ExecutionRegistry extends Effect.Service<ExecutionRegistry>()(
   "ExecutionRegistry",
   {
@@ -62,17 +101,22 @@ export class ExecutionRegistry extends Effect.Service<ExecutionRegistry>()(
     scoped: Effect.gen(function* () {
       const code = yield* VsCode;
       const cellStateManager = yield* CellStateManager;
-      const ref = yield* Ref.make(HashMap.empty<NotebookCellId, CellEntry>());
+      const records = yield* Ref.make(
+        HashMap.empty<NotebookCellId, RunRecord>(),
+      );
 
       yield* Effect.addFinalizer(() =>
-        Ref.update(ref, (map) => {
-          HashMap.forEach(map, (entry) => {
-            if (
-              Option.isSome(entry.pendingExecution) &&
-              entry.pendingExecution.value.kind !== "completed"
-            ) {
-              // Ensure all pending or running executions are ended
-              entry.pendingExecution.value.end(false);
+        Ref.update(records, (map) => {
+          HashMap.forEach(map, (record) => {
+            if (Option.isSome(record.resource)) {
+              // Ensure all in-flight executions are ended on shutdown. `end`
+              // throws if one was already ended (a benign race); swallow it so
+              // disposal still completes.
+              try {
+                record.resource.value.execution.end(false);
+              } catch {
+                // already ended
+              }
             }
           });
           return HashMap.empty();
@@ -121,19 +165,163 @@ export class ExecutionRegistry extends Effect.Service<ExecutionRegistry>()(
           errorDiagnostics.set(document.uri, [diagnostic]);
         });
 
-      return {
-        handleInterrupted(editor: vscode.NotebookEditor) {
-          return Ref.update(ref, (map) =>
-            HashMap.map(map, (cell) =>
-              Option.match(cell.pendingExecution, {
-                onSome: () => cell.editor === editor,
-                onNone: () => false,
-              })
-                ? CellEntry.interrupt(cell)
-                : cell,
+      const setResource = (
+        cellId: NotebookCellId,
+        resource: Option.Option<RunResource>,
+      ) =>
+        Ref.update(records, (map) =>
+          Option.match(HashMap.get(map, cellId), {
+            onSome: (record) =>
+              HashMap.set(map, cellId, { ...record, resource }),
+            onNone: () => map,
+          }),
+        );
+
+      const getResource = (cellId: NotebookCellId) =>
+        Ref.get(records).pipe(
+          Effect.map((map) =>
+            HashMap.get(map, cellId).pipe(
+              Option.flatMap((record) => record.resource),
+            ),
+          ),
+        );
+
+      // Run `f` against the cell's live execution, or log+skip when there is
+      // none (a benign race: the execution was ended concurrently).
+      const withResource = (
+        cellId: NotebookCellId,
+        f: (resource: RunResource) => Effect.Effect<void>,
+      ) =>
+        getResource(cellId).pipe(
+          Effect.flatMap(
+            Option.match({
+              onSome: f,
+              onNone: () =>
+                Effect.logDebug(
+                  "No live execution for cell; skipping action",
+                ).pipe(Effect.annotateLogs({ cellId })),
+            }),
+          ),
+        );
+
+      const emitOutputs = (
+        ctx: PerformContext,
+        state: CellRuntimeState,
+        final: boolean,
+      ) =>
+        withResource(ctx.cellId, ({ projection }) => {
+          const keyed = buildKeyedCellOutputs(
+            ctx.cellId,
+            state,
+            code,
+            ctx.notebook,
+          );
+          return Effect.tryPromise(() =>
+            final ? projection.commit(keyed) : projection.project(keyed),
+          ).pipe(
+            // A concurrent op may have ended the execution; not actionable.
+            Effect.catchAllCause((cause) =>
+              Effect.logWarning("Failed to update cell output").pipe(
+                Effect.annotateLogs({ cause, cellId: ctx.cellId }),
+              ),
             ),
           );
-        },
+        });
+
+      // The operation interpreter: perform one Action against the real world.
+      const perform = (action: Action, ctx: PerformContext) =>
+        Action.$match(action, {
+          CreateExecution: () =>
+            Effect.gen(function* () {
+              assert(
+                ctx.notebookCell !== undefined && ctx.controller !== undefined,
+                "CreateExecution requires a notebook cell and controller",
+              );
+              const notebookCell = ctx.notebookCell;
+              const controller = ctx.controller;
+              const execution = yield* Effect.try({
+                try: () => controller.createNotebookCellExecution(notebookCell),
+                catch: (cause) =>
+                  new InvalidCellError({ cellId: ctx.cellId, cause }),
+              });
+              yield* setResource(
+                ctx.cellId,
+                Option.some({
+                  execution,
+                  projection: new CellOutputProjection(execution),
+                }),
+              );
+            }),
+          StartExecution: ({ startTime }) =>
+            withResource(ctx.cellId, ({ execution }) =>
+              Effect.sync(() => execution.start(startTime)),
+            ),
+          EmitOutputs: ({ state }) => emitOutputs(ctx, state, false),
+          FinalizeOutputs: ({ state }) => emitOutputs(ctx, state, true),
+          EndExecution: ({ success, endTime }) =>
+            withResource(ctx.cellId, ({ execution }) =>
+              Effect.gen(function* () {
+                // `end` throws if already ended (a race); swallow it.
+                yield* Effect.try(() => execution.end(success, endTime)).pipe(
+                  Effect.ignore,
+                );
+                yield* setResource(ctx.cellId, Option.none());
+              }),
+            ),
+          ApplyRuntimeError: ({ state }) => {
+            assert(
+              ctx.notebookCell !== undefined,
+              "ApplyRuntimeError requires a notebook cell",
+            );
+            return applyErrorDiagnostic(ctx.notebookCell, ctx.cellId, state);
+          },
+          ClearRuntimeError: () => {
+            assert(
+              ctx.notebookCell !== undefined,
+              "ClearRuntimeError requires a notebook cell",
+            );
+            return clearErrorDiagnostic(ctx.notebookCell.document.uri);
+          },
+          RecordExecution: () => {
+            assert(
+              ctx.notebookCell !== undefined,
+              "RecordExecution requires a notebook cell",
+            );
+            return cellStateManager.recordExecution(ctx.notebookCell);
+          },
+          InvalidateCell: () => {
+            assert(
+              ctx.notebookCell !== undefined,
+              "InvalidateCell requires a notebook cell",
+            );
+            return cellStateManager.invalidateCell(ctx.notebookCell);
+          },
+        });
+
+      return {
+        handleInterrupted: (editor: vscode.NotebookEditor) =>
+          Effect.gen(function* () {
+            const map = yield* Ref.get(records);
+            const targets = EffectArray.fromIterable(
+              HashMap.entries(map),
+            ).filter(([, record]) => record.editor === editor);
+            for (const [cellId, record] of targets) {
+              const { entry, actions } = step(record.entry, Op.Interrupt());
+              yield* Ref.update(records, (m) =>
+                HashMap.set(m, cellId, { ...record, entry }),
+              );
+              const ctx: PerformContext = {
+                cellId,
+                notebookCell: undefined,
+                controller: undefined,
+                notebook: undefined,
+              };
+              for (const action of actions) {
+                // oxlint-disable-next-line eslint/no-await-in-loop -- ordered
+                yield* perform(action, ctx);
+              }
+            }
+          }),
         handleCellOperation: (
           msg: CellOperationNotification,
           options: {
@@ -145,126 +333,48 @@ export class ExecutionRegistry extends Effect.Service<ExecutionRegistry>()(
             const { editor, controller } = options;
             const cellId = extractCellIdFromCellMessage(msg);
 
-            const cell = yield* Ref.modify(ref, (map) => {
-              const prev = Option.match(HashMap.get(map, cellId), {
-                onSome: (cell) => cell,
-                onNone: () => CellEntry.make(cellId, editor),
-              });
-              const update = CellEntry.transition(prev, msg);
-              return [update, HashMap.set(map, cellId, update)];
-            });
+            const map = yield* Ref.get(records);
+            const record = Option.getOrElse(HashMap.get(map, cellId), () => ({
+              entry: makeCellRunEntry(cellId),
+              editor,
+              resource: Option.none<RunResource>(),
+            }));
 
             const notebook = MarimoNotebookDocument.from(editor.notebook);
-            const notebookCell = yield* findNotebookCell(notebook, cell.id);
+            const notebookCell = yield* findNotebookCell(notebook, cellId);
 
-            // If cell has stale inputs, invalidate its execution record
-            if (cell.state.staleInputs) {
-              yield* cellStateManager.invalidateCell(notebookCell);
+            // Fold the cell-op into the run state once, up front, so the folded
+            // state is persisted even for an op we end up dropping.
+            const next = transitionCell(record.entry.state, msg);
+            const op = parseOp(next, msg);
+            if (Option.isNone(op)) {
+              yield* Effect.logWarning(
+                "Queued cell-op missing run_id; cannot track execution",
+              ).pipe(Effect.annotateLogs({ cellId, status: msg.status }));
+              yield* Ref.update(records, (m) =>
+                HashMap.set(m, cellId, {
+                  ...record,
+                  entry: { ...record.entry, state: next },
+                }),
+              );
+              return;
             }
 
-            switch (msg.status) {
-              case "queued": {
-                const runIdOpt = extractRunId(msg);
-                if (Option.isNone(runIdOpt)) {
-                  yield* Effect.logWarning(
-                    "Queued cell-op missing run_id; cannot track execution",
-                  ).pipe(Effect.annotateLogs({ cellId, status: msg.status }));
-                  return;
-                }
-                const runId = runIdOpt.value;
+            const result = step(record.entry, op.value);
+            yield* Ref.update(records, (m) =>
+              HashMap.set(m, cellId, { ...record, entry: result.entry }),
+            );
 
-                // Record execution — clears stale state
-                yield* cellStateManager.recordExecution(notebookCell);
-
-                // Clear any prior runtime-error squiggle before this re-run.
-                yield* clearErrorDiagnostic(notebookCell.document.uri);
-
-                // End any in-progress execution before creating a new one
-                yield* Ref.update(ref, (map) => {
-                  const handle = HashMap.get(map, cellId).pipe(
-                    Option.andThen((v) => v.pendingExecution),
-                  );
-                  if (
-                    Option.isSome(handle) &&
-                    handle.value.kind !== "completed"
-                  ) {
-                    handle.value.end(true);
-                  }
-                  return map;
-                });
-
-                // Create new execution — can fail if the cell was removed
-                const execution = yield* Effect.try({
-                  try: () =>
-                    controller.createNotebookCellExecution(notebookCell),
-                  catch: (cause) => new InvalidCellError({ cellId, cause }),
-                });
-
-                yield* Ref.update(ref, (map) =>
-                  HashMap.set(
-                    map,
-                    cellId,
-                    CellEntry.withExecution(
-                      cell,
-                      new PendingExecutionHandle({
-                        runId,
-                        inner: execution,
-                      }),
-                    ),
-                  ),
-                );
-                return;
-              }
-
-              case "running": {
-                if (Option.isNone(cell.pendingExecution)) {
-                  yield* Effect.logWarning(
-                    "Got running message but no cell execution found",
-                  );
-                }
-                const update = yield* Ref.modify(ref, (map) => {
-                  const update = CellEntry.start(cell, msg.timestamp ?? 0);
-                  return [update, HashMap.set(map, cellId, update)];
-                });
-                yield* CellEntry.maybeUpdateCellOutput(update, code, options);
-                return;
-              }
-
-              case "idle": {
-                if (Option.isNone(cell.pendingExecution)) {
-                  yield* Effect.logWarning(
-                    "Got idle message but no cell execution found",
-                  );
-                }
-                // MUST modify cell output before `ExecutionHandle.end`
-                yield* CellEntry.maybeUpdateCellOutput(cell, code, options);
-                // Place (or clear) the red squiggle on the raising line.
-                yield* applyErrorDiagnostic(notebookCell, cellId, cell.state);
-                yield* Ref.update(ref, (map) =>
-                  Option.match(HashMap.get(map, cellId), {
-                    onSome: (entry) =>
-                      HashMap.set(
-                        map,
-                        cellId,
-                        // Report failure when the cell ended on an error so
-                        // VS Code marks the cell with the red error icon
-                        // (matches Jupyter); a marimo-error output channel is
-                        // the kernel's signal that the run raised.
-                        CellEntry.end(
-                          entry,
-                          entry.state.output?.channel !== "marimo-error",
-                          msg.timestamp,
-                        ),
-                      ),
-                    onNone: () => map,
-                  }),
-                );
-                return;
-              }
-
-              default: {
-                yield* CellEntry.maybeUpdateCellOutput(cell, code, options);
-              }
+            const ctx: PerformContext = {
+              cellId,
+              notebookCell,
+              controller,
+              notebook: editor.notebook,
+            };
+            for (const action of result.actions) {
+              // oxlint-disable-next-line eslint/no-await-in-loop -- actions are
+              // ordered (e.g. FinalizeOutputs must land before EndExecution)
+              yield* perform(action, ctx);
             }
           }).pipe(
             Effect.catchTag("NotebookCellNotFoundError", () =>
@@ -281,237 +391,6 @@ export class ExecutionRegistry extends Effect.Service<ExecutionRegistry>()(
     }),
   },
 ) {}
-
-class PendingExecutionHandle extends Data.TaggedClass(
-  "PendingExecutionHandle",
-)<{
-  readonly inner: vscode.NotebookCellExecution;
-  readonly runId: RunId;
-}> {
-  readonly kind = "pending";
-  start(startTime: number) {
-    this.inner.start(startTime);
-    return new RunningExecutionHandle({
-      inner: this.inner,
-      runId: this.runId,
-    });
-  }
-  end(success: boolean, endTime?: number) {
-    this.inner.end(success, endTime);
-    return new CompletedExecutionHandle({
-      inner: this.inner,
-      runId: this.runId,
-    });
-  }
-}
-
-class RunningExecutionHandle extends Data.TaggedClass(
-  "RunningExecutionHandle",
-)<{
-  readonly inner: vscode.NotebookCellExecution;
-  readonly runId: RunId;
-}> {
-  readonly kind = "running";
-  end(success: boolean, endTime?: number) {
-    this.inner.end(success, endTime);
-    return new CompletedExecutionHandle({
-      inner: this.inner,
-      runId: this.runId,
-    });
-  }
-  updateCellOutput(options: {
-    cellId: NotebookCellId;
-    state: CellRuntimeState;
-    code: VsCode;
-  }) {
-    const { cellId, state, code } = options;
-    const notebook = this.inner.cell.notebook;
-    const outputs = buildCellOutputs(cellId, state, code, notebook);
-    return Effect.tryPromise(() => this.inner.replaceOutput(outputs)).pipe(
-      Effect.annotateLogs({ cellId }),
-      Effect.catchAllCause((cause) =>
-        // Race condition: execution may have been ended by a concurrent
-        // operation (e.g., a new queued message ending the old execution).
-        // This is expected and not an actionable error.
-        Effect.logWarning("Failed to update cell output").pipe(
-          Effect.annotateLogs({ cause }),
-        ),
-      ),
-    );
-  }
-}
-
-class CompletedExecutionHandle extends Data.TaggedClass(
-  "CompletedExecutionHandle",
-)<{
-  readonly inner: vscode.NotebookCellExecution;
-  readonly runId: RunId;
-}> {
-  readonly kind = "completed";
-}
-
-type ExecutionHandle =
-  | PendingExecutionHandle
-  | RunningExecutionHandle
-  | CompletedExecutionHandle;
-
-class CellEntry extends Data.TaggedClass("CellEntry")<{
-  readonly id: NotebookCellId;
-  readonly state: CellRuntimeState;
-  readonly editor: vscode.NotebookEditor;
-  readonly pendingExecution: Option.Option<ExecutionHandle>;
-}> {
-  static make(id: NotebookCellId, editor: vscode.NotebookEditor) {
-    return new CellEntry({
-      id,
-      editor,
-      state: createCellRuntimeState(),
-      pendingExecution: Option.none(),
-    });
-  }
-  private with(
-    overrides: Partial<Pick<CellEntry, "state" | "pendingExecution">>,
-  ) {
-    return new CellEntry({
-      id: this.id,
-      editor: this.editor,
-      state: overrides.state ?? this.state,
-      pendingExecution: overrides.pendingExecution ?? this.pendingExecution,
-    });
-  }
-  static transition(cell: CellEntry, message: CellOperationNotification) {
-    return cell.with({ state: transitionCell(cell.state, message) });
-  }
-  static withExecution(cell: CellEntry, execution: ExecutionHandle) {
-    return cell.with({
-      pendingExecution: Option.some(execution),
-    });
-  }
-  static interrupt(cell: CellEntry) {
-    if (
-      Option.isSome(cell.pendingExecution) &&
-      cell.pendingExecution.value.kind !== "completed"
-    ) {
-      cell.pendingExecution.value.end(false);
-    }
-    return cell.with({ pendingExecution: Option.none() });
-  }
-  static start(cell: CellEntry, timestamp: number) {
-    let pendingExecution = cell.pendingExecution;
-    if (
-      Option.isSome(cell.pendingExecution) &&
-      cell.pendingExecution.value.kind === "pending"
-    ) {
-      pendingExecution = Option.some(
-        cell.pendingExecution.value.start(timestamp * 1000),
-      );
-    }
-    return cell.with({ pendingExecution });
-  }
-  static end(cell: CellEntry, success: boolean, timestamp?: number) {
-    if (
-      Option.isSome(cell.pendingExecution) &&
-      cell.pendingExecution.value.kind !== "completed"
-    ) {
-      cell.pendingExecution.value.inner.end(
-        success,
-        timestamp ? timestamp * 1000 : undefined,
-      );
-    }
-    return cell.with({ pendingExecution: Option.none() });
-  }
-  static maybeUpdateCellOutput = Effect.fn(function* (
-    cell: CellEntry,
-    code: VsCode,
-    deps?: {
-      editor: vscode.NotebookEditor;
-      controller: PythonController | SandboxController;
-    },
-  ) {
-    const { pendingExecution, id: cellId, state } = cell;
-
-    if (Option.isNone(pendingExecution)) {
-      // If it is an error, the cell likely never got queued and errored during compilation.
-      // Create an ephemeral execution to display the error.
-      const hasError = state.output?.channel === "marimo-error";
-
-      if (hasError && deps) {
-        yield* Effect.logDebug(
-          "Creating ephemeral execution for marimo error without pending execution",
-        );
-
-        const notebookCell = yield* findNotebookCell(
-          MarimoNotebookDocument.from(deps.editor.notebook),
-          cellId,
-        );
-        const execution = yield* Effect.try({
-          try: () => deps.controller.createNotebookCellExecution(notebookCell),
-          catch: (cause) => new InvalidCellError({ cellId, cause }),
-        });
-
-        execution.start();
-        const outputs = buildCellOutputs(
-          cellId,
-          state,
-          code,
-          deps.editor.notebook,
-        );
-        yield* Effect.tryPromise(() => execution.replaceOutput(outputs)).pipe(
-          Effect.catchAllCause((cause) =>
-            Effect.logWarning(
-              "Failed to update cell output for ephemeral execution",
-              cause,
-            ),
-          ),
-        );
-        execution.end(false);
-
-        return;
-      }
-
-      yield* Effect.logWarning("No pending execution to update");
-      return;
-    }
-
-    if (pendingExecution.value.kind !== "running") {
-      yield* Effect.logDebug(
-        "Pending execution is not running, skipping output update",
-      ).pipe(Effect.annotateLogs({ status: state.status }));
-      return;
-    }
-
-    yield* pendingExecution.value
-      .updateCellOutput({
-        cellId,
-        state,
-        code,
-      })
-      .pipe(
-        Effect.catchAllCause((cause) =>
-          Effect.logWarning("Failed to update cell output").pipe(
-            Effect.annotateLogs({ cause }),
-          ),
-        ),
-        Effect.annotateLogs({ cellId }),
-      );
-  });
-}
-
-type RunId = Brand.Branded<string, "RunId">;
-const RunId = Brand.nominal<RunId>();
-function extractRunId(msg: CellOperationNotification): Option.Option<RunId> {
-  return Option.fromNullable(msg.run_id).pipe(
-    Option.map((idStr) => RunId(idStr)),
-  );
-}
-
-/* Type-safe wrapper around marimo's `transitionCell` we import above */
-function transitionCell(
-  cell: CellRuntimeState,
-  message: CellOperationNotification,
-): CellRuntimeState {
-  return untypedTransitionCell(cell, message);
-}
 
 /**
  * Convert CellOperationNotification(s) to VSCode NotebookCellOutput.
@@ -547,7 +426,29 @@ export function buildCellOutputs(
   code: VsCode,
   notebook?: vscode.NotebookDocument,
 ): vscode.NotebookCellOutput[] {
-  const outputs: vscode.NotebookCellOutput[] = [];
+  return buildKeyedCellOutputs(cellId, state, code, notebook).map(
+    (keyed) => keyed.output,
+  );
+}
+
+/**
+ * Like {@link buildCellOutputs}, but each output carries a stable {@link
+ * KeyedCellOutput.key}.
+ *
+ * Outputs are emitted in **arrival order** — console streams (`stdout`,
+ * `stderr`) first, then the cell's result / error / traceback — mirroring
+ * Jupyter rather than marimo's historical result-first layout. Combined with
+ * the append-based reconcile in {@link CellOutputProjection}, this means each
+ * slot is created once, in the order it first appears, and tall built-in
+ * outputs (a traceback) are measured once instead of on every cell-op.
+ */
+export function buildKeyedCellOutputs(
+  cellId: NotebookCellId,
+  state: CellRuntimeState,
+  code: VsCode,
+  notebook?: vscode.NotebookDocument,
+): KeyedCellOutput[] {
+  const outputs: KeyedCellOutput[] = [];
 
   // Collect items by channel
   const stdoutItems: vscode.NotebookCellOutputItem[] = [];
@@ -623,52 +524,66 @@ export function buildCellOutputs(
     }
   }
 
-  // Create NotebookCellOutputs for each channel with items.
-  //
-  // marimo-error and a traceback are present, the traceback already renders
-  // `<Type>: <message>` as its header, so the marimo-error item is dropped.
-  if (errorItems.length > 0 && !shouldSuppressMarimoError(state)) {
-    outputs.push(
-      new code.NotebookCellOutput(errorItems, {
-        channel: "marimo-error",
-      }),
-    );
-  }
-
-  if (outputItems.length > 0) {
-    outputs.push(new code.NotebookCellOutput(outputItems));
-  }
-
+  // Create keyed NotebookCellOutputs in arrival order: console streams first,
+  // then the cell's result / error / traceback. Each `key` is the logical slot
+  // the output reconciler tracks across cell-ops, so it must be stable for a
+  // given channel within a run.
   if (stdoutItems.length > 0) {
-    outputs.push(
-      new code.NotebookCellOutput(stdoutItems, {
-        channel: "stdout",
-      }),
-    );
+    outputs.push({
+      key: "stdout",
+      output: new code.NotebookCellOutput(stdoutItems, { channel: "stdout" }),
+    });
   }
 
   if (stderrItems.length > 0) {
-    outputs.push(
-      new code.NotebookCellOutput(stderrItems, {
-        channel: "stderr",
-      }),
-    );
+    outputs.push({
+      key: "stderr",
+      output: new code.NotebookCellOutput(stderrItems, { channel: "stderr" }),
+    });
   }
 
-  for (const tracebackItem of tracebackItems) {
-    outputs.push(
-      new code.NotebookCellOutput([tracebackItem], {
+  // Result, error, and (when the error is redundant with a traceback) the
+  // traceback all share one stable `"main"` key, so "error box, then traceback
+  // supersedes it" is an in-place swap rather than a remove+append. The
+  // marimo-error item is dropped when a traceback is present — the traceback
+  // already renders `<Type>: <message>` as its header.
+  const errorShown = errorItems.length > 0 && !shouldSuppressMarimoError(state);
+  let mainSlotTaken = false;
+  if (errorShown) {
+    outputs.push({
+      key: "main",
+      output: new code.NotebookCellOutput(errorItems, {
+        channel: "marimo-error",
+      }),
+    });
+    mainSlotTaken = true;
+  } else if (outputItems.length > 0) {
+    outputs.push({
+      key: "main",
+      output: new code.NotebookCellOutput(outputItems),
+    });
+    mainSlotTaken = true;
+  }
+
+  tracebackItems.forEach((tracebackItem, index) => {
+    // The first traceback claims the `"main"` slot when nothing else does (the
+    // suppressed-error case), so an error box already shown there is swapped to
+    // the traceback in place rather than removed.
+    const key = !mainSlotTaken && index === 0 ? "main" : `traceback:${index}`;
+    if (key === "main") mainSlotTaken = true;
+    outputs.push({
+      key,
+      output: new code.NotebookCellOutput([tracebackItem], {
         channel: "stderr",
       }),
-    );
-  }
+    });
+  });
 
   if (stdinItems.length > 0) {
-    outputs.push(
-      new code.NotebookCellOutput(stdinItems, {
-        channel: "stdin",
-      }),
-    );
+    outputs.push({
+      key: "stdin",
+      output: new code.NotebookCellOutput(stdinItems, { channel: "stdin" }),
+    });
   }
 
   return outputs;

--- a/extension/src/kernel/__tests__/CellOutputProjection.test.ts
+++ b/extension/src/kernel/__tests__/CellOutputProjection.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect } from "effect";
+import type * as vscode from "vscode";
+
+import { TestVsCode } from "../../__mocks__/TestVsCode.ts";
+import { VsCode } from "../../platform/VsCode.ts";
+import {
+  CellOutputProjection,
+  type KeyedCellOutput,
+  type OutputExecution,
+} from "../CellOutputProjection.ts";
+
+const decoder = new TextDecoder();
+const decode = (o: vscode.NotebookCellOutput) =>
+  o.items.map((i) => decoder.decode(i.data)).join("|");
+
+/** Records the projection's calls; mirrors `cell.outputs` like VS Code does. */
+class FakeExecution implements OutputExecution {
+  readonly #outputs: vscode.NotebookCellOutput[] = [];
+  readonly log: string[] = [];
+  readonly cell = { outputs: this.#outputs };
+
+  constructor(initial: ReadonlyArray<vscode.NotebookCellOutput> = []) {
+    this.#outputs.push(...initial);
+  }
+  clearOutput(): Thenable<void> {
+    this.log.push("clear");
+    this.#outputs.length = 0;
+    return Promise.resolve();
+  }
+  appendOutput(output: vscode.NotebookCellOutput): Thenable<void> {
+    this.log.push(`append(${decode(output)})`);
+    this.#outputs.push(output);
+    return Promise.resolve();
+  }
+  replaceOutputItems(
+    items: ReadonlyArray<vscode.NotebookCellOutputItem>,
+    _output: vscode.NotebookCellOutput,
+  ): Thenable<void> {
+    this.log.push(
+      `replace(${items.map((i) => decoder.decode(i.data)).join("|")})`,
+    );
+    return Promise.resolve();
+  }
+}
+
+/** Keyed-output builders bound to the test's VS Code value constructors. */
+const builders = (code: VsCode) => ({
+  stdout: (text: string): KeyedCellOutput => ({
+    key: "stdout",
+    output: new code.NotebookCellOutput([
+      code.NotebookCellOutputItem.stdout(text),
+    ]),
+  }),
+  main: (text: string): KeyedCellOutput => ({
+    key: "main",
+    output: new code.NotebookCellOutput([
+      code.NotebookCellOutputItem.stderr(text),
+    ]),
+  }),
+});
+
+describe("CellOutputProjection", () => {
+  it.effect(
+    "clears once on first output, then appends; commit re-measures each slot",
+    Effect.fn(function* () {
+      const vscode = yield* TestVsCode.make({});
+      yield* Effect.gen(function* () {
+        const { stdout, main } = builders(yield* VsCode);
+        const exec = new FakeExecution();
+        const p = new CellOutputProjection(exec);
+
+        yield* Effect.promise(() => p.project([stdout("10")]));
+        yield* Effect.promise(() => p.project([stdout("10"), main("trace")]));
+        yield* Effect.promise(() => p.commit([stdout("10"), main("trace")]));
+
+        expect(exec.log).toEqual([
+          "clear",
+          "append(10)",
+          // stdout unchanged → skipped; only the new slot appends
+          "append(trace)",
+          // commit touches every slot to force a height measurement
+          "replace(10)",
+          "replace(trace)",
+        ]);
+      }).pipe(Effect.provide(vscode.layer));
+    }),
+  );
+
+  it.effect(
+    "clears a previous run's outputs on this run's first output",
+    Effect.fn(function* () {
+      const vscode = yield* TestVsCode.make({});
+      yield* Effect.gen(function* () {
+        const { stdout } = builders(yield* VsCode);
+        const exec = new FakeExecution([stdout("stale").output]);
+        const p = new CellOutputProjection(exec);
+
+        yield* Effect.promise(() => p.project([stdout("10")]));
+
+        expect(exec.log).toEqual(["clear", "append(10)"]);
+      }).pipe(Effect.provide(vscode.layer));
+    }),
+  );
+
+  it.effect(
+    "only re-emits a slot whose items changed",
+    Effect.fn(function* () {
+      const vscode = yield* TestVsCode.make({});
+      yield* Effect.gen(function* () {
+        const { stdout } = builders(yield* VsCode);
+        const exec = new FakeExecution();
+        const p = new CellOutputProjection(exec);
+
+        yield* Effect.promise(() => p.project([stdout("10")]));
+        yield* Effect.promise(() => p.project([stdout("10")])); // no-op
+        yield* Effect.promise(() => p.project([stdout("10\n20")]));
+
+        expect(exec.log).toEqual(["clear", "append(10)", "replace(10\n20)"]);
+      }).pipe(Effect.provide(vscode.layer));
+    }),
+  );
+
+  it.effect(
+    "rebuilds from a clean slate when commit order differs (no phantom)",
+    Effect.fn(function* () {
+      const vscode = yield* TestVsCode.make({});
+      yield* Effect.gen(function* () {
+        const { stdout, main } = builders(yield* VsCode);
+        const exec = new FakeExecution();
+        const p = new CellOutputProjection(exec);
+
+        // Arrival order put the error first, then stdout.
+        yield* Effect.promise(() => p.project([main("trace")]));
+        yield* Effect.promise(() => p.project([main("trace"), stdout("10")]));
+        // Canonical order is stdout-first: commit re-clears and re-appends.
+        yield* Effect.promise(() => p.commit([stdout("10"), main("trace")]));
+
+        expect(exec.log).toEqual([
+          "clear",
+          "append(trace)",
+          "append(10)",
+          // order mismatch → clean rebuild, then measure
+          "clear",
+          "append(10)",
+          "append(trace)",
+          "replace(10)",
+          "replace(trace)",
+        ]);
+      }).pipe(Effect.provide(vscode.layer));
+    }),
+  );
+});

--- a/extension/src/kernel/__tests__/CellRunReducer.test.ts
+++ b/extension/src/kernel/__tests__/CellRunReducer.test.ts
@@ -1,0 +1,151 @@
+import { createCellRuntimeState } from "@marimo-team/frontend/unstable_internal/core/cells/types.ts";
+import { describe, expect, it } from "vitest";
+
+import { cellId } from "../../lib/__tests__/branded.ts";
+import type { CellRuntimeState } from "../../types.ts";
+import {
+  Action,
+  type CellRunEntry,
+  Op,
+  RunId,
+  RunPhase,
+  step,
+} from "../CellRunReducer.ts";
+
+const ID = cellId("cell-1");
+const RUN = RunId("run-1");
+
+const entry = (phase: RunPhase): CellRunEntry => ({
+  id: ID,
+  state: createCellRuntimeState(),
+  phase,
+});
+
+const okState = (): CellRuntimeState => createCellRuntimeState();
+const errorState = (): CellRuntimeState => ({
+  ...createCellRuntimeState(),
+  output: {
+    channel: "marimo-error",
+    mimetype: "application/vnd.marimo+error",
+    data: [],
+    timestamp: 0,
+  },
+});
+const staleState = (): CellRuntimeState => ({
+  ...createCellRuntimeState(),
+  staleInputs: true,
+});
+
+/** The sequence of action tags — the load-bearing, order-sensitive bit. */
+const tags = (actions: ReadonlyArray<Action>) => actions.map((a) => a._tag);
+
+describe("cell run reducer", () => {
+  it("drives a normal run: queue → start → update → settle", () => {
+    let e = entry(RunPhase.Idle());
+
+    const queued = step(e, Op.Queue({ runId: RUN, next: okState() }));
+    expect(tags(queued.actions)).toEqual([
+      "RecordExecution",
+      "ClearRuntimeError",
+      "CreateExecution",
+    ]);
+    expect(queued.entry.phase).toEqual(RunPhase.Queued({ runId: RUN }));
+    e = queued.entry;
+
+    const started = step(e, Op.Start({ startTime: 5, next: okState() }));
+    expect(tags(started.actions)).toEqual(["StartExecution", "EmitOutputs"]);
+    expect(started.entry.phase).toEqual(RunPhase.Running({ runId: RUN }));
+    e = started.entry;
+
+    const updated = step(e, Op.Update({ next: okState() }));
+    expect(tags(updated.actions)).toEqual(["EmitOutputs"]);
+    e = updated.entry;
+
+    const settled = step(
+      e,
+      Op.Settle({ success: true, endTime: 9, next: okState() }),
+    );
+    expect(tags(settled.actions)).toEqual([
+      "FinalizeOutputs",
+      "ApplyRuntimeError",
+      "EndExecution",
+    ]);
+    expect(settled.entry.phase).toEqual(RunPhase.Completed());
+  });
+
+  it("settles a raised cell as a failure", () => {
+    const running = entry(RunPhase.Running({ runId: RUN }));
+    const { actions } = step(
+      running,
+      Op.Settle({ success: false, endTime: undefined, next: errorState() }),
+    );
+    const end = actions.find((a) => a._tag === "EndExecution");
+    expect(end).toEqual(
+      Action.EndExecution({ success: false, endTime: undefined }),
+    );
+  });
+
+  it("ends the prior execution before re-queuing (race guard)", () => {
+    const running = entry(RunPhase.Running({ runId: RUN }));
+    const { actions } = step(
+      running,
+      Op.Queue({ runId: RunId("run-2"), next: okState() }),
+    );
+    expect(tags(actions)).toEqual([
+      "RecordExecution",
+      "ClearRuntimeError",
+      "EndExecution",
+      "CreateExecution",
+    ]);
+    // The prior run is ended as a success — it's superseded, not failed.
+    const end = actions.find((a) => a._tag === "EndExecution");
+    expect(end).toEqual(
+      Action.EndExecution({ success: true, endTime: undefined }),
+    );
+  });
+
+  it("interrupts a live run, and is a no-op otherwise", () => {
+    const running = step(
+      entry(RunPhase.Running({ runId: RUN })),
+      Op.Interrupt(),
+    );
+    expect(tags(running.actions)).toEqual(["EndExecution"]);
+    expect(running.entry.phase).toEqual(RunPhase.Completed());
+
+    const idle = step(entry(RunPhase.Idle()), Op.Interrupt());
+    expect(idle.actions).toEqual([]);
+    expect(idle.entry.phase).toEqual(RunPhase.Idle());
+  });
+
+  it("renders a compile error with no prior run via an ephemeral execution", () => {
+    const { actions, entry: next } = step(
+      entry(RunPhase.Idle()),
+      Op.Settle({ success: false, endTime: undefined, next: errorState() }),
+    );
+    expect(tags(actions)).toEqual([
+      "CreateExecution",
+      "StartExecution",
+      "FinalizeOutputs",
+      "ApplyRuntimeError",
+      "EndExecution",
+    ]);
+    // The cell never entered a tracked run, so it stays Idle.
+    expect(next.phase).toEqual(RunPhase.Idle());
+  });
+
+  it("reconciles the squiggle on an idle with nothing to render", () => {
+    const { actions } = step(
+      entry(RunPhase.Idle()),
+      Op.Settle({ success: true, endTime: undefined, next: okState() }),
+    );
+    expect(tags(actions)).toEqual(["ApplyRuntimeError"]);
+  });
+
+  it("invalidates the cell when an op carries stale inputs", () => {
+    const { actions } = step(
+      entry(RunPhase.Running({ runId: RUN })),
+      Op.Update({ next: staleState() }),
+    );
+    expect(actions[0]).toEqual(Action.InvalidateCell());
+  });
+});

--- a/extension/src/kernel/__tests__/__snapshots__/ExecutionRegistry.test.ts.snap
+++ b/extension/src/kernel/__tests__/__snapshots__/ExecutionRegistry.test.ts.snap
@@ -157,15 +157,6 @@ exports[`buildCellOutputs > handles mixed output and console streams 1`] = `
   {
     "items": [
       {
-        "data": "{"cellId":"test-cell-id","state":{"outline":null,"output":{"mimetype":"text/html","channel":"output","data":"<div>Result: 42</div>","timestamp":2},"consoleOutputs":[],"status":"idle","staleInputs":false,"interrupted":false,"errored":false,"stopped":false,"runElapsedTimeMs":null,"runStartTimestamp":null,"lastRunStartTimestamp":null,"debuggerActive":false}}",
-        "mime": "application/vnd.marimo.ui+json",
-      },
-    ],
-    "metadata": undefined,
-  },
-  {
-    "items": [
-      {
         "data": "Processing...
 ",
         "mime": "application/vnd.code.notebook.stdout",
@@ -186,6 +177,15 @@ exports[`buildCellOutputs > handles mixed output and console streams 1`] = `
     "metadata": {
       "channel": "stderr",
     },
+  },
+  {
+    "items": [
+      {
+        "data": "{"cellId":"test-cell-id","state":{"outline":null,"output":{"mimetype":"text/html","channel":"output","data":"<div>Result: 42</div>","timestamp":2},"consoleOutputs":[],"status":"idle","staleInputs":false,"interrupted":false,"errored":false,"stopped":false,"runElapsedTimeMs":null,"runStartTimestamp":null,"lastRunStartTimestamp":null,"debuggerActive":false}}",
+        "mime": "application/vnd.marimo.ui+json",
+      },
+    ],
+    "metadata": undefined,
   },
 ]
 `;
@@ -320,15 +320,6 @@ exports[`buildCellOutputs > handles stdout + stderr + output together 1`] = `
   {
     "items": [
       {
-        "data": "{"cellId":"test-cell-id","state":{"outline":null,"output":{"mimetype":"application/json","channel":"output","data":{"result":"success","value":100},"timestamp":3},"consoleOutputs":[],"status":"idle","staleInputs":false,"interrupted":false,"errored":false,"stopped":false,"runElapsedTimeMs":null,"runStartTimestamp":null,"lastRunStartTimestamp":null,"debuggerActive":false}}",
-        "mime": "application/vnd.marimo.ui+json",
-      },
-    ],
-    "metadata": undefined,
-  },
-  {
-    "items": [
-      {
         "data": "Starting computation...
 ",
         "mime": "application/vnd.code.notebook.stdout",
@@ -354,6 +345,15 @@ exports[`buildCellOutputs > handles stdout + stderr + output together 1`] = `
     "metadata": {
       "channel": "stderr",
     },
+  },
+  {
+    "items": [
+      {
+        "data": "{"cellId":"test-cell-id","state":{"outline":null,"output":{"mimetype":"application/json","channel":"output","data":{"result":"success","value":100},"timestamp":3},"consoleOutputs":[],"status":"idle","staleInputs":false,"interrupted":false,"errored":false,"stopped":false,"runElapsedTimeMs":null,"runStartTimestamp":null,"lastRunStartTimestamp":null,"debuggerActive":false}}",
+        "mime": "application/vnd.marimo.ui+json",
+      },
+    ],
+    "metadata": undefined,
   },
 ]
 `;
@@ -495,15 +495,6 @@ exports[`buildCellOutputs > separates console outputs from main output correctly
   {
     "items": [
       {
-        "data": "{"cellId":"test-cell-id","state":{"outline":null,"output":{"mimetype":"text/html","channel":"output","data":"<div>Main output</div>","timestamp":1},"consoleOutputs":[],"status":"idle","staleInputs":false,"interrupted":false,"errored":false,"stopped":false,"runElapsedTimeMs":null,"runStartTimestamp":null,"lastRunStartTimestamp":null,"debuggerActive":false}}",
-        "mime": "application/vnd.marimo.ui+json",
-      },
-    ],
-    "metadata": undefined,
-  },
-  {
-    "items": [
-      {
         "data": "Console output",
         "mime": "application/vnd.code.notebook.stdout",
       },
@@ -511,6 +502,15 @@ exports[`buildCellOutputs > separates console outputs from main output correctly
     "metadata": {
       "channel": "stdout",
     },
+  },
+  {
+    "items": [
+      {
+        "data": "{"cellId":"test-cell-id","state":{"outline":null,"output":{"mimetype":"text/html","channel":"output","data":"<div>Main output</div>","timestamp":1},"consoleOutputs":[],"status":"idle","staleInputs":false,"interrupted":false,"errored":false,"stopped":false,"runElapsedTimeMs":null,"runStartTimestamp":null,"lastRunStartTimestamp":null,"debuggerActive":false}}",
+        "mime": "application/vnd.marimo.ui+json",
+      },
+    ],
+    "metadata": undefined,
   },
 ]
 `;

--- a/extension/tests/output-reconcile.test.cjs
+++ b/extension/tests/output-reconcile.test.cjs
@@ -1,0 +1,194 @@
+// @ts-check
+/// <reference types="mocha" />
+
+// Integration coverage for the cell-output emission/reconcile path
+// (`ExecutionRegistry`): re-running a cell must reconcile its outputs in place
+// rather than stacking or duplicating them, and the built-in error/stdout
+// outputs must survive every re-run.
+//
+// The *visual* defect this guards against (a traceback collapsing/overlapping
+// on repeated runs) is a webview height problem the test harness can't see as
+// pixels — that's verified separately via the dev host. What we can assert
+// structurally is that the emission model stays well-formed across re-runs:
+// stable output count, correct order, and a failed-execution summary.
+
+const NodeAssert = require("node:assert");
+const vscode = require("vscode");
+
+const { createTestContext, selectKernel, runCell } = require("./helpers.cjs");
+
+const SCRIPT_HEADER = `# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "marimo",
+# ]
+# ///
+
+import marimo
+
+app = marimo.App()
+`;
+
+const SCRIPT_FOOTER = `
+
+if __name__ == "__main__":
+    app.run()
+`;
+
+const STDOUT_MIME = "application/vnd.code.notebook.stdout";
+const ERROR_MIME = "application/vnd.code.notebook.error";
+
+/**
+ * Build marimo notebook source from an array of cell body strings.
+ *
+ * @param {string[]} bodies
+ */
+function makeSource(bodies) {
+  const blocks = bodies.map((body) => {
+    const indented = body
+      .split("\n")
+      .map((line) => `    ${line}`)
+      .join("\n");
+    return `\n\n@app.cell\ndef _():\n${indented}\n    return\n`;
+  });
+  return SCRIPT_HEADER + blocks.join("") + SCRIPT_FOOTER;
+}
+
+/**
+ * Flatten a cell's outputs into `{ mime }` descriptors, in order.
+ *
+ * @param {vscode.NotebookCell} cell
+ */
+function outputItemMimes(cell) {
+  return cell.outputs.flatMap((output) =>
+    output.items.map((item) => item.mime),
+  );
+}
+
+/**
+ * @param {vscode.NotebookCell} cell
+ */
+function cellOutputText(cell) {
+  const decoder = new TextDecoder();
+  return cell.outputs
+    .flatMap((output) => output.items.map((item) => decoder.decode(item.data)))
+    .join("");
+}
+
+// The canonical acceptance repro from the goal: stdout followed by an
+// uncaught exception. Running it any number of times must leave exactly the
+// same well-formed output set.
+const ERROR_REPRO = "print(10)\nraise ValueError()";
+
+suite("output reconcile on re-run", function () {
+  test("repeated runs keep stdout + traceback without stacking", async function () {
+    this.timeout(60_000);
+    await using ctx = createTestContext();
+    const nb = await ctx.writeAndOpenNotebook(makeSource([ERROR_REPRO]));
+    await selectKernel(nb);
+
+    /** @type {number | undefined} */
+    let baselineCount;
+
+    for (let run = 1; run <= 3; run++) {
+      const cell = nb.cellAt(0);
+      // oxlint-disable-next-line eslint/no-await-in-loop
+      await runCell(cell);
+
+      // The execution failed (red error icon), matching Jupyter.
+      NodeAssert.strictEqual(
+        cell.executionSummary?.success,
+        false,
+        `run ${run}: expected a failed execution, got ${JSON.stringify(
+          cell.executionSummary,
+        )}`,
+      );
+
+      const mimes = outputItemMimes(cell);
+
+      // Both built-in outputs survive every run...
+      NodeAssert.ok(
+        mimes.includes(STDOUT_MIME),
+        `run ${run}: expected a stdout output, got ${JSON.stringify(mimes)}`,
+      );
+      NodeAssert.ok(
+        mimes.includes(ERROR_MIME),
+        `run ${run}: expected a built-in error (traceback) output, got ${JSON.stringify(
+          mimes,
+        )}`,
+      );
+
+      // ...and the printed value is still visible.
+      NodeAssert.match(cellOutputText(cell), /10/);
+
+      // ...in arrival order: stdout precedes the traceback (Jupyter-like),
+      // not result-first.
+      NodeAssert.ok(
+        mimes.indexOf(STDOUT_MIME) < mimes.indexOf(ERROR_MIME),
+        `run ${run}: stdout should precede the traceback, got ${JSON.stringify(
+          mimes,
+        )}`,
+      );
+
+      // Re-running reconciles in place — the output count never grows.
+      if (baselineCount === undefined) {
+        baselineCount = cell.outputs.length;
+        NodeAssert.ok(
+          baselineCount >= 2,
+          `expected at least stdout + traceback outputs, got ${baselineCount}`,
+        );
+      } else {
+        NodeAssert.strictEqual(
+          cell.outputs.length,
+          baselineCount,
+          `run ${run}: output count changed across re-runs (stacking?)`,
+        );
+      }
+    }
+  });
+
+  test("rapid re-runs settle to a single well-formed output set", async function () {
+    this.timeout(60_000);
+    await using ctx = createTestContext();
+    const nb = await ctx.writeAndOpenNotebook(makeSource([ERROR_REPRO]));
+    await selectKernel(nb);
+
+    // Establish the steady-state output count with one clean run.
+    await runCell(nb.cellAt(0));
+    const baselineCount = nb.cellAt(0).outputs.length;
+
+    // Spam executions; only await the final one's finalization.
+    for (let i = 0; i < 3; i++) {
+      void vscode.commands.executeCommand("notebook.cell.execute", {
+        ranges: [{ start: 0, end: 1 }],
+        document: nb.uri,
+      });
+    }
+    await runCell(nb.cellAt(0));
+
+    // Outputs settle back to the same shape — no leftover/duplicated outputs
+    // from the interrupted-then-restarted runs.
+    await ctx.waitUntil(() => {
+      const cell = nb.cellAt(0);
+      NodeAssert.strictEqual(
+        cell.executionSummary?.success,
+        false,
+        `expected a failed execution, got ${JSON.stringify(
+          cell.executionSummary,
+        )}`,
+      );
+      const mimes = outputItemMimes(cell);
+      NodeAssert.ok(
+        mimes.includes(STDOUT_MIME) && mimes.includes(ERROR_MIME),
+        `expected stdout + traceback after rapid re-runs, got ${JSON.stringify(
+          mimes,
+        )}`,
+      );
+      NodeAssert.strictEqual(
+        cell.outputs.length,
+        baselineCount,
+        `output count drifted after rapid re-runs, got ${cell.outputs.length} vs ${baselineCount}`,
+      );
+    });
+  });
+});


### PR DESCRIPTION
Errors rendered with no space reserved, so a cell's traceback was hidden behind the next cell and blank space accumulated on repeated runs (#598). Moving tracebacks onto VS Code's built-in error renderer exposed this behavior since we drove the `NotebookCellExecution` output API with a full `replaceOutput` on every cell-op, which tears down and re-measures every output each op, so tall built-in outputs lose the measure-before-paint race.

These changes sequence the output edits the way vscode-jupyter does instead. We clear once on the run's first output, then `appendOutput` / `replaceOutputItems` incrementally, and then a final measurement pass on idle so each output is created once and measured once. The output order becomes arrival order (stdout before result/traceback), which also fixes the stdout-above-HTML jump (#516).

The lifecycle changes behind this fix are in three pieces:

- `CellRunReducer` — a pure `step(entry, op) -> { entry, actions }` over `Op` / `Action` / `RunPhase` tagged enums.
- `CellOutputProjection` — `project()` / `commit()` owning the webview-measurement reconcile.
- `ExecutionRegistry` — a thin shell plus an exhaustive action interpreter.