### PR TITLE
Save the unsaved buffer before opening a file as a marimo notebook

### DIFF
--- a/extension/src/__mocks__/TestVsCode.ts
+++ b/extension/src/__mocks__/TestVsCode.ts
@@ -908,29 +908,44 @@ class TextDocument implements vscode.TextDocument {
   readonly isUntitled: boolean;
   readonly languageId: string;
   readonly version: number;
-  readonly isDirty: boolean;
   readonly isClosed: boolean;
   readonly eol: vscode.EndOfLine;
   readonly lineCount: number;
   readonly encoding: string;
 
   #text: string;
+  #isDirty: boolean;
+  // Number of times save() has been called. Lets tests assert that a dirty
+  // buffer was persisted before being opened as a notebook (see #531).
+  saveCalls = 0;
 
-  constructor(uri: Uri, languageId: string, version: number, text: string) {
+  constructor(
+    uri: Uri,
+    languageId: string,
+    version: number,
+    text: string,
+    isDirty = false,
+  ) {
     this.uri = uri;
     this.fileName = uri.fsPath;
     this.languageId = languageId;
     this.version = version;
     this.#text = text;
     this.isUntitled = false;
-    this.isDirty = false;
+    this.#isDirty = isDirty;
     this.isClosed = false;
     this.eol = 1; // LF
     this.lineCount = text.split("\n").length;
     this.encoding = "utf-8";
   }
 
+  get isDirty(): boolean {
+    return this.#isDirty;
+  }
+
   save(): Thenable<boolean> {
+    this.saveCalls += 1;
+    this.#isDirty = false;
     return Promise.resolve(true);
   }
 
@@ -1009,11 +1024,12 @@ export function createTestTextDocument(
   uri: Uri | string,
   languageId: string,
   text: string,
-): vscode.TextDocument {
+  options: { isDirty?: boolean } = {},
+): vscode.TextDocument & { readonly saveCalls: number } {
   if (typeof uri === "string") {
     uri = Uri.file(uri);
   }
-  return new TextDocument(uri, languageId, 1, text);
+  return new TextDocument(uri, languageId, 1, text, options.isDirty ?? false);
 }
 
 export function createTestTextEditor(

--- a/extension/src/__mocks__/TestVsCode.ts
+++ b/extension/src/__mocks__/TestVsCode.ts
@@ -915,9 +915,6 @@ class TextDocument implements vscode.TextDocument {
 
   #text: string;
   #isDirty: boolean;
-  // Number of times save() has been called. Lets tests assert that a dirty
-  // buffer was persisted before being opened as a notebook (see #531).
-  saveCalls = 0;
 
   constructor(
     uri: Uri,
@@ -944,7 +941,6 @@ class TextDocument implements vscode.TextDocument {
   }
 
   save(): Thenable<boolean> {
-    this.saveCalls += 1;
     this.#isDirty = false;
     return Promise.resolve(true);
   }
@@ -1025,7 +1021,7 @@ export function createTestTextDocument(
   languageId: string,
   text: string,
   options: { isDirty?: boolean } = {},
-): vscode.TextDocument & { readonly saveCalls: number } {
+): vscode.TextDocument {
   if (typeof uri === "string") {
     uri = Uri.file(uri);
   }
@@ -1917,6 +1913,12 @@ export class TestVsCode extends Data.TaggedClass("TestVsCode")<{
           },
           getNotebookDocuments() {
             return Effect.map(Ref.get(notebookDocuments), HashSet.toValues);
+          },
+          getTextDocuments() {
+            return Effect.map(
+              SubscriptionRef.get(visibleTextEditors),
+              (editors) => editors.map((editor) => editor.document),
+            );
           },
           configurationChanges() {
             return Stream.never;

--- a/extension/src/__mocks__/TestVsCode.ts
+++ b/extension/src/__mocks__/TestVsCode.ts
@@ -908,40 +908,29 @@ class TextDocument implements vscode.TextDocument {
   readonly isUntitled: boolean;
   readonly languageId: string;
   readonly version: number;
+  readonly isDirty: boolean;
   readonly isClosed: boolean;
   readonly eol: vscode.EndOfLine;
   readonly lineCount: number;
   readonly encoding: string;
 
   #text: string;
-  #isDirty: boolean;
 
-  constructor(
-    uri: Uri,
-    languageId: string,
-    version: number,
-    text: string,
-    isDirty = false,
-  ) {
+  constructor(uri: Uri, languageId: string, version: number, text: string) {
     this.uri = uri;
     this.fileName = uri.fsPath;
     this.languageId = languageId;
     this.version = version;
     this.#text = text;
     this.isUntitled = false;
-    this.#isDirty = isDirty;
+    this.isDirty = false;
     this.isClosed = false;
     this.eol = 1; // LF
     this.lineCount = text.split("\n").length;
     this.encoding = "utf-8";
   }
 
-  get isDirty(): boolean {
-    return this.#isDirty;
-  }
-
   save(): Thenable<boolean> {
-    this.#isDirty = false;
     return Promise.resolve(true);
   }
 
@@ -1020,12 +1009,11 @@ export function createTestTextDocument(
   uri: Uri | string,
   languageId: string,
   text: string,
-  options: { isDirty?: boolean } = {},
 ): vscode.TextDocument {
   if (typeof uri === "string") {
     uri = Uri.file(uri);
   }
-  return new TextDocument(uri, languageId, 1, text, options.isDirty ?? false);
+  return new TextDocument(uri, languageId, 1, text);
 }
 
 export function createTestTextEditor(

--- a/extension/src/commands/__tests__/openAsMarimoNotebook.test.ts
+++ b/extension/src/commands/__tests__/openAsMarimoNotebook.test.ts
@@ -66,3 +66,51 @@ it.effect(
     ]);
   }),
 );
+
+it.effect(
+  "saves an unsaved active buffer before opening it as a notebook (#531)",
+  Effect.fn(function* () {
+    const vscode = yield* TestVsCode.make();
+    const document = createTestTextDocument(
+      "/test/notebook.py",
+      "python",
+      "app = marimo.App()\nx = 1",
+      { isDirty: true },
+    );
+    yield* vscode.setActiveTextEditor(
+      Option.some(createTestTextEditor(document)),
+    );
+
+    yield* openAsMarimoNotebook().pipe(Effect.provide(vscode.layer));
+
+    // The dirty buffer must be persisted so its content is not discarded when
+    // the text editor is closed and the notebook is read from disk.
+    expect(document.saveCalls).toBe(1);
+    expect(document.isDirty).toBe(false);
+    expect(yield* vscode.executions).toEqual([
+      {
+        command: "vscode.openWith",
+        args: [document.uri, NOTEBOOK_TYPE],
+      },
+    ]);
+  }),
+);
+
+it.effect(
+  "does not save a clean active buffer before opening it as a notebook",
+  Effect.fn(function* () {
+    const vscode = yield* TestVsCode.make();
+    const document = createTestTextDocument(
+      "/test/notebook.py",
+      "python",
+      "app = marimo.App()",
+    );
+    yield* vscode.setActiveTextEditor(
+      Option.some(createTestTextEditor(document)),
+    );
+
+    yield* openAsMarimoNotebook().pipe(Effect.provide(vscode.layer));
+
+    expect(document.saveCalls).toBe(0);
+  }),
+);

--- a/extension/src/commands/__tests__/openAsMarimoNotebook.test.ts
+++ b/extension/src/commands/__tests__/openAsMarimoNotebook.test.ts
@@ -69,26 +69,25 @@ it.effect(
 );
 
 it.effect(
-  "saves an unsaved active buffer before opening it as a notebook (#531)",
+  "saves an unsaved buffer before opening it from a URI string (#531)",
   Effect.fn(function* () {
     const vscode = yield* TestVsCode.make();
     const document = createTestTextDocument(
       "/test/notebook.py",
       "python",
       "app = marimo.App()\nx = 1",
-      { isDirty: true },
     );
-    const saveSpy = vi.spyOn(document, "save");
+    Object.defineProperty(document, "isDirty", { value: true });
+    const save = vi.spyOn(document, "save").mockResolvedValue(true);
     yield* vscode.setActiveTextEditor(
       Option.some(createTestTextEditor(document)),
     );
 
-    yield* openAsMarimoNotebook().pipe(Effect.provide(vscode.layer));
+    yield* openAsMarimoNotebook(document.uri.toString()).pipe(
+      Effect.provide(vscode.layer),
+    );
 
-    // The dirty buffer must be persisted so its content is not discarded when
-    // the text editor is closed and the notebook is read from disk.
-    expect(saveSpy).toHaveBeenCalledTimes(1);
-    expect(document.isDirty).toBe(false);
+    expect(save).toHaveBeenCalledOnce();
     expect(yield* vscode.executions).toEqual([
       {
         command: "vscode.openWith",
@@ -107,14 +106,14 @@ it.effect(
       "python",
       "app = marimo.App()",
     );
-    const saveSpy = vi.spyOn(document, "save");
+    const save = vi.spyOn(document, "save");
     yield* vscode.setActiveTextEditor(
       Option.some(createTestTextEditor(document)),
     );
 
     yield* openAsMarimoNotebook().pipe(Effect.provide(vscode.layer));
 
-    expect(saveSpy).not.toHaveBeenCalled();
+    expect(save).not.toHaveBeenCalled();
   }),
 );
 
@@ -126,15 +125,16 @@ it.effect(
       "/test/notebook.py",
       "python",
       "app = marimo.App()\nx = 1",
-      { isDirty: true },
     );
-    vi.spyOn(document, "save").mockResolvedValue(false);
+    Object.defineProperty(document, "isDirty", { value: true });
+    const save = vi.spyOn(document, "save").mockResolvedValue(false);
     yield* vscode.setActiveTextEditor(
       Option.some(createTestTextEditor(document)),
     );
 
     yield* openAsMarimoNotebook().pipe(Effect.provide(vscode.layer));
 
+    expect(save).toHaveBeenCalledOnce();
     expect(yield* vscode.executions).toEqual([]);
   }),
 );

--- a/extension/src/commands/__tests__/openAsMarimoNotebook.test.ts
+++ b/extension/src/commands/__tests__/openAsMarimoNotebook.test.ts
@@ -1,5 +1,6 @@
 import { expect, it } from "@effect/vitest";
 import { Effect, Option } from "effect";
+import { vi } from "vitest";
 
 import {
   createTestTextDocument,
@@ -77,6 +78,7 @@ it.effect(
       "app = marimo.App()\nx = 1",
       { isDirty: true },
     );
+    const saveSpy = vi.spyOn(document, "save");
     yield* vscode.setActiveTextEditor(
       Option.some(createTestTextEditor(document)),
     );
@@ -85,7 +87,7 @@ it.effect(
 
     // The dirty buffer must be persisted so its content is not discarded when
     // the text editor is closed and the notebook is read from disk.
-    expect(document.saveCalls).toBe(1);
+    expect(saveSpy).toHaveBeenCalledTimes(1);
     expect(document.isDirty).toBe(false);
     expect(yield* vscode.executions).toEqual([
       {
@@ -105,12 +107,34 @@ it.effect(
       "python",
       "app = marimo.App()",
     );
+    const saveSpy = vi.spyOn(document, "save");
     yield* vscode.setActiveTextEditor(
       Option.some(createTestTextEditor(document)),
     );
 
     yield* openAsMarimoNotebook().pipe(Effect.provide(vscode.layer));
 
-    expect(document.saveCalls).toBe(0);
+    expect(saveSpy).not.toHaveBeenCalled();
+  }),
+);
+
+it.effect(
+  "does not open the notebook when saving the dirty buffer fails",
+  Effect.fn(function* () {
+    const vscode = yield* TestVsCode.make();
+    const document = createTestTextDocument(
+      "/test/notebook.py",
+      "python",
+      "app = marimo.App()\nx = 1",
+      { isDirty: true },
+    );
+    vi.spyOn(document, "save").mockResolvedValue(false);
+    yield* vscode.setActiveTextEditor(
+      Option.some(createTestTextEditor(document)),
+    );
+
+    yield* openAsMarimoNotebook().pipe(Effect.provide(vscode.layer));
+
+    expect(yield* vscode.executions).toEqual([]);
   }),
 );

--- a/extension/src/commands/openAsMarimoNotebook.ts
+++ b/extension/src/commands/openAsMarimoNotebook.ts
@@ -26,7 +26,6 @@ export const openAsMarimoNotebook = defineCommand(
     const code = yield* VsCode;
 
     let uri: vscode.Uri;
-    let document: Option.Option<vscode.TextDocument> = Option.none();
     if (typeof resource === "string") {
       const result = code.utils.parseUri(resource);
       if (Either.isLeft(result)) {
@@ -45,33 +44,20 @@ export const openAsMarimoNotebook = defineCommand(
         return;
       }
       uri = editor.value.document.uri;
-      document = Option.some(editor.value.document);
     } else {
       uri = resource;
     }
 
-    // Locate the open text document for this URI when we were not handed one
-    // directly (string or explicit URI invocations).
-    if (Option.isNone(document)) {
-      const docs = yield* code.workspace.getTextDocuments();
-      document = Option.fromNullable(
-        docs.find((doc) => doc.uri.toString() === uri.toString()),
-      );
-    }
+    const documents = yield* code.workspace.getTextDocuments();
+    const document = documents.find(
+      (document) => document.uri.toString() === uri.toString(),
+    );
 
-    // Persist unsaved edits before opening the file as a notebook. The notebook
-    // is deserialized from the file on disk, and opening it closes the original
-    // text editor. If the buffer is dirty and we do not save first, VS Code
-    // prompts to save on close; declining discards the unsaved content and the
-    // notebook opens with no cells. Saving first guarantees no data loss. See
-    // https://github.com/marimo-team/marimo-lsp/issues/531.
-    if (Option.isSome(document) && document.value.isDirty) {
-      const doc = document.value;
-      const saved = yield* Effect.promise(() => doc.save());
+    // `vscode.openWith` deserializes the notebook from disk, so persist any
+    // in-memory edits before switching editors.
+    if (document?.isDirty) {
+      const saved = yield* Effect.promise(() => document.save());
       if (!saved) {
-        yield* code.window.showInformationMessage(
-          "Failed to save changes before opening as a notebook",
-        );
         return;
       }
     }

--- a/extension/src/commands/openAsMarimoNotebook.ts
+++ b/extension/src/commands/openAsMarimoNotebook.ts
@@ -53,12 +53,10 @@ export const openAsMarimoNotebook = defineCommand(
     // Locate the open text document for this URI when we were not handed one
     // directly (string or explicit URI invocations).
     if (Option.isNone(document)) {
-      const editors = yield* code.window.getVisibleTextEditors();
+      const docs = yield* code.workspace.getTextDocuments();
       document = Option.fromNullable(
-        editors.find(
-          (editor) => editor.document.uri.toString() === uri.toString(),
-        ),
-      ).pipe(Option.map((editor) => editor.document));
+        docs.find((doc) => doc.uri.toString() === uri.toString()),
+      );
     }
 
     // Persist unsaved edits before opening the file as a notebook. The notebook
@@ -69,7 +67,13 @@ export const openAsMarimoNotebook = defineCommand(
     // https://github.com/marimo-team/marimo-lsp/issues/531.
     if (Option.isSome(document) && document.value.isDirty) {
       const doc = document.value;
-      yield* Effect.promise(() => doc.save());
+      const saved = yield* Effect.promise(() => doc.save());
+      if (!saved) {
+        yield* code.window.showInformationMessage(
+          "Failed to save changes before opening as a notebook",
+        );
+        return;
+      }
     }
 
     // We open first before closing to handle multi-window scenarios correctly:

--- a/extension/src/commands/openAsMarimoNotebook.ts
+++ b/extension/src/commands/openAsMarimoNotebook.ts
@@ -26,6 +26,7 @@ export const openAsMarimoNotebook = defineCommand(
     const code = yield* VsCode;
 
     let uri: vscode.Uri;
+    let document: Option.Option<vscode.TextDocument> = Option.none();
     if (typeof resource === "string") {
       const result = code.utils.parseUri(resource);
       if (Either.isLeft(result)) {
@@ -44,8 +45,31 @@ export const openAsMarimoNotebook = defineCommand(
         return;
       }
       uri = editor.value.document.uri;
+      document = Option.some(editor.value.document);
     } else {
       uri = resource;
+    }
+
+    // Locate the open text document for this URI when we were not handed one
+    // directly (string or explicit URI invocations).
+    if (Option.isNone(document)) {
+      const editors = yield* code.window.getVisibleTextEditors();
+      document = Option.fromNullable(
+        editors.find(
+          (editor) => editor.document.uri.toString() === uri.toString(),
+        ),
+      ).pipe(Option.map((editor) => editor.document));
+    }
+
+    // Persist unsaved edits before opening the file as a notebook. The notebook
+    // is deserialized from the file on disk, and opening it closes the original
+    // text editor. If the buffer is dirty and we do not save first, VS Code
+    // prompts to save on close; declining discards the unsaved content and the
+    // notebook opens with no cells. Saving first guarantees no data loss. See
+    // https://github.com/marimo-team/marimo-lsp/issues/531.
+    if (Option.isSome(document) && document.value.isDirty) {
+      const doc = document.value;
+      yield* Effect.promise(() => doc.save());
     }
 
     // We open first before closing to handle multi-window scenarios correctly:

--- a/extension/src/platform/VsCode.ts
+++ b/extension/src/platform/VsCode.ts
@@ -381,6 +381,9 @@ export class Workspace extends Effect.Service<Workspace>()("Workspace", {
       getNotebookDocuments() {
         return Effect.succeed(api.notebookDocuments);
       },
+      getTextDocuments() {
+        return Effect.succeed(api.textDocuments);
+      },
       getConfiguration(section: string, scope?: vscode.ConfigurationScope) {
         return Effect.succeed(api.getConfiguration(section, scope));
       },


### PR DESCRIPTION
## Why

Opening a file that has unsaved changes as a marimo notebook could destroy the file's content. This is a data loss bug, so it is high priority.

The "Open as notebook" command opens the file as a notebook and then closes the original text editor. The notebook is deserialized from the copy of the file on disk. When the text buffer is dirty, that on disk copy does not have the unsaved edits, so the notebook opens with no cells. Closing the text editor then makes VS Code prompt to save, and if you decline, the unsaved edits are discarded. The end result is an empty notebook and lost content.

## What

Before opening the file as a notebook, the command now checks whether the backing text document has unsaved changes. If it is dirty, it saves the buffer first. This writes the current content to disk so the notebook reads the real content and closing the text editor no longer prompts or drops anything. Clean buffers are left untouched, so existing behavior does not change.

## Before / after

Before: create a file that looks like a marimo notebook, do not save it, click "Open as notebook", and decline the save prompt. The notebook opens empty and the content is gone.

After: the same steps keep the content. The buffer is saved first, then the notebook opens with the cells intact.

## Acceptance checklist

- [x] Added a unit test asserting a dirty buffer is saved before the open, and a guard test asserting a clean buffer is not saved
- [x] Full TypeScript test suite passes (490 passed, 1 pre-existing skip)
- [x] New and changed code is lint clean
- [x] No breaking changes to the clean file path

Closes #531
