### PR TITLE
Align LSP sessions with marimo IPC routing

### DIFF
--- a/src/marimo_lsp/kernel_manager.py
+++ b/src/marimo_lsp/kernel_manager.py
@@ -20,7 +20,7 @@ from marimo_lsp.loggers import get_logger
 if typing.TYPE_CHECKING:
     from marimo._config.manager import MarimoConfigManager
     from marimo._ipc.types import ConnectionInfo
-    from marimo._session import QueueManager
+    from marimo._session.types import QueueManager
 
     from marimo_lsp.app_file_manager import LspAppFileManager
 
@@ -89,7 +89,7 @@ class LspKernelManager(KernelManagerImpl):
         self,
         *,
         executable: str,
-        queue_manager: ipc.QueueManager,
+        queue_manager: QueueManager,
         app_file_manager: LspAppFileManager,
         config_manager: MarimoConfigManager,
         connection_info: ConnectionInfo,
@@ -107,7 +107,7 @@ class LspKernelManager(KernelManagerImpl):
             mode=SessionMode.RUN,
             config_manager=config_manager,
             configs=app_file_manager.app.cell_manager.config_map(),
-            queue_manager=typing.cast("QueueManager", queue_manager),
+            queue_manager=queue_manager,
             app_metadata=AppMetadata(
                 query_params={},
                 filename=app_file_manager.path,

--- a/src/marimo_lsp/session.py
+++ b/src/marimo_lsp/session.py
@@ -21,8 +21,8 @@ from marimo_lsp.loggers import get_logger
 
 if TYPE_CHECKING:
     from marimo._config.manager import MarimoConfigManager
-    from marimo._ipc import QueueManager
     from marimo._server.models.models import InstantiateNotebookRequest
+    from marimo._session.types import QueueManager
     from marimo._types.ids import ConsumerId
 
     from marimo_lsp.app_file_manager import LspAppFileManager
@@ -78,6 +78,8 @@ class LspSession:
             while not self._closed:
                 try:
                     msg = stream_queue.get(timeout=0.1)
+                    if msg is None:
+                        return
                     self.session_view.add_raw_notification(msg)
                     self._consumer.notify(msg)
                 except queue.Empty:  # noqa: PERF203
@@ -101,7 +103,7 @@ class LspSession:
     ) -> None:
         """Send a command to the kernel."""
         del from_consumer_id
-        self._queue_manager.control_queue.put(request)
+        self._queue_manager.put_control_request(request)
 
     def instantiate(
         self,

--- a/src/marimo_lsp/session_manager.py
+++ b/src/marimo_lsp/session_manager.py
@@ -7,10 +7,11 @@ from __future__ import annotations
 import typing
 from uuid import uuid4
 
-import marimo._ipc as ipc
 from marimo._config.manager import (
     get_default_config_manager,
 )
+from marimo._ipc import QueueManager as IpcQueues
+from marimo._session.managers import IPCQueueManagerImpl as IpcQueueManager
 
 from marimo_lsp.app_file_manager import LspAppFileManager
 from marimo_lsp.kernel_manager import LspKernelManager
@@ -77,7 +78,10 @@ class LspSessionManager:
         if notebook_uri in self._sessions:
             self.close_session(notebook_uri)
 
-        queue_manager, connection_info = ipc.QueueManager.create()
+        # IpcQueues owns the IPC transport; IpcQueueManager adapts it to
+        # marimo's session-level command routing and batching interface.
+        ipc_queues, connection_info = IpcQueues.create()
+        queue_manager = IpcQueueManager.from_ipc(ipc_queues)
         app_file_manager = LspAppFileManager(server=server, notebook_uri=notebook_uri)
         config_manager = get_default_config_manager(current_path=app_file_manager.path)
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,0 +1,59 @@
+# Copyright 2026 Marimo. All rights reserved.
+
+"""Tests for the LSP session."""
+
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+from marimo._runtime.commands import (
+    CodeCompletionCommand,
+    StopKernelCommand,
+    UpdateUIElementCommand,
+)
+from marimo._session.managers import IPCQueueManagerImpl
+from marimo._types.ids import CellId_t, RequestId, UIElementId
+
+from marimo_lsp.session import LspSession
+
+
+def _make_session() -> tuple[LspSession, Mock]:
+    session = LspSession.__new__(LspSession)
+    ipc_queue_manager = Mock()
+    session._queue_manager = IPCQueueManagerImpl.from_ipc(ipc_queue_manager)
+    return session, ipc_queue_manager
+
+
+def test_ui_element_updates_use_marimo_ipc_batching_route() -> None:
+    session, queue_manager = _make_session()
+    command = UpdateUIElementCommand(object_ids=[UIElementId("slider")], values=[1])
+
+    session.put_control_request(command, from_consumer_id=None)
+
+    queue_manager.control_queue.put.assert_called_once_with(command)
+    queue_manager.set_ui_element_queue.put.assert_called_once_with(command)
+    queue_manager.completion_queue.put.assert_not_called()
+
+
+def test_regular_commands_are_routed_to_control_queue_only() -> None:
+    session, queue_manager = _make_session()
+    command = StopKernelCommand()
+
+    session.put_control_request(command, from_consumer_id=None)
+
+    queue_manager.control_queue.put.assert_called_once_with(command)
+    queue_manager.set_ui_element_queue.put.assert_not_called()
+    queue_manager.completion_queue.put.assert_not_called()
+
+
+def test_out_of_band_commands_are_routed_to_completion_queue() -> None:
+    session, queue_manager = _make_session()
+    command = CodeCompletionCommand(
+        id=RequestId("request"), document="mo.", cell_id=CellId_t("cell")
+    )
+
+    session.put_control_request(command, from_consumer_id=None)
+
+    queue_manager.completion_queue.put.assert_called_once_with(command)
+    queue_manager.control_queue.put.assert_not_called()
+    queue_manager.set_ui_element_queue.put.assert_not_called()


### PR DESCRIPTION
marimo-lsp wrote commands directly to the raw control queue, bypassing the routing used by sandboxed marimo sessions. Wrap the IPC queues with `IPCQueueManagerImpl` and delegate session requests through it so UI, completion, and regular commands reach the appropriate queues.

Add regression tests for each routing category.
