### PR TITLE
Route kernel messages through runtime sessions

### DIFF
--- a/extension/src/commands/exportNotebookAsHtml.ts
+++ b/extension/src/commands/exportNotebookAsHtml.ts
@@ -1,14 +1,14 @@
 import { Effect, Either, Option, Schema } from "effect";
 
 import { showErrorAndPromptLogs } from "../lib/showErrorAndPromptLogs.ts";
-import { LanguageClient } from "../lsp/LanguageClient.ts";
+import { MarimoApiClient } from "../lsp/MarimoApiClient.ts";
 import { VsCode } from "../platform/VsCode.ts";
 import { MarimoNotebookDocument } from "../schemas/MarimoNotebookDocument.ts";
 
 export const exportNotebookAsHtml = Effect.fn("command.exportNotebookAsHtml")(
   function* () {
     const code = yield* VsCode;
-    const client = yield* LanguageClient;
+    const api = yield* MarimoApiClient;
     const notebook = Option.filterMap(
       yield* code.window.getActiveNotebookEditor(),
       (editor) => MarimoNotebookDocument.tryFrom(editor.notebook),
@@ -54,20 +54,14 @@ export const exportNotebookAsHtml = Effect.fn("command.exportNotebookAsHtml")(
       },
       Effect.fn(function* () {
         // Call the LSP API to export the notebook
-        const result = yield* client
-          .executeCommand({
-            command: "marimo.api",
-            params: {
-              method: "export-as-html",
-              params: {
-                notebookUri: notebook.value.id,
-                inner: {
-                  download: false,
-                  files: [],
-                  includeCode: true,
-                  assetUrl: null,
-                },
-              },
+        const result = yield* api
+          .exportAsHtml({
+            notebookUri: notebook.value.id,
+            inner: {
+              download: false,
+              files: [],
+              includeCode: true,
+              assetUrl: null,
             },
           })
           .pipe(

--- a/extension/src/commands/publishMarimoNotebookGist.ts
+++ b/extension/src/commands/publishMarimoNotebookGist.ts
@@ -3,7 +3,7 @@ import * as NodePath from "node:path";
 import { Cause, Chunk, Effect, Either, flow, Schema, Option } from "effect";
 
 import { showErrorAndPromptLogs } from "../lib/showErrorAndPromptLogs.ts";
-import { LanguageClient } from "../lsp/LanguageClient.ts";
+import { MarimoApiClient } from "../lsp/MarimoApiClient.ts";
 import { NotebookSerializer } from "../notebook/NotebookSerializer.ts";
 import { GitHubClient } from "../platform/GitHubClient.ts";
 import { VsCode } from "../platform/VsCode.ts";
@@ -15,7 +15,7 @@ export const publishMarimoNotebookGist = Effect.fn(
   function* () {
     const code = yield* VsCode;
     const gh = yield* GitHubClient;
-    const client = yield* LanguageClient;
+    const api = yield* MarimoApiClient;
     const serializer = yield* NotebookSerializer;
 
     const notebook = Option.filterMap(
@@ -62,16 +62,10 @@ export const publishMarimoNotebookGist = Effect.fn(
     };
 
     // Try to export ipynb with outputs for GitHub rendering
-    const ipynbResult = yield* client
-      .executeCommand({
-        command: "marimo.api",
-        params: {
-          method: "export-as-ipynb",
-          params: {
-            notebookUri: notebook.value.id,
-            inner: {},
-          },
-        },
+    const ipynbResult = yield* api
+      .exportAsIpynb({
+        notebookUri: notebook.value.id,
+        inner: {},
       })
       .pipe(Effect.andThen(Schema.decodeUnknown(Schema.String)), Effect.either);
 

--- a/extension/src/commands/restartKernel.ts
+++ b/extension/src/commands/restartKernel.ts
@@ -1,14 +1,14 @@
 import { Effect, Either, Option } from "effect";
 
 import { ExecutionRegistry } from "../kernel/ExecutionRegistry.ts";
+import { RuntimeSessions } from "../kernel/RuntimeSessions.ts";
 import { showErrorAndPromptLogs } from "../lib/showErrorAndPromptLogs.ts";
-import { LanguageClient } from "../lsp/LanguageClient.ts";
 import { VsCode } from "../platform/VsCode.ts";
 import { MarimoNotebookDocument } from "../schemas/MarimoNotebookDocument.ts";
 
 export const restartKernel = Effect.fn("command.restartKernel")(function* () {
   const code = yield* VsCode;
-  const client = yield* LanguageClient;
+  const runtimeSessions = yield* RuntimeSessions;
   const executions = yield* ExecutionRegistry;
 
   const editor = yield* code.window.getActiveNotebookEditor();
@@ -36,18 +36,8 @@ export const restartKernel = Effect.fn("command.restartKernel")(function* () {
     Effect.fn(function* (progress) {
       progress.report({ message: "Closing session..." });
 
-      const result = yield* client
-        .executeCommand({
-          command: "marimo.api",
-          params: {
-            method: "close-session",
-            params: {
-              notebookUri: notebook.value.id,
-              inner: {},
-            },
-          },
-        })
-        .pipe(Effect.either);
+      const session = yield* runtimeSessions.getOrCreate(notebook.value.id);
+      const result = yield* session.close().pipe(Effect.either);
 
       if (Either.isLeft(result)) {
         yield* Effect.logFatal("Failed to restart kernel", result.left);

--- a/extension/src/config/MarimoConfigurationService.ts
+++ b/extension/src/config/MarimoConfigurationService.ts
@@ -7,7 +7,7 @@ import {
   SubscriptionRef,
 } from "effect";
 
-import { LanguageClient } from "../lsp/LanguageClient.ts";
+import { MarimoApiClient } from "../lsp/MarimoApiClient.ts";
 import { NotebookEditorRegistry } from "../notebook/NotebookEditorRegistry.ts";
 import type { NotebookId } from "../schemas/MarimoNotebookDocument.ts";
 import type { MarimoConfig } from "../types.ts";
@@ -22,8 +22,9 @@ import { MarimoConfigResponseSchema } from "./schemas.ts";
 export class MarimoConfigurationService extends Effect.Service<MarimoConfigurationService>()(
   "MarimoConfigurationService",
   {
+    dependencies: [MarimoApiClient.Default],
     scoped: Effect.gen(function* () {
-      const client = yield* LanguageClient;
+      const api = yield* MarimoApiClient;
       const editorRegistry = yield* NotebookEditorRegistry;
 
       // Track configurations: NotebookUri -> MarimoConfig
@@ -50,15 +51,9 @@ export class MarimoConfigurationService extends Effect.Service<MarimoConfigurati
               Effect.annotateLogs({ notebookUri }),
             );
 
-            const result = yield* client.executeCommand({
-              command: "marimo.api",
-              params: {
-                method: "get-configuration",
-                params: {
-                  notebookUri,
-                  inner: {},
-                },
-              },
+            const result = yield* api.getConfiguration({
+              notebookUri,
+              inner: {},
             });
 
             // The LSP may return null when the server is restarting, the
@@ -108,16 +103,10 @@ export class MarimoConfigurationService extends Effect.Service<MarimoConfigurati
             );
 
             // Send update to LSP server
-            const result = yield* client.executeCommand({
-              command: "marimo.api",
-              params: {
-                method: "update-configuration",
-                params: {
-                  notebookUri,
-                  inner: {
-                    config: partialConfig,
-                  },
-                },
+            const result = yield* api.updateConfiguration({
+              notebookUri,
+              inner: {
+                config: partialConfig,
               },
             });
 

--- a/extension/src/features/Main.ts
+++ b/extension/src/features/Main.ts
@@ -17,6 +17,7 @@ import { ControllerRegistry } from "../kernel/ControllerRegistry.ts";
 import { DebugAdapter } from "../kernel/DebugAdapter.ts";
 import { ExecutionRegistry } from "../kernel/ExecutionRegistry.ts";
 import { KernelManager } from "../kernel/KernelManager.ts";
+import { RuntimeSessions } from "../kernel/RuntimeSessions.ts";
 import { SandboxController } from "../kernel/SandboxController.ts";
 import { SessionStateManager } from "../kernel/SessionStateManager.ts";
 import type { LanguageClient } from "../lsp/LanguageClient.ts";
@@ -104,6 +105,7 @@ const MainLive = Layer.empty
     Layer.provide(CellStateManager.Default),
     Layer.provide(SessionStateManager.Default),
     Layer.provide(ControllerRegistry.Default),
+    Layer.provide(RuntimeSessions.Default),
     Layer.provide(NotebookEditorRegistry.Default),
     Layer.provide(SandboxController.Default),
     Layer.provide(Uv.Default),

--- a/extension/src/features/Main.ts
+++ b/extension/src/features/Main.ts
@@ -21,6 +21,7 @@ import { RuntimeSessions } from "../kernel/RuntimeSessions.ts";
 import { SandboxController } from "../kernel/SandboxController.ts";
 import { SessionStateManager } from "../kernel/SessionStateManager.ts";
 import type { LanguageClient } from "../lsp/LanguageClient.ts";
+import { MarimoApiClient } from "../lsp/MarimoApiClient.ts";
 import type { RuffLanguageServer } from "../lsp/RuffLanguageServer.ts";
 import type { TyLanguageServer } from "../lsp/TyLanguageServer.ts";
 import { CellMetadataUIBindingService } from "../notebook/CellMetadataUIBindingService.ts";
@@ -116,6 +117,7 @@ const MainLive = Layer.empty
     Layer.provide(OutputChannel.Default),
     Layer.provide(PythonEnvInvalidation.Default),
     Layer.provide(RuntimeSessions.Default),
+    Layer.provide(MarimoApiClient.Default),
   );
 
 export function makeActivate(

--- a/extension/src/features/Main.ts
+++ b/extension/src/features/Main.ts
@@ -105,7 +105,6 @@ const MainLive = Layer.empty
     Layer.provide(CellStateManager.Default),
     Layer.provide(SessionStateManager.Default),
     Layer.provide(ControllerRegistry.Default),
-    Layer.provide(RuntimeSessions.Default),
     Layer.provide(NotebookEditorRegistry.Default),
     Layer.provide(SandboxController.Default),
     Layer.provide(Uv.Default),
@@ -116,6 +115,7 @@ const MainLive = Layer.empty
     Layer.provide(Config.Default),
     Layer.provide(OutputChannel.Default),
     Layer.provide(PythonEnvInvalidation.Default),
+    Layer.provide(RuntimeSessions.Default),
   );
 
 export function makeActivate(

--- a/extension/src/features/ThemeSync.ts
+++ b/extension/src/features/ThemeSync.ts
@@ -1,6 +1,6 @@
 import { Effect, Layer, Stream } from "effect";
 
-import { LanguageClient } from "../lsp/LanguageClient.ts";
+import { MarimoApiClient } from "../lsp/MarimoApiClient.ts";
 import { NotebookEditorRegistry } from "../notebook/NotebookEditorRegistry.ts";
 import { VsCode } from "../platform/VsCode.ts";
 
@@ -14,7 +14,7 @@ import { VsCode } from "../platform/VsCode.ts";
 export const ThemeSyncLive = Layer.scopedDiscard(
   Effect.gen(function* () {
     const code = yield* VsCode;
-    const client = yield* LanguageClient;
+    const api = yield* MarimoApiClient;
     const editorRegistry = yield* NotebookEditorRegistry;
 
     yield* Effect.forkScoped(
@@ -24,26 +24,18 @@ export const ThemeSyncLive = Layer.scopedDiscard(
       ).pipe(
         Stream.runForEach(
           Effect.fn("ThemeSync.sync")(function* ([theme]) {
-            yield* client
-              .executeCommand({
-                command: "marimo.api",
-                params: {
-                  method: "set-display-theme",
-                  params: { theme },
-                },
-              })
-              .pipe(
-                Effect.catchAll(
-                  Effect.fn(function* (error) {
-                    yield* Effect.logWarning("Failed to sync theme").pipe(
-                      Effect.annotateLogs({ error }),
-                    );
-                  }),
-                ),
-              );
+            yield* api.setDisplayTheme({ theme }).pipe(
+              Effect.catchAll(
+                Effect.fn(function* (error) {
+                  yield* Effect.logWarning("Failed to sync theme").pipe(
+                    Effect.annotateLogs({ error }),
+                  );
+                }),
+              ),
+            );
           }),
         ),
       ),
     );
   }),
-);
+).pipe(Layer.provide(MarimoApiClient.Default));

--- a/extension/src/kernel/KernelManager.ts
+++ b/extension/src/kernel/KernelManager.ts
@@ -2,7 +2,6 @@ import {
   Data,
   Effect,
   Option,
-  Queue,
   Runtime,
   Stream,
   Array as EffectArray,
@@ -47,6 +46,22 @@ export class NoActiveKernelError extends Data.TaggedError(
 )<{ readonly notebookUri: NotebookId }> {}
 
 /**
+ * Process operations in arrival order for each notebook. Operations from
+ * different notebooks may run concurrently.
+ */
+export function processRuntimeOperations<E, R>(
+  operations: Stream.Stream<MarimoOperation>,
+  process: (operation: MarimoOperation) => Effect.Effect<void, E, R>,
+): Effect.Effect<void, E, R> {
+  return operations.pipe(
+    Stream.mapEffect(process, {
+      key: (operation) => operation.notebookUri,
+    }),
+    Stream.runDrain,
+  );
+}
+
+/**
  * Orchestrates kernel operations for marimo notebooks by composing
  * MarimoLanguageClient, MarimoNotebookRenderer, and MarimoNotebookControllers.
  *
@@ -77,18 +92,10 @@ export class KernelManager extends Effect.Service<KernelManager>()(
       const controllers = yield* ControllerRegistry;
       const runtimeSessions = yield* RuntimeSessions;
 
-      const queue = yield* Queue.unbounded<MarimoOperation>();
-
       yield* Effect.forkScoped(
-        runtimeSessions
-          .operations()
-          .pipe(Stream.runForEach((msg) => Queue.offer(queue, msg))),
-      );
-
-      yield* Effect.forkScoped(
-        Effect.gen(function* () {
-          while (true) {
-            const msg = yield* Queue.take(queue);
+        processRuntimeOperations(
+          runtimeSessions.operations(),
+          Effect.fn("KernelManager.processOperation")(function* (msg) {
             yield* processOperation(msg).pipe(
               Effect.annotateLogs({
                 notebookUri: msg.notebookUri,
@@ -108,8 +115,8 @@ export class KernelManager extends Effect.Service<KernelManager>()(
                 }),
               ),
             );
-          }
-        }),
+          }),
+        ),
       );
 
       // renderer (i.e., front end) -> kernel

--- a/extension/src/kernel/KernelManager.ts
+++ b/extension/src/kernel/KernelManager.ts
@@ -1,14 +1,10 @@
 import {
   Data,
   Effect,
-  Exit,
   Option,
-  PubSub,
   Queue,
   Runtime,
-  STM,
   Stream,
-  TSemaphore,
   Array as EffectArray,
 } from "effect";
 
@@ -16,7 +12,6 @@ import { unreachable } from "../assert.ts";
 import { Config } from "../config/Config.ts";
 import { SCRATCH_CELL_ID } from "../constants.ts";
 import { showErrorAndPromptLogs } from "../lib/showErrorAndPromptLogs.ts";
-import { LanguageClient } from "../lsp/LanguageClient.ts";
 import { applyDocumentTransaction } from "../notebook/applyDocumentTransaction.ts";
 import { NotebookEditorRegistry } from "../notebook/NotebookEditorRegistry.ts";
 import { NotebookRenderer } from "../notebook/NotebookRenderer.ts";
@@ -51,40 +46,6 @@ export class NoActiveKernelError extends Data.TaggedError(
   "NoActiveKernelError",
 )<{ readonly notebookUri: NotebookId }> {}
 
-interface ScratchEvent {
-  readonly notebookUri: NotebookId;
-  readonly event: CellOperationNotification | NotificationOf<"completed-run">;
-}
-
-function hasRunId<T extends { run_id?: string | null }>(
-  event: T,
-): event is T & { run_id: string } {
-  return typeof event.run_id === "string" && event.run_id.length > 0;
-}
-
-/** Whether a cell-op carries stdout/stderr console output. */
-function hasConsoleOutput(op: CellOperationNotification): boolean {
-  if (op.console == null) {
-    return false;
-  }
-  return EffectArray.ensure(op.console).some(
-    (o) => o.channel === "stdout" || o.channel === "stderr",
-  );
-}
-
-function isCompletedRunFor(notebookUri: NotebookId, runId: string) {
-  return (
-    tagged: ScratchEvent,
-  ): tagged is {
-    notebookUri: NotebookId;
-    event: NotificationOf<"completed-run"> & { run_id: string };
-  } =>
-    tagged.notebookUri === notebookUri &&
-    tagged.event.op === "completed-run" &&
-    hasRunId(tagged.event) &&
-    tagged.event.run_id === runId;
-}
-
 /**
  * Orchestrates kernel operations for marimo notebooks by composing
  * MarimoLanguageClient, MarimoNotebookRenderer, and MarimoNotebookControllers.
@@ -112,21 +73,11 @@ export class KernelManager extends Effect.Service<KernelManager>()(
     scoped: Effect.gen(function* () {
       yield* Effect.logDebug("Setting up kernel manager");
       const code = yield* VsCode;
-      const client = yield* LanguageClient;
       const renderer = yield* NotebookRenderer;
       const controllers = yield* ControllerRegistry;
       const runtimeSessions = yield* RuntimeSessions;
 
       const queue = yield* Queue.unbounded<MarimoOperation>();
-
-      // PubSub for scratch cell operations + the completed-run that ends them.
-      // A scratchpad's `completed-run` echoes the command's `runId`, so a
-      // consumer waits for *its* completion — including any code-mode cascade —
-      // rather than the scratch cell merely going idle.
-      const scratchOps = yield* PubSub.unbounded<ScratchEvent>();
-
-      // Semaphore to serialize concurrent scratchpad executions
-      const scratchLock = yield* STM.commit(TSemaphore.make(1));
 
       yield* Effect.forkScoped(
         runtimeSessions
@@ -138,7 +89,7 @@ export class KernelManager extends Effect.Service<KernelManager>()(
         Effect.gen(function* () {
           while (true) {
             const msg = yield* Queue.take(queue);
-            yield* processOperation(msg, scratchOps).pipe(
+            yield* processOperation(msg).pipe(
               Effect.annotateLogs({
                 notebookUri: msg.notebookUri,
                 operation: msg.operation.op,
@@ -265,13 +216,8 @@ export class KernelManager extends Effect.Service<KernelManager>()(
          * cascade has settled, not merely when the scratch cell goes idle.
          */
         executeCodeUnsafe(notebookUri: NotebookId, sourceCode: string) {
-          return Stream.unwrapScoped(
+          return Stream.unwrap(
             Effect.gen(function* () {
-              // Hold the lock for the full stream lifetime. withPermitsScoped
-              // registers the release on the Scope that Stream.unwrapScoped
-              // keeps open until any runner finishes.
-              yield* TSemaphore.withPermitsScoped(scratchLock, 1);
-
               // No selected kernel means no executable to start a session with,
               // so fail before sending code that can never run.
               const notebooks = yield* code.workspace.getNotebookDocuments();
@@ -295,57 +241,8 @@ export class KernelManager extends Effect.Service<KernelManager>()(
                 notebook.value,
               );
 
-              // 1. Subscribe BEFORE sending command (avoid race)
-              const sub = yield* PubSub.subscribe(scratchOps);
-
-              // 2. Send command to kernel, tagged with a runId the kernel echoes
-              //    back on the terminating completed-run.
-              const runId = crypto.randomUUID();
-              yield* client.executeCommand({
-                command: "marimo.api",
-                params: {
-                  method: "execute-scratchpad",
-                  params: {
-                    notebookUri,
-                    executable,
-                    inner: { code: sourceCode, runId },
-                  },
-                },
-              });
-
-              // If the consumer abandons this stream before completed-run, interrupt.
-              yield* Effect.addFinalizer((exit) =>
-                Exit.isInterrupted(exit)
-                  ? client
-                      .executeCommand({
-                        command: "marimo.api",
-                        params: {
-                          method: "interrupt",
-                          params: { notebookUri, inner: {} },
-                        },
-                      })
-                      .pipe(
-                        Effect.catchAllCause((cause) =>
-                          Effect.logWarning(
-                            "Failed to interrupt kernel after scratchpad stream was abandoned",
-                          ).pipe(Effect.annotateLogs({ cause })),
-                        ),
-                      )
-                  : Effect.void,
-              );
-
-              // 3. Stream ops for this notebook until *our* completed-run.
-              //    Filter by notebookUri first so a concurrent execution on a
-              //    different notebook doesn't leak cell-ops into this stream.
-              //    takeUntil is inclusive; filterMap drops the sentinel and
-              //    non-cell-op events (e.g. completed-run) in one pass.
-              return Stream.fromQueue(sub).pipe(
-                Stream.filter((tagged) => tagged.notebookUri === notebookUri),
-                Stream.takeUntil(isCompletedRunFor(notebookUri, runId)),
-                Stream.filterMap(({ event }) =>
-                  event.op === "cell-op" ? Option.some(event) : Option.none(),
-                ),
-              );
+              const session = yield* runtimeSessions.getOrCreate(notebookUri);
+              return session.executeScratchpad(sourceCode, executable);
             }),
           );
         },
@@ -365,10 +262,7 @@ function isValueUpdateEcho(
   );
 }
 
-function processOperation(
-  { notebookUri, operation }: MarimoOperation,
-  scratchOps: PubSub.PubSub<ScratchEvent>,
-) {
+function processOperation({ notebookUri, operation }: MarimoOperation) {
   return Effect.gen(function* () {
     const variables = yield* VariablesService;
     const datasources = yield* DatasourcesService;
@@ -430,10 +324,7 @@ function processOperation(
       case "validate-sql-result": {
         break;
       }
-      // Ends a scratchpad stream (matched by notebookUri + runId). Published
-      // unconditionally; dropped when no scratchpad execution is subscribed.
       case "completed-run": {
-        yield* PubSub.publish(scratchOps, { notebookUri, event: operation });
         break;
       }
       // Replay kernel-originated document edits onto the VS Code notebook.
@@ -449,7 +340,7 @@ function processOperation(
       case "function-call-result":
       case "send-ui-element-message":
       case "model-lifecycle": {
-        yield* processSessionOperation(notebookUri, operation, scratchOps);
+        yield* processSessionOperation(notebookUri, operation);
         break;
       }
       default: {
@@ -499,7 +390,6 @@ function processSessionOperation(
     | NotificationOf<"function-call-result">
     | NotificationOf<"send-ui-element-message">
     | NotificationOf<"model-lifecycle">,
-  scratchOps: PubSub.PubSub<ScratchEvent>,
 ) {
   return Effect.gen(function* () {
     const uv = yield* Uv;
@@ -534,19 +424,9 @@ function processSessionOperation(
       case "cell-op": {
         const cellId = extractCellIdFromCellMessage(operation);
 
-        // Mirror marimo's ScratchCellListener: while a scratchpad runs it
-        // streams the scratch cell's own ops plus console output from cells a
-        // code-mode cascade runs. Feed those to the scratch PubSub (a no-op
-        // when no executeCode call is subscribed). marimo doesn't stamp our
-        // runId onto cell-ops — only onto the terminating completed-run — so
-        // we route the scratch cell by id and cascade cells by having console.
         if (cellId === SCRATCH_CELL_ID) {
-          // The scratch cell isn't a real notebook cell: stream it, don't render.
-          yield* PubSub.publish(scratchOps, { notebookUri, event: operation });
+          // The scratch cell isn't a real notebook cell.
           break;
-        }
-        if (hasConsoleOutput(operation)) {
-          yield* PubSub.publish(scratchOps, { notebookUri, event: operation });
         }
 
         yield* executions.handleCellOperation(operation, {

--- a/extension/src/kernel/KernelManager.ts
+++ b/extension/src/kernel/KernelManager.ts
@@ -44,11 +44,7 @@ import {
 import { ExecutionRegistry } from "./ExecutionRegistry.ts";
 import { resolveImageDataUri, saveImageToDisk } from "./imageResolver.ts";
 import { handleMissingPackageAlert } from "./operations.ts";
-
-interface MarimoOperation {
-  notebookUri: NotebookId;
-  operation: Notification;
-}
+import { type MarimoOperation, RuntimeSessions } from "./RuntimeSessions.ts";
 
 /** An error returned when code is run for a notebook that has no kernel selected. */
 export class NoActiveKernelError extends Data.TaggedError(
@@ -118,6 +114,7 @@ export class KernelManager extends Effect.Service<KernelManager>()(
       const client = yield* LanguageClient;
       const renderer = yield* NotebookRenderer;
       const controllers = yield* ControllerRegistry;
+      const runtimeSessions = yield* RuntimeSessions;
 
       const queue = yield* Queue.unbounded<MarimoOperation>();
 
@@ -131,8 +128,8 @@ export class KernelManager extends Effect.Service<KernelManager>()(
       const scratchLock = yield* STM.commit(TSemaphore.make(1));
 
       yield* Effect.forkScoped(
-        client
-          .streamOf("marimo/operation")
+        runtimeSessions
+          .operations()
           .pipe(Stream.runForEach((msg) => Queue.offer(queue, msg))),
       );
 

--- a/extension/src/kernel/KernelManager.ts
+++ b/extension/src/kernel/KernelManager.ts
@@ -168,42 +168,24 @@ export class KernelManager extends Effect.Service<KernelManager>()(
               const notebook = MarimoNotebookDocument.from(editor.notebook);
               switch (message.command) {
                 case "update-ui-element": {
-                  yield* client.executeCommand({
-                    command: "marimo.api",
-                    params: {
-                      method: message.command,
-                      params: {
-                        notebookUri: notebook.id,
-                        inner: message.params,
-                      },
-                    },
-                  });
+                  const session = yield* runtimeSessions.getOrCreate(
+                    notebook.id,
+                  );
+                  yield* session.updateUIElements(message.params);
                   return;
                 }
                 case "invoke-function": {
-                  yield* client.executeCommand({
-                    command: "marimo.api",
-                    params: {
-                      method: message.command,
-                      params: {
-                        notebookUri: notebook.id,
-                        inner: message.params,
-                      },
-                    },
-                  });
+                  const session = yield* runtimeSessions.getOrCreate(
+                    notebook.id,
+                  );
+                  yield* session.invokeFunction(message.params);
                   return;
                 }
                 case "set-model-value": {
-                  yield* client.executeCommand({
-                    command: "marimo.api",
-                    params: {
-                      method: message.command,
-                      params: {
-                        notebookUri: notebook.id,
-                        inner: message.params,
-                      },
-                    },
-                  });
+                  const session = yield* runtimeSessions.getOrCreate(
+                    notebook.id,
+                  );
+                  yield* session.updateModel(message.params);
                   return;
                 }
                 case "navigate-to-cell": {

--- a/extension/src/kernel/KernelManager.ts
+++ b/extension/src/kernel/KernelManager.ts
@@ -107,6 +107,7 @@ export class KernelManager extends Effect.Service<KernelManager>()(
       DatasourcesService.Default,
       NotebookEditorRegistry.Default,
       PythonEnvInvalidation.Default,
+      RuntimeSessions.Default,
     ],
     scoped: Effect.gen(function* () {
       yield* Effect.logDebug("Setting up kernel manager");
@@ -616,7 +617,7 @@ function handleStdinPrompt(
 ) {
   return Effect.gen(function* () {
     const code = yield* VsCode;
-    const client = yield* LanguageClient;
+    const runtimeSessions = yield* RuntimeSessions;
     if (operation.console == null) {
       return;
     }
@@ -635,28 +636,12 @@ function handleStdinPrompt(
       });
 
       if (Option.isSome(result)) {
-        yield* client.executeCommand({
-          command: "marimo.api",
-          params: {
-            method: "send-stdin",
-            params: {
-              notebookUri,
-              inner: { text: result.value },
-            },
-          },
-        });
+        const session = yield* runtimeSessions.getOrCreate(notebookUri);
+        yield* session.sendStdin({ text: result.value });
       } else {
         // User cancelled — interrupt the kernel so it stops waiting for input
-        yield* client.executeCommand({
-          command: "marimo.api",
-          params: {
-            method: "interrupt",
-            params: {
-              notebookUri,
-              inner: {},
-            },
-          },
-        });
+        const session = yield* runtimeSessions.getOrCreate(notebookUri);
+        yield* session.interrupt();
       }
     }
   });

--- a/extension/src/kernel/NotebookControllerFactory.ts
+++ b/extension/src/kernel/NotebookControllerFactory.ts
@@ -11,7 +11,6 @@ import { extractPythonError } from "../lib/extractPythonError.ts";
 import { formatControllerLabel } from "../lib/formatControllerLabel.ts";
 import { installPackages } from "../lib/installPackages.ts";
 import { isProblematicFilename } from "../lib/validateNotebookFilename.ts";
-import { LanguageClient } from "../lsp/LanguageClient.ts";
 import { NotebookSerializer } from "../notebook/NotebookSerializer.ts";
 import { Constants } from "../platform/Constants.ts";
 import { VsCode } from "../platform/VsCode.ts";
@@ -22,6 +21,7 @@ import {
   type MarimoNotebookCell,
   MarimoNotebookDocument,
 } from "../schemas/MarimoNotebookDocument.ts";
+import { RuntimeSessions } from "./RuntimeSessions.ts";
 
 const NotebookControllerId = Brand.nominal<NotebookControllerId>();
 export type NotebookControllerId = Brand.Branded<string, "ControllerId">;
@@ -35,12 +35,13 @@ export class NotebookControllerFactory extends Effect.Service<NotebookController
       Constants.Default,
       EnvironmentValidator.Default,
       NotebookSerializer.Default,
+      RuntimeSessions.Default,
     ],
     scoped: Effect.gen(function* () {
       const uv = yield* Uv;
       const code = yield* VsCode;
       const config = yield* Config;
-      const marimo = yield* LanguageClient;
+      const runtimeSessions = yield* RuntimeSessions;
       const validator = yield* EnvironmentValidator;
       const serializer = yield* NotebookSerializer;
       const { LanguageId } = yield* Constants;
@@ -89,17 +90,8 @@ export class NotebookControllerFactory extends Effect.Service<NotebookController
 
                 const validEnv = yield* validator.validate(options.env);
 
-                yield* marimo.executeCommand({
-                  command: "marimo.api",
-                  params: {
-                    method: "execute-cells",
-                    params: {
-                      notebookUri: notebook.id,
-                      executable: validEnv.executable,
-                      inner: request.value,
-                    },
-                  },
-                });
+                const session = yield* runtimeSessions.getOrCreate(notebook.id);
+                yield* session.executeCells(request.value, validEnv.executable);
               }).pipe(
                 Effect.withSpan("PythonController.execute", {
                   attributes: {
@@ -110,6 +102,11 @@ export class NotebookControllerFactory extends Effect.Service<NotebookController
                 }),
                 // Known exceptions
                 Effect.catchTags({
+                  RuntimeCommandQueueClosedError: Effect.fn(function* () {
+                    yield* code.window.showErrorMessage(
+                      "The marimo runtime session closed before execution could start.",
+                    );
+                  }),
                   ExecuteCommandError: Effect.fn(function* (error) {
                     yield* Effect.logError("Failed to execute command").pipe(
                       Effect.annotateLogs({
@@ -225,16 +222,8 @@ export class NotebookControllerFactory extends Effect.Service<NotebookController
             runPromise(
               Effect.gen(function* () {
                 const notebook = MarimoNotebookDocument.from(rawNotebook);
-                yield* marimo.executeCommand({
-                  command: "marimo.api",
-                  params: {
-                    method: "interrupt",
-                    params: {
-                      notebookUri: notebook.id,
-                      inner: {},
-                    },
-                  },
-                });
+                const session = yield* runtimeSessions.getOrCreate(notebook.id);
+                yield* session.interrupt();
               }).pipe(
                 Effect.withSpan("PythonController.interrupt", {
                   attributes: {

--- a/extension/src/kernel/RuntimeCommandQueue.ts
+++ b/extension/src/kernel/RuntimeCommandQueue.ts
@@ -1,0 +1,312 @@
+import {
+  Cause,
+  Data,
+  Deferred,
+  Effect,
+  Exit,
+  Option,
+  Ref,
+  Scope,
+} from "effect";
+
+/**
+ * Raised when work is submitted after its runtime session has been closed.
+ */
+export class RuntimeCommandQueueClosedError extends Data.TaggedError(
+  "RuntimeCommandQueueClosedError",
+)<{}> {}
+
+/**
+ * State that may replace an adjacent pending update of the same kind.
+ *
+ * The queue never merges the command currently being sent, nor does it merge
+ * across another kind or an ordered command.
+ */
+export interface StateUpdate<Command> {
+  readonly kind: string;
+  readonly command: Command;
+  readonly merge: (older: Command, newer: Command) => Command;
+}
+
+type QueueItem<Command, Error> = Data.TaggedEnum<{
+  Replaceable: StateUpdate<Command>;
+  Ordered: {
+    readonly command: Command;
+    readonly sent: Deferred.Deferred<
+      void,
+      Error | RuntimeCommandQueueClosedError
+    >;
+  };
+}>;
+
+type QueueState<Command, Error> = Data.TaggedEnum<{
+  Idle: {};
+  Active: {
+    readonly inFlight: QueueItem<Command, Error>;
+    readonly pending: ReadonlyArray<QueueItem<Command, Error>>;
+  };
+  Closed: {};
+}>;
+
+const stateItem = <Command, Error>(
+  update: StateUpdate<Command>,
+): QueueItem<Command, Error> => ({
+  _tag: "Replaceable",
+  ...update,
+});
+
+const orderedItem = <Command, Error>(
+  command: Command,
+  sent: Deferred.Deferred<void, Error | RuntimeCommandQueueClosedError>,
+): QueueItem<Command, Error> => ({
+  _tag: "Ordered",
+  command,
+  sent,
+});
+
+/**
+ * The outbound command queue for one live marimo runtime session.
+ *
+ * ```ts
+ * interface RuntimeCommandQueue<Command> {
+ *   enqueueState(update): Effect<void>
+ *   send(command): Effect<void>
+ *   close(): Effect<void>
+ * }
+ * ```
+ *
+ * Only one command is sent at a time. `send` preserves every command and waits
+ * for that send to finish. `enqueueState` returns once the update is queued;
+ * adjacent pending updates of the same kind may be merged before they are sent.
+ *
+ * Closing the queue rejects new work, fails callers waiting in `send`, and
+ * interrupts the active send.
+ */
+export interface RuntimeCommandQueue<Command, Error, Requirements = never> {
+  /**
+   * Queue state without waiting for it to be sent. A later pending update of
+   * the same kind may replace it.
+   */
+  readonly enqueueState: (
+    update: StateUpdate<Command>,
+  ) => Effect.Effect<void, RuntimeCommandQueueClosedError, Requirements>;
+
+  /**
+   * Queue a command without merging it, and wait for the send to finish.
+   */
+  readonly send: (
+    command: Command,
+  ) => Effect.Effect<
+    void,
+    Error | RuntimeCommandQueueClosedError,
+    Requirements
+  >;
+
+  /**
+   * Reject new work, fail waiting callers, and interrupt the active send.
+   */
+  readonly close: () => Effect.Effect<void>;
+}
+
+interface EnqueueResult<Command, Error> {
+  readonly start: Option.Option<QueueItem<Command, Error>>;
+  readonly accepted: boolean;
+}
+
+function mergePending<Command, Error>(
+  pending: ReadonlyArray<QueueItem<Command, Error>>,
+  incoming: QueueItem<Command, Error>,
+): ReadonlyArray<QueueItem<Command, Error>> {
+  if (incoming._tag !== "Replaceable") {
+    return [...pending, incoming];
+  }
+
+  const previous = pending.at(-1);
+  if (previous?._tag !== "Replaceable" || previous.kind !== incoming.kind) {
+    return [...pending, incoming];
+  }
+
+  return [
+    ...pending.slice(0, -1),
+    stateItem<Command, Error>({
+      ...incoming,
+      command: incoming.merge(previous.command, incoming.command),
+    }),
+  ];
+}
+
+/**
+ * Creates the outbound command queue for one runtime session.
+ */
+export const makeRuntimeCommandQueue = Effect.fn("RuntimeCommandQueue.make")(
+  function* <Command, Error, Requirements>(
+    sendCommand: (command: Command) => Effect.Effect<void, Error, Requirements>,
+  ) {
+    const State = Data.taggedEnum<QueueState<Command, Error>>();
+    const state = yield* Ref.make<QueueState<Command, Error>>(State.Idle());
+    const sendScope = yield* Scope.make();
+
+    const enqueue = Effect.fn("RuntimeCommandQueue.enqueue")(function* (
+      item: QueueItem<Command, Error>,
+    ) {
+      return yield* Ref.modify(
+        state,
+        (
+          current,
+        ): readonly [
+          EnqueueResult<Command, Error>,
+          QueueState<Command, Error>,
+        ] => {
+          return State.$match(current, {
+            Closed: () =>
+              [{ start: Option.none(), accepted: false }, current] as const,
+            Idle: () =>
+              [
+                { start: Option.some(item), accepted: true },
+                State.Active({ inFlight: item, pending: [] }),
+              ] as const,
+            Active: (active) =>
+              [
+                { start: Option.none(), accepted: true },
+                State.Active({
+                  ...active,
+                  pending: mergePending(active.pending, item),
+                }),
+              ] as const,
+          });
+        },
+      );
+    });
+
+    const next = Effect.fn("RuntimeCommandQueue.next")(function* () {
+      return yield* Ref.modify(
+        state,
+        (
+          current,
+        ): readonly [
+          Option.Option<QueueItem<Command, Error>>,
+          QueueState<Command, Error>,
+        ] => {
+          return State.$match(current, {
+            Idle: () => [Option.none(), current] as const,
+            Closed: () => [Option.none(), current] as const,
+            Active: ({ pending }) => {
+              const [next, ...remaining] = pending;
+              if (next === undefined) {
+                return [Option.none(), State.Idle()] as const;
+              }
+              return [
+                Option.some(next),
+                State.Active({ inFlight: next, pending: remaining }),
+              ] as const;
+            },
+          });
+        },
+      );
+    });
+
+    const drain = Effect.fn("RuntimeCommandQueue.drain")(function* (
+      initial: QueueItem<Command, Error>,
+    ) {
+      let current = initial;
+      while (true) {
+        const exit = yield* Effect.exit(sendCommand(current.command));
+
+        if (current._tag === "Ordered") {
+          yield* Deferred.done(current.sent, exit);
+        } else if (
+          Exit.isFailure(exit) &&
+          !Cause.isInterruptedOnly(exit.cause)
+        ) {
+          yield* Effect.logWarning("Failed to send queued runtime state").pipe(
+            Effect.annotateLogs({
+              cause: exit.cause,
+              kind: current.kind,
+            }),
+          );
+        }
+
+        const following = yield* next();
+        if (Option.isNone(following)) return;
+        current = following.value;
+      }
+    });
+
+    const startDrain = Effect.fn("RuntimeCommandQueue.startDrain")(function* (
+      item: QueueItem<Command, Error>,
+    ) {
+      yield* Effect.forkIn(drain(item), sendScope);
+    });
+
+    const enqueueState = Effect.fn("RuntimeCommandQueue.enqueueState")(
+      function* (update: StateUpdate<Command>) {
+        const item: QueueItem<Command, Error> = stateItem<Command, Error>(
+          update,
+        );
+        const result = yield* enqueue(item);
+        if (!result.accepted) {
+          yield* new RuntimeCommandQueueClosedError();
+        }
+        if (Option.isSome(result.start)) {
+          yield* startDrain(result.start.value);
+        }
+        return;
+      },
+    );
+
+    const send = Effect.fn("RuntimeCommandQueue.send")(function* (
+      command: Command,
+    ) {
+      const sent = yield* Deferred.make<
+        void,
+        Error | RuntimeCommandQueueClosedError
+      >();
+      const item = orderedItem<Command, Error>(command, sent);
+      const result = yield* enqueue(item);
+      if (!result.accepted) {
+        yield* new RuntimeCommandQueueClosedError();
+      }
+      if (Option.isSome(result.start)) {
+        yield* startDrain(result.start.value);
+      }
+      return yield* Deferred.await(sent);
+    });
+
+    const close = Effect.fn("RuntimeCommandQueue.close")(function* () {
+      const abandoned = yield* Ref.modify(
+        state,
+        (
+          current,
+        ): readonly [
+          ReadonlyArray<QueueItem<Command, Error>>,
+          QueueState<Command, Error>,
+        ] => {
+          return State.$match(current, {
+            Idle: () => [[], State.Closed()] as const,
+            Closed: () => [[], State.Closed()] as const,
+            Active: ({ inFlight, pending }) =>
+              [[inFlight, ...pending], State.Closed()] as const,
+          });
+        },
+      );
+
+      yield* Effect.forEach(
+        abandoned,
+        (item) =>
+          item._tag === "Ordered"
+            ? Deferred.fail(item.sent, new RuntimeCommandQueueClosedError())
+            : Effect.void,
+        { discard: true },
+      );
+      yield* Scope.close(sendScope, Exit.void);
+    });
+
+    yield* Effect.addFinalizer(() => close());
+
+    return {
+      enqueueState,
+      send,
+      close,
+    };
+  },
+);

--- a/extension/src/kernel/RuntimeSessions.ts
+++ b/extension/src/kernel/RuntimeSessions.ts
@@ -1,4 +1,5 @@
 import {
+  Data,
   Effect,
   Exit,
   HashMap,
@@ -9,21 +10,61 @@ import {
   SynchronizedRef,
 } from "effect";
 
-import { LanguageClient } from "../lsp/LanguageClient.ts";
+import { assert } from "../assert.ts";
+import {
+  type ExecuteCommandError,
+  LanguageClient,
+  type LanguageClientStartError,
+} from "../lsp/LanguageClient.ts";
 import type { NotebookId } from "../schemas/MarimoNotebookDocument.ts";
-import type { MarimoLspNotificationOf, Notification } from "../types.ts";
+import type {
+  InvokeFunctionRequest,
+  MarimoCommand,
+  MarimoLspNotificationOf,
+  ModelRequest,
+  Notification,
+  UpdateUIElementRequest,
+} from "../types.ts";
+import {
+  makeRuntimeCommandQueue,
+  RuntimeCommandQueueClosedError,
+} from "./RuntimeCommandQueue.ts";
 
 export type MarimoOperation = MarimoLspNotificationOf<"marimo/operation">;
+
+type RuntimeRequest = Data.TaggedEnum<{
+  Api: { readonly command: MarimoCommand };
+  UIState: { readonly request: UpdateUIElementRequest };
+  ModelState: {
+    readonly requests: ReadonlyMap<ModelRequest["modelId"], ModelRequest>;
+  };
+}>;
+const RuntimeRequest = Data.taggedEnum<RuntimeRequest>();
+
+type RuntimeSendError =
+  | ExecuteCommandError
+  | LanguageClientStartError
+  | RuntimeCommandQueueClosedError;
 
 /**
  * One live marimo runtime, identified by its notebook URI.
  *
  * Operations are ordered as received from the language server. The stream ends
- * when this session is closed.
+ * when this session is closed. UI and model state may merge while waiting to
+ * send; function calls and custom model messages are always sent in order.
  */
 export interface RuntimeSession {
   readonly notebookUri: NotebookId;
   readonly operations: () => Stream.Stream<Notification>;
+  readonly updateUIElements: (
+    request: UpdateUIElementRequest,
+  ) => Effect.Effect<void, RuntimeCommandQueueClosedError>;
+  readonly updateModel: (
+    request: ModelRequest,
+  ) => Effect.Effect<void, RuntimeSendError>;
+  readonly invokeFunction: (
+    request: InvokeFunctionRequest,
+  ) => Effect.Effect<void, RuntimeSendError>;
   readonly shutdown: () => Effect.Effect<void>;
 }
 
@@ -32,6 +73,132 @@ interface SessionEntry {
   readonly session: RuntimeSession;
   readonly operations: PubSub.PubSub<Notification>;
   readonly scope: Scope.CloseableScope;
+}
+
+function modelCommand(
+  notebookUri: NotebookId,
+  request: ModelRequest,
+): MarimoCommand {
+  return {
+    command: "marimo.api",
+    params: {
+      method: "set-model-value",
+      params: { notebookUri, inner: request },
+    },
+  };
+}
+
+function invokeFunctionCommand(
+  notebookUri: NotebookId,
+  request: InvokeFunctionRequest,
+): MarimoCommand {
+  return {
+    command: "marimo.api",
+    params: {
+      method: "invoke-function",
+      params: { notebookUri, inner: request },
+    },
+  };
+}
+
+function uiCommand(
+  notebookUri: NotebookId,
+  request: UpdateUIElementRequest,
+): MarimoCommand {
+  return {
+    command: "marimo.api",
+    params: {
+      method: "update-ui-element",
+      params: { notebookUri, inner: request },
+    },
+  };
+}
+
+function mergeUIState(
+  older: UpdateUIElementRequest,
+  newer: UpdateUIElementRequest,
+): UpdateUIElementRequest {
+  const values = new Map(
+    older.objectIds.map((objectId, index) => [objectId, older.values[index]]),
+  );
+  for (const [index, objectId] of newer.objectIds.entries()) {
+    values.set(objectId, newer.values[index]);
+  }
+  return {
+    ...newer,
+    objectIds: [...values.keys()],
+    values: [...values.values()],
+  };
+}
+
+function mergeModelUpdate(
+  older: ModelRequest,
+  newer: ModelRequest,
+): ModelRequest {
+  if (older.message.method !== "update" || newer.message.method !== "update") {
+    return newer;
+  }
+
+  const updatedKeys = new Set(Object.keys(newer.message.state));
+  const buffers = new Map<
+    string,
+    {
+      readonly path: ReadonlyArray<string | number>;
+      readonly buffer: ModelRequest["buffers"][number];
+    }
+  >();
+
+  for (const [index, path] of older.message.bufferPaths.entries()) {
+    const buffer = older.buffers[index];
+    if (buffer !== undefined && !updatedKeys.has(String(path[0]))) {
+      buffers.set(JSON.stringify(path), { path, buffer });
+    }
+  }
+  for (const [index, path] of newer.message.bufferPaths.entries()) {
+    const buffer = newer.buffers[index];
+    if (buffer !== undefined) {
+      buffers.set(JSON.stringify(path), { path, buffer });
+    }
+  }
+
+  return {
+    ...newer,
+    message: {
+      method: "update",
+      state: { ...older.message.state, ...newer.message.state },
+      bufferPaths: [...buffers.values()].map(({ path }) => [...path]),
+    },
+    buffers: [...buffers.values()].map(({ buffer }) => buffer),
+  };
+}
+
+function mergeModelState(
+  older: RuntimeRequest,
+  newer: RuntimeRequest,
+): RuntimeRequest {
+  assert(older._tag === "ModelState", "Expected pending model state");
+  assert(newer._tag === "ModelState", "Expected new model state");
+
+  const requests = new Map(older.requests);
+  for (const [modelId, request] of newer.requests) {
+    const previous = requests.get(modelId);
+    requests.set(
+      modelId,
+      previous === undefined ? request : mergeModelUpdate(previous, request),
+    );
+  }
+  return RuntimeRequest.ModelState({ requests });
+}
+
+function mergeUIRequest(
+  older: RuntimeRequest,
+  newer: RuntimeRequest,
+): RuntimeRequest {
+  assert(older._tag === "UIState", "Expected pending UI state");
+  assert(newer._tag === "UIState", "Expected new UI state");
+  return RuntimeRequest.UIState({
+    request: mergeUIState(older.request, newer.request),
+  });
 }
 
 /**
@@ -51,6 +218,29 @@ export class RuntimeSessions extends Effect.Service<RuntimeSessions>()(
       const sessions = yield* SynchronizedRef.make(
         HashMap.empty<NotebookId, SessionEntry>(),
       );
+
+      const sendRequest = Effect.fn("RuntimeSession.sendRequest")(function* (
+        notebookUri: NotebookId,
+        runtimeRequest: RuntimeRequest,
+      ) {
+        return yield* RuntimeRequest.$match(runtimeRequest, {
+          Api: ({ command }) =>
+            client.executeCommand(command).pipe(Effect.asVoid),
+          UIState: ({ request }) =>
+            client
+              .executeCommand(uiCommand(notebookUri, request))
+              .pipe(Effect.asVoid),
+          ModelState: ({ requests }) =>
+            Effect.forEach(
+              requests.values(),
+              (request) =>
+                client
+                  .executeCommand(modelCommand(notebookUri, request))
+                  .pipe(Effect.asVoid),
+              { discard: true },
+            ),
+        });
+      });
 
       const shutdown = Effect.fn("RuntimeSessions.shutdown")(function* (
         notebookUri: NotebookId,
@@ -75,20 +265,83 @@ export class RuntimeSessions extends Effect.Service<RuntimeSessions>()(
       ) {
         const token = {};
         const scope = yield* Scope.make();
-        const operations = yield* Scope.extend(
+        const resources = yield* Scope.extend(
           Effect.gen(function* () {
             const operations = yield* PubSub.unbounded<Notification>();
             yield* Effect.addFinalizer(() => PubSub.shutdown(operations));
-            return operations;
+            const queue = yield* makeRuntimeCommandQueue(
+              (request: RuntimeRequest) => sendRequest(notebookUri, request),
+            );
+            return { operations, queue };
           }),
           scope,
         );
         const session: RuntimeSession = {
           notebookUri,
-          operations: () => Stream.fromPubSub(operations),
+          operations: () => Stream.fromPubSub(resources.operations),
+          updateUIElements: Effect.fn("RuntimeSession.updateUIElements")(
+            function* (request) {
+              if (
+                request.objectIds.length === 0 ||
+                request.objectIds.length !== request.values.length
+              ) {
+                yield* Effect.logWarning(
+                  "Dropping invalid UI element update",
+                ).pipe(
+                  Effect.annotateLogs({
+                    notebookUri,
+                    objectIdCount: request.objectIds.length,
+                    valueCount: request.values.length,
+                  }),
+                );
+                return;
+              }
+
+              yield* resources.queue.enqueueState({
+                kind: "ui-elements",
+                command: RuntimeRequest.UIState({ request }),
+                merge: mergeUIRequest,
+              });
+            },
+          ),
+          updateModel: Effect.fn("RuntimeSession.updateModel")(
+            function* (request) {
+              if (request.message.method === "custom") {
+                yield* resources.queue.send(
+                  RuntimeRequest.Api({
+                    command: modelCommand(notebookUri, request),
+                  }),
+                );
+                return;
+              }
+
+              yield* resources.queue.enqueueState({
+                kind: "models",
+                command: RuntimeRequest.ModelState({
+                  requests: new Map([[request.modelId, request]]),
+                }),
+                merge: mergeModelState,
+              });
+              return;
+            },
+          ),
+          invokeFunction: Effect.fn("RuntimeSession.invokeFunction")(
+            function* (request) {
+              yield* resources.queue.send(
+                RuntimeRequest.Api({
+                  command: invokeFunctionCommand(notebookUri, request),
+                }),
+              );
+            },
+          ),
           shutdown: () => shutdown(notebookUri, token),
         };
-        return { token, session, operations, scope } satisfies SessionEntry;
+        return {
+          token,
+          session,
+          operations: resources.operations,
+          scope,
+        } satisfies SessionEntry;
       });
 
       const getOrCreate = Effect.fn("RuntimeSessions.getOrCreate")(function* (

--- a/extension/src/kernel/RuntimeSessions.ts
+++ b/extension/src/kernel/RuntimeSessions.ts
@@ -19,13 +19,14 @@ import {
   LanguageClient,
   type LanguageClientStartError,
 } from "../lsp/LanguageClient.ts";
+import { MarimoApiClient } from "../lsp/MarimoApiClient.ts";
 import type { NotebookId } from "../schemas/MarimoNotebookDocument.ts";
 import type {
   DeleteCellRequest,
   CellOperationNotification,
   ExecuteCellsRequest,
   InvokeFunctionRequest,
-  MarimoCommand,
+  MarimoApiRequest,
   MarimoLspNotificationOf,
   ModelRequest,
   Notification,
@@ -40,7 +41,7 @@ import {
 export type MarimoOperation = MarimoLspNotificationOf<"marimo/operation">;
 
 type RuntimeRequest = Data.TaggedEnum<{
-  Api: { readonly command: MarimoCommand };
+  Api: { readonly request: MarimoApiRequest };
   UIState: { readonly request: UpdateUIElementRequest };
   ModelState: {
     readonly requests: ReadonlyMap<ModelRequest["modelId"], ModelRequest>;
@@ -102,121 +103,94 @@ interface SessionEntry {
   readonly scope: Scope.CloseableScope;
 }
 
-function modelCommand(
+function modelRequest(
   notebookUri: NotebookId,
   request: ModelRequest,
-): MarimoCommand {
+): MarimoApiRequest {
   return {
-    command: "marimo.api",
-    params: {
-      method: "set-model-value",
-      params: { notebookUri, inner: request },
-    },
+    method: "set-model-value",
+    params: { notebookUri, inner: request },
   };
 }
 
-function invokeFunctionCommand(
+function invokeFunctionRequest(
   notebookUri: NotebookId,
   request: InvokeFunctionRequest,
-): MarimoCommand {
+): MarimoApiRequest {
   return {
-    command: "marimo.api",
-    params: {
-      method: "invoke-function",
-      params: { notebookUri, inner: request },
-    },
+    method: "invoke-function",
+    params: { notebookUri, inner: request },
   };
 }
 
-function uiCommand(
+function uiRequest(
   notebookUri: NotebookId,
   request: UpdateUIElementRequest,
-): MarimoCommand {
+): MarimoApiRequest {
   return {
-    command: "marimo.api",
-    params: {
-      method: "update-ui-element",
-      params: { notebookUri, inner: request },
-    },
+    method: "update-ui-element",
+    params: { notebookUri, inner: request },
   };
 }
 
-function executeCellsCommand(
+function executeCellsRequest(
   notebookUri: NotebookId,
   executable: string,
   request: ExecuteCellsRequest,
-): MarimoCommand {
+): MarimoApiRequest {
   return {
-    command: "marimo.api",
-    params: {
-      method: "execute-cells",
-      params: { notebookUri, executable, inner: request },
-    },
+    method: "execute-cells",
+    params: { notebookUri, executable, inner: request },
   };
 }
 
-function executeScratchpadCommand(
+function executeScratchpadRequest(
   notebookUri: NotebookId,
   executable: string,
   code: string,
   runId: string,
-): MarimoCommand {
+): MarimoApiRequest {
   return {
-    command: "marimo.api",
+    method: "execute-scratchpad",
     params: {
-      method: "execute-scratchpad",
-      params: {
-        notebookUri,
-        executable,
-        inner: { code, runId },
-      },
+      notebookUri,
+      executable,
+      inner: { code, runId },
     },
   };
 }
 
-function deleteCellCommand(
+function deleteCellRequest(
   notebookUri: NotebookId,
   request: DeleteCellRequest,
-): MarimoCommand {
+): MarimoApiRequest {
   return {
-    command: "marimo.api",
-    params: {
-      method: "delete-cell",
-      params: { notebookUri, inner: request },
-    },
+    method: "delete-cell",
+    params: { notebookUri, inner: request },
   };
 }
 
-function sendStdinCommand(
+function sendStdinRequest(
   notebookUri: NotebookId,
   request: SendStdinRequest,
-): MarimoCommand {
+): MarimoApiRequest {
   return {
-    command: "marimo.api",
-    params: {
-      method: "send-stdin",
-      params: { notebookUri, inner: request },
-    },
+    method: "send-stdin",
+    params: { notebookUri, inner: request },
   };
 }
 
-function interruptCommand(notebookUri: NotebookId): MarimoCommand {
+function interruptRequest(notebookUri: NotebookId): MarimoApiRequest {
   return {
-    command: "marimo.api",
-    params: {
-      method: "interrupt",
-      params: { notebookUri, inner: {} },
-    },
+    method: "interrupt",
+    params: { notebookUri, inner: {} },
   };
 }
 
-function closeSessionCommand(notebookUri: NotebookId): MarimoCommand {
+function closeSessionRequest(notebookUri: NotebookId): MarimoApiRequest {
   return {
-    command: "marimo.api",
-    params: {
-      method: "close-session",
-      params: { notebookUri, inner: {} },
-    },
+    method: "close-session",
+    params: { notebookUri, inner: {} },
   };
 }
 
@@ -341,8 +315,10 @@ function mergeUIRequest(
 export class RuntimeSessions extends Effect.Service<RuntimeSessions>()(
   "RuntimeSessions",
   {
+    dependencies: [MarimoApiClient.Default],
     scoped: Effect.gen(function* () {
       const client = yield* LanguageClient;
+      const api = yield* MarimoApiClient;
       const allOperations = yield* PubSub.unbounded<MarimoOperation>();
       const sessions = yield* SynchronizedRef.make(
         HashMap.empty<NotebookId, SessionEntry>(),
@@ -353,18 +329,15 @@ export class RuntimeSessions extends Effect.Service<RuntimeSessions>()(
         runtimeRequest: RuntimeRequest,
       ) {
         return yield* RuntimeRequest.$match(runtimeRequest, {
-          Api: ({ command }) =>
-            client.executeCommand(command).pipe(Effect.asVoid),
+          Api: ({ request }) => api.execute(request).pipe(Effect.asVoid),
           UIState: ({ request }) =>
-            client
-              .executeCommand(uiCommand(notebookUri, request))
-              .pipe(Effect.asVoid),
+            api.execute(uiRequest(notebookUri, request)).pipe(Effect.asVoid),
           ModelState: ({ requests }) =>
             Effect.forEach(
               requests.values(),
               (request) =>
-                client
-                  .executeCommand(modelCommand(notebookUri, request))
+                api
+                  .execute(modelRequest(notebookUri, request))
                   .pipe(Effect.asVoid),
               { discard: true },
             ),
@@ -420,9 +393,7 @@ export class RuntimeSessions extends Effect.Service<RuntimeSessions>()(
         );
         const interrupt = Effect.fn("RuntimeSession.interrupt")(function* () {
           yield* ensureCurrent(notebookUri, token);
-          yield* client
-            .executeCommand(interruptCommand(notebookUri))
-            .pipe(Effect.asVoid);
+          yield* api.execute(interruptRequest(notebookUri)).pipe(Effect.asVoid);
         });
         const session: RuntimeSession = {
           notebookUri,
@@ -431,7 +402,7 @@ export class RuntimeSessions extends Effect.Service<RuntimeSessions>()(
             function* (request, executable) {
               yield* resources.queue.send(
                 RuntimeRequest.Api({
-                  command: executeCellsCommand(
+                  request: executeCellsRequest(
                     notebookUri,
                     executable,
                     request,
@@ -486,7 +457,7 @@ export class RuntimeSessions extends Effect.Service<RuntimeSessions>()(
                   resources.queue
                     .send(
                       RuntimeRequest.Api({
-                        command: executeScratchpadCommand(
+                        request: executeScratchpadRequest(
                           notebookUri,
                           executable,
                           code,
@@ -533,7 +504,7 @@ export class RuntimeSessions extends Effect.Service<RuntimeSessions>()(
               if (request.message.method === "custom") {
                 yield* resources.queue.send(
                   RuntimeRequest.Api({
-                    command: modelCommand(notebookUri, request),
+                    request: modelRequest(notebookUri, request),
                   }),
                 );
                 return;
@@ -553,7 +524,7 @@ export class RuntimeSessions extends Effect.Service<RuntimeSessions>()(
             function* (request) {
               yield* resources.queue.send(
                 RuntimeRequest.Api({
-                  command: invokeFunctionCommand(notebookUri, request),
+                  request: invokeFunctionRequest(notebookUri, request),
                 }),
               );
             },
@@ -562,7 +533,7 @@ export class RuntimeSessions extends Effect.Service<RuntimeSessions>()(
             function* (request) {
               yield* resources.queue.send(
                 RuntimeRequest.Api({
-                  command: deleteCellCommand(notebookUri, request),
+                  request: deleteCellRequest(notebookUri, request),
                 }),
               );
             },
@@ -570,7 +541,7 @@ export class RuntimeSessions extends Effect.Service<RuntimeSessions>()(
           sendStdin: Effect.fn("RuntimeSession.sendStdin")(function* (request) {
             yield* resources.queue.send(
               RuntimeRequest.Api({
-                command: sendStdinCommand(notebookUri, request),
+                request: sendStdinRequest(notebookUri, request),
               }),
             );
           }),
@@ -578,8 +549,8 @@ export class RuntimeSessions extends Effect.Service<RuntimeSessions>()(
           close: Effect.fn("RuntimeSession.close")(function* () {
             yield* ensureCurrent(notebookUri, token);
             yield* resources.queue.close();
-            yield* client
-              .executeCommand(closeSessionCommand(notebookUri))
+            yield* api
+              .execute(closeSessionRequest(notebookUri))
               .pipe(
                 Effect.asVoid,
                 Effect.ensuring(shutdown(notebookUri, token)),

--- a/extension/src/kernel/RuntimeSessions.ts
+++ b/extension/src/kernel/RuntimeSessions.ts
@@ -5,12 +5,15 @@ import {
   HashMap,
   Option,
   PubSub,
+  Ref,
   Scope,
   Stream,
   SynchronizedRef,
+  Array as EffectArray,
 } from "effect";
 
 import { assert } from "../assert.ts";
+import { SCRATCH_CELL_ID } from "../constants.ts";
 import {
   type ExecuteCommandError,
   LanguageClient,
@@ -19,6 +22,7 @@ import {
 import type { NotebookId } from "../schemas/MarimoNotebookDocument.ts";
 import type {
   DeleteCellRequest,
+  CellOperationNotification,
   ExecuteCellsRequest,
   InvokeFunctionRequest,
   MarimoCommand,
@@ -63,6 +67,14 @@ export interface RuntimeSession {
     request: ExecuteCellsRequest,
     executable: string,
   ) => Effect.Effect<void, RuntimeSendError>;
+  /**
+   * Run isolated code and stream its output until the matching run completes.
+   * Only one scratchpad runs at a time within this session.
+   */
+  readonly executeScratchpad: (
+    code: string,
+    executable: string,
+  ) => Stream.Stream<CellOperationNotification, RuntimeSendError>;
   readonly updateUIElements: (
     request: UpdateUIElementRequest,
   ) => Effect.Effect<void, RuntimeCommandQueueClosedError>;
@@ -143,6 +155,25 @@ function executeCellsCommand(
   };
 }
 
+function executeScratchpadCommand(
+  notebookUri: NotebookId,
+  executable: string,
+  code: string,
+  runId: string,
+): MarimoCommand {
+  return {
+    command: "marimo.api",
+    params: {
+      method: "execute-scratchpad",
+      params: {
+        notebookUri,
+        executable,
+        inner: { code, runId },
+      },
+    },
+  };
+}
+
 function deleteCellCommand(
   notebookUri: NotebookId,
   request: DeleteCellRequest,
@@ -187,6 +218,29 @@ function closeSessionCommand(notebookUri: NotebookId): MarimoCommand {
       params: { notebookUri, inner: {} },
     },
   };
+}
+
+function hasConsoleOutput(operation: CellOperationNotification): boolean {
+  if (operation.console == null) {
+    return false;
+  }
+  return EffectArray.ensure(operation.console).some(
+    (output) => output.channel === "stdout" || output.channel === "stderr",
+  );
+}
+
+function isScratchpadOutput(
+  operation: Notification,
+): operation is CellOperationNotification {
+  return (
+    operation.op === "cell-op" &&
+    (operation.cell_id === SCRATCH_CELL_ID || hasConsoleOutput(operation))
+  );
+}
+
+function isCompletedRunFor(runId: string) {
+  return (operation: Notification): boolean =>
+    operation.op === "completed-run" && operation.run_id === runId;
 }
 
 function mergeUIState(
@@ -356,13 +410,20 @@ export class RuntimeSessions extends Effect.Service<RuntimeSessions>()(
           Effect.gen(function* () {
             const operations = yield* PubSub.unbounded<Notification>();
             yield* Effect.addFinalizer(() => PubSub.shutdown(operations));
+            const scratchpadLock = yield* Effect.makeSemaphore(1);
             const queue = yield* makeRuntimeCommandQueue(
               (request: RuntimeRequest) => sendRequest(notebookUri, request),
             );
-            return { operations, queue };
+            return { operations, queue, scratchpadLock };
           }),
           scope,
         );
+        const interrupt = Effect.fn("RuntimeSession.interrupt")(function* () {
+          yield* ensureCurrent(notebookUri, token);
+          yield* client
+            .executeCommand(interruptCommand(notebookUri))
+            .pipe(Effect.asVoid);
+        });
         const session: RuntimeSession = {
           notebookUri,
           operations: () => Stream.fromPubSub(resources.operations),
@@ -379,6 +440,69 @@ export class RuntimeSessions extends Effect.Service<RuntimeSessions>()(
               );
             },
           ),
+          executeScratchpad: (code, executable) =>
+            Stream.unwrapScoped(
+              Effect.gen(function* () {
+                yield* Effect.acquireRelease(
+                  resources.scratchpadLock.take(1),
+                  () => resources.scratchpadLock.release(1),
+                );
+
+                // Subscribe before sending so an immediate completed-run cannot
+                // overtake the stream.
+                const operations = yield* PubSub.subscribe(
+                  resources.operations,
+                );
+                const runId = crypto.randomUUID();
+                const commandSent = yield* Ref.make(false);
+
+                yield* Effect.addFinalizer((exit) =>
+                  Exit.isInterrupted(exit)
+                    ? Ref.get(commandSent).pipe(
+                        Effect.flatMap((sent) =>
+                          sent
+                            ? interrupt().pipe(
+                                Effect.catchAllCause((cause) =>
+                                  Effect.logWarning(
+                                    "Failed to interrupt abandoned scratchpad execution",
+                                  ).pipe(
+                                    Effect.annotateLogs({
+                                      cause,
+                                      notebookUri,
+                                      runId,
+                                    }),
+                                  ),
+                                ),
+                              )
+                            : Effect.void,
+                        ),
+                      )
+                    : Effect.void,
+                );
+
+                // Once queued, finish the send even if the stream is abandoned.
+                // The finalizer will then interrupt the run.
+                yield* Effect.uninterruptible(
+                  resources.queue
+                    .send(
+                      RuntimeRequest.Api({
+                        command: executeScratchpadCommand(
+                          notebookUri,
+                          executable,
+                          code,
+                          runId,
+                        ),
+                      }),
+                    )
+                    .pipe(Effect.andThen(Ref.set(commandSent, true))),
+                );
+
+                return Stream.fromQueue(operations).pipe(
+                  Stream.takeUntil(isCompletedRunFor(runId)),
+                  Stream.filter(isScratchpadOutput),
+                );
+              }),
+            ),
           updateUIElements: Effect.fn("RuntimeSession.updateUIElements")(
             function* (request) {
               if (
@@ -450,12 +574,7 @@ export class RuntimeSessions extends Effect.Service<RuntimeSessions>()(
               }),
             );
           }),
-          interrupt: Effect.fn("RuntimeSession.interrupt")(function* () {
-            yield* ensureCurrent(notebookUri, token);
-            yield* client
-              .executeCommand(interruptCommand(notebookUri))
-              .pipe(Effect.asVoid);
-          }),
+          interrupt,
           close: Effect.fn("RuntimeSession.close")(function* () {
             yield* ensureCurrent(notebookUri, token);
             yield* resources.queue.close();

--- a/extension/src/kernel/RuntimeSessions.ts
+++ b/extension/src/kernel/RuntimeSessions.ts
@@ -1,0 +1,155 @@
+import {
+  Effect,
+  Exit,
+  HashMap,
+  Option,
+  PubSub,
+  Scope,
+  Stream,
+  SynchronizedRef,
+} from "effect";
+
+import { LanguageClient } from "../lsp/LanguageClient.ts";
+import type { NotebookId } from "../schemas/MarimoNotebookDocument.ts";
+import type { MarimoLspNotificationOf, Notification } from "../types.ts";
+
+export type MarimoOperation = MarimoLspNotificationOf<"marimo/operation">;
+
+/**
+ * One live marimo runtime, identified by its notebook URI.
+ *
+ * Operations are ordered as received from the language server. The stream ends
+ * when this session is closed.
+ */
+export interface RuntimeSession {
+  readonly notebookUri: NotebookId;
+  readonly operations: () => Stream.Stream<Notification>;
+  readonly shutdown: () => Effect.Effect<void>;
+}
+
+interface SessionEntry {
+  readonly token: object;
+  readonly session: RuntimeSession;
+  readonly operations: PubSub.PubSub<Notification>;
+  readonly scope: Scope.CloseableScope;
+}
+
+/**
+ * Owns live runtime sessions and the extension's single subscription to
+ * `marimo/operation`.
+ *
+ * `getOrCreate` returns the current session for a notebook URI. Shutting down
+ * the session ends its operation stream and removes it from the registry. A
+ * later `getOrCreate` creates a fresh session.
+ */
+export class RuntimeSessions extends Effect.Service<RuntimeSessions>()(
+  "RuntimeSessions",
+  {
+    scoped: Effect.gen(function* () {
+      const client = yield* LanguageClient;
+      const allOperations = yield* PubSub.unbounded<MarimoOperation>();
+      const sessions = yield* SynchronizedRef.make(
+        HashMap.empty<NotebookId, SessionEntry>(),
+      );
+
+      const shutdown = Effect.fn("RuntimeSessions.shutdown")(function* (
+        notebookUri: NotebookId,
+        token: object,
+      ) {
+        yield* SynchronizedRef.updateEffect(
+          sessions,
+          Effect.fnUntraced(function* (entries) {
+            const entry = HashMap.get(entries, notebookUri);
+            if (Option.isNone(entry) || entry.value.token !== token) {
+              return entries;
+            }
+
+            yield* Scope.close(entry.value.scope, Exit.void);
+            return HashMap.remove(entries, notebookUri);
+          }),
+        );
+      });
+
+      const makeSession = Effect.fn("RuntimeSessions.makeSession")(function* (
+        notebookUri: NotebookId,
+      ) {
+        const token = {};
+        const scope = yield* Scope.make();
+        const operations = yield* Scope.extend(
+          Effect.gen(function* () {
+            const operations = yield* PubSub.unbounded<Notification>();
+            yield* Effect.addFinalizer(() => PubSub.shutdown(operations));
+            return operations;
+          }),
+          scope,
+        );
+        const session: RuntimeSession = {
+          notebookUri,
+          operations: () => Stream.fromPubSub(operations),
+          shutdown: () => shutdown(notebookUri, token),
+        };
+        return { token, session, operations, scope } satisfies SessionEntry;
+      });
+
+      const getOrCreate = Effect.fn("RuntimeSessions.getOrCreate")(function* (
+        notebookUri: NotebookId,
+      ) {
+        return yield* SynchronizedRef.modifyEffect(
+          sessions,
+          Effect.fnUntraced(function* (entries) {
+            const existing = HashMap.get(entries, notebookUri);
+            if (Option.isSome(existing)) {
+              return [existing.value.session, entries] as const;
+            }
+
+            const entry = yield* makeSession(notebookUri);
+            return [
+              entry.session,
+              HashMap.set(entries, notebookUri, entry),
+            ] as const;
+          }),
+        );
+      });
+
+      yield* Effect.forkScoped(
+        client.streamOf("marimo/operation").pipe(
+          Stream.runForEach(
+            Effect.fn("RuntimeSessions.routeOperation")(function* (message) {
+              yield* PubSub.publish(allOperations, message);
+
+              const entry = HashMap.get(
+                yield* SynchronizedRef.get(sessions),
+                message.notebookUri,
+              );
+              if (Option.isSome(entry)) {
+                yield* PubSub.publish(
+                  entry.value.operations,
+                  message.operation,
+                );
+              }
+            }),
+          ),
+        ),
+      );
+
+      yield* Effect.addFinalizer((exit) =>
+        SynchronizedRef.updateEffect(
+          sessions,
+          Effect.fnUntraced(function* (entries) {
+            yield* Effect.forEach(
+              HashMap.values(entries),
+              (entry) => Scope.close(entry.scope, exit),
+              { discard: true },
+            );
+            return HashMap.empty();
+          }),
+        ).pipe(Effect.andThen(PubSub.shutdown(allOperations))),
+      );
+
+      return {
+        getOrCreate,
+        operations: () => Stream.fromPubSub(allOperations),
+      };
+    }),
+  },
+) {}

--- a/extension/src/kernel/RuntimeSessions.ts
+++ b/extension/src/kernel/RuntimeSessions.ts
@@ -18,11 +18,14 @@ import {
 } from "../lsp/LanguageClient.ts";
 import type { NotebookId } from "../schemas/MarimoNotebookDocument.ts";
 import type {
+  DeleteCellRequest,
+  ExecuteCellsRequest,
   InvokeFunctionRequest,
   MarimoCommand,
   MarimoLspNotificationOf,
   ModelRequest,
   Notification,
+  SendStdinRequest,
   UpdateUIElementRequest,
 } from "../types.ts";
 import {
@@ -56,6 +59,10 @@ type RuntimeSendError =
 export interface RuntimeSession {
   readonly notebookUri: NotebookId;
   readonly operations: () => Stream.Stream<Notification>;
+  readonly executeCells: (
+    request: ExecuteCellsRequest,
+    executable: string,
+  ) => Effect.Effect<void, RuntimeSendError>;
   readonly updateUIElements: (
     request: UpdateUIElementRequest,
   ) => Effect.Effect<void, RuntimeCommandQueueClosedError>;
@@ -65,6 +72,14 @@ export interface RuntimeSession {
   readonly invokeFunction: (
     request: InvokeFunctionRequest,
   ) => Effect.Effect<void, RuntimeSendError>;
+  readonly deleteCell: (
+    request: DeleteCellRequest,
+  ) => Effect.Effect<void, RuntimeSendError>;
+  readonly sendStdin: (
+    request: SendStdinRequest,
+  ) => Effect.Effect<void, RuntimeSendError>;
+  readonly interrupt: () => Effect.Effect<void, RuntimeSendError>;
+  readonly close: () => Effect.Effect<void, RuntimeSendError>;
   readonly shutdown: () => Effect.Effect<void>;
 }
 
@@ -110,6 +125,66 @@ function uiCommand(
     params: {
       method: "update-ui-element",
       params: { notebookUri, inner: request },
+    },
+  };
+}
+
+function executeCellsCommand(
+  notebookUri: NotebookId,
+  executable: string,
+  request: ExecuteCellsRequest,
+): MarimoCommand {
+  return {
+    command: "marimo.api",
+    params: {
+      method: "execute-cells",
+      params: { notebookUri, executable, inner: request },
+    },
+  };
+}
+
+function deleteCellCommand(
+  notebookUri: NotebookId,
+  request: DeleteCellRequest,
+): MarimoCommand {
+  return {
+    command: "marimo.api",
+    params: {
+      method: "delete-cell",
+      params: { notebookUri, inner: request },
+    },
+  };
+}
+
+function sendStdinCommand(
+  notebookUri: NotebookId,
+  request: SendStdinRequest,
+): MarimoCommand {
+  return {
+    command: "marimo.api",
+    params: {
+      method: "send-stdin",
+      params: { notebookUri, inner: request },
+    },
+  };
+}
+
+function interruptCommand(notebookUri: NotebookId): MarimoCommand {
+  return {
+    command: "marimo.api",
+    params: {
+      method: "interrupt",
+      params: { notebookUri, inner: {} },
+    },
+  };
+}
+
+function closeSessionCommand(notebookUri: NotebookId): MarimoCommand {
+  return {
+    command: "marimo.api",
+    params: {
+      method: "close-session",
+      params: { notebookUri, inner: {} },
     },
   };
 }
@@ -260,6 +335,18 @@ export class RuntimeSessions extends Effect.Service<RuntimeSessions>()(
         );
       });
 
+      const ensureCurrent = Effect.fn("RuntimeSessions.ensureCurrent")(
+        function* (notebookUri: NotebookId, token: object) {
+          const entry = HashMap.get(
+            yield* SynchronizedRef.get(sessions),
+            notebookUri,
+          );
+          if (Option.isNone(entry) || entry.value.token !== token) {
+            yield* new RuntimeCommandQueueClosedError();
+          }
+        },
+      );
+
       const makeSession = Effect.fn("RuntimeSessions.makeSession")(function* (
         notebookUri: NotebookId,
       ) {
@@ -279,6 +366,19 @@ export class RuntimeSessions extends Effect.Service<RuntimeSessions>()(
         const session: RuntimeSession = {
           notebookUri,
           operations: () => Stream.fromPubSub(resources.operations),
+          executeCells: Effect.fn("RuntimeSession.executeCells")(
+            function* (request, executable) {
+              yield* resources.queue.send(
+                RuntimeRequest.Api({
+                  command: executeCellsCommand(
+                    notebookUri,
+                    executable,
+                    request,
+                  ),
+                }),
+              );
+            },
+          ),
           updateUIElements: Effect.fn("RuntimeSession.updateUIElements")(
             function* (request) {
               if (
@@ -334,6 +434,38 @@ export class RuntimeSessions extends Effect.Service<RuntimeSessions>()(
               );
             },
           ),
+          deleteCell: Effect.fn("RuntimeSession.deleteCell")(
+            function* (request) {
+              yield* resources.queue.send(
+                RuntimeRequest.Api({
+                  command: deleteCellCommand(notebookUri, request),
+                }),
+              );
+            },
+          ),
+          sendStdin: Effect.fn("RuntimeSession.sendStdin")(function* (request) {
+            yield* resources.queue.send(
+              RuntimeRequest.Api({
+                command: sendStdinCommand(notebookUri, request),
+              }),
+            );
+          }),
+          interrupt: Effect.fn("RuntimeSession.interrupt")(function* () {
+            yield* ensureCurrent(notebookUri, token);
+            yield* client
+              .executeCommand(interruptCommand(notebookUri))
+              .pipe(Effect.asVoid);
+          }),
+          close: Effect.fn("RuntimeSession.close")(function* () {
+            yield* ensureCurrent(notebookUri, token);
+            yield* resources.queue.close();
+            yield* client
+              .executeCommand(closeSessionCommand(notebookUri))
+              .pipe(
+                Effect.asVoid,
+                Effect.ensuring(shutdown(notebookUri, token)),
+              );
+          }),
           shutdown: () => shutdown(notebookUri, token),
         };
         return {

--- a/extension/src/kernel/SandboxController.ts
+++ b/extension/src/kernel/SandboxController.ts
@@ -23,6 +23,7 @@ import {
   type NotebookId,
 } from "../schemas/MarimoNotebookDocument.ts";
 import { SemVerFromString } from "../schemas/SemVerFromString.ts";
+import { RuntimeSessions } from "./RuntimeSessions.ts";
 
 /**
  * An error returned when a sandbox kernel is asked to run for an unsaved
@@ -36,11 +37,17 @@ export class UnsavedNotebookError extends Data.TaggedError(
 export class SandboxController extends Effect.Service<SandboxController>()(
   "SandboxController",
   {
-    dependencies: [Uv.Default, OutputChannel.Default, Constants.Default],
+    dependencies: [
+      Uv.Default,
+      OutputChannel.Default,
+      Constants.Default,
+      RuntimeSessions.Default,
+    ],
     scoped: Effect.gen(function* () {
       const uv = yield* Uv;
       const code = yield* VsCode;
       const client = yield* LanguageClient;
+      const runtimeSessions = yield* RuntimeSessions;
       const python = yield* PythonExtension;
       const { LanguageId } = yield* Constants;
 
@@ -118,17 +125,8 @@ export class SandboxController extends Effect.Service<SandboxController>()(
             // handled below with an interactive save prompt.
             const executable = yield* resolveExecutable(notebook);
 
-            yield* client.executeCommand({
-              command: "marimo.api",
-              params: {
-                method: "execute-cells",
-                params: {
-                  notebookUri: notebook.id,
-                  executable,
-                  inner: request.value,
-                },
-              },
-            });
+            const session = yield* runtimeSessions.getOrCreate(notebook.id);
+            yield* session.executeCells(request.value, executable);
           }).pipe(
             // Handle the expected "unsaved notebook" path before logging, so a
             // normal save prompt isn't recorded as an error. (sandboxing only
@@ -178,6 +176,11 @@ export class SandboxController extends Effect.Service<SandboxController>()(
                 "Failed to start marimo language server (marimo-lsp).",
               ),
             ),
+            Effect.catchTag("RuntimeCommandQueueClosedError", () =>
+              showErrorAndPromptLogs(
+                "The marimo runtime session closed before execution could start.",
+              ),
+            ),
             Effect.annotateLogs({ notebook: rawNotebook.uri.fsPath }),
           ),
         );
@@ -186,16 +189,8 @@ export class SandboxController extends Effect.Service<SandboxController>()(
         runPromise(
           Effect.gen(function* () {
             const notebook = MarimoNotebookDocument.from(doc);
-            yield* client.executeCommand({
-              command: "marimo.api",
-              params: {
-                method: "interrupt",
-                params: {
-                  notebookUri: notebook.id,
-                  inner: {},
-                },
-              },
-            });
+            const session = yield* runtimeSessions.getOrCreate(notebook.id);
+            yield* session.interrupt();
           }).pipe(
             Effect.withSpan("SandboxController.interrupt", {
               attributes: {

--- a/extension/src/kernel/__tests__/KernelManager.test.ts
+++ b/extension/src/kernel/__tests__/KernelManager.test.ts
@@ -18,10 +18,13 @@ import { TestTelemetryLive } from "../../__mocks__/TestTelemetry.ts";
 import { TestVsCode } from "../../__mocks__/TestVsCode.ts";
 import { NOTEBOOK_TYPE, SCRATCH_CELL_ID } from "../../constants.ts";
 import { ControllerRegistry } from "../../kernel/ControllerRegistry.ts";
-import { KernelManager } from "../../kernel/KernelManager.ts";
+import {
+  KernelManager,
+  processRuntimeOperations,
+} from "../../kernel/KernelManager.ts";
 import { PythonController } from "../../kernel/NotebookControllerFactory.ts";
 import { RuntimeSessions } from "../../kernel/RuntimeSessions.ts";
-import { cellId } from "../../lib/__tests__/branded.ts";
+import { cellId, notebookId } from "../../lib/__tests__/branded.ts";
 import { LanguageClient } from "../../lsp/LanguageClient.ts";
 import { VsCode } from "../../platform/VsCode.ts";
 import { MarimoNotebookDocument } from "../../schemas/MarimoNotebookDocument.ts";
@@ -143,6 +146,58 @@ function makeIdleCellOperation(
     },
   };
 }
+
+describe("processRuntimeOperations", () => {
+  it.scoped(
+    "preserves notebook order without blocking other notebooks",
+    Effect.fn(function* () {
+      const firstAStarted = yield* Effect.makeLatch();
+      const releaseFirstA = yield* Effect.makeLatch();
+      const bProcessed = yield* Effect.makeLatch();
+      const processed = yield* Ref.make<ReadonlyArray<string>>([]);
+      const notebookA = notebookId("notebook-a");
+      const notebookB = notebookId("notebook-b");
+
+      const operation = (
+        notebookUri: NotebookId,
+        runId: string,
+      ): MarimoLspNotificationOf<"marimo/operation"> => ({
+        notebookUri,
+        operation: { op: "completed-run", run_id: runId },
+      });
+
+      const fiber = yield* processRuntimeOperations(
+        Stream.make(
+          operation(notebookA, "a-1"),
+          operation(notebookA, "a-2"),
+          operation(notebookB, "b-1"),
+        ),
+        Effect.fn(function* ({ operation }) {
+          assert(operation.op === "completed-run");
+          if (operation.run_id === "a-1") {
+            yield* firstAStarted.open;
+            yield* releaseFirstA.await;
+          }
+          yield* Ref.update(processed, (runIds) => [
+            ...runIds,
+            operation.run_id ?? "",
+          ]);
+          if (operation.run_id === "b-1") {
+            yield* bProcessed.open;
+          }
+        }),
+      ).pipe(Effect.fork);
+
+      yield* firstAStarted.await;
+      yield* bProcessed.await;
+      assert.deepStrictEqual(yield* Ref.get(processed), ["b-1"]);
+
+      yield* releaseFirstA.open;
+      yield* Fiber.join(fiber);
+      assert.deepStrictEqual(yield* Ref.get(processed), ["b-1", "a-1", "a-2"]);
+    }),
+  );
+});
 
 describe("KernelManager stdin", () => {
   it.scoped(

--- a/extension/src/kernel/__tests__/KernelManager.test.ts
+++ b/extension/src/kernel/__tests__/KernelManager.test.ts
@@ -20,6 +20,7 @@ import { NOTEBOOK_TYPE, SCRATCH_CELL_ID } from "../../constants.ts";
 import { ControllerRegistry } from "../../kernel/ControllerRegistry.ts";
 import { KernelManager } from "../../kernel/KernelManager.ts";
 import { PythonController } from "../../kernel/NotebookControllerFactory.ts";
+import { RuntimeSessions } from "../../kernel/RuntimeSessions.ts";
 import { cellId } from "../../lib/__tests__/branded.ts";
 import { LanguageClient } from "../../lsp/LanguageClient.ts";
 import { VsCode } from "../../platform/VsCode.ts";
@@ -77,6 +78,7 @@ const withTestCtx = Effect.fn(function* () {
 
   const layer = Layer.empty.pipe(
     Layer.provideMerge(KernelManager.Default),
+    Layer.provide(RuntimeSessions.Default),
     Layer.provide(
       Layer.succeed(
         ControllerRegistry,

--- a/extension/src/kernel/__tests__/RuntimeCommandQueue.test.ts
+++ b/extension/src/kernel/__tests__/RuntimeCommandQueue.test.ts
@@ -1,0 +1,325 @@
+import { assert, describe, it } from "@effect/vitest";
+import {
+  Deferred,
+  Effect,
+  Either,
+  Fiber,
+  Option,
+  Ref,
+  TestClock,
+} from "effect";
+
+import {
+  makeRuntimeCommandQueue,
+  RuntimeCommandQueueClosedError,
+} from "../RuntimeCommandQueue.ts";
+
+type Command =
+  | {
+      readonly _tag: "State";
+      readonly kind: "ui" | "model";
+      readonly values: ReadonlyMap<string, number>;
+    }
+  | { readonly _tag: "Event"; readonly name: string };
+
+const state = (
+  kind: "ui" | "model",
+  ...entries: ReadonlyArray<readonly [string, number]>
+): Command => ({ _tag: "State", kind, values: new Map(entries) });
+
+const event = (name: string): Command => ({ _tag: "Event", name });
+
+const mergeState = (older: Command, newer: Command): Command => {
+  assert(older._tag === "State");
+  assert(newer._tag === "State");
+  return {
+    ...newer,
+    values: new Map([...older.values, ...newer.values]),
+  };
+};
+
+const summarize = (command: Command): string => {
+  if (command._tag === "Event") return command.name;
+  const values = [...command.values]
+    .map(([key, value]) => `${key}=${value}`)
+    .join(",");
+  return `${command.kind}(${values})`;
+};
+
+describe("RuntimeCommandQueue", () => {
+  it.scoped(
+    "keeps the latest adjacent replaceable state while send is in flight",
+    Effect.fn(function* () {
+      const firstStarted = yield* Deferred.make<void>();
+      const releaseFirst = yield* Deferred.make<void>();
+      const secondStarted = yield* Deferred.make<void>();
+      const sent = yield* Ref.make<ReadonlyArray<Command>>([]);
+
+      const queue = yield* makeRuntimeCommandQueue(
+        Effect.fn(function* (command: Command) {
+          yield* Ref.update(sent, (commands) => [...commands, command]);
+          if (summarize(command) === "ui(slider=1)") {
+            yield* Deferred.succeed(firstStarted, undefined);
+            yield* Deferred.await(releaseFirst);
+          } else {
+            yield* Deferred.succeed(secondStarted, undefined);
+          }
+        }),
+      );
+
+      yield* queue.enqueueState({
+        kind: "ui",
+        command: state("ui", ["slider", 1]),
+        merge: mergeState,
+      });
+      yield* Deferred.await(firstStarted);
+      yield* queue.enqueueState({
+        kind: "ui",
+        command: state("ui", ["slider", 2], ["other", 9]),
+        merge: mergeState,
+      });
+      yield* queue.enqueueState({
+        kind: "ui",
+        command: state("ui", ["slider", 3]),
+        merge: mergeState,
+      });
+
+      assert.deepStrictEqual((yield* Ref.get(sent)).map(summarize), [
+        "ui(slider=1)",
+      ]);
+
+      yield* Deferred.succeed(releaseFirst, undefined);
+      yield* Deferred.await(secondStarted);
+
+      assert.deepStrictEqual((yield* Ref.get(sent)).map(summarize), [
+        "ui(slider=1)",
+        "ui(slider=3,other=9)",
+      ]);
+    }),
+  );
+
+  it.scoped(
+    "keeps commands and different kinds of state in order",
+    Effect.fn(function* () {
+      const firstStarted = yield* Deferred.make<void>();
+      const releaseFirst = yield* Deferred.make<void>();
+      const sent = yield* Ref.make<ReadonlyArray<Command>>([]);
+
+      const queue = yield* makeRuntimeCommandQueue(
+        Effect.fn(function* (command: Command) {
+          yield* Ref.update(sent, (commands) => [...commands, command]);
+          if (summarize(command) === "ui(slider=1)") {
+            yield* Deferred.succeed(firstStarted, undefined);
+            yield* Deferred.await(releaseFirst);
+          }
+        }),
+      );
+
+      yield* queue.enqueueState({
+        kind: "ui",
+        command: state("ui", ["slider", 1]),
+        merge: mergeState,
+      });
+      yield* Deferred.await(firstStarted);
+      yield* queue.enqueueState({
+        kind: "ui",
+        command: state("ui", ["slider", 2]),
+        merge: mergeState,
+      });
+      const ordered = yield* queue.send(event("custom")).pipe(Effect.fork);
+      yield* TestClock.adjust("1 millis");
+      yield* queue.enqueueState({
+        kind: "ui",
+        command: state("ui", ["slider", 3]),
+        merge: mergeState,
+      });
+      yield* queue.enqueueState({
+        kind: "ui",
+        command: state("ui", ["slider", 4]),
+        merge: mergeState,
+      });
+      yield* queue.enqueueState({
+        kind: "model",
+        command: state("model", ["value", 1]),
+        merge: mergeState,
+      });
+      yield* queue.enqueueState({
+        kind: "model",
+        command: state("model", ["value", 2]),
+        merge: mergeState,
+      });
+
+      yield* Deferred.succeed(releaseFirst, undefined);
+      yield* Fiber.join(ordered);
+
+      assert.deepStrictEqual((yield* Ref.get(sent)).map(summarize), [
+        "ui(slider=1)",
+        "ui(slider=2)",
+        "custom",
+        "ui(slider=4)",
+        "model(value=2)",
+      ]);
+    }),
+  );
+
+  it.scoped(
+    "reports a send failure, then sends the next command without retrying",
+    Effect.fn(function* () {
+      const failedStarted = yield* Deferred.make<void>();
+      const releaseFailure = yield* Deferred.make<void>();
+      const nextStarted = yield* Deferred.make<void>();
+      const attempts = yield* Ref.make<ReadonlyArray<string>>([]);
+
+      const queue = yield* makeRuntimeCommandQueue(
+        Effect.fn(function* (command: Command) {
+          const name = summarize(command);
+          yield* Ref.update(attempts, (names) => [...names, name]);
+          if (name === "fails") {
+            yield* Deferred.succeed(failedStarted, undefined);
+            yield* Deferred.await(releaseFailure);
+            return yield* Effect.fail("not sent");
+          }
+          return yield* Deferred.succeed(nextStarted, undefined);
+        }),
+      );
+
+      const failed = yield* queue
+        .send(event("fails"))
+        .pipe(Effect.either, Effect.fork);
+      yield* Deferred.await(failedStarted);
+      const next = yield* queue.send(event("next")).pipe(Effect.fork);
+
+      assert(Option.isNone(yield* Fiber.poll(failed)));
+      assert(Option.isNone(yield* Fiber.poll(next)));
+
+      yield* Deferred.succeed(releaseFailure, undefined);
+      assert.deepStrictEqual(
+        yield* Fiber.join(failed),
+        Either.left("not sent"),
+      );
+      yield* Deferred.await(nextStarted);
+      yield* Fiber.join(next);
+      assert.deepStrictEqual(yield* Ref.get(attempts), ["fails", "next"]);
+    }),
+  );
+
+  it.scoped(
+    "continues after a replaceable send fails without retrying it",
+    Effect.fn(function* () {
+      const firstStarted = yield* Deferred.make<void>();
+      const releaseFailure = yield* Deferred.make<void>();
+      const secondStarted = yield* Deferred.make<void>();
+      const attempts = yield* Ref.make<ReadonlyArray<string>>([]);
+
+      const queue = yield* makeRuntimeCommandQueue(
+        Effect.fn(function* (command: Command) {
+          const summary = summarize(command);
+          yield* Ref.update(attempts, (commands) => [...commands, summary]);
+          if (summary === "ui(slider=1)") {
+            yield* Deferred.succeed(firstStarted, undefined);
+            yield* Deferred.await(releaseFailure);
+            return yield* Effect.fail("not sent");
+          }
+          return yield* Deferred.succeed(secondStarted, undefined);
+        }),
+      );
+
+      yield* queue.enqueueState({
+        kind: "ui",
+        command: state("ui", ["slider", 1]),
+        merge: mergeState,
+      });
+      yield* Deferred.await(firstStarted);
+      yield* queue.enqueueState({
+        kind: "ui",
+        command: state("ui", ["slider", 2]),
+        merge: mergeState,
+      });
+
+      yield* Deferred.succeed(releaseFailure, undefined);
+      yield* Deferred.await(secondStarted);
+
+      assert.deepStrictEqual(yield* Ref.get(attempts), [
+        "ui(slider=1)",
+        "ui(slider=2)",
+      ]);
+    }),
+  );
+
+  it.scoped(
+    "lets separate session queues send independently",
+    Effect.fn(function* () {
+      const releaseA = yield* Deferred.make<void>();
+      const startedA = yield* Deferred.make<void>();
+      const startedB = yield* Deferred.make<void>();
+
+      const queueA = yield* makeRuntimeCommandQueue(
+        Effect.fn(function* (_command: Command) {
+          yield* Deferred.succeed(startedA, undefined);
+          yield* Deferred.await(releaseA);
+        }),
+      );
+      const queueB = yield* makeRuntimeCommandQueue((_command: Command) =>
+        Deferred.succeed(startedB, undefined),
+      );
+
+      yield* queueA.enqueueState({
+        kind: "ui",
+        command: state("ui", ["slider", 1]),
+        merge: mergeState,
+      });
+      yield* Deferred.await(startedA);
+      yield* queueB.enqueueState({
+        kind: "ui",
+        command: state("ui", ["slider", 2]),
+        merge: mergeState,
+      });
+
+      yield* Deferred.await(startedB);
+      yield* Deferred.succeed(releaseA, undefined);
+    }),
+  );
+
+  it.scoped(
+    "invalidates in-flight and pending work when closed",
+    Effect.fn(function* () {
+      const started = yield* Deferred.make<void>();
+      const queue = yield* makeRuntimeCommandQueue(
+        Effect.fn(function* (_command: Command) {
+          yield* Deferred.succeed(started, undefined);
+          yield* Effect.never;
+        }),
+      );
+
+      const inFlight = yield* queue
+        .send(event("in-flight"))
+        .pipe(Effect.either, Effect.fork);
+      yield* Deferred.await(started);
+      const pending = yield* queue
+        .send(event("pending"))
+        .pipe(Effect.either, Effect.fork);
+      yield* TestClock.adjust("1 millis");
+
+      yield* queue.close();
+
+      for (const result of [
+        yield* Fiber.join(inFlight),
+        yield* Fiber.join(pending),
+        yield* queue.send(event("late")).pipe(Effect.either),
+      ]) {
+        assert(Either.isLeft(result));
+        assert(result.left instanceof RuntimeCommandQueueClosedError);
+      }
+
+      const lateState = yield* queue
+        .enqueueState({
+          kind: "ui",
+          command: state("ui", ["slider", 1]),
+          merge: mergeState,
+        })
+        .pipe(Effect.either);
+      assert(Either.isLeft(lateState));
+      assert(lateState.left instanceof RuntimeCommandQueueClosedError);
+    }),
+  );
+});

--- a/extension/src/kernel/__tests__/RuntimeSessions.test.ts
+++ b/extension/src/kernel/__tests__/RuntimeSessions.test.ts
@@ -1,0 +1,161 @@
+import { assert, describe, expect, it } from "@effect/vitest";
+import {
+  Chunk,
+  Effect,
+  Fiber,
+  Layer,
+  Option,
+  PubSub,
+  Ref,
+  Stream,
+  TestClock,
+} from "effect";
+
+import { notebookId } from "../../lib/__tests__/branded.ts";
+import { LanguageClient } from "../../lsp/LanguageClient.ts";
+import type { NotebookId } from "../../schemas/MarimoNotebookDocument.ts";
+import type { MarimoCommand, Notification } from "../../types.ts";
+import { type MarimoOperation, RuntimeSessions } from "../RuntimeSessions.ts";
+
+const NOTEBOOK_A = notebookId("notebook-a");
+const NOTEBOOK_B = notebookId("notebook-b");
+
+const completedRun = (
+  notebookUri: NotebookId,
+  runId: string,
+): MarimoOperation => ({
+  notebookUri,
+  operation: {
+    op: "completed-run",
+    run_id: runId,
+  },
+});
+
+const withTestContext = Effect.fn(function* () {
+  const source = yield* PubSub.unbounded<MarimoOperation>();
+  const rawSubscriptions = yield* Ref.make(0);
+
+  const client = Layer.succeed(
+    LanguageClient,
+    LanguageClient.make({
+      channel: { name: "marimo-lsp", show() {} },
+      restart: () => Effect.void,
+      executeCommand: (_command: MarimoCommand) => Effect.void,
+      streamOf() {
+        const stream = Stream.unwrap(
+          Ref.updateAndGet(rawSubscriptions, (count) => count + 1).pipe(
+            Effect.as(Stream.fromPubSub(source)),
+          ),
+        );
+        // SAFETY: this fake only serves the marimo/operation stream used by
+        // RuntimeSessions.
+        // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+        return stream as never;
+      },
+    }),
+  );
+
+  return {
+    source,
+    rawSubscriptions,
+    layer: RuntimeSessions.Default.pipe(Layer.provide(client)),
+  };
+});
+
+const runIds = (
+  operations: Chunk.Chunk<Notification>,
+): ReadonlyArray<string | null | undefined> =>
+  Chunk.toReadonlyArray(operations)
+    .filter((operation) => operation.op === "completed-run")
+    .map((operation) => operation.run_id);
+
+describe("RuntimeSessions", () => {
+  it.scoped(
+    "routes operations to the matching session in order",
+    Effect.fn(function* () {
+      const ctx = yield* withTestContext();
+
+      yield* Effect.gen(function* () {
+        const sessions = yield* RuntimeSessions;
+        const sessionA = yield* sessions.getOrCreate(NOTEBOOK_A);
+        const sameSessionA = yield* sessions.getOrCreate(NOTEBOOK_A);
+        const sessionB = yield* sessions.getOrCreate(NOTEBOOK_B);
+        expect(sameSessionA).toBe(sessionA);
+
+        const operationsA = yield* sessionA
+          .operations()
+          .pipe(Stream.take(2), Stream.runCollect, Effect.fork);
+        const operationsB = yield* sessionB
+          .operations()
+          .pipe(Stream.take(1), Stream.runCollect, Effect.fork);
+        yield* TestClock.adjust("1 millis");
+
+        yield* PubSub.publish(ctx.source, completedRun(NOTEBOOK_A, "a-1"));
+        yield* PubSub.publish(ctx.source, completedRun(NOTEBOOK_B, "b-1"));
+        yield* PubSub.publish(ctx.source, completedRun(NOTEBOOK_A, "a-2"));
+
+        assert.deepStrictEqual(runIds(yield* Fiber.join(operationsA)), [
+          "a-1",
+          "a-2",
+        ]);
+        assert.deepStrictEqual(runIds(yield* Fiber.join(operationsB)), ["b-1"]);
+        assert.strictEqual(yield* Ref.get(ctx.rawSubscriptions), 1);
+      }).pipe(Effect.provide(ctx.layer));
+    }),
+  );
+
+  it.scoped(
+    "closes a session stream and creates a fresh session when reopened",
+    Effect.fn(function* () {
+      const ctx = yield* withTestContext();
+
+      yield* Effect.gen(function* () {
+        const sessions = yield* RuntimeSessions;
+        const first = yield* sessions.getOrCreate(NOTEBOOK_A);
+        const firstOperations = yield* first
+          .operations()
+          .pipe(Stream.runCollect, Effect.fork);
+        yield* TestClock.adjust("1 millis");
+
+        yield* first.shutdown();
+        assert(Chunk.isEmpty(yield* Fiber.join(firstOperations)));
+
+        const reopened = yield* sessions.getOrCreate(NOTEBOOK_A);
+        expect(reopened).not.toBe(first);
+        const nextOperation = yield* reopened
+          .operations()
+          .pipe(Stream.runHead, Effect.fork);
+        yield* TestClock.adjust("1 millis");
+
+        // A stale handle cannot shut down the replacement session.
+        yield* first.shutdown();
+        yield* PubSub.publish(ctx.source, completedRun(NOTEBOOK_A, "new"));
+
+        const received = yield* Fiber.join(nextOperation);
+        assert(Option.isSome(received));
+        expect(received.value).toMatchObject({ run_id: "new" });
+      }).pipe(Effect.provide(ctx.layer));
+    }),
+  );
+
+  it.scoped(
+    "keeps the shared operation stream available for unopened sessions",
+    Effect.fn(function* () {
+      const ctx = yield* withTestContext();
+
+      yield* Effect.gen(function* () {
+        const sessions = yield* RuntimeSessions;
+        const operation = yield* sessions
+          .operations()
+          .pipe(Stream.runHead, Effect.fork);
+        yield* TestClock.adjust("1 millis");
+
+        yield* PubSub.publish(ctx.source, completedRun(NOTEBOOK_B, "run"));
+
+        const received = yield* Fiber.join(operation);
+        assert(Option.isSome(received));
+        expect(received.value).toEqual(completedRun(NOTEBOOK_B, "run"));
+      }).pipe(Effect.provide(ctx.layer));
+    }),
+  );
+});

--- a/extension/src/kernel/__tests__/RuntimeSessions.test.ts
+++ b/extension/src/kernel/__tests__/RuntimeSessions.test.ts
@@ -3,6 +3,7 @@ import {
   Chunk,
   Deferred,
   Effect,
+  Either,
   Fiber,
   Layer,
   Option,
@@ -14,6 +15,7 @@ import {
 
 import {
   base64String,
+  cellId,
   notebookId,
   requestId,
   uiElementId,
@@ -22,6 +24,7 @@ import {
 import { LanguageClient } from "../../lsp/LanguageClient.ts";
 import type { NotebookId } from "../../schemas/MarimoNotebookDocument.ts";
 import type { MarimoCommand, Notification } from "../../types.ts";
+import { RuntimeCommandQueueClosedError } from "../RuntimeCommandQueue.ts";
 import { type MarimoOperation, RuntimeSessions } from "../RuntimeSessions.ts";
 
 const NOTEBOOK_A = notebookId("notebook-a");
@@ -91,6 +94,11 @@ const marimoApiCommands = (
   commands.filter(
     (command): command is MarimoApiCommand => command.command === "marimo.api",
   );
+
+const apiMethods = (
+  commands: ReadonlyArray<MarimoCommand>,
+): ReadonlyArray<MarimoApiCommand["params"]["method"]> =>
+  marimoApiCommands(commands).map((command) => command.params.method);
 
 describe("RuntimeSessions", () => {
   it.scoped(
@@ -386,6 +394,162 @@ describe("RuntimeSessions", () => {
             },
           },
         });
+      }).pipe(Effect.provide(ctx.layer));
+    }),
+  );
+
+  it.scoped(
+    "sends ordinary commands in order while interrupt bypasses the queue",
+    Effect.fn(function* () {
+      const executionStarted = yield* Deferred.make<void>();
+      const releaseExecution = yield* Deferred.make<void>();
+      const ctx = yield* withTestContext(
+        Effect.fn(function* (command) {
+          if (
+            command.command === "marimo.api" &&
+            command.params.method === "execute-cells"
+          ) {
+            yield* Deferred.succeed(executionStarted, undefined);
+            yield* Deferred.await(releaseExecution);
+          }
+        }),
+      );
+
+      yield* Effect.gen(function* () {
+        const session = yield* (yield* RuntimeSessions).getOrCreate(NOTEBOOK_A);
+        const execution = yield* session
+          .executeCells(
+            { cellIds: [cellId("cell-1")], codes: ["value = 1"] },
+            "/usr/bin/python",
+          )
+          .pipe(Effect.fork);
+        yield* Deferred.await(executionStarted);
+
+        const deletion = yield* session
+          .deleteCell({ cellId: cellId("cell-2") })
+          .pipe(Effect.fork);
+        yield* TestClock.adjust("1 millis");
+
+        yield* session.interrupt();
+        assert.deepStrictEqual(apiMethods(yield* Ref.get(ctx.sentCommands)), [
+          "execute-cells",
+          "interrupt",
+        ]);
+
+        yield* Deferred.succeed(releaseExecution, undefined);
+        yield* Fiber.join(execution);
+        yield* Fiber.join(deletion);
+        yield* session.sendStdin({ text: "answer" });
+
+        expect(marimoApiCommands(yield* Ref.get(ctx.sentCommands)))
+          .toMatchInlineSnapshot(`
+          [
+            {
+              "command": "marimo.api",
+              "params": {
+                "method": "execute-cells",
+                "params": {
+                  "executable": "/usr/bin/python",
+                  "inner": {
+                    "cellIds": [
+                      "cell-1",
+                    ],
+                    "codes": [
+                      "value = 1",
+                    ],
+                  },
+                  "notebookUri": "notebook-a",
+                },
+              },
+            },
+            {
+              "command": "marimo.api",
+              "params": {
+                "method": "interrupt",
+                "params": {
+                  "inner": {},
+                  "notebookUri": "notebook-a",
+                },
+              },
+            },
+            {
+              "command": "marimo.api",
+              "params": {
+                "method": "delete-cell",
+                "params": {
+                  "inner": {
+                    "cellId": "cell-2",
+                  },
+                  "notebookUri": "notebook-a",
+                },
+              },
+            },
+            {
+              "command": "marimo.api",
+              "params": {
+                "method": "send-stdin",
+                "params": {
+                  "inner": {
+                    "text": "answer",
+                  },
+                  "notebookUri": "notebook-a",
+                },
+              },
+            },
+          ]
+        `);
+      }).pipe(Effect.provide(ctx.layer));
+    }),
+  );
+
+  it.scoped(
+    "close invalidates queued work and the old session handle",
+    Effect.fn(function* () {
+      const executionStarted = yield* Deferred.make<void>();
+      const ctx = yield* withTestContext(
+        Effect.fn(function* (command) {
+          if (
+            command.command === "marimo.api" &&
+            command.params.method === "execute-cells"
+          ) {
+            yield* Deferred.succeed(executionStarted, undefined);
+            yield* Effect.never;
+          }
+        }),
+      );
+
+      yield* Effect.gen(function* () {
+        const sessions = yield* RuntimeSessions;
+        const session = yield* sessions.getOrCreate(NOTEBOOK_A);
+        const execution = yield* session
+          .executeCells(
+            { cellIds: [cellId("cell-1")], codes: ["value = 1"] },
+            "/usr/bin/python",
+          )
+          .pipe(Effect.either, Effect.fork);
+        yield* Deferred.await(executionStarted);
+        const deletion = yield* session
+          .deleteCell({ cellId: cellId("cell-2") })
+          .pipe(Effect.either, Effect.fork);
+        yield* TestClock.adjust("1 millis");
+
+        yield* session.close();
+
+        for (const result of [
+          yield* Fiber.join(execution),
+          yield* Fiber.join(deletion),
+          yield* session.interrupt().pipe(Effect.either),
+        ]) {
+          assert(Either.isLeft(result));
+          assert(result.left instanceof RuntimeCommandQueueClosedError);
+        }
+        assert.deepStrictEqual(apiMethods(yield* Ref.get(ctx.sentCommands)), [
+          "execute-cells",
+          "close-session",
+        ]);
+
+        const replacement = yield* sessions.getOrCreate(NOTEBOOK_A);
+        expect(replacement).not.toBe(session);
       }).pipe(Effect.provide(ctx.layer));
     }),
   );

--- a/extension/src/kernel/__tests__/RuntimeSessions.test.ts
+++ b/extension/src/kernel/__tests__/RuntimeSessions.test.ts
@@ -1,6 +1,7 @@
 import { assert, describe, expect, it } from "@effect/vitest";
 import {
   Chunk,
+  Deferred,
   Effect,
   Fiber,
   Layer,
@@ -11,7 +12,13 @@ import {
   TestClock,
 } from "effect";
 
-import { notebookId } from "../../lib/__tests__/branded.ts";
+import {
+  base64String,
+  notebookId,
+  requestId,
+  uiElementId,
+  widgetModelId,
+} from "../../lib/__tests__/branded.ts";
 import { LanguageClient } from "../../lsp/LanguageClient.ts";
 import type { NotebookId } from "../../schemas/MarimoNotebookDocument.ts";
 import type { MarimoCommand, Notification } from "../../types.ts";
@@ -31,16 +38,22 @@ const completedRun = (
   },
 });
 
-const withTestContext = Effect.fn(function* () {
+const withTestContext = Effect.fn(function* (
+  onSend: (command: MarimoCommand) => Effect.Effect<void> = () => Effect.void,
+) {
   const source = yield* PubSub.unbounded<MarimoOperation>();
   const rawSubscriptions = yield* Ref.make(0);
+  const sentCommands = yield* Ref.make<ReadonlyArray<MarimoCommand>>([]);
 
   const client = Layer.succeed(
     LanguageClient,
     LanguageClient.make({
       channel: { name: "marimo-lsp", show() {} },
       restart: () => Effect.void,
-      executeCommand: (_command: MarimoCommand) => Effect.void,
+      executeCommand: (command: MarimoCommand) =>
+        Ref.update(sentCommands, (commands) => [...commands, command]).pipe(
+          Effect.andThen(onSend(command)),
+        ),
       streamOf() {
         const stream = Stream.unwrap(
           Ref.updateAndGet(rawSubscriptions, (count) => count + 1).pipe(
@@ -58,6 +71,7 @@ const withTestContext = Effect.fn(function* () {
   return {
     source,
     rawSubscriptions,
+    sentCommands,
     layer: RuntimeSessions.Default.pipe(Layer.provide(client)),
   };
 });
@@ -68,6 +82,15 @@ const runIds = (
   Chunk.toReadonlyArray(operations)
     .filter((operation) => operation.op === "completed-run")
     .map((operation) => operation.run_id);
+
+type MarimoApiCommand = Extract<MarimoCommand, { command: "marimo.api" }>;
+
+const marimoApiCommands = (
+  commands: ReadonlyArray<MarimoCommand>,
+): ReadonlyArray<MarimoApiCommand> =>
+  commands.filter(
+    (command): command is MarimoApiCommand => command.command === "marimo.api",
+  );
 
 describe("RuntimeSessions", () => {
   it.scoped(
@@ -100,6 +123,269 @@ describe("RuntimeSessions", () => {
         ]);
         assert.deepStrictEqual(runIds(yield* Fiber.join(operationsB)), ["b-1"]);
         assert.strictEqual(yield* Ref.get(ctx.rawSubscriptions), 1);
+      }).pipe(Effect.provide(ctx.layer));
+    }),
+  );
+
+  it.scoped(
+    "merges pending UI element values by ID",
+    Effect.fn(function* () {
+      const firstStarted = yield* Deferred.make<void>();
+      const releaseFirst = yield* Deferred.make<void>();
+      const secondStarted = yield* Deferred.make<void>();
+      const slider = uiElementId("slider");
+      const other = uiElementId("other");
+      const ctx = yield* withTestContext(
+        Effect.fn(function* (command) {
+          if (
+            command.command !== "marimo.api" ||
+            command.params.method !== "update-ui-element"
+          ) {
+            return;
+          }
+          const value = command.params.params.inner.values[0];
+          if (value === 1) {
+            yield* Deferred.succeed(firstStarted, undefined);
+            yield* Deferred.await(releaseFirst);
+          } else {
+            yield* Deferred.succeed(secondStarted, undefined);
+          }
+        }),
+      );
+
+      yield* Effect.gen(function* () {
+        const sessions = yield* RuntimeSessions;
+        const session = yield* sessions.getOrCreate(NOTEBOOK_A);
+
+        yield* session.updateUIElements({
+          objectIds: [slider],
+          values: [1],
+        });
+        yield* Deferred.await(firstStarted);
+        yield* session.updateUIElements({
+          objectIds: [slider, other],
+          values: [2, 9],
+        });
+        yield* session.updateUIElements({
+          objectIds: [slider],
+          values: [3],
+        });
+
+        yield* Deferred.succeed(releaseFirst, undefined);
+        yield* Deferred.await(secondStarted);
+
+        yield* session.updateUIElements({ objectIds: [], values: [] });
+        yield* session.updateUIElements({
+          objectIds: [slider, other],
+          values: [4],
+        });
+
+        const commands = marimoApiCommands(
+          yield* Ref.get(ctx.sentCommands),
+        ).filter((command) => command.params.method === "update-ui-element");
+        expect(commands).toHaveLength(2);
+        expect(commands[1]).toMatchObject({
+          params: {
+            method: "update-ui-element",
+            params: {
+              notebookUri: NOTEBOOK_A,
+              inner: {
+                objectIds: [slider, other],
+                values: [3, 9],
+              },
+            },
+          },
+        });
+      }).pipe(Effect.provide(ctx.layer));
+    }),
+  );
+
+  it.scoped(
+    "merges model state and keeps custom messages in order",
+    Effect.fn(function* () {
+      const firstStarted = yield* Deferred.make<void>();
+      const releaseFirst = yield* Deferred.make<void>();
+      const finalStarted = yield* Deferred.make<void>();
+      const modelA = widgetModelId("model-a");
+      const modelB = widgetModelId("model-b");
+      const ctx = yield* withTestContext(
+        Effect.fn(function* (command) {
+          if (
+            command.command === "marimo.api" &&
+            command.params.method === "update-ui-element"
+          ) {
+            yield* Deferred.succeed(firstStarted, undefined);
+            yield* Deferred.await(releaseFirst);
+          }
+          if (
+            command.command === "marimo.api" &&
+            command.params.method === "set-model-value" &&
+            command.params.params.inner.message.method === "update" &&
+            command.params.params.inner.message.state.after === 3
+          ) {
+            yield* Deferred.succeed(finalStarted, undefined);
+          }
+        }),
+      );
+
+      yield* Effect.gen(function* () {
+        const sessions = yield* RuntimeSessions;
+        const session = yield* sessions.getOrCreate(NOTEBOOK_A);
+
+        yield* session.updateUIElements({
+          objectIds: [uiElementId("slider")],
+          values: [1],
+        });
+        yield* Deferred.await(firstStarted);
+
+        yield* session.updateModel({
+          modelId: modelA,
+          message: {
+            method: "update",
+            state: { value: 1, keep: true },
+            bufferPaths: [
+              ["value", "data"],
+              ["keep", "data"],
+            ],
+          },
+          buffers: [base64String("old-value"), base64String("keep")],
+          token: "first",
+        });
+        yield* session.updateModel({
+          modelId: modelB,
+          message: {
+            method: "update",
+            state: { other: 1 },
+            bufferPaths: [],
+          },
+          buffers: [],
+        });
+        yield* session.updateModel({
+          modelId: modelA,
+          message: {
+            method: "update",
+            state: { value: 2 },
+            bufferPaths: [["value", "data"]],
+          },
+          buffers: [base64String("new-value")],
+          token: "latest",
+        });
+
+        const custom = yield* session
+          .updateModel({
+            modelId: modelA,
+            message: { method: "custom", content: { event: "click" } },
+            buffers: [],
+          })
+          .pipe(Effect.fork);
+        yield* TestClock.adjust("1 millis");
+
+        yield* session.updateModel({
+          modelId: modelA,
+          message: {
+            method: "update",
+            state: { after: 3 },
+            bufferPaths: [],
+          },
+          buffers: [],
+        });
+
+        yield* Deferred.succeed(releaseFirst, undefined);
+        yield* Fiber.join(custom);
+        yield* Deferred.await(finalStarted);
+
+        const modelRequests = marimoApiCommands(
+          yield* Ref.get(ctx.sentCommands),
+        ).flatMap((command) =>
+          command.params.method === "set-model-value"
+            ? [command.params.params.inner]
+            : [],
+        );
+        expect(modelRequests).toHaveLength(4);
+        expect(modelRequests).toMatchInlineSnapshot(`
+          [
+            {
+              "buffers": [
+                "keep",
+                "new-value",
+              ],
+              "message": {
+                "bufferPaths": [
+                  [
+                    "keep",
+                    "data",
+                  ],
+                  [
+                    "value",
+                    "data",
+                  ],
+                ],
+                "method": "update",
+                "state": {
+                  "keep": true,
+                  "value": 2,
+                },
+              },
+              "modelId": "model-a",
+              "token": "latest",
+            },
+            {
+              "buffers": [],
+              "message": {
+                "bufferPaths": [],
+                "method": "update",
+                "state": {
+                  "other": 1,
+                },
+              },
+              "modelId": "model-b",
+            },
+            {
+              "buffers": [],
+              "message": {
+                "content": {
+                  "event": "click",
+                },
+                "method": "custom",
+              },
+              "modelId": "model-a",
+            },
+            {
+              "buffers": [],
+              "message": {
+                "bufferPaths": [],
+                "method": "update",
+                "state": {
+                  "after": 3,
+                },
+              },
+              "modelId": "model-a",
+            },
+          ]
+        `);
+
+        yield* session.invokeFunction({
+          functionCallId: requestId("call"),
+          namespace: "widget",
+          functionName: "run",
+          args: { value: 1 },
+        });
+        expect(
+          marimoApiCommands(yield* Ref.get(ctx.sentCommands)).at(-1),
+        ).toMatchObject({
+          params: {
+            method: "invoke-function",
+            params: {
+              notebookUri: NOTEBOOK_A,
+              inner: {
+                functionCallId: "call",
+                namespace: "widget",
+                functionName: "run",
+                args: { value: 1 },
+              },
+            },
+          },
+        });
       }).pipe(Effect.provide(ctx.layer));
     }),
   );

--- a/extension/src/kernel/__tests__/RuntimeSessions.test.ts
+++ b/extension/src/kernel/__tests__/RuntimeSessions.test.ts
@@ -13,6 +13,7 @@ import {
   TestClock,
 } from "effect";
 
+import { SCRATCH_CELL_ID } from "../../constants.ts";
 import {
   base64String,
   cellId,
@@ -23,7 +24,11 @@ import {
 } from "../../lib/__tests__/branded.ts";
 import { LanguageClient } from "../../lsp/LanguageClient.ts";
 import type { NotebookId } from "../../schemas/MarimoNotebookDocument.ts";
-import type { MarimoCommand, Notification } from "../../types.ts";
+import type {
+  CellOperationNotification,
+  MarimoCommand,
+  Notification,
+} from "../../types.ts";
 import { RuntimeCommandQueueClosedError } from "../RuntimeCommandQueue.ts";
 import { type MarimoOperation, RuntimeSessions } from "../RuntimeSessions.ts";
 
@@ -38,6 +43,20 @@ const completedRun = (
   operation: {
     op: "completed-run",
     run_id: runId,
+  },
+});
+
+const cellOperation = (
+  notebookUri: NotebookId,
+  id: string,
+  overrides: Partial<CellOperationNotification> = {},
+): MarimoOperation => ({
+  notebookUri,
+  operation: {
+    op: "cell-op",
+    cell_id: cellId(id),
+    status: "idle",
+    ...overrides,
   },
 });
 
@@ -87,12 +106,26 @@ const runIds = (
     .map((operation) => operation.run_id);
 
 type MarimoApiCommand = Extract<MarimoCommand, { command: "marimo.api" }>;
+type ScratchpadCommand = MarimoApiCommand & {
+  readonly params: Extract<
+    MarimoApiCommand["params"],
+    { method: "execute-scratchpad" }
+  >;
+};
 
 const marimoApiCommands = (
   commands: ReadonlyArray<MarimoCommand>,
 ): ReadonlyArray<MarimoApiCommand> =>
   commands.filter(
     (command): command is MarimoApiCommand => command.command === "marimo.api",
+  );
+
+const scratchpadCommands = (
+  commands: ReadonlyArray<MarimoCommand>,
+): ReadonlyArray<ScratchpadCommand> =>
+  marimoApiCommands(commands).filter(
+    (command): command is ScratchpadCommand =>
+      command.params.method === "execute-scratchpad",
   );
 
 const apiMethods = (
@@ -131,6 +164,131 @@ describe("RuntimeSessions", () => {
         ]);
         assert.deepStrictEqual(runIds(yield* Fiber.join(operationsB)), ["b-1"]);
         assert.strictEqual(yield* Ref.get(ctx.rawSubscriptions), 1);
+      }).pipe(Effect.provide(ctx.layer));
+    }),
+  );
+
+  it.scoped(
+    "streams scratchpad output until its completed run",
+    Effect.fn(function* () {
+      const ctx = yield* withTestContext();
+
+      yield* Effect.gen(function* () {
+        const session = yield* (yield* RuntimeSessions).getOrCreate(NOTEBOOK_A);
+        const execution = yield* session
+          .executeScratchpad("print('hi')", "/usr/bin/python")
+          .pipe(Stream.runCollect, Effect.fork);
+        yield* TestClock.adjust("1 millis");
+
+        const command = scratchpadCommands(yield* Ref.get(ctx.sentCommands))[0];
+        assert(command !== undefined);
+        const runId = command.params.params.inner.runId;
+        assert(runId !== undefined);
+
+        yield* PubSub.publish(
+          ctx.source,
+          cellOperation(NOTEBOOK_A, SCRATCH_CELL_ID, {
+            console: [
+              {
+                channel: "stdout",
+                data: "scratch",
+                mimetype: "text/plain",
+                timestamp: 0,
+              },
+            ],
+          }),
+        );
+        yield* PubSub.publish(
+          ctx.source,
+          cellOperation(NOTEBOOK_A, "cascade", {
+            console: [
+              {
+                channel: "stderr",
+                data: "cascade",
+                mimetype: "text/plain",
+                timestamp: 0,
+              },
+            ],
+          }),
+        );
+        yield* PubSub.publish(
+          ctx.source,
+          cellOperation(NOTEBOOK_A, "status-only"),
+        );
+        yield* PubSub.publish(
+          ctx.source,
+          completedRun(NOTEBOOK_A, "other-run"),
+        );
+        yield* PubSub.publish(ctx.source, completedRun(NOTEBOOK_A, runId));
+
+        assert.deepStrictEqual(
+          Chunk.toReadonlyArray(yield* Fiber.join(execution)).map(
+            (operation) => operation.cell_id,
+          ),
+          [SCRATCH_CELL_ID, cellId("cascade")],
+        );
+      }).pipe(Effect.provide(ctx.layer));
+    }),
+  );
+
+  it.scoped(
+    "serializes scratchpads within a session but not across sessions",
+    Effect.fn(function* () {
+      const ctx = yield* withTestContext();
+
+      yield* Effect.gen(function* () {
+        const sessions = yield* RuntimeSessions;
+        const sessionA = yield* sessions.getOrCreate(NOTEBOOK_A);
+        const sessionB = yield* sessions.getOrCreate(NOTEBOOK_B);
+
+        const a1 = yield* sessionA
+          .executeScratchpad("a1", "/usr/bin/python")
+          .pipe(Stream.runDrain, Effect.fork);
+        const a2 = yield* sessionA
+          .executeScratchpad("a2", "/usr/bin/python")
+          .pipe(Stream.runDrain, Effect.fork);
+        const b1 = yield* sessionB
+          .executeScratchpad("b1", "/usr/bin/python")
+          .pipe(Stream.runDrain, Effect.fork);
+        yield* TestClock.adjust("1 millis");
+
+        const firstCommands = scratchpadCommands(
+          yield* Ref.get(ctx.sentCommands),
+        );
+        expect(firstCommands).toHaveLength(2);
+
+        const firstA = firstCommands.find(
+          ({ params }) => params.params.notebookUri === NOTEBOOK_A,
+        );
+        const firstB = firstCommands.find(
+          ({ params }) => params.params.notebookUri === NOTEBOOK_B,
+        );
+        assert(firstA !== undefined);
+        assert(firstB !== undefined);
+
+        yield* PubSub.publish(
+          ctx.source,
+          completedRun(NOTEBOOK_A, firstA.params.params.inner.runId ?? ""),
+        );
+        yield* PubSub.publish(
+          ctx.source,
+          completedRun(NOTEBOOK_B, firstB.params.params.inner.runId ?? ""),
+        );
+        yield* Fiber.join(a1);
+        yield* Fiber.join(b1);
+        yield* TestClock.adjust("1 millis");
+
+        const commands = scratchpadCommands(yield* Ref.get(ctx.sentCommands));
+        expect(commands).toHaveLength(3);
+        const secondA = commands[2];
+        assert(secondA !== undefined);
+        expect(secondA.params.params.inner.code).toBe("a2");
+
+        yield* PubSub.publish(
+          ctx.source,
+          completedRun(NOTEBOOK_A, secondA.params.params.inner.runId ?? ""),
+        );
+        yield* Fiber.join(a2);
       }).pipe(Effect.provide(ctx.layer));
     }),
   );

--- a/extension/src/lsp/MarimoApiClient.ts
+++ b/extension/src/lsp/MarimoApiClient.ts
@@ -1,0 +1,54 @@
+import { Effect } from "effect";
+
+import type {
+  MarimoApiMethod,
+  MarimoApiParams,
+  MarimoApiRequest,
+} from "../types.ts";
+import { LanguageClient } from "./LanguageClient.ts";
+
+/**
+ * Typed access to the `marimo.api` LSP command.
+ *
+ * This service only maps API methods to the LSP command envelope. Runtime
+ * ordering, lifecycle, and operation streams belong to RuntimeSession.
+ */
+export class MarimoApiClient extends Effect.Service<MarimoApiClient>()(
+  "MarimoApiClient",
+  {
+    effect: Effect.gen(function* () {
+      const client = yield* LanguageClient;
+
+      const execute = <K extends MarimoApiMethod>(
+        request: MarimoApiRequest<K>,
+      ) =>
+        client.executeCommand({
+          command: "marimo.api",
+          params: request,
+        });
+
+      return {
+        execute,
+        serialize: (params: MarimoApiParams<"serialize">) =>
+          execute({ method: "serialize", params }),
+        deserialize: (params: MarimoApiParams<"deserialize">) =>
+          execute({ method: "deserialize", params }),
+        getConfiguration: (params: MarimoApiParams<"get-configuration">) =>
+          execute({ method: "get-configuration", params }),
+        updateConfiguration: (
+          params: MarimoApiParams<"update-configuration">,
+        ) => execute({ method: "update-configuration", params }),
+        getDependencyTree: (params: MarimoApiParams<"get-dependency-tree">) =>
+          execute({ method: "get-dependency-tree", params }),
+        getPackageList: (params: MarimoApiParams<"get-package-list">) =>
+          execute({ method: "get-package-list", params }),
+        exportAsHtml: (params: MarimoApiParams<"export-as-html">) =>
+          execute({ method: "export-as-html", params }),
+        exportAsIpynb: (params: MarimoApiParams<"export-as-ipynb">) =>
+          execute({ method: "export-as-ipynb", params }),
+        setDisplayTheme: (params: MarimoApiParams<"set-display-theme">) =>
+          execute({ method: "set-display-theme", params }),
+      };
+    }),
+  },
+) {}

--- a/extension/src/lsp/__tests__/MarimoApiClient.test.ts
+++ b/extension/src/lsp/__tests__/MarimoApiClient.test.ts
@@ -1,0 +1,58 @@
+import { assert, it } from "@effect/vitest";
+import { Effect, Layer, Ref, Stream } from "effect";
+
+import { notebookId } from "../../lib/__tests__/branded.ts";
+import type { MarimoCommand } from "../../types.ts";
+import { LanguageClient } from "../LanguageClient.ts";
+import { MarimoApiClient } from "../MarimoApiClient.ts";
+
+it.scoped(
+  "MarimoApiClient constructs typed marimo.api commands",
+  Effect.fn(function* () {
+    const notebook = notebookId("notebook-a");
+    const commands = yield* Ref.make<ReadonlyArray<MarimoCommand>>([]);
+    const client = Layer.succeed(
+      LanguageClient,
+      LanguageClient.make({
+        channel: { name: "marimo-lsp", show() {} },
+        restart: () => Effect.void,
+        executeCommand: (command) =>
+          Ref.update(commands, (current) => [...current, command]),
+        streamOf() {
+          // SAFETY: this client is only used to test command execution.
+          // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+          return Stream.empty as never;
+        },
+      }),
+    );
+
+    yield* Effect.gen(function* () {
+      const api = yield* MarimoApiClient;
+      yield* api.setDisplayTheme({ theme: "dark" });
+      yield* api.getConfiguration({
+        notebookUri: notebook,
+        inner: {},
+      });
+
+      assert.deepStrictEqual(yield* Ref.get(commands), [
+        {
+          command: "marimo.api",
+          params: {
+            method: "set-display-theme",
+            params: { theme: "dark" },
+          },
+        },
+        {
+          command: "marimo.api",
+          params: {
+            method: "get-configuration",
+            params: {
+              notebookUri: notebook,
+              inner: {},
+            },
+          },
+        },
+      ]);
+    }).pipe(Effect.provide(MarimoApiClient.Default), Effect.provide(client));
+  }),
+);

--- a/extension/src/notebook/CellStateManager.ts
+++ b/extension/src/notebook/CellStateManager.ts
@@ -1,7 +1,7 @@
 import { Effect, HashMap, Option, Stream, SubscriptionRef } from "effect";
 import type * as vscode from "vscode";
 
-import { LanguageClient } from "../lsp/LanguageClient.ts";
+import { RuntimeSessions } from "../kernel/RuntimeSessions.ts";
 import { VsCode } from "../platform/VsCode.ts";
 import {
   MarimoNotebookCell,
@@ -35,11 +35,11 @@ import { NotebookEditorRegistry } from "./NotebookEditorRegistry.ts";
 export class CellStateManager extends Effect.Service<CellStateManager>()(
   "CellStateManager",
   {
-    dependencies: [NotebookEditorRegistry.Default],
+    dependencies: [NotebookEditorRegistry.Default, RuntimeSessions.Default],
     scoped: Effect.gen(function* () {
       const code = yield* VsCode;
       const editorRegistry = yield* NotebookEditorRegistry;
-      const client = yield* LanguageClient;
+      const runtimeSessions = yield* RuntimeSessions;
 
       // The only mutable state: what code the kernel last ran for each cell.
       // None = never executed or invalidated. Some(code) = output reflects code.
@@ -181,30 +181,22 @@ export class CellStateManager extends Effect.Service<CellStateManager>()(
                 });
 
                 // Notify backend
-                yield* client
-                  .executeCommand({
-                    command: "marimo.api",
-                    params: {
-                      method: "delete-cell",
-                      params: {
+                const session = yield* runtimeSessions.getOrCreate(
+                  event.notebook.id,
+                );
+                yield* session.deleteCell({ cellId }).pipe(
+                  Effect.catchAllCause((cause) =>
+                    Effect.logWarning(
+                      "Failed to notify backend about cell deletion",
+                      cause,
+                    ).pipe(
+                      Effect.annotateLogs({
                         notebookUri: event.notebook.id,
-                        inner: { cellId },
-                      },
-                    },
-                  })
-                  .pipe(
-                    Effect.catchAllCause((cause) =>
-                      Effect.logWarning(
-                        "Failed to notify backend about cell deletion",
-                        cause,
-                      ).pipe(
-                        Effect.annotateLogs({
-                          notebookUri: event.notebook.id,
-                          cellId,
-                        }),
-                      ),
+                        cellId,
+                      }),
                     ),
-                  );
+                  ),
+                );
               }
             }),
           ),

--- a/extension/src/notebook/NotebookSerializer.ts
+++ b/extension/src/notebook/NotebookSerializer.ts
@@ -12,7 +12,7 @@ import type * as vscode from "vscode";
 
 import { NOTEBOOK_TYPE } from "../constants.ts";
 import { enrichNotebookFromLive } from "../lib/enrichNotebookFromLive.ts";
-import { LanguageClient } from "../lsp/LanguageClient.ts";
+import { MarimoApiClient } from "../lsp/MarimoApiClient.ts";
 import { Constants } from "../platform/Constants.ts";
 import { VsCode } from "../platform/VsCode.ts";
 import {
@@ -39,9 +39,9 @@ const NotebookCellKind = {
 export class NotebookSerializer extends Effect.Service<NotebookSerializer>()(
   "NotebookSerializer",
   {
-    dependencies: [Constants.Default],
+    dependencies: [Constants.Default, MarimoApiClient.Default],
     scoped: Effect.gen(function* () {
-      const client = yield* LanguageClient;
+      const api = yield* MarimoApiClient;
       const constants = yield* Constants;
       const code = yield* Effect.serviceOption(VsCode);
 
@@ -49,17 +49,11 @@ export class NotebookSerializer extends Effect.Service<NotebookSerializer>()(
         function* (notebook: vscode.NotebookData) {
           yield* Effect.annotateCurrentSpan("cellCount", notebook.cells.length);
 
-          const resp = yield* client.executeCommand({
-            command: "marimo.api",
-            params: {
-              method: "serialize",
-              params: {
-                notebook: yield* notebookDataToSerializedNotebook(
-                  notebook,
-                  constants,
-                ),
-              },
-            },
+          const resp = yield* api.serialize({
+            notebook: yield* notebookDataToSerializedNotebook(
+              notebook,
+              constants,
+            ),
           });
           const result = yield* decodeSerializeResponse(resp);
           return new TextEncoder().encode(result.source);
@@ -69,12 +63,8 @@ export class NotebookSerializer extends Effect.Service<NotebookSerializer>()(
       const deserializeEffect = Effect.fn("NotebookSerializer.deserialize")(
         function* (bytes: Uint8Array) {
           yield* Effect.annotateCurrentSpan("bytes", bytes.length);
-          const resp = yield* client.executeCommand({
-            command: "marimo.api",
-            params: {
-              method: "deserialize",
-              params: { source: new TextDecoder().decode(bytes) },
-            },
+          const resp = yield* api.deserialize({
+            source: new TextDecoder().decode(bytes),
           });
           const { cells, ...metadata } = yield* decodeDeserializeResponse(resp);
 

--- a/extension/src/panel/packages/PackagesService.ts
+++ b/extension/src/panel/packages/PackagesService.ts
@@ -5,7 +5,7 @@ import {
   ControllerRegistry,
 } from "../../kernel/ControllerRegistry.ts";
 import { PythonController } from "../../kernel/NotebookControllerFactory.ts";
-import { LanguageClient } from "../../lsp/LanguageClient.ts";
+import { MarimoApiClient } from "../../lsp/MarimoApiClient.ts";
 import { NotebookEditorRegistry } from "../../notebook/NotebookEditorRegistry.ts";
 import { MarimoNotebookDocument } from "../../schemas/MarimoNotebookDocument.ts";
 import type { NotebookId } from "../../schemas/MarimoNotebookDocument.ts";
@@ -59,8 +59,9 @@ interface DependencyTreeState {
 export class PackagesService extends Effect.Service<PackagesService>()(
   "PackagesService",
   {
+    dependencies: [MarimoApiClient.Default],
     scoped: Effect.gen(function* () {
-      const client = yield* LanguageClient;
+      const api = yield* MarimoApiClient;
       const controllers = yield* ControllerRegistry;
       const editors = yield* NotebookEditorRegistry;
 
@@ -279,17 +280,11 @@ export class PackagesService extends Effect.Service<PackagesService>()(
             );
 
             // Fetch from language server
-            const rawResult = yield* client
-              .executeCommand({
-                command: "marimo.api",
-                params: {
-                  method: "get-dependency-tree",
-                  params: {
-                    notebookUri,
-                    source,
-                    inner: {},
-                  },
-                },
+            const rawResult = yield* api
+              .getDependencyTree({
+                notebookUri,
+                source,
+                inner: {},
               })
               .pipe(
                 Effect.tap((result) =>
@@ -331,17 +326,11 @@ export class PackagesService extends Effect.Service<PackagesService>()(
                     // Venv fallback: fetch the flat package list (which the
                     // server backs with `uv pip list -p <exe>`) and synthesize
                     // a single-level tree from it.
-                    const packageListRaw = yield* client
-                      .executeCommand({
-                        command: "marimo.api",
-                        params: {
-                          method: "get-package-list",
-                          params: {
-                            notebookUri,
-                            source,
-                            inner: {},
-                          },
-                        },
+                    const packageListRaw = yield* api
+                      .getPackageList({
+                        notebookUri,
+                        source,
+                        inner: {},
                       })
                       .pipe(
                         Effect.catchAll((fallbackError) =>

--- a/extension/src/platform/__tests__/Api.test.ts
+++ b/extension/src/platform/__tests__/Api.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "@effect/vitest";
-import { Effect, Layer } from "effect";
+import { Effect, Layer, Stream } from "effect";
 
 import { TestExtensionContextLive } from "../../__mocks__/TestExtensionContext.ts";
 import { TestPythonExtension } from "../../__mocks__/TestPythonExtension.ts";
@@ -10,6 +10,7 @@ import {
   TestVsCode,
 } from "../../__mocks__/TestVsCode.ts";
 import { ControllerRegistry } from "../../kernel/ControllerRegistry.ts";
+import { RuntimeSessions } from "../../kernel/RuntimeSessions.ts";
 import { LanguageClient } from "../../lsp/LanguageClient.ts";
 import { Api } from "../Api.ts";
 import { VsCode } from "../VsCode.ts";
@@ -23,6 +24,7 @@ const withTestCtx = Effect.fn(function* (
     layer: Layer.empty.pipe(
       Layer.merge(Api.Default),
       Layer.provideMerge(ControllerRegistry.Default),
+      Layer.provide(RuntimeSessions.Default),
       Layer.provide(
         Layer.succeed(
           LanguageClient,
@@ -33,7 +35,7 @@ const withTestCtx = Effect.fn(function* (
               return Effect.die("not implemented");
             },
             streamOf() {
-              return Effect.die("not implemented");
+              return Stream.never;
             },
           }),
         ),

--- a/extension/src/types.ts
+++ b/extension/src/types.ts
@@ -59,11 +59,11 @@ interface PackageScoped<T> extends NotebookScoped<T> {
   source: PackageSource;
 }
 
-type ExecuteCellsRequest = Schemas["ExecuteCellsRequest"];
+export type ExecuteCellsRequest = Schemas["ExecuteCellsRequest"];
 export type UpdateUIElementRequest = Schemas["UpdateUIElementRequest"];
 export type ModelRequest = Schemas["ModelRequest"];
 export type InvokeFunctionRequest = Schemas["InvokeFunctionRequest"];
-type DeleteCellRequest = Schemas["DeleteCellRequest"];
+export type DeleteCellRequest = Schemas["DeleteCellRequest"];
 type ExportAsHtmlRequest = Schemas["ExportAsHTMLRequest"];
 interface DeserializeRequest {
   source: string;
@@ -84,7 +84,7 @@ interface ExecuteScratchRequest {
   runId?: string;
 }
 
-type SendStdinRequest = Schemas["StdinRequest"];
+export type SendStdinRequest = Schemas["StdinRequest"];
 
 interface UpdateConfigurationRequest {
   config: Record<string, unknown>;

--- a/extension/src/types.ts
+++ b/extension/src/types.ts
@@ -125,6 +125,11 @@ type ApiRequest<K extends keyof MarimoApiMethodMap> = {
   };
 }[K];
 
+export type MarimoApiMethod = keyof MarimoApiMethodMap;
+export type MarimoApiParams<K extends MarimoApiMethod> = MarimoApiMethodMap[K];
+export type MarimoApiRequest<K extends MarimoApiMethod = MarimoApiMethod> =
+  ApiRequest<K>;
+
 // client -> language server
 type MarimoCommandMap = {
   "marimo.api": ApiRequest<keyof MarimoApiMethodMap>;

--- a/extension/src/types.ts
+++ b/extension/src/types.ts
@@ -60,9 +60,9 @@ interface PackageScoped<T> extends NotebookScoped<T> {
 }
 
 type ExecuteCellsRequest = Schemas["ExecuteCellsRequest"];
-type UpdateUIElementRequest = Schemas["UpdateUIElementRequest"];
-type ModelRequest = Schemas["ModelRequest"];
-type InvokeFunctionRequest = Schemas["InvokeFunctionRequest"];
+export type UpdateUIElementRequest = Schemas["UpdateUIElementRequest"];
+export type ModelRequest = Schemas["ModelRequest"];
+export type InvokeFunctionRequest = Schemas["InvokeFunctionRequest"];
 type DeleteCellRequest = Schemas["DeleteCellRequest"];
 type ExportAsHtmlRequest = Schemas["ExportAsHTMLRequest"];
 interface DeserializeRequest {


### PR DESCRIPTION
Rapid slider changes exposed a larger problem in how the extension sends messages to marimo.

The renderer handled each message as a separate LSP request and waited for it before handling the next message. If UI values arrived faster than those requests completed, old values accumulated and continued executing after the slider had moved on.

Conflating only UI updates would fix that symptom, but decisions about ordering and cleanup would remain spread across the extension. The extension now gets a `RuntimeSession` for each notebook and sends kernel work through this interface:

```ts
interface RuntimeSession {
  readonly notebookUri: NotebookId

  operations(): Stream<Notification>

  updateUIElements(request): Effect<void>
  updateModel(request): Effect<void>
  invokeFunction(request): Effect<void>

  executeCells(request, executable): Effect<void>
  executeScratchpad(code, executable): Stream<CellOperation>
  deleteCell(request): Effect<void>
  sendStdin(request): Effect<void>
  interrupt(): Effect<void>
  close(): Effect<void>
}
```

`RuntimeSession` keeps commands ordered within a notebook while allowing pending UI and model state to be combined. Interrupt and close remain immediate operations rather than waiting behind queued work.

The session also exposes incoming kernel operations. This lets scratchpad execution use the same stream for run completion and cancellation, and lets different notebooks process their operations independently.

`MarimoApiClient` is now the only place that constructs the raw `marimo.api` LSP command. Callers use typed methods instead.

For UI elements, this means keeping the latest pending value for each element instead of sending every intermediate value. The same session now handles the ordering and cleanup rules for other kernel messages.

Fixes #627.

