### PR TITLE
Start the kernel on demand when executing scratchpad code

### DIFF
--- a/extension/src/features/RegisterLanguageModelTools.ts
+++ b/extension/src/features/RegisterLanguageModelTools.ts
@@ -101,7 +101,10 @@ export const RegisterLanguageModelToolsLive = Layer.scopedDiscard(
       const notebookId = yield* resolveNotebookId(input);
       if (Option.isNone(notebookId)) {
         return result(
-          `No open marimo notebook matches \`${input.notebookUri}\`.`,
+          `No open marimo notebook matches \`${input.notebookUri}\`. ` +
+            `Pass the URI of a marimo notebook open in VS Code's notebook editor. ` +
+            `Do not fall back to editing the \`.py\` file with Edit/Write/NotebookEdit — ` +
+            `that bypasses the live kernel.`,
         );
       }
 
@@ -151,9 +154,31 @@ export const RegisterLanguageModelToolsLive = Layer.scopedDiscard(
         };
       },
       invoke(options, token) {
-        return runPromise(executeCode(options.input), {
-          signal: signalFromToken(token),
-        });
+        return runPromise(
+          executeCode(options.input).pipe(
+            Effect.catchTags({
+              // No live kernel — the notebook is open but nothing can run. Tell
+              // the agent to have the user start one rather than file-edit.
+              NoActiveKernelError: () =>
+                Effect.succeed(
+                  result(
+                    `This marimo notebook is open but has no active kernel, so code can't run. ` +
+                      `Ask the user to select a kernel and run a cell to start it, then try again. ` +
+                      `Do not edit the \`.py\` file directly as a fallback — that bypasses the live kernel.`,
+                  ),
+                ),
+              // Sandbox kernel needs a script file on disk to resolve its venv.
+              UnsavedNotebookError: () =>
+                Effect.succeed(
+                  result(
+                    `This notebook uses a sandbox kernel, which requires the notebook to be saved to a file before it can run. ` +
+                      `Ask the user to save it, then try again.`,
+                  ),
+                ),
+            }),
+          ),
+          { signal: signalFromToken(token) },
+        );
       },
     });
   }),

--- a/extension/src/kernel/ControllerRegistry.ts
+++ b/extension/src/kernel/ControllerRegistry.ts
@@ -32,6 +32,20 @@ import { SandboxController } from "./SandboxController.ts";
 
 export type AnyController = PythonController | SandboxController;
 
+/**
+ * The python executable for running `notebook` on `controller`. A Python
+ * controller's executable is fixed; the sandbox controller resolves (and syncs)
+ * a per-notebook venv, so it needs the notebook.
+ */
+export function resolveControllerExecutable(
+  controller: AnyController,
+  notebook: MarimoNotebookDocument,
+) {
+  return controller._tag === "PythonController"
+    ? Effect.succeed(controller.executable)
+    : controller.resolveExecutable(notebook);
+}
+
 interface NotebookControllerHandle {
   readonly controller: PythonController;
   readonly scope: Scope.CloseableScope;

--- a/extension/src/kernel/DebugAdapter.ts
+++ b/extension/src/kernel/DebugAdapter.ts
@@ -1,7 +1,7 @@
 import * as NodeFs from "node:fs";
 import * as NodePath from "node:path";
 
-import { Effect, HashMap, Option, Ref, Schema, Stream } from "effect";
+import { Data, Effect, HashMap, Option, Ref, Schema, Stream } from "effect";
 
 import { createSourceMapping, makeDapProxy } from "../lib/dap-proxy.ts";
 import { showErrorAndPromptLogs } from "../lib/showErrorAndPromptLogs.ts";
@@ -47,6 +47,18 @@ const DebugpyState = Schema.Struct({
   port: Schema.Number,
   tmpdir: Schema.String,
 });
+
+/**
+ * An error returned when debugpy fails to start in the notebook's kernel.
+ *
+ * Activation runs a snippet in the kernel that reports the port debugpy is
+ * listening on. This is returned when that port can't be obtained — for
+ * example, the kernel emitted no parseable activation output. The `reason`
+ * field describes the specific failure.
+ */
+class DebugpyActivationError extends Data.TaggedError(
+  "DebugpyActivationError",
+)<{ readonly reason: string }> {}
 
 /** Schema for the debug configuration passed through `startDebugging`. */
 const MarimoDebugConfiguration = Schema.Struct({
@@ -156,92 +168,102 @@ export class DebugAdapter extends Effect.Service<DebugAdapter>()(
       });
 
       return {
-        debugCell: Effect.fn("DebugAdapter.debugCell")(function* (
-          cell: MarimoNotebookCell,
-        ) {
-          if (!debugpyLibsPath) {
-            yield* showErrorAndPromptLogs(
-              "Cannot debug: ms-python.debugpy extension is not installed.",
-            );
-            return;
-          }
-
-          const cellId = cell.id;
-          if (Option.isNone(cellId)) {
-            yield* code.window.showWarningMessage(
-              "No notebook kernel is running. Run a cell first to start the kernel.",
-            );
-            return;
-          }
-
-          const notebook = cell.notebook;
-          const notebookUri = notebook.id;
-
-          // Stop any existing debug session for this notebook
-          const existingSessionId = HashMap.get(
-            yield* Ref.get(activeSessions),
-            notebookUri,
-          );
-          if (Option.isSome(existingSessionId)) {
-            yield* Effect.logInfo("Stopping existing debug session");
-            yield* code.debug.stopDebugging(existingSessionId.value);
-          }
-          const cellIndex = cell.index;
-          const allCells = notebook.getCells();
-
-          // Activate debugpy (idempotent — returns existing port if already running)
-          yield* Effect.logInfo("Activating debugpy in kernel");
-          const state = yield* activateDebugpy(
-            kernelManager,
-            notebookUri,
-            debugpyLibsPath,
-          );
-          yield* Effect.logInfo("debugpy ready").pipe(
-            Effect.annotateLogs({
-              port: state.port,
-              tmpdir: state.tmpdir,
-            }),
-          );
-
-          // Build mappings for ALL cells so stepping across cells works.
-          // Each cell URI maps to its temp file path on disk.
-          const cellMappings: Record<string, string> = {};
-          yield* Effect.try(() => {
-            NodeFs.mkdirSync(state.tmpdir, { recursive: true });
-            for (const c of allCells) {
-              const id = c.id;
-              if (Option.isNone(id)) continue;
-              const filePath = NodePath.join(
-                state.tmpdir,
-                `__marimo__cell_${id.value}_.py`,
+        debugCell: Effect.fn("DebugAdapter.debugCell")(
+          function* (cell: MarimoNotebookCell) {
+            if (!debugpyLibsPath) {
+              yield* showErrorAndPromptLogs(
+                "Cannot debug: ms-python.debugpy extension is not installed.",
               );
-              cellMappings[c.document.uri.toString()] = filePath;
-              NodeFs.writeFileSync(filePath, c.document.getText(), "utf-8");
+              return;
             }
-          }).pipe(
-            Effect.tapError((error) =>
-              Effect.logError("Failed to write cell files to disk").pipe(
-                Effect.annotateLogs({
-                  error: String(error),
-                  tmpdir: state.tmpdir,
-                }),
-              ),
-            ),
-          );
 
-          yield* code.debug.startDebugging(undefined, {
-            type: DEBUG_TYPE,
-            request: "attach",
-            name: "Debug Cell",
-            justMyCode: false,
-            marimo: {
+            const cellId = cell.id;
+            if (Option.isNone(cellId)) {
+              yield* code.window.showWarningMessage(
+                "No notebook kernel is running. Run a cell first to start the kernel.",
+              );
+              return;
+            }
+
+            const notebook = cell.notebook;
+            const notebookUri = notebook.id;
+
+            // Stop any existing debug session for this notebook
+            const existingSessionId = HashMap.get(
+              yield* Ref.get(activeSessions),
               notebookUri,
-              port: state.port,
-              cellIndex,
-              cellMappings,
-            },
-          });
-        }),
+            );
+            if (Option.isSome(existingSessionId)) {
+              yield* Effect.logInfo("Stopping existing debug session");
+              yield* code.debug.stopDebugging(existingSessionId.value);
+            }
+            const cellIndex = cell.index;
+            const allCells = notebook.getCells();
+
+            // Activate debugpy (idempotent — returns existing port if running).
+            yield* Effect.logInfo("Activating debugpy in kernel");
+            const state = yield* activateDebugpy(
+              kernelManager,
+              notebookUri,
+              debugpyLibsPath,
+            );
+            yield* Effect.logInfo("debugpy ready").pipe(
+              Effect.annotateLogs({
+                port: state.port,
+                tmpdir: state.tmpdir,
+              }),
+            );
+
+            // Build mappings for ALL cells so stepping across cells works.
+            // Each cell URI maps to its temp file path on disk.
+            const cellMappings: Record<string, string> = {};
+            yield* Effect.try(() => {
+              NodeFs.mkdirSync(state.tmpdir, { recursive: true });
+              for (const c of allCells) {
+                const id = c.id;
+                if (Option.isNone(id)) continue;
+                const filePath = NodePath.join(
+                  state.tmpdir,
+                  `__marimo__cell_${id.value}_.py`,
+                );
+                cellMappings[c.document.uri.toString()] = filePath;
+                NodeFs.writeFileSync(filePath, c.document.getText(), "utf-8");
+              }
+            }).pipe(
+              Effect.tapError((error) =>
+                Effect.logError("Failed to write cell files to disk").pipe(
+                  Effect.annotateLogs({
+                    error: String(error),
+                    tmpdir: state.tmpdir,
+                  }),
+                ),
+              ),
+            );
+
+            yield* code.debug.startDebugging(undefined, {
+              type: DEBUG_TYPE,
+              request: "attach",
+              name: "Debug Cell",
+              justMyCode: false,
+              marimo: {
+                notebookUri,
+                port: state.port,
+                cellIndex,
+                cellMappings,
+              },
+            });
+          },
+          Effect.catchTags({
+            NoActiveKernelError: () =>
+              code.window.showWarningMessage(
+                "No active kernel for this notebook — run a cell to start one before debugging.",
+              ),
+            UnsavedNotebookError: () =>
+              code.window.showWarningMessage(
+                "Save the notebook before debugging — its sandbox kernel needs a file on disk.",
+              ),
+          }),
+        ),
       };
     }),
   },
@@ -300,20 +322,9 @@ function activateDebugpy(
     );
 
     if (!result) {
-      return yield* Effect.fail(
-        new Error("Failed to activate debugpy: no port received"),
-      );
+      return yield* new DebugpyActivationError({ reason: "no port received" });
     }
 
     return result;
-  }).pipe(
-    Effect.catchAll((error) =>
-      Effect.gen(function* () {
-        yield* Effect.logError("debugpy activation failed").pipe(
-          Effect.annotateLogs({ error: String(error) }),
-        );
-        return yield* Effect.die(error);
-      }),
-    ),
-  );
+  });
 }

--- a/extension/src/kernel/KernelManager.ts
+++ b/extension/src/kernel/KernelManager.ts
@@ -50,7 +50,7 @@ interface MarimoOperation {
   operation: Notification;
 }
 
-/** Scratchpad code was requested for a notebook with no selected kernel. */
+/** An error returned when code is run for a notebook that has no kernel selected. */
 export class NoActiveKernelError extends Data.TaggedError(
   "NoActiveKernelError",
 )<{ readonly notebookUri: NotebookId }> {}

--- a/extension/src/kernel/KernelManager.ts
+++ b/extension/src/kernel/KernelManager.ts
@@ -1,4 +1,5 @@
 import {
+  Data,
   Effect,
   Exit,
   Option,
@@ -36,7 +37,10 @@ import type {
   Notification,
   NotificationOf,
 } from "../types.ts";
-import { ControllerRegistry } from "./ControllerRegistry.ts";
+import {
+  ControllerRegistry,
+  resolveControllerExecutable,
+} from "./ControllerRegistry.ts";
 import { ExecutionRegistry } from "./ExecutionRegistry.ts";
 import { resolveImageDataUri, saveImageToDisk } from "./imageResolver.ts";
 import { handleMissingPackageAlert } from "./operations.ts";
@@ -45,6 +49,11 @@ interface MarimoOperation {
   notebookUri: NotebookId;
   operation: Notification;
 }
+
+/** Scratchpad code was requested for a notebook with no selected kernel. */
+export class NoActiveKernelError extends Data.TaggedError(
+  "NoActiveKernelError",
+)<{ readonly notebookUri: NotebookId }> {}
 
 interface ScratchEvent {
   readonly notebookUri: NotebookId;
@@ -108,6 +117,7 @@ export class KernelManager extends Effect.Service<KernelManager>()(
       const code = yield* VsCode;
       const client = yield* LanguageClient;
       const renderer = yield* NotebookRenderer;
+      const controllers = yield* ControllerRegistry;
 
       const queue = yield* Queue.unbounded<MarimoOperation>();
 
@@ -274,13 +284,36 @@ export class KernelManager extends Effect.Service<KernelManager>()(
          * scratchpad's `completed-run` arrives — i.e. after any code-mode
          * cascade has settled, not merely when the scratch cell goes idle.
          */
-        executeCodeUnsafe(notebookUri: NotebookId, code: string) {
+        executeCodeUnsafe(notebookUri: NotebookId, sourceCode: string) {
           return Stream.unwrapScoped(
             Effect.gen(function* () {
               // Hold the lock for the full stream lifetime. withPermitsScoped
               // registers the release on the Scope that Stream.unwrapScoped
               // keeps open until any runner finishes.
               yield* TSemaphore.withPermitsScoped(scratchLock, 1);
+
+              // No selected kernel means no executable to start a session with,
+              // so fail before sending code that can never run.
+              const notebooks = yield* code.workspace.getNotebookDocuments();
+              const notebook = EffectArray.findFirst(
+                EffectArray.getSomes(
+                  notebooks.map((raw) => MarimoNotebookDocument.tryFrom(raw)),
+                ),
+                (nb) => nb.id === notebookUri,
+              );
+              if (Option.isNone(notebook)) {
+                return yield* new NoActiveKernelError({ notebookUri });
+              }
+              const controller = yield* controllers.getActiveController(
+                notebook.value,
+              );
+              if (Option.isNone(controller)) {
+                return yield* new NoActiveKernelError({ notebookUri });
+              }
+              const executable = yield* resolveControllerExecutable(
+                controller.value,
+                notebook.value,
+              );
 
               // 1. Subscribe BEFORE sending command (avoid race)
               const sub = yield* PubSub.subscribe(scratchOps);
@@ -292,7 +325,11 @@ export class KernelManager extends Effect.Service<KernelManager>()(
                 command: "marimo.api",
                 params: {
                   method: "execute-scratchpad",
-                  params: { notebookUri, inner: { code, runId } },
+                  params: {
+                    notebookUri,
+                    executable,
+                    inner: { code: sourceCode, runId },
+                  },
                 },
               });
 

--- a/extension/src/kernel/NotebookControllerFactory.ts
+++ b/extension/src/kernel/NotebookControllerFactory.ts
@@ -265,6 +265,7 @@ export class NotebookControllerFactory extends Effect.Service<NotebookController
 export class PythonController {
   readonly _tag = "PythonController";
   #inner: Omit<vscode.NotebookController, "dispose">;
+  /** The python interpreter this controller's environment runs on. */
   executable: string;
   constructor(
     inner: Omit<vscode.NotebookController, "dispose">,

--- a/extension/src/kernel/SandboxController.ts
+++ b/extension/src/kernel/SandboxController.ts
@@ -25,11 +25,9 @@ import {
 import { SemVerFromString } from "../schemas/SemVerFromString.ts";
 
 /**
- * Raised when a sandbox kernel is asked to run for an unsaved notebook. The
- * sandbox resolves a per-notebook venv from the script file on disk, so it
- * needs a saved path. Surfaced as a typed error so each caller can present it
- * its own way (the run handler prompts to save interactively; the scratchpad
- * path turns it into an agent-facing message).
+ * An error returned when a sandbox kernel is asked to run for an unsaved
+ * notebook. The sandbox derives a per-notebook virtual environment from the
+ * script file on disk, so the notebook must be saved first.
  */
 export class UnsavedNotebookError extends Data.TaggedError(
   "UnsavedNotebookError",

--- a/extension/src/kernel/SandboxController.ts
+++ b/extension/src/kernel/SandboxController.ts
@@ -1,5 +1,5 @@
 import * as semver from "@std/semver";
-import { Effect, Option, Runtime, Schema, Stream } from "effect";
+import { Data, Effect, Option, Runtime, Schema, Stream } from "effect";
 import type * as vscode from "vscode";
 
 import { MINIMUM_MARIMO_KERNEL_VERSION } from "../constants.ts";
@@ -20,8 +20,20 @@ import { Uv } from "../python/Uv.ts";
 import {
   type MarimoNotebookCell,
   MarimoNotebookDocument,
+  type NotebookId,
 } from "../schemas/MarimoNotebookDocument.ts";
 import { SemVerFromString } from "../schemas/SemVerFromString.ts";
+
+/**
+ * Raised when a sandbox kernel is asked to run for an unsaved notebook. The
+ * sandbox resolves a per-notebook venv from the script file on disk, so it
+ * needs a saved path. Surfaced as a typed error so each caller can present it
+ * its own way (the run handler prompts to save interactively; the scratchpad
+ * path turns it into an agent-facing message).
+ */
+export class UnsavedNotebookError extends Data.TaggedError(
+  "UnsavedNotebookError",
+)<{ readonly notebookUri: NotebookId }> {}
 
 export class SandboxController extends Effect.Service<SandboxController>()(
   "SandboxController",
@@ -48,6 +60,39 @@ export class SandboxController extends Effect.Service<SandboxController>()(
       controller.supportedLanguages = [LanguageId.Python, LanguageId.Sql];
       controller.description = "marimo sandbox controller";
 
+      // Sync the script's PEP 723 env and return the venv interpreter.
+      const resolveExecutable = Effect.fn(
+        "SandboxController.resolveExecutable",
+      )(function* (notebook: MarimoNotebookDocument) {
+        // The sandbox venv is derived from the script file on disk; an unsaved
+        // notebook has no path to sync. The run handler guards this earlier
+        // (prompts to save); the scratchpad path reaches here directly.
+        if (notebook.isUntitled) {
+          return yield* new UnsavedNotebookError({ notebookUri: notebook.id });
+        }
+
+        const requirements = yield* findRequirements(uv, notebook);
+
+        if (requirements.length > 0) {
+          yield* uvAddScriptSafe(requirements, notebook).pipe(
+            Effect.provideService(VsCode, code),
+            Effect.provideService(Uv, uv),
+          );
+        }
+
+        // always ensure the env is up to date
+        const venv = yield* uv.syncScript({ script: notebook.uri.fsPath }).pipe(
+          // Should be added by findRequirements or uvAddScriptSafe
+          Effect.catchTag("UvMissingPep723MetadataError", () =>
+            Effect.die("Expected PEP 723 metadata to be present"),
+          ),
+        );
+
+        const executable = getVenvPythonPath(venv);
+        yield* python.updateActiveEnvironmentPath(executable);
+        return executable;
+      });
+
       // Set up execution handler
       controller.executeHandler = (rawCells, rawNotebook) =>
         runPromise<void, never>(
@@ -71,45 +116,9 @@ export class SandboxController extends Effect.Service<SandboxController>()(
               return;
             }
 
-            // sandboxing only works with titled (saved) notebooks
-            if (notebook.isUntitled) {
-              const choice = yield* code.window.showInformationMessage(
-                "Sandboxing requires a saved file. Please save your notebook and re-run cells.",
-                {
-                  modal: true,
-                  items: ["Save"],
-                },
-              );
-
-              if (Option.isNone(choice)) {
-                return;
-              }
-
-              yield* notebook.save();
-              return;
-            }
-
-            const requirements = yield* findRequirements(uv, notebook);
-
-            if (requirements.length > 0) {
-              yield* uvAddScriptSafe(requirements, notebook).pipe(
-                Effect.provideService(VsCode, code),
-                Effect.provideService(Uv, uv),
-              );
-            }
-
-            // always ensure the env is up to date
-            const venv = yield* uv
-              .syncScript({ script: notebook.uri.fsPath })
-              .pipe(
-                // Should be added by findRequirements or uvAddScriptSafe
-                Effect.catchTag("UvMissingPep723MetadataError", () =>
-                  Effect.die("Expected PEP 723 metadata to be present"),
-                ),
-              );
-
-            const executable = getVenvPythonPath(venv);
-            yield* python.updateActiveEnvironmentPath(executable);
+            // resolveExecutable rejects unsaved notebooks (UnsavedNotebookError),
+            // handled below with an interactive save prompt.
+            const executable = yield* resolveExecutable(notebook);
 
             yield* client.executeCommand({
               command: "marimo.api",
@@ -123,7 +132,21 @@ export class SandboxController extends Effect.Service<SandboxController>()(
               },
             });
           }).pipe(
-            // Log everything
+            // Handle the expected "unsaved notebook" path before logging, so a
+            // normal save prompt isn't recorded as an error. (sandboxing only
+            // works with titled/saved notebooks)
+            Effect.catchTag("UnsavedNotebookError", () =>
+              Effect.gen(function* () {
+                const choice = yield* code.window.showInformationMessage(
+                  "Sandboxing requires a saved file. Please save your notebook and re-run cells.",
+                  { modal: true, items: ["Save"] },
+                );
+                if (Option.isSome(choice)) {
+                  yield* MarimoNotebookDocument.from(rawNotebook).save();
+                }
+              }),
+            ),
+            // Log everything else
             Effect.tapErrorCause(Effect.logError),
             Effect.catchTag("UvExecutionError", () =>
               showErrorAndPromptLogs(
@@ -194,7 +217,9 @@ export class SandboxController extends Effect.Service<SandboxController>()(
         );
 
       return {
+        _tag: "SandboxController" as const,
         id: controller.id,
+        resolveExecutable,
         createNotebookCellExecution(cell: MarimoNotebookCell) {
           return controller.createNotebookCellExecution(cell.rawNotebookCell);
         },

--- a/extension/src/types.ts
+++ b/extension/src/types.ts
@@ -107,7 +107,7 @@ type MarimoApiMethodMap = {
   "get-configuration": NotebookScoped<GetConfigurationRequest>;
   "update-configuration": NotebookScoped<UpdateConfigurationRequest>;
   "close-session": NotebookScoped<CloseSessionRequest>;
-  "execute-scratchpad": NotebookScoped<ExecuteScratchRequest>;
+  "execute-scratchpad": SessionScoped<ExecuteScratchRequest>;
   "export-as-html": NotebookScoped<ExportAsHtmlRequest>;
   "export-as-ipynb": NotebookScoped<ExportAsIpynbRequest>;
   interrupt: NotebookScoped<InterruptRequest>;

--- a/src/marimo_lsp/api.py
+++ b/src/marimo_lsp/api.py
@@ -171,7 +171,7 @@ async def close_session(
 async def execute_scratch(
     ls: LanguageServer,
     manager: LspSessionManager,
-    args: NotebookCommand[ExecuteScratchRequest],
+    args: SessionCommand[ExecuteScratchRequest],
 ):
     """Execute code in the scratchpad (isolated from dependency graph).
 
@@ -179,13 +179,10 @@ async def execute_scratch(
     ``marimo._code_mode.get_context()`` can bind inside the kernel. Cells come
     from the LSP notebook document (id-aligned with VS Code);
     outputs come from the session view.
+
+    Creates the session on demand when none exists, like :func:`run`.
     """
     logger.info(f"execute_scratch for {args.notebook_uri}")
-    session = manager.get_session(args.notebook_uri)
-    if not session:
-        logger.warning(f"No session found for {args.notebook_uri}")
-        return
-
     try:
         notebook = find_notebook_document(ls.workspace, args.notebook_uri)
     except KeyError:
@@ -194,6 +191,15 @@ async def execute_scratch(
             "skipping scratchpad execution"
         )
         return
+
+    session = manager.get_session(args.notebook_uri)
+    if session is None or session.kernel_manager.executable != args.executable:
+        session = manager.create_session(
+            server=ls,
+            executable=args.executable,
+            notebook_uri=args.notebook_uri,
+        )
+        logger.info(f"Created and synced session {args.notebook_uri}")
 
     session.instantiate(
         InstantiateNotebookRequest(auto_run=False, object_ids=[], values=[]),
@@ -543,7 +549,7 @@ async def handle_api_command(  # noqa: C901, PLR0911, PLR0912
         return await execute_scratch(
             ls,
             manager,
-            msgspec.convert(params, type=NotebookCommand[ExecuteScratchRequest]),
+            msgspec.convert(params, type=SessionCommand[ExecuteScratchRequest]),
         )
 
     logger.warning(f"Unknown API method: {method}")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -519,6 +519,7 @@ async def test_execute_scratchpad_binds_code_mode_and_emits_transaction(
                     "method": "execute-scratchpad",
                     "params": {
                         "notebookUri": uri,
+                        "executable": sys.executable,
                         "inner": {
                             "code": (
                                 "import marimo._code_mode as cm\n"
@@ -1786,3 +1787,82 @@ y\
             },
         ]
     )
+
+
+@pytest.mark.asyncio
+async def test_scratchpad_creates_session_when_missing(
+    client: LanguageClient,
+) -> None:
+    """execute-scratchpad creates the session on demand when none exists.
+
+    The notebook is opened but never run, so no session exists yet. Running
+    scratchpad code with an ``executable`` should behave like the user running
+    a cell: create the session, start the kernel, and run the code — emitting
+    the scratch cell's output — rather than hanging waiting for a completed-run
+    that a missing session could never send.
+    """
+    uri = "file:///create_on_scratch.py"
+    client.notebook_document_did_open(
+        lsp.DidOpenNotebookDocumentParams(
+            notebook_document=lsp.NotebookDocument(
+                uri=uri,
+                notebook_type="marimo-notebook",
+                version=1,
+                cells=[
+                    NotebookCell(
+                        kind=lsp.NotebookCellKind.Code,
+                        document=f"{uri}#cell1",
+                    )
+                ],
+            ),
+            cell_text_documents=[
+                lsp.TextDocumentItem(
+                    uri=f"{uri}#cell1",
+                    language_id="python",
+                    version=1,
+                    text="x = 10",
+                )
+            ],
+        ),
+    )
+
+    scratch_messages: list[dict] = []
+    scratch_done = asyncio.Event()
+
+    @client.feature("marimo/operation")
+    async def on_marimo_operation(params: Any) -> None:  # noqa: ANN401
+        msg = asdict(params)
+        op = msg.get("operation", {})
+        if op.get("op") == "cell-op" and op.get("cell_id") == "__scratch__":
+            scratch_messages.append(msg)
+            if op.get("status") == "idle":
+                await asyncio.sleep(0.1)
+                scratch_done.set()
+
+    # No cell was ever executed, so there is no session for this notebook yet.
+    await client.workspace_execute_command_async(
+        lsp.ExecuteCommandParams(
+            command="marimo.api",
+            arguments=[
+                {
+                    "method": "execute-scratchpad",
+                    "params": {
+                        "notebookUri": uri,
+                        "executable": sys.executable,
+                        "inner": {"code": "print('from new session')"},
+                    },
+                }
+            ],
+        )
+    )
+
+    # Must not hang: the session is created and the code runs.
+    await asyncio.wait_for(scratch_done.wait(), timeout=10.0)
+
+    stdout = "".join(
+        op["operation"]["console"]["data"]
+        for op in scratch_messages
+        if isinstance(op["operation"].get("console"), dict)
+        and op["operation"]["console"].get("channel") == "stdout"
+    )
+    assert stdout == snapshot("from new session\n")


### PR DESCRIPTION
Running scratchpad code—for example from the `executeCode` tool an agent uses
to drive a notebook—previously required a kernel session to already be running.
If the notebook was open but no cell had been run yet, the request quietly went
nowhere and the caller was left waiting on a result that never arrived.

Start the kernel on demand instead, the same way running a cell does: resolve
the interpreter for the notebook's selected kernel and bring up a session if one
isn't already running. An agent can now act on a notebook from the very first
step rather than depending on the user to run a cell first.

When no kernel is selected at all, that's reported back as an actionable signal
rather than failing silently, so the caller can ask the user to pick one.
