### PR TITLE
Show cell number and link in error messages instead of the raw cell id (#581)

### DIFF
--- a/extension/src/lib/__tests__/errors.test.ts
+++ b/extension/src/lib/__tests__/errors.test.ts
@@ -200,6 +200,57 @@ describe("prettyErrorMessage", () => {
     expect(result).toContain("cell-1</a>");
   });
 
+  it("escapes HTML-like content in an exception message when a cell ID mapper produces a link", () => {
+    const error: MarimoError = {
+      type: "exception",
+      msg: "<b>bad</b> value",
+      exception_type: "<script>Evil</script>",
+      raising_cell: cellId("918d2406-014b-4a20-9c9a-ba8cb7ab2ba2"),
+    };
+    const cellIdMapper = (id: string) =>
+      id === "918d2406-014b-4a20-9c9a-ba8cb7ab2ba2"
+        ? '<a href="#" data-message="...">cell-1</a>'
+        : undefined;
+    const result = prettyErrorMessage(error, cellIdMapper);
+    expect(result).not.toContain("<b>bad</b>");
+    expect(result).not.toContain("<script>Evil</script>");
+    expect(result).toContain("&lt;b&gt;bad&lt;/b&gt;");
+    expect(result).toContain("&lt;script&gt;Evil&lt;/script&gt;");
+    expect(result).toContain("<a href=");
+    expect(result).toContain("cell-1</a>");
+  });
+
+  it("does not escape HTML-like content in an exception message without a cell ID mapper link", () => {
+    const error: MarimoError = {
+      type: "exception",
+      msg: "<b>bad</b> value",
+      exception_type: "ValueError",
+      raising_cell: cellId("cell_5"),
+    };
+    expect(prettyErrorMessage(error)).toMatchInlineSnapshot(
+      `"ValueError: <b>bad</b> value (raised in cell: cell_5)"`,
+    );
+  });
+
+  it("escapes HTML-like content in a strict-exception message when a cell ID mapper produces a link", () => {
+    const error: MarimoError = {
+      type: "strict-exception",
+      msg: "<b>bad</b> access",
+      ref: "<img src=x>",
+      blamed_cell: cellId("918d2406-014b-4a20-9c9a-ba8cb7ab2ba2"),
+    };
+    const cellIdMapper = (id: string) =>
+      id === "918d2406-014b-4a20-9c9a-ba8cb7ab2ba2"
+        ? '<a href="#" data-message="...">cell-1</a>'
+        : undefined;
+    const result = prettyErrorMessage(error, cellIdMapper);
+    expect(result).not.toContain("<b>bad</b>");
+    expect(result).not.toContain("<img src=x>");
+    expect(result).toContain("&lt;b&gt;bad&lt;/b&gt;");
+    expect(result).toContain("&lt;img src=x&gt;");
+    expect(result).toContain("<a href=");
+  });
+
   it("handles ancestor-stopped error with cell ID mapper", () => {
     const error: MarimoError = {
       type: "ancestor-stopped",

--- a/extension/src/lib/__tests__/errors.test.ts
+++ b/extension/src/lib/__tests__/errors.test.ts
@@ -167,6 +167,52 @@ describe("prettyErrorMessage", () => {
     );
   });
 
+  it("handles exception error with raising cell and cell ID mapper (plain text)", () => {
+    const error: MarimoError = {
+      type: "exception",
+      msg: "division by zero",
+      exception_type: "ZeroDivisionError",
+      raising_cell: cellId("918d2406-014b-4a20-9c9a-ba8cb7ab2ba2"),
+    };
+    const cellIdMapper = (id: string) =>
+      id === "918d2406-014b-4a20-9c9a-ba8cb7ab2ba2" ? "cell-6" : undefined;
+    const result = prettyErrorMessage(error, cellIdMapper);
+    expect(result).not.toContain("918d2406-014b-4a20-9c9a-ba8cb7ab2ba2");
+    expect(result).toMatchInlineSnapshot(
+      `"ZeroDivisionError: division by zero (raised in cell: cell-6)"`,
+    );
+  });
+
+  it("handles exception error with raising cell and cell ID mapper (HTML link)", () => {
+    const error: MarimoError = {
+      type: "exception",
+      msg: "An ancestor raised an exception (NameError): ",
+      exception_type: "Ancestor raised",
+      raising_cell: cellId("918d2406-014b-4a20-9c9a-ba8cb7ab2ba2"),
+    };
+    const cellIdMapper = (id: string) =>
+      id === "918d2406-014b-4a20-9c9a-ba8cb7ab2ba2"
+        ? '<a href="#" data-message="...">cell-1</a>'
+        : undefined;
+    const result = prettyErrorMessage(error, cellIdMapper);
+    expect(result).not.toContain("918d2406-014b-4a20-9c9a-ba8cb7ab2ba2");
+    expect(result).toContain("<a href=");
+    expect(result).toContain("cell-1</a>");
+  });
+
+  it("handles ancestor-stopped error with cell ID mapper", () => {
+    const error: MarimoError = {
+      type: "ancestor-stopped",
+      msg: "Cell was not run because an ancestor was stopped",
+      raising_cell: cellId("918d2406-014b-4a20-9c9a-ba8cb7ab2ba2"),
+    };
+    const cellIdMapper = (id: string) =>
+      id === "918d2406-014b-4a20-9c9a-ba8cb7ab2ba2" ? "cell-3" : undefined;
+    const result = prettyErrorMessage(error, cellIdMapper);
+    expect(result).not.toContain("918d2406-014b-4a20-9c9a-ba8cb7ab2ba2");
+    expect(result).toContain("cell-3");
+  });
+
   it("handles exception error without raising cell", () => {
     const error: MarimoError = {
       type: "exception",

--- a/extension/src/lib/errors.ts
+++ b/extension/src/lib/errors.ts
@@ -9,14 +9,36 @@ export type MarimoError = ExtendsArray<CellOutput["data"]>;
 
 export type CellIdMapper = (cellId: NotebookCellId) => string | undefined;
 
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+/**
+ * Maps a raw cell id to a human-readable cell number (or clickable HTML link)
+ * when a mapper is available, falling back to the raw id otherwise. `isHtml`
+ * tells the caller whether the resulting message will be rendered as HTML, so
+ * user-controlled text interpolated alongside it can be escaped accordingly.
+ */
+function resolveCellRef(
+  cellId: NotebookCellId,
+  cellIdMapper?: CellIdMapper,
+): { text: string; isHtml: boolean } {
+  const mapped = cellIdMapper?.(cellId);
+  if (mapped === undefined) {
+    return { text: cellId, isHtml: false };
+  }
+  return { text: mapped, isHtml: mapped.includes("<a href=") };
+}
+
 export function prettyErrorMessage(
   error: MarimoError,
   cellIdMapper?: CellIdMapper,
 ): string {
-  // Map a raw cell id to a human-readable cell number (or clickable link) when
-  // a mapper is available, falling back to the raw id otherwise.
-  const cellRef = (cellId: NotebookCellId) => cellIdMapper?.(cellId) ?? cellId;
-
   switch (error.type) {
     case "setup-refs":
       return formatSetupRootError(error);
@@ -26,14 +48,36 @@ export function prettyErrorMessage(
       return formatMultipleDefinitionError(error, cellIdMapper);
     case "import-star":
       return error.msg;
-    case "ancestor-stopped":
-      return `Execution stopped because cell ${cellRef(error.raising_cell)} was stopped. ${error.msg}`;
-    case "ancestor-prevented":
-      return `Execution prevented: ${error.msg}${error.blamed_cell ? ` (cell: ${cellRef(error.blamed_cell)})` : ""}`;
-    case "exception":
-      return `${error.exception_type}: ${error.msg}${error.raising_cell ? ` (raised in cell: ${cellRef(error.raising_cell)})` : ""}`;
-    case "strict-exception":
-      return `Strict execution error: ${error.msg} (ref: ${error.ref}${error.blamed_cell ? `, cell: ${cellRef(error.blamed_cell)}` : ""})`;
+    case "ancestor-stopped": {
+      const cellRef = resolveCellRef(error.raising_cell, cellIdMapper);
+      const msg = cellRef.isHtml ? escapeHtml(error.msg) : error.msg;
+      return `Execution stopped because cell ${cellRef.text} was stopped. ${msg}`;
+    }
+    case "ancestor-prevented": {
+      const cellRef = error.blamed_cell
+        ? resolveCellRef(error.blamed_cell, cellIdMapper)
+        : undefined;
+      const msg = cellRef?.isHtml ? escapeHtml(error.msg) : error.msg;
+      return `Execution prevented: ${msg}${cellRef ? ` (cell: ${cellRef.text})` : ""}`;
+    }
+    case "exception": {
+      const cellRef = error.raising_cell
+        ? resolveCellRef(error.raising_cell, cellIdMapper)
+        : undefined;
+      const msg = cellRef?.isHtml ? escapeHtml(error.msg) : error.msg;
+      const exceptionType = cellRef?.isHtml
+        ? escapeHtml(error.exception_type)
+        : error.exception_type;
+      return `${exceptionType}: ${msg}${cellRef ? ` (raised in cell: ${cellRef.text})` : ""}`;
+    }
+    case "strict-exception": {
+      const cellRef = error.blamed_cell
+        ? resolveCellRef(error.blamed_cell, cellIdMapper)
+        : undefined;
+      const msg = cellRef?.isHtml ? escapeHtml(error.msg) : error.msg;
+      const ref = cellRef?.isHtml ? escapeHtml(error.ref) : error.ref;
+      return `Strict execution error: ${msg} (ref: ${ref}${cellRef ? `, cell: ${cellRef.text}` : ""})`;
+    }
     case "interruption":
       return "Execution interrupted";
     case "syntax":

--- a/extension/src/lib/errors.ts
+++ b/extension/src/lib/errors.ts
@@ -13,6 +13,10 @@ export function prettyErrorMessage(
   error: MarimoError,
   cellIdMapper?: CellIdMapper,
 ): string {
+  // Map a raw cell id to a human-readable cell number (or clickable link) when
+  // a mapper is available, falling back to the raw id otherwise.
+  const cellRef = (cellId: NotebookCellId) => cellIdMapper?.(cellId) ?? cellId;
+
   switch (error.type) {
     case "setup-refs":
       return formatSetupRootError(error);
@@ -23,13 +27,13 @@ export function prettyErrorMessage(
     case "import-star":
       return error.msg;
     case "ancestor-stopped":
-      return `Execution stopped because cell ${error.raising_cell} was stopped. ${error.msg}`;
+      return `Execution stopped because cell ${cellRef(error.raising_cell)} was stopped. ${error.msg}`;
     case "ancestor-prevented":
-      return `Execution prevented: ${error.msg}${error.blamed_cell ? ` (cell: ${error.blamed_cell})` : ""}`;
+      return `Execution prevented: ${error.msg}${error.blamed_cell ? ` (cell: ${cellRef(error.blamed_cell)})` : ""}`;
     case "exception":
-      return `${error.exception_type}: ${error.msg}${error.raising_cell ? ` (raised in cell: ${error.raising_cell})` : ""}`;
+      return `${error.exception_type}: ${error.msg}${error.raising_cell ? ` (raised in cell: ${cellRef(error.raising_cell)})` : ""}`;
     case "strict-exception":
-      return `Strict execution error: ${error.msg} (ref: ${error.ref}${error.blamed_cell ? `, cell: ${error.blamed_cell}` : ""})`;
+      return `Strict execution error: ${error.msg} (ref: ${error.ref}${error.blamed_cell ? `, cell: ${cellRef(error.blamed_cell)}` : ""})`;
     case "interruption":
       return "Execution interrupted";
     case "syntax":


### PR DESCRIPTION
## Why

When a cell fails because an ancestor raised, the error message pointed at the cell using its raw UUID, for example `(raised in cell: 918d2406-014b-4a20-9c9a-ba8cb7ab2ba2)`. That id means nothing to the user and gives no way to jump to the cell. This is issue marimo-team/marimo-lsp#581, where the maintainer confirmed we can fix it with a hyperlink.

`prettyErrorMessage` already takes a `cellIdMapper` that turns a cell id into a `cell-N` label, and into a clickable navigation link when a notebook is available. The multiple definition error already uses it. The exception and the other ancestor messages just did not.

## What

Thread the existing `cellIdMapper` through the remaining cases that render a raw cell id: exception, ancestor stopped, ancestor prevented, and strict exception. When a mapper is present the message shows the cell number and a link. When it is not, it falls back to the raw id exactly as before.

Before: `Ancestor raised: An ancestor raised an exception (NameError):  (raised in cell: 918d2406-014b-4a20-9c9a-ba8cb7ab2ba2)`

After: `Ancestor raised: An ancestor raised an exception (NameError):  (raised in cell: cell-1)` where `cell-1` is a clickable link to the cell.

## Acceptance criteria

- [X] Tests added (exception and ancestor stopped, plain text and HTML link)
- [X] Full TS suite passes (491 passed, 1 skipped)
- [X] No new lint or type errors introduced
- [X] No breaking changes (fallback to raw id preserved, existing snapshots unchanged)

Closes marimo-team/marimo-lsp#581