### PR TITLE
Cache environment validation across cell runs

### DIFF
--- a/extension/src/python/EnvironmentValidator.ts
+++ b/extension/src/python/EnvironmentValidator.ts
@@ -84,7 +84,7 @@ class EnvironmentRequirementError extends Data.TaggedError(
  *
  *   - marimo (with version requirement)
  *
- * using `env.executable`.
+ * by invoking the interpreter at `env.path`.
  *
  * Successful validations are cached per interpreter path — the check spawns
  * a subprocess that imports marimo, which costs seconds per run on slow
@@ -274,6 +274,11 @@ print(json.dumps(packages), flush=True)`,
   },
 ) {}
 
+/**
+ * A validated `py.Environment`. Cached by interpreter path, so only expose
+ * path-derived data — anything else (version, sysPrefix, …) can be stale on a
+ * cache hit.
+ */
 export class ValidPythonEnvironment extends Data.TaggedClass(
   "ValidPythonEnvironment",
 )<{

--- a/extension/src/python/EnvironmentValidator.ts
+++ b/extension/src/python/EnvironmentValidator.ts
@@ -3,10 +3,24 @@ import { NodeContext } from "@effect/platform-node";
 import type { PlatformError } from "@effect/platform/Error";
 import * as semver from "@std/semver";
 import type * as py from "@vscode/python-extension";
-import { Data, Effect, type ParseResult, Schema, Stream, String } from "effect";
+import {
+  Cache,
+  Data,
+  Duration,
+  Effect,
+  Equal,
+  Hash,
+  Option,
+  type ParseResult,
+  Schema,
+  Stream,
+  String,
+} from "effect";
 
 import { MINIMUM_MARIMO_KERNEL_VERSION } from "../constants.ts";
+import { VsCode } from "../platform/VsCode.ts";
 import { SemVerFromString } from "../schemas/SemVerFromString.ts";
+import { PythonEnvInvalidation } from "./PythonEnvInvalidation.ts";
 
 class InvalidExecutableError extends Data.TaggedError(
   "InvalidExecutableError",
@@ -26,6 +40,36 @@ class EnvironmentInspectionError extends Data.TaggedError(
   readonly stderr?: string;
 }> {}
 
+/**
+ * Upper bound on the environment-inspection subprocess. Spawning the
+ * interpreter can stall indefinitely on pathological filesystems (e.g. a
+ * venv on `/mnt/c` under WSL2); without a bound the cell execution that
+ * awaits validation hangs forever with no way to interrupt it.
+ *
+ * The check is a preflight nicety, not a correctness gate — a timeout is
+ * inconclusive, so we warn and proceed rather than block the run. If
+ * marimo genuinely isn't importable, the kernel launch fails with a clear
+ * error anyway.
+ */
+const INSPECTION_TIMEOUT = Duration.seconds(10);
+
+/**
+ * Cache key comparing environments by interpreter path while carrying the
+ * full `py.Environment` for the cache's lookup function.
+ */
+class EnvironmentKey implements Equal.Equal {
+  readonly env: py.Environment;
+  constructor(env: py.Environment) {
+    this.env = env;
+  }
+  [Equal.symbol](that: unknown): boolean {
+    return that instanceof EnvironmentKey && that.env.path === this.env.path;
+  }
+  [Hash.symbol](): number {
+    return Hash.string(this.env.path);
+  }
+}
+
 class EnvironmentRequirementError extends Data.TaggedError(
   "EnvironmentRequirementError",
 )<{
@@ -41,14 +85,25 @@ class EnvironmentRequirementError extends Data.TaggedError(
  *   - marimo (with version requirement)
  *
  * using `env.executable`.
+ *
+ * Successful validations are cached per interpreter path — the check spawns
+ * a subprocess that imports marimo, which costs seconds per run on slow
+ * platforms, and `validate` sits on the hot path of every cell execution.
+ * Failures are never cached, and the whole cache is dropped on
+ * `PythonEnvInvalidation` events (package installs, interpreter changes).
+ * An inspection that times out is treated (and cached) as valid with a
+ * warning, so a slow environment pays the wait once instead of on every
+ * run.
  */
 export class EnvironmentValidator extends Effect.Service<EnvironmentValidator>()(
   "EnvironmentValidator",
   {
-    dependencies: [NodeContext.layer],
-    effect: Effect.gen(function* () {
+    dependencies: [NodeContext.layer, PythonEnvInvalidation.Default],
+    scoped: Effect.gen(function* () {
       const executor = yield* CommandExecutor.CommandExecutor;
       const fs = yield* FileSystem.FileSystem;
+      const code = yield* VsCode;
+      const invalidation = yield* PythonEnvInvalidation;
 
       const EnvCheck = Schema.Array(
         Schema.Struct({
@@ -57,12 +112,11 @@ export class EnvironmentValidator extends Effect.Service<EnvironmentValidator>()
         }),
       );
 
-      return {
-        validate: Effect.fn(function* (env: py.Environment) {
-          const packages = yield* Command.make(
-            env.path,
-            "-c",
-            `\
+      const inspect = Effect.fnUntraced(function* (env: py.Environment) {
+        const packages = yield* Command.make(
+          env.path,
+          "-c",
+          `\
 import json, sys, io
 
 # Redirect stdout during imports so that noisy packages
@@ -82,91 +136,138 @@ except Exception:
 # Restore stdout and emit the result
 sys.stdout = _real_stdout
 print(json.dumps(packages), flush=True)`,
-          ).pipe(
-            Command.start,
-            Effect.flatMap((process) =>
-              Effect.all(
-                [
-                  process.exitCode,
-                  collectString(process.stdout),
-                  collectString(process.stderr),
-                ],
-                { concurrency: 3 },
-              ),
+        ).pipe(
+          Command.start,
+          Effect.flatMap((process) =>
+            Effect.all(
+              [
+                process.exitCode,
+                collectString(process.stdout),
+                collectString(process.stderr),
+              ],
+              { concurrency: 3 },
             ),
-            Effect.scoped,
-            Effect.andThen(([exitCode, stdout, stderr]) => {
-              if (exitCode !== 0) {
-                return Effect.fail(
-                  new EnvironmentInspectionError({ env, stdout, stderr }),
-                );
-              }
-              return Schema.decodeUnknown(Schema.parseJson(EnvCheck))(
-                stdout,
-              ).pipe(
-                Effect.catchAll(
-                  (cause) =>
-                    new EnvironmentInspectionError({
-                      env,
-                      cause,
-                      stdout,
-                      stderr,
-                    }),
-                ),
+          ),
+          Effect.scoped,
+          Effect.andThen(([exitCode, stdout, stderr]) => {
+            if (exitCode !== 0) {
+              return Effect.fail(
+                new EnvironmentInspectionError({ env, stdout, stderr }),
               );
-            }),
-            Effect.catchTag(
-              "SystemError",
-              Effect.fn(function* (error) {
-                const exists = yield* fs.exists(env.path);
-                return yield* exists
-                  ? error
-                  : new InvalidExecutableError({ env });
-              }),
-            ),
-            Effect.catchTag(
-              "BadArgument",
-              Effect.fn(function* (error) {
-                const exists = yield* fs.exists(env.path);
-                return yield* exists
-                  ? error
-                  : new InvalidExecutableError({ env });
-              }),
-            ),
-            Effect.catchAll((cause) =>
-              cause._tag === "EnvironmentInspectionError"
-                ? cause
-                : new EnvironmentInspectionError({ env, cause }),
-            ),
-            Effect.provideService(CommandExecutor.CommandExecutor, executor),
-          );
-
-          const diagnostics: Array<RequirementDiagnostic> = [];
-
-          for (const pkg of packages) {
-            if (pkg.version == null) {
-              diagnostics.push({ kind: "missing", package: pkg.name });
-            } else if (
-              pkg.name === "marimo" &&
-              !semver.greaterOrEqual(pkg.version, MINIMUM_MARIMO_KERNEL_VERSION)
-            ) {
-              diagnostics.push({
-                kind: "outdated",
-                package: "marimo",
-                currentVersion: pkg.version,
-                requiredVersion: MINIMUM_MARIMO_KERNEL_VERSION,
-              });
             }
-          }
+            return Schema.decodeUnknown(Schema.parseJson(EnvCheck))(
+              stdout,
+            ).pipe(
+              Effect.catchAll(
+                (cause) =>
+                  new EnvironmentInspectionError({
+                    env,
+                    cause,
+                    stdout,
+                    stderr,
+                  }),
+              ),
+            );
+          }),
+          Effect.catchTag(
+            "SystemError",
+            Effect.fn(function* (error) {
+              const exists = yield* fs.exists(env.path);
+              return yield* exists
+                ? error
+                : new InvalidExecutableError({ env });
+            }),
+          ),
+          Effect.catchTag(
+            "BadArgument",
+            Effect.fn(function* (error) {
+              const exists = yield* fs.exists(env.path);
+              return yield* exists
+                ? error
+                : new InvalidExecutableError({ env });
+            }),
+          ),
+          Effect.catchAll((cause) =>
+            cause._tag === "EnvironmentInspectionError"
+              ? cause
+              : new EnvironmentInspectionError({ env, cause }),
+          ),
+          Effect.timeoutOption(INSPECTION_TIMEOUT),
+          Effect.provideService(CommandExecutor.CommandExecutor, executor),
+        );
 
-          if (diagnostics.length > 0) {
-            return yield* new EnvironmentRequirementError({
-              env,
-              diagnostics,
+        if (Option.isNone(packages)) {
+          yield* Effect.logWarning(
+            "Environment inspection timed out; running without verification",
+          ).pipe(Effect.annotateLogs({ executable: env.path }));
+          yield* Effect.forkDaemon(
+            code.window.showWarningMessage(
+              `Could not verify marimo in ${env.path} (timed out); running anyway. ` +
+                `This can happen when the environment lives on a slow filesystem (e.g. a Windows drive mounted in WSL2).`,
+            ),
+          );
+          return new ValidPythonEnvironment({ inner: env });
+        }
+
+        const diagnostics: Array<RequirementDiagnostic> = [];
+
+        for (const pkg of packages.value) {
+          if (pkg.version == null) {
+            diagnostics.push({ kind: "missing", package: pkg.name });
+          } else if (
+            pkg.name === "marimo" &&
+            !semver.greaterOrEqual(pkg.version, MINIMUM_MARIMO_KERNEL_VERSION)
+          ) {
+            diagnostics.push({
+              kind: "outdated",
+              package: "marimo",
+              currentVersion: pkg.version,
+              requiredVersion: MINIMUM_MARIMO_KERNEL_VERSION,
             });
           }
+        }
 
-          return new ValidPythonEnvironment({ inner: env });
+        if (diagnostics.length > 0) {
+          return yield* new EnvironmentRequirementError({
+            env,
+            diagnostics,
+          });
+        }
+
+        return new ValidPythonEnvironment({ inner: env });
+      });
+
+      const cache = yield* Cache.make({
+        capacity: 32,
+        timeToLive: Duration.infinity,
+        lookup: (key: EnvironmentKey) => inspect(key.env),
+      });
+
+      yield* Effect.forkScoped(
+        invalidation
+          .changes()
+          .pipe(
+            Stream.runForEach((reason) =>
+              Effect.logDebug("Invalidating environment validation cache").pipe(
+                Effect.annotateLogs({ reason }),
+                Effect.andThen(cache.invalidateAll),
+              ),
+            ),
+          ),
+      );
+
+      return {
+        validate: Effect.fn("EnvironmentValidator.validate")(function* (
+          env: py.Environment,
+        ) {
+          const key = new EnvironmentKey(env);
+          // Only reuse successes: drop failed entries so a just-fixed
+          // environment (e.g. marimo installed in a terminal) is re-checked
+          // on the next run. Concurrent lookups for the same key still
+          // dedupe while the inspection is in flight.
+          return yield* cache
+            .get(key)
+            .pipe(Effect.tapError(() => cache.invalidate(key)));
         }),
       };
     }),

--- a/extension/src/python/__tests__/EnvironmentValidator.test.ts
+++ b/extension/src/python/__tests__/EnvironmentValidator.test.ts
@@ -12,6 +12,7 @@ import { TestTelemetryLive } from "../../__mocks__/TestTelemetry.ts";
 import { TestVsCode } from "../../__mocks__/TestVsCode.ts";
 import { EnvironmentValidator } from "../../python/EnvironmentValidator.ts";
 import { getVenvPythonPath } from "../../python/getVenvPythonPath.ts";
+import { PythonEnvInvalidation } from "../../python/PythonEnvInvalidation.ts";
 import { Uv } from "../../python/Uv.ts";
 import { SemVerFromString } from "../../schemas/SemVerFromString.ts";
 
@@ -37,6 +38,8 @@ const EnvironmentValidatorLive = Layer.empty.pipe(
   Layer.provideMerge(TempDir.Default),
   Layer.provideMerge(Uv.Default),
   Layer.provideMerge(EnvironmentValidator.Default),
+  Layer.provideMerge(PythonEnvInvalidation.Default),
+  Layer.provide(TestPythonExtension.Default),
   Layer.provide(TestSentryLive),
   Layer.provide(TestTelemetryLive),
   Layer.provide(TestVsCode.Default),
@@ -60,7 +63,9 @@ it.layer(EnvironmentValidatorLive)("EnvironmentValidator", (it) => {
       const validator = yield* EnvironmentValidator;
       const tmpdir = yield* TempDir;
 
-      const venv = NodePath.join(tmpdir.path, ".venv");
+      // Validation results are cached per interpreter path, so each test
+      // uses its own venv directory.
+      const venv = NodePath.join(tmpdir.path, ".venv-missing");
       yield* uv.venv(venv, { python, clear: true });
 
       const result = yield* Effect.either(
@@ -95,7 +100,7 @@ it.layer(EnvironmentValidatorLive)("EnvironmentValidator", (it) => {
       const validator = yield* EnvironmentValidator;
       const tmpdir = yield* TempDir;
 
-      const venv = NodePath.join(tmpdir.path, ".venv");
+      const venv = NodePath.join(tmpdir.path, ".venv-outdated");
       yield* uv.venv(venv, { python, clear: true });
       yield* uv.pipInstall(["marimo<0.16.0"], { venv });
 
@@ -139,7 +144,7 @@ it.layer(EnvironmentValidatorLive)("EnvironmentValidator", (it) => {
       const validator = yield* EnvironmentValidator;
       const tmpdir = yield* TempDir;
 
-      const venv = NodePath.join(tmpdir.path, ".venv");
+      const venv = NodePath.join(tmpdir.path, ".venv-ok");
       yield* uv.venv(venv, { python, clear: true });
       yield* uv.pipInstall(["marimo"], { venv });
 
@@ -161,7 +166,7 @@ it.layer(EnvironmentValidatorLive)("EnvironmentValidator", (it) => {
       const validator = yield* EnvironmentValidator;
       const tmpdir = yield* TempDir;
 
-      const venv = NodePath.join(tmpdir.path, ".venv");
+      const venv = NodePath.join(tmpdir.path, ".venv-nonexistent");
       NodeFs.rmSync(venv, { recursive: true, force: true });
 
       const result = yield* Effect.either(
@@ -330,6 +335,84 @@ it.layer(EnvironmentValidatorLive)("EnvironmentValidator", (it) => {
     );
 
     it.effect(
+      "should cache successful validation per environment",
+      Effect.fn(function* () {
+        const validator = yield* EnvironmentValidator;
+        const tmpdir = yield* TempDir;
+        const countFile = NodePath.join(tmpdir.path, "cached-success-count");
+        const json = JSON.stringify([{ name: "marimo", version: "1.0.0" }]);
+        const script = makeFakeExecutable(tmpdir.path, "cached-success", {
+          stdout: json,
+          exitCode: 0,
+          countFile,
+        });
+        const env = TestPythonExtension.makeGlobalEnv(script);
+
+        const first = yield* validator.validate(env);
+        const second = yield* validator.validate(env);
+
+        assert.strictEqual(first._tag, "ValidPythonEnvironment");
+        assert.strictEqual(second._tag, "ValidPythonEnvironment");
+        expect(runCount(countFile)).toBe(1);
+      }),
+    );
+
+    it.effect(
+      "should not cache failed validation",
+      Effect.fn(function* () {
+        const validator = yield* EnvironmentValidator;
+        const tmpdir = yield* TempDir;
+        const countFile = NodePath.join(tmpdir.path, "uncached-failure-count");
+        const json = JSON.stringify([{ name: "marimo", version: null }]);
+        const script = makeFakeExecutable(tmpdir.path, "uncached-failure", {
+          stdout: json,
+          exitCode: 0,
+          countFile,
+        });
+        const env = TestPythonExtension.makeGlobalEnv(script);
+
+        const first = yield* Effect.either(validator.validate(env));
+        const second = yield* Effect.either(validator.validate(env));
+
+        assert(Either.isLeft(first), "Expected first validation to fail");
+        assert(Either.isLeft(second), "Expected second validation to fail");
+        expect(runCount(countFile)).toBe(2);
+      }),
+    );
+
+    it.effect(
+      "should re-validate after a PythonEnvInvalidation event",
+      Effect.fn(function* () {
+        const validator = yield* EnvironmentValidator;
+        const invalidation = yield* PythonEnvInvalidation;
+        const tmpdir = yield* TempDir;
+        const countFile = NodePath.join(tmpdir.path, "invalidation-count");
+        const json = JSON.stringify([{ name: "marimo", version: "1.0.0" }]);
+        const script = makeFakeExecutable(tmpdir.path, "invalidation", {
+          stdout: json,
+          exitCode: 0,
+          countFile,
+        });
+        const env = TestPythonExtension.makeGlobalEnv(script);
+
+        yield* validator.validate(env);
+        expect(runCount(countFile)).toBe(1);
+
+        yield* invalidation.invalidate("package-install");
+
+        // The cache clears in a background fiber; yield and re-validate
+        // until the subprocess is spawned again.
+        let count = runCount(countFile);
+        for (let i = 0; i < 100 && count < 2; i++) {
+          yield* Effect.yieldNow();
+          yield* validator.validate(env);
+          count = runCount(countFile);
+        }
+        expect(count).toBe(2);
+      }),
+    );
+
+    it.effect(
       "should fail with EnvironmentInspectionError when stderr has content but exit code 0 and empty stdout",
       Effect.fn(function* () {
         const validator = yield* EnvironmentValidator;
@@ -355,10 +438,19 @@ it.layer(EnvironmentValidatorLive)("EnvironmentValidator", (it) => {
 function makeFakeExecutable(
   dir: string,
   name: string,
-  opts: { stdout: string; stderr?: string; exitCode: number },
+  opts: {
+    stdout: string;
+    stderr?: string;
+    exitCode: number;
+    /** File the script appends a line to on every invocation. */
+    countFile?: string;
+  },
 ): string {
   const scriptPath = NodePath.join(dir, name);
   const lines = ["#!/bin/bash"];
+  if (opts.countFile) {
+    lines.push(`echo run >> ${shellEscape(opts.countFile)}`);
+  }
   if (opts.stdout) {
     lines.push(`printf '%s' ${shellEscape(opts.stdout)}`);
   }
@@ -368,6 +460,16 @@ function makeFakeExecutable(
   lines.push(`exit ${opts.exitCode}`);
   NodeFs.writeFileSync(scriptPath, lines.join("\n"), { mode: 0o755 });
   return scriptPath;
+}
+
+/** Number of times a `countFile`-instrumented fake executable ran. */
+function runCount(countFile: string): number {
+  try {
+    return NodeFs.readFileSync(countFile, "utf8").split("\n").filter(Boolean)
+      .length;
+  } catch {
+    return 0;
+  }
 }
 
 function shellEscape(s: string): string {


### PR DESCRIPTION
Fixes #618

Every cell execution spawned a Python subprocess that imported marimo to check the interpreter before the run request was sent to the kernel. That put seconds of latency on every run, and could stall forever with no way to interrupt on some file systems.

Validation results are now cached per interpreter path, invalidated on package installs and interpreter changes (and immediately for failures), and the subprocess is bounded by a timeout.