### PR TITLE
ci: don't fail coverage comment on fork PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -304,6 +304,9 @@ jobs:
         run: python3 scripts/coverage_comment.py coverage-artifacts > comment.md
 
       - name: Post sticky PR comment
+        # Fork PRs run with a read-only GITHUB_TOKEN, so posting a comment
+        # fails with 403. Don't fail the check for external contributors.
+        continue-on-error: true
         uses: marocchino/sticky-pull-request-comment@52423e01640425a022ef5fd42c6fb5f633a02728 # v2.9.1
         with:
           header: coverage-report


### PR DESCRIPTION
## What

Add `continue-on-error: true` to the `Post sticky PR comment` step in the `coverage-report` job.

## Why

marimo-lsp is public and receives PRs from forks. On a fork PR, the `pull_request` event runs with a **read-only** `GITHUB_TOKEN`, so `marocchino/sticky-pull-request-comment` gets a 403 when it tries to post the coverage comment. Today that surfaces as a red X on the `Coverage / Report` check for external contributors — a confusing failure on a job that is purely informational.

## Approach

I used `continue-on-error: true` on the comment step rather than skipping the whole job with an `if:` guard on `github.event.pull_request.head.repo.fork`. This keeps the behavior maximally useful: the coverage comment is still attempted and posted whenever the token allows (all internal-branch PRs), and the check simply never turns red when the token is read-only. It's also robust to any other transient comment-post failure, not just the fork case. The rest of the job (artifact download, building `comment.md`) still runs, so its logs remain available.

The `coverage-report` job already unifies TypeScript (vitest json-summary) and Python (pytest-cov json) into a single sticky comment via `scripts/coverage_comment.py`, so no additional reporting actions are needed — this PR only hardens the existing, working setup against fork PRs.

Part of the marimo-team engineering-excellence initiative to make CI signal reliable for outside contributors.

## Verification

- `ci.yml` validated as well-formed YAML.
- Single-line behavior change; the existing coverage comment is confirmed working on internal PRs (e.g. #633, #607 carry the rendered "Coverage Report" table).