### PR TITLE
Allow Python 3.14 for bundled language server

### DIFF
--- a/extension/src/lsp/LanguageClient.ts
+++ b/extension/src/lsp/LanguageClient.ts
@@ -276,20 +276,33 @@ export class LanguageClient extends Effect.Service<LanguageClient>()(
 
 export const findLspExecutable = Effect.fn("findLspExecutable")(function* (
   uvBinary: string,
+  searchDirectory = __dirname,
 ) {
   // Look for bundled wheel matching marimo_lsp-* pattern
-  const sdistDir = NodeFs.readdirSync(__dirname).find((f) =>
+  const sdistDir = NodeFs.readdirSync(searchDirectory).find((f) =>
     f.startsWith("marimo_lsp-"),
   );
 
   if (sdistDir) {
-    const sdist = NodePath.join(__dirname, sdistDir);
+    const sdist = NodePath.join(searchDirectory, sdistDir);
     yield* Effect.logDebug("Using bundled marimo-lsp").pipe(
       Effect.annotateLogs({ sdist }),
     );
     return {
       command: uvBinary,
-      args: ["tool", "run", "--python", "3.13", "--from", sdist, "marimo-lsp"],
+      // Python 3.13 was originally pinned because marimo-lsp's dependencies
+      // did not support Python 3.14t. They now support 3.14 and 3.14t, so
+      // accept either minor version while retaining an upper bound to avoid
+      // selecting a future Python before its dependency support is verified.
+      args: [
+        "tool",
+        "run",
+        "--python",
+        ">=3.13,<3.15",
+        "--from",
+        sdist,
+        "marimo-lsp",
+      ],
     };
   }
 
@@ -298,6 +311,6 @@ export const findLspExecutable = Effect.fn("findLspExecutable")(function* (
 
   return {
     command: uvBinary,
-    args: ["run", "--directory", __dirname, "marimo-lsp"],
+    args: ["run", "--directory", searchDirectory, "marimo-lsp"],
   };
 });

--- a/extension/src/lsp/__tests__/LanguageClient.test.ts
+++ b/extension/src/lsp/__tests__/LanguageClient.test.ts
@@ -1,0 +1,44 @@
+import * as NodeFs from "node:fs";
+import * as NodeOs from "node:os";
+import * as NodePath from "node:path";
+
+import { describe, expect, it } from "@effect/vitest";
+import { Effect } from "effect";
+
+import { findLspExecutable } from "../LanguageClient.ts";
+
+describe("findLspExecutable", () => {
+  it.scoped("uses a compatible Python range for the bundled LSP", () =>
+    Effect.acquireUseRelease(
+      Effect.sync(() =>
+        NodeFs.mkdtempDisposableSync(
+          NodePath.join(NodeOs.tmpdir(), "marimo-lsp-language-client-"),
+        ),
+      ),
+      (directory) =>
+        Effect.gen(function* () {
+          const sdist = NodePath.join(directory.path, "marimo_lsp-0.1.0");
+          NodeFs.mkdirSync(sdist);
+
+          const executable = yield* findLspExecutable(
+            "bundled-uv",
+            directory.path,
+          );
+
+          expect(executable).toEqual({
+            command: "bundled-uv",
+            args: [
+              "tool",
+              "run",
+              "--python",
+              ">=3.13,<3.15",
+              "--from",
+              sdist,
+              "marimo-lsp",
+            ],
+          });
+        }),
+      (directory) => Effect.sync(() => directory.remove()),
+    ),
+  );
+});


### PR DESCRIPTION
The extension previously pinned Python 3.13 because dependencies did not support Python 3.14t. That support is now available, so a bounded range lets `uv` reuse more compatible installations without selecting an untested future
Python version.

Fixes #637.

