### PR TITLE
Filter noise from Sentry

### DIFF
--- a/extension/src/telemetry/Sentry.ts
+++ b/extension/src/telemetry/Sentry.ts
@@ -237,10 +237,15 @@ function shouldFilterMessage(message: string) {
     return false;
   }
 
-  // Filter '.vscode/extensions' or '.vscode\extensions'
+  // Filter noise from other extensions:
+  // - '.vscode/extensions' or '.vscode\extensions' paths
+  // - the Augment AI extension (AugmentExtensionSidecar / augmentcode.com),
+  //   which dominates this project's Sentry volume
   return (
     lowerMessage.includes(".vscode/extensions") ||
-    lowerMessage.includes(".vscode\\extensions")
+    lowerMessage.includes(".vscode\\extensions") ||
+    lowerMessage.includes("augmentextensionsidecar") ||
+    lowerMessage.includes("augmentcode")
   );
 }
 


### PR DESCRIPTION
The Augment AI extension (`AugmentExtensionSidecar` / `augmentcode.com`) accounts for ~78% of this project's Sentry volume (591k of 758k events in the last 24h), burying real signal like "Failed to start language server."

Extend `shouldFilterMessage` to drop those events alongside the existing `.vscode/extensions` filter. Messages containing "marimo" are still kept (existing early-return).