### PR TITLE
Conflate pending UI element updates in the extension

### DIFF
--- a/extension/src/kernel/KernelManager.ts
+++ b/extension/src/kernel/KernelManager.ts
@@ -44,6 +44,7 @@ import {
 import { ExecutionRegistry } from "./ExecutionRegistry.ts";
 import { resolveImageDataUri, saveImageToDisk } from "./imageResolver.ts";
 import { handleMissingPackageAlert } from "./operations.ts";
+import { makeUiElementDispatcher } from "./UiElementDispatcher.ts";
 
 interface MarimoOperation {
   notebookUri: NotebookId;
@@ -130,6 +131,17 @@ export class KernelManager extends Effect.Service<KernelManager>()(
       // Semaphore to serialize concurrent scratchpad executions
       const scratchLock = yield* STM.commit(TSemaphore.make(1));
 
+      const uiElementDispatcher = yield* makeUiElementDispatcher(
+        (notebookId, request) =>
+          client.executeCommand({
+            command: "marimo.api",
+            params: {
+              method: "update-ui-element",
+              params: { notebookUri: notebookId, inner: request },
+            },
+          }),
+      );
+
       yield* Effect.forkScoped(
         client
           .streamOf("marimo/operation")
@@ -171,16 +183,7 @@ export class KernelManager extends Effect.Service<KernelManager>()(
               const notebook = MarimoNotebookDocument.from(editor.notebook);
               switch (message.command) {
                 case "update-ui-element": {
-                  yield* client.executeCommand({
-                    command: "marimo.api",
-                    params: {
-                      method: message.command,
-                      params: {
-                        notebookUri: notebook.id,
-                        inner: message.params,
-                      },
-                    },
-                  });
+                  yield* uiElementDispatcher.offer(notebook.id, message.params);
                   return;
                 }
                 case "invoke-function": {

--- a/extension/src/kernel/UiElementDispatcher.ts
+++ b/extension/src/kernel/UiElementDispatcher.ts
@@ -1,0 +1,180 @@
+import { Effect, HashMap, Option, Ref, Scope } from "effect";
+
+import type { NotebookId } from "../schemas/MarimoNotebookDocument.ts";
+import type { UIElementId, UpdateUIElementRequest } from "../types.ts";
+
+const NonEmptyUiPatchTypeId: unique symbol = Symbol("NonEmptyUiPatch");
+
+/** A last-write-wins collection containing at least one UI element update. */
+interface NonEmptyUiPatch {
+  readonly [NonEmptyUiPatchTypeId]: typeof NonEmptyUiPatchTypeId;
+  readonly values: HashMap.HashMap<UIElementId, unknown>;
+}
+
+/**
+ * A lane exists if and only if it has one request in flight.
+ *
+ * Absence from the lanes map represents idle, making "idle with pending work"
+ * unrepresentable. Pending is optional, but when present is guaranteed non-empty.
+ */
+interface ActiveUiLane {
+  readonly inFlight: NonEmptyUiPatch;
+  readonly pending: Option.Option<NonEmptyUiPatch>;
+}
+
+type UiLanes = HashMap.HashMap<NotebookId, ActiveUiLane>;
+
+function nonEmptyPatch(
+  values: HashMap.HashMap<UIElementId, unknown>,
+): NonEmptyUiPatch {
+  return { [NonEmptyUiPatchTypeId]: NonEmptyUiPatchTypeId, values };
+}
+
+function fromRequest(
+  request: UpdateUIElementRequest,
+): Option.Option<NonEmptyUiPatch> {
+  if (
+    request.objectIds.length === 0 ||
+    request.objectIds.length !== request.values.length
+  ) {
+    return Option.none();
+  }
+
+  let values = HashMap.empty<UIElementId, unknown>();
+  for (const [index, objectId] of request.objectIds.entries()) {
+    values = HashMap.set(values, objectId, request.values[index]);
+  }
+  return Option.some(nonEmptyPatch(values));
+}
+
+function merge(
+  older: NonEmptyUiPatch,
+  newer: NonEmptyUiPatch,
+): NonEmptyUiPatch {
+  let values = older.values;
+  for (const [objectId, value] of HashMap.entries(newer.values)) {
+    values = HashMap.set(values, objectId, value);
+  }
+  return nonEmptyPatch(values);
+}
+
+function toRequest(patch: NonEmptyUiPatch): UpdateUIElementRequest {
+  const entries = Array.from(HashMap.entries(patch.values));
+  return {
+    objectIds: entries.map(([objectId]) => objectId),
+    values: entries.map(([, value]) => value),
+  };
+}
+
+type SendUiElementRequest = (
+  notebookId: NotebookId,
+  request: UpdateUIElementRequest,
+) => Effect.Effect<unknown, unknown>;
+
+/**
+ * Creates a per-notebook, single-flight dispatcher for replaceable UI state.
+ *
+ * At most one request is sent at a time for each notebook. Updates received
+ * while it is in flight are merged by UI element ID into one pending request.
+ */
+export const makeUiElementDispatcher = Effect.fn(function* (
+  send: SendUiElementRequest,
+) {
+  const lanes = yield* Ref.make<UiLanes>(HashMap.empty());
+
+  const drain = Effect.fn(function* (
+    notebookId: NotebookId,
+    initial: NonEmptyUiPatch,
+  ) {
+    let current = initial;
+    while (true) {
+      yield* send(notebookId, toRequest(current)).pipe(
+        Effect.catchAll((error) =>
+          Effect.logError("Failed to send UI element update").pipe(
+            Effect.annotateLogs({ error, notebookId }),
+          ),
+        ),
+      );
+
+      const next = yield* Ref.modify(lanes, (state) =>
+        Option.match(HashMap.get(state, notebookId), {
+          onNone: () => [Option.none<NonEmptyUiPatch>(), state] as const,
+          onSome: (lane) =>
+            Option.match(lane.pending, {
+              onNone: () =>
+                [
+                  Option.none<NonEmptyUiPatch>(),
+                  HashMap.remove(state, notebookId),
+                ] as const,
+              onSome: (pending) =>
+                [
+                  Option.some(pending),
+                  HashMap.set(state, notebookId, {
+                    inFlight: pending,
+                    pending: Option.none(),
+                  }),
+                ] as const,
+            }),
+        }),
+      );
+
+      if (Option.isNone(next)) {
+        return;
+      }
+      current = next.value;
+    }
+  });
+
+  return {
+    offer(
+      notebookId: NotebookId,
+      request: UpdateUIElementRequest,
+    ): Effect.Effect<void, never, Scope.Scope> {
+      return Option.match(fromRequest(request), {
+        onNone: () =>
+          Effect.logWarning("Dropping invalid UI element update").pipe(
+            Effect.annotateLogs({
+              notebookId,
+              objectIdCount: request.objectIds.length,
+              valueCount: request.values.length,
+            }),
+          ),
+        onSome: (patch) =>
+          Effect.gen(function* () {
+            const start = yield* Ref.modify(lanes, (state) =>
+              Option.match(HashMap.get(state, notebookId), {
+                onNone: () =>
+                  [
+                    Option.some(patch),
+                    HashMap.set(state, notebookId, {
+                      inFlight: patch,
+                      pending: Option.none(),
+                    }),
+                  ] as const,
+                onSome: (lane) =>
+                  [
+                    Option.none<NonEmptyUiPatch>(),
+                    HashMap.set(state, notebookId, {
+                      ...lane,
+                      pending: Option.some(
+                        Option.match(lane.pending, {
+                          onNone: () => patch,
+                          onSome: (pending) => merge(pending, patch),
+                        }),
+                      ),
+                    }),
+                  ] as const,
+              }),
+            );
+
+            if (Option.isSome(start)) {
+              yield* drain(notebookId, start.value).pipe(
+                Effect.forkScoped,
+                Effect.asVoid,
+              );
+            }
+          }),
+      });
+    },
+  };
+});

--- a/extension/src/kernel/__tests__/UiElementDispatcher.test.ts
+++ b/extension/src/kernel/__tests__/UiElementDispatcher.test.ts
@@ -1,0 +1,176 @@
+import { assert, describe, it } from "@effect/vitest";
+import { Deferred, Effect, Ref } from "effect";
+
+import { makeUiElementDispatcher } from "../../kernel/UiElementDispatcher.ts";
+import { notebookId, uiElementId } from "../../lib/__tests__/branded.ts";
+import type { NotebookId } from "../../schemas/MarimoNotebookDocument.ts";
+import type { UIElementId, UpdateUIElementRequest } from "../../types.ts";
+
+const NOTEBOOK_A = notebookId("notebook-a");
+const NOTEBOOK_B = notebookId("notebook-b");
+const SLIDER = uiElementId("slider");
+const OTHER = uiElementId("other");
+
+function update(
+  ...entries: ReadonlyArray<readonly [UIElementId, unknown]>
+): UpdateUIElementRequest {
+  return {
+    objectIds: entries.map(([objectId]) => objectId),
+    values: entries.map(([, value]) => value),
+  };
+}
+
+function asMap(request: UpdateUIElementRequest): Map<UIElementId, unknown> {
+  return new Map(
+    request.objectIds.map((objectId, index) => [
+      objectId,
+      request.values[index],
+    ]),
+  );
+}
+
+describe("UiElementDispatcher", () => {
+  it.scoped(
+    "keeps only the latest pending value while a request is in flight",
+    Effect.fn(function* () {
+      const firstStarted = yield* Deferred.make<void>();
+      const releaseFirst = yield* Deferred.make<void>();
+      const secondStarted = yield* Deferred.make<void>();
+      const sent = yield* Ref.make<ReadonlyArray<UpdateUIElementRequest>>([]);
+
+      const dispatcher = yield* makeUiElementDispatcher(
+        Effect.fn(function* (_notebookId, request) {
+          yield* Ref.update(sent, (requests) => [...requests, request]);
+          const value = asMap(request).get(SLIDER);
+          if (value === 1) {
+            yield* Deferred.succeed(firstStarted, undefined);
+            yield* Deferred.await(releaseFirst);
+          } else if (value === 3) {
+            yield* Deferred.succeed(secondStarted, undefined);
+          }
+        }),
+      );
+
+      yield* dispatcher.offer(NOTEBOOK_A, update([SLIDER, 1]));
+      yield* Deferred.await(firstStarted);
+      yield* dispatcher.offer(NOTEBOOK_A, update([SLIDER, 2]));
+      yield* dispatcher.offer(NOTEBOOK_A, update([SLIDER, 3]));
+
+      assert.deepStrictEqual(
+        (yield* Ref.get(sent)).map((request) => asMap(request).get(SLIDER)),
+        [1],
+      );
+
+      yield* Deferred.succeed(releaseFirst, undefined);
+      yield* Deferred.await(secondStarted);
+
+      assert.deepStrictEqual(
+        (yield* Ref.get(sent)).map((request) => asMap(request).get(SLIDER)),
+        [1, 3],
+      );
+    }),
+  );
+
+  it.scoped(
+    "preserves pending updates for different UI elements",
+    Effect.fn(function* () {
+      const firstStarted = yield* Deferred.make<void>();
+      const releaseFirst = yield* Deferred.make<void>();
+      const secondStarted = yield* Deferred.make<UpdateUIElementRequest>();
+
+      const dispatcher = yield* makeUiElementDispatcher(
+        Effect.fn(function* (_notebookId, request) {
+          if (asMap(request).get(SLIDER) === 1) {
+            yield* Deferred.succeed(firstStarted, undefined);
+            yield* Deferred.await(releaseFirst);
+          } else {
+            yield* Deferred.succeed(secondStarted, request);
+          }
+        }),
+      );
+
+      yield* dispatcher.offer(NOTEBOOK_A, update([SLIDER, 1]));
+      yield* Deferred.await(firstStarted);
+      yield* dispatcher.offer(NOTEBOOK_A, update([SLIDER, 2]));
+      yield* dispatcher.offer(NOTEBOOK_A, update([OTHER, 9]));
+      yield* Deferred.succeed(releaseFirst, undefined);
+
+      assert.deepStrictEqual(
+        asMap(yield* Deferred.await(secondStarted)),
+        new Map([
+          [SLIDER, 2],
+          [OTHER, 9],
+        ]),
+      );
+    }),
+  );
+
+  it.scoped(
+    "does not let one notebook block another",
+    Effect.fn(function* () {
+      const notebookAStarted = yield* Deferred.make<void>();
+      const releaseNotebookA = yield* Deferred.make<void>();
+      const notebookBStarted = yield* Deferred.make<void>();
+
+      const dispatcher = yield* makeUiElementDispatcher(
+        Effect.fn(function* (notebookId: NotebookId) {
+          if (notebookId === NOTEBOOK_A) {
+            yield* Deferred.succeed(notebookAStarted, undefined);
+            yield* Deferred.await(releaseNotebookA);
+          } else {
+            yield* Deferred.succeed(notebookBStarted, undefined);
+          }
+        }),
+      );
+
+      yield* dispatcher.offer(NOTEBOOK_A, update([SLIDER, 1]));
+      yield* Deferred.await(notebookAStarted);
+      yield* dispatcher.offer(NOTEBOOK_B, update([SLIDER, 2]));
+      yield* Deferred.await(notebookBStarted);
+      yield* Deferred.succeed(releaseNotebookA, undefined);
+    }),
+  );
+
+  it.scoped(
+    "continues with the latest pending value after a send failure",
+    Effect.fn(function* () {
+      const firstStarted = yield* Deferred.make<void>();
+      const secondStarted = yield* Deferred.make<void>();
+
+      const dispatcher = yield* makeUiElementDispatcher(
+        (_notebookId, request) => {
+          const value = asMap(request).get(SLIDER);
+          if (value === 1) {
+            return Deferred.succeed(firstStarted, undefined).pipe(
+              Effect.andThen(Effect.fail("send failed")),
+            );
+          }
+          return Deferred.succeed(secondStarted, undefined);
+        },
+      );
+
+      yield* dispatcher.offer(NOTEBOOK_A, update([SLIDER, 1]));
+      yield* Deferred.await(firstStarted);
+      yield* dispatcher.offer(NOTEBOOK_A, update([SLIDER, 2]));
+      yield* Deferred.await(secondStarted);
+    }),
+  );
+
+  it.scoped(
+    "drops empty or misaligned wire requests",
+    Effect.fn(function* () {
+      const sends = yield* Ref.make(0);
+      const dispatcher = yield* makeUiElementDispatcher(() =>
+        Ref.update(sends, (n) => n + 1),
+      );
+
+      yield* dispatcher.offer(NOTEBOOK_A, { objectIds: [], values: [] });
+      yield* dispatcher.offer(NOTEBOOK_A, {
+        objectIds: [SLIDER, OTHER],
+        values: [1],
+      });
+
+      assert.strictEqual(yield* Ref.get(sends), 0);
+    }),
+  );
+});

--- a/extension/src/types.ts
+++ b/extension/src/types.ts
@@ -60,7 +60,8 @@ interface PackageScoped<T> extends NotebookScoped<T> {
 }
 
 type ExecuteCellsRequest = Schemas["ExecuteCellsRequest"];
-type UpdateUIElementRequest = Schemas["UpdateUIElementRequest"];
+export type UpdateUIElementRequest = Schemas["UpdateUIElementRequest"];
+export type UIElementId = UpdateUIElementRequest["objectIds"][number];
 type ModelRequest = Schemas["ModelRequest"];
 type InvokeFunctionRequest = Schemas["InvokeFunctionRequest"];
 type DeleteCellRequest = Schemas["DeleteCellRequest"];


### PR DESCRIPTION
Renderer messages were handled sequentially, so rapid slider updates accumulated while each LSP request was in flight and stale values kept executing after the interaction ended.

Add a per-notebook, single-flight dispatcher that retains one in-flight request and conflates pending values by UI element ID. This bounds queued work while preserving the latest value for every element.

Fixes #627.