### PR TITLE
Fix open-as-notebook URI handling

### DIFF
--- a/extension/src/commands/__tests__/openAsMarimoNotebook.test.ts
+++ b/extension/src/commands/__tests__/openAsMarimoNotebook.test.ts
@@ -1,0 +1,68 @@
+import { expect, it } from "@effect/vitest";
+import { Effect, Option } from "effect";
+
+import {
+  createTestTextDocument,
+  createTestTextEditor,
+  TestVsCode,
+} from "../../__mocks__/TestVsCode.ts";
+import { NOTEBOOK_TYPE } from "../../constants.ts";
+import { openAsMarimoNotebook } from "../openAsMarimoNotebook.ts";
+
+it.effect(
+  "opens a native VS Code URI passed by an editor action",
+  Effect.fn(function* () {
+    const vscode = yield* TestVsCode.make();
+    const uri = vscode.createMockUri("/test/notebook.py");
+
+    yield* openAsMarimoNotebook(uri).pipe(Effect.provide(vscode.layer));
+
+    expect(yield* vscode.executions).toEqual([
+      {
+        command: "vscode.openWith",
+        args: [uri, NOTEBOOK_TYPE],
+      },
+    ]);
+  }),
+);
+
+it.effect(
+  "parses and opens a URI string passed by a programmatic caller",
+  Effect.fn(function* () {
+    const vscode = yield* TestVsCode.make();
+
+    yield* openAsMarimoNotebook("file:///test/notebook.py").pipe(
+      Effect.provide(vscode.layer),
+    );
+
+    const executions = yield* vscode.executions;
+    expect(executions).toHaveLength(1);
+    expect(executions[0]?.command).toBe("vscode.openWith");
+    expect(executions[0]?.args[0]?.toString()).toBe("file:///test/notebook.py");
+    expect(executions[0]?.args[1]).toBe(NOTEBOOK_TYPE);
+  }),
+);
+
+it.effect(
+  "opens the active editor when called without an argument",
+  Effect.fn(function* () {
+    const vscode = yield* TestVsCode.make();
+    const document = createTestTextDocument(
+      "/test/notebook.py",
+      "python",
+      "app = marimo.App()",
+    );
+    yield* vscode.setActiveTextEditor(
+      Option.some(createTestTextEditor(document)),
+    );
+
+    yield* openAsMarimoNotebook().pipe(Effect.provide(vscode.layer));
+
+    expect(yield* vscode.executions).toEqual([
+      {
+        command: "vscode.openWith",
+        args: [document.uri, NOTEBOOK_TYPE],
+      },
+    ]);
+  }),
+);

--- a/extension/src/commands/openAsMarimoNotebook.ts
+++ b/extension/src/commands/openAsMarimoNotebook.ts
@@ -5,22 +5,37 @@ import { NOTEBOOK_TYPE } from "../constants.ts";
 import { VsCode } from "../platform/VsCode.ts";
 import { defineCommand } from "./defineCommand.ts";
 
+const UriSchema = Schema.declare<vscode.Uri>(
+  (value): value is vscode.Uri =>
+    typeof value === "object" &&
+    value !== null &&
+    "scheme" in value &&
+    typeof value.scheme === "string" &&
+    "path" in value &&
+    typeof value.path === "string" &&
+    "with" in value &&
+    typeof value.with === "function" &&
+    "toString" in value &&
+    typeof value.toString === "function",
+  { identifier: "vscode.Uri" },
+);
+
 export const openAsMarimoNotebook = defineCommand(
-  Schema.UndefinedOr(Schema.String),
-  Effect.fn("command.openAsMarimoNotebook")(function* (uriString) {
+  Schema.UndefinedOr(Schema.Union(Schema.String, UriSchema)),
+  Effect.fn("command.openAsMarimoNotebook")(function* (resource) {
     const code = yield* VsCode;
 
     let uri: vscode.Uri;
-    if (uriString !== undefined) {
-      const result = code.utils.parseUri(uriString);
+    if (typeof resource === "string") {
+      const result = code.utils.parseUri(resource);
       if (Either.isLeft(result)) {
         yield* code.window.showInformationMessage(
-          `Failed to parse notebook URI: ${JSON.stringify(uriString)}`,
+          `Failed to parse notebook URI: ${JSON.stringify(resource)}`,
         );
         return;
       }
       uri = result.right;
-    } else {
+    } else if (resource === undefined) {
       const editor = yield* code.window.getActiveTextEditor();
       if (Option.isNone(editor)) {
         yield* code.window.showInformationMessage(
@@ -29,6 +44,8 @@ export const openAsMarimoNotebook = defineCommand(
         return;
       }
       uri = editor.value.document.uri;
+    } else {
+      uri = resource;
     }
 
     // We open first before closing to handle multi-window scenarios correctly:


### PR DESCRIPTION
Closes #631

Editor title actions pass a vscode.Uri instead of a string.