### PR TITLE
Make the `marimo.api` method table the source of truth

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
   "lsprotocol==2025.0.0",
   "marimo==0.23.16",
   "pygls==2.1.1",
+  "typing-extensions>=4.15.0",
 ]
 
 [project.scripts]

--- a/src/marimo_lsp/api.py
+++ b/src/marimo_lsp/api.py
@@ -5,15 +5,13 @@
 from __future__ import annotations
 
 import dataclasses
+import inspect
 import json
 import typing
 from typing import TYPE_CHECKING, cast
 
-if TYPE_CHECKING:
-    from collections.abc import Callable
-
 import msgspec
-from marimo._config.config import DEFAULT_CONFIG
+from marimo._config.config import DEFAULT_CONFIG, MarimoConfig
 from marimo._convert.converters import MarimoConvert
 from marimo._export.exporter import Exporter
 from marimo._export.requests import HTMLExportRequest, IPYNBExportRequest
@@ -60,7 +58,6 @@ from marimo_lsp.models import (
     SetDisplayThemeResponse,
     StdinRequest,
     UpdateConfigurationRequest,
-    UpdateConfigurationResponse,
     UpdateUIElementRequest,
     VenvSource,
 )
@@ -69,7 +66,6 @@ from marimo_lsp.package_manager import LspPackageManager
 if TYPE_CHECKING:
     from marimo._config.config import (
         DisplayConfig,
-        MarimoConfig,
         PartialMarimoConfig,
         SharingConfig,
     )
@@ -78,9 +74,116 @@ if TYPE_CHECKING:
     from marimo_lsp.sessions import Sessions
 
 
-__all__ = ["API_METHODS", "ApiMethod", "handle_api_command"]
+__all__ = ["API_METHODS", "ApiBuilder", "ApiMethod", "handle_api_command"]
 
 logger = get_logger()
+_API_HANDLER_PARAMETER_COUNT = 2
+
+
+@dataclasses.dataclass(frozen=True)
+class ApiContext:
+    """Server-side dependencies available to API handlers."""
+
+    ls: LanguageServer
+    sessions: Sessions
+
+
+type ApiHandler[Req, Res] = typing.Callable[
+    [ApiContext, Req],
+    typing.Awaitable[Res],
+]
+
+
+@dataclasses.dataclass(frozen=True)
+class ApiMethod[Req, Res]:
+    """One ``marimo.api`` method and its wire contract."""
+
+    name: str
+    request: TypeForm[Req]
+    response: TypeForm[Res]
+    handler: ApiHandler[Req, Res]
+
+
+class ApiBuilder:
+    """Build a method table from typed async handler declarations."""
+
+    def __init__(self) -> None:
+        self._methods: list[ApiMethod[typing.Any, typing.Any]] = []
+        self._built = False
+
+    def __call__[Req, Res](
+        self,
+        name: str,
+    ) -> typing.Callable[[ApiHandler[Req, Res]], ApiHandler[Req, Res]]:
+        """Register an async handler under its wire method name."""
+
+        def register(handler: ApiHandler[Req, Res]) -> ApiHandler[Req, Res]:
+            if self._built:
+                msg = "cannot register API methods after build()"
+                raise RuntimeError(msg)
+            if not inspect.iscoroutinefunction(handler):
+                msg = f"API handler {name!r} must be async"
+                raise TypeError(msg)
+
+            parameters = list(inspect.signature(handler).parameters.values())
+            positional = {
+                inspect.Parameter.POSITIONAL_ONLY,
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            }
+            if len(parameters) != _API_HANDLER_PARAMETER_COUNT or any(
+                parameter.kind not in positional for parameter in parameters
+            ):
+                msg = f"API handler {name!r} must accept (ApiContext, request)"
+                raise TypeError(msg)
+
+            hints = typing.get_type_hints(handler)
+            context_parameter, request_parameter = parameters
+            if hints.get(context_parameter.name) is not ApiContext:
+                msg = f"API handler {name!r} first parameter must be ApiContext"
+                raise TypeError(msg)
+            if request_parameter.name not in hints:
+                msg = f"API handler {name!r} request parameter must be annotated"
+                raise TypeError(msg)
+            if "return" not in hints:
+                msg = f"API handler {name!r} return type must be annotated"
+                raise TypeError(msg)
+
+            request = cast("TypeForm[Req]", hints[request_parameter.name])
+            response_hint = hints["return"]
+            response = cast(
+                "TypeForm[Res]",
+                type(None) if response_hint is None else response_hint,
+            )
+            self._methods.append(ApiMethod(name, request, response, handler))
+            return handler
+
+        return register
+
+    def build(self) -> tuple[ApiMethod[typing.Any, typing.Any], ...]:
+        """Validate and return the immutable method table."""
+        if self._built:
+            msg = "API method table has already been built"
+            raise RuntimeError(msg)
+
+        names: set[str] = set()
+        for method in self._methods:
+            if method.name in names:
+                msg = f"duplicate API method: {method.name!r}"
+                raise ValueError(msg)
+            names.add(method.name)
+
+        self._built = True
+        return tuple(self._methods)
+
+
+marimo_api = ApiBuilder()
+
+
+class SessionNotFoundError(ValueError):
+    """Raised when an API command requires a live notebook session."""
+
+    def __init__(self, notebook_uri: str) -> None:
+        super().__init__(f"No session found for {notebook_uri}")
 
 
 def _get_display_config(config: MarimoConfig) -> DisplayConfig:
@@ -91,12 +194,13 @@ def _get_display_config(config: MarimoConfig) -> DisplayConfig:
     return cast("DisplayConfig", config.get("display", {}))
 
 
+@marimo_api("execute-cells")
 async def run(
-    sessions: Sessions,
+    ctx: ApiContext,
     args: SessionCommand[ExecuteCellsRequest],
-):
+) -> None:
     logger.info(f"run for {args.notebook_uri}")
-    session = sessions.start(args.notebook_uri, args.executable)
+    session = ctx.sessions.start(args.notebook_uri, args.executable)
 
     session.instantiate(
         InstantiateNotebookRequest(auto_run=False, object_ids=[], values=[]),
@@ -106,42 +210,46 @@ async def run(
     logger.info(f"Execution request sent for {args.notebook_uri}")
 
 
+@marimo_api("update-ui-element")
 async def set_ui_element_value(
-    sessions: Sessions,
+    ctx: ApiContext,
     args: NotebookCommand[UpdateUIElementRequest],
-):
+) -> None:
     logger.info(f"set_ui_element_value for {args.notebook_uri}")
-    session = sessions.get(args.notebook_uri)
+    session = ctx.sessions.get(args.notebook_uri)
     assert session, f"No session in workspace for {args.notebook_uri}"
     session.put_control_request(args.inner.as_command(), from_consumer_id=None)
 
 
+@marimo_api("set-model-value")
 async def set_model_value(
-    sessions: Sessions,
+    ctx: ApiContext,
     args: NotebookCommand[ModelRequest],
-):
+) -> None:
     logger.info(f"set_model_value for {args.notebook_uri}")
-    session = sessions.get(args.notebook_uri)
+    session = ctx.sessions.get(args.notebook_uri)
     assert session, f"No session in workspace for {args.notebook_uri}"
     session.put_control_request(args.inner.as_command(), from_consumer_id=None)
 
 
+@marimo_api("invoke-function")
 async def function_call_request(
-    sessions: Sessions,
+    ctx: ApiContext,
     args: NotebookCommand[InvokeFunctionCommand],
-):
+) -> None:
     logger.info(f"function_call_request for {args.notebook_uri}")
-    session = sessions.get(args.notebook_uri)
+    session = ctx.sessions.get(args.notebook_uri)
     assert session, f"No session in workspace for {args.notebook_uri}"
     session.put_control_request(args.inner, from_consumer_id=None)
 
 
+@marimo_api("interrupt")
 async def interrupt(
-    sessions: Sessions,
+    ctx: ApiContext,
     args: NotebookCommand[InterruptRequest],
-):
+) -> None:
     logger.info(f"interrupt for {args.notebook_uri}")
-    session = sessions.get(args.notebook_uri)
+    session = ctx.sessions.get(args.notebook_uri)
     if session:
         session.try_interrupt()
         logger.info(f"Interrupt request sent for {args.notebook_uri}")
@@ -149,12 +257,13 @@ async def interrupt(
         logger.warning(f"No session found for {args.notebook_uri}")
 
 
+@marimo_api("delete-cell")
 async def delete_cell(
-    sessions: Sessions,
+    ctx: ApiContext,
     args: NotebookCommand[DeleteCellRequest],
-):
+) -> None:
     logger.info(f"delete_cell for {args.notebook_uri}")
-    session = sessions.get(args.notebook_uri)
+    session = ctx.sessions.get(args.notebook_uri)
     if session:
         session.put_control_request(args.inner.as_command(), from_consumer_id=None)
         logger.info(f"Delete cell request sent for {args.notebook_uri}")
@@ -162,31 +271,33 @@ async def delete_cell(
         logger.warning(f"No session found for {args.notebook_uri}")
 
 
+@marimo_api("send-stdin")
 async def send_stdin(
-    sessions: Sessions,
+    ctx: ApiContext,
     args: NotebookCommand[StdinRequest],
-):
+) -> None:
     logger.info(f"send_stdin for {args.notebook_uri}")
-    session = sessions.get(args.notebook_uri)
+    session = ctx.sessions.get(args.notebook_uri)
     if session:
         session.put_input(args.inner.text)
     else:
         logger.warning(f"No session found for {args.notebook_uri}")
 
 
+@marimo_api("close-session")
 async def close_session(
-    sessions: Sessions,
+    ctx: ApiContext,
     args: NotebookCommand[CloseSessionRequest],
-):
+) -> None:
     logger.info(f"close_session for {args.notebook_uri}")
-    sessions.close(args.notebook_uri)
+    ctx.sessions.close(args.notebook_uri)
 
 
+@marimo_api("execute-scratchpad")
 async def execute_scratch(
-    ls: LanguageServer,
-    sessions: Sessions,
+    ctx: ApiContext,
     args: SessionCommand[ExecuteScratchRequest],
-):
+) -> None:
     """Execute code in the scratchpad (isolated from dependency graph).
 
     Populates the document + output snapshot on the command so that
@@ -198,7 +309,7 @@ async def execute_scratch(
     """
     logger.info(f"execute_scratch for {args.notebook_uri}")
     try:
-        notebook = find_notebook_document(ls.workspace, args.notebook_uri)
+        notebook = find_notebook_document(ctx.ls.workspace, args.notebook_uri)
     except KeyError:
         logger.warning(
             f"No notebook document found for {args.notebook_uri}; "
@@ -206,7 +317,7 @@ async def execute_scratch(
         )
         return
 
-    session = sessions.start(args.notebook_uri, args.executable)
+    session = ctx.sessions.start(args.notebook_uri, args.executable)
 
     session.instantiate(
         InstantiateNotebookRequest(auto_run=False, object_ids=[], values=[]),
@@ -214,7 +325,7 @@ async def execute_scratch(
     )
 
     notebook_cells, cell_outputs = snapshot_for_scratchpad(
-        workspace=ls.workspace,
+        workspace=ctx.ls.workspace,
         session=session,
         notebook=notebook,
     )
@@ -231,7 +342,9 @@ async def execute_scratch(
     logger.info(f"Scratchpad execution request sent for {args.notebook_uri}")
 
 
+@marimo_api("get-package-list")
 async def get_package_list(
+    _ctx: ApiContext,
     args: PackageCommand[ListPackagesRequest],
 ) -> ListPackagesResponse:
     logger.info(f"get_package_list for {args.notebook_uri}")
@@ -254,7 +367,9 @@ async def get_package_list(
     return ListPackagesResponse(packages=package_manager.list_packages())
 
 
+@marimo_api("get-dependency-tree")
 async def get_dependency_tree(
+    _ctx: ApiContext,
     args: PackageCommand[DependencyTreeRequest],
 ) -> DependencyTreeResponse:
     logger.info(f"get_dependency_tree for {args.notebook_uri}")
@@ -329,12 +444,17 @@ def _package_manager_for(source: VenvSource | ScriptSource) -> LspPackageManager
     )
 
 
-async def serialize(args: SerializeRequest) -> SerializeResponse:
+@marimo_api("serialize")
+async def serialize(_ctx: ApiContext, args: SerializeRequest) -> SerializeResponse:
     ir = parse_raw(args.notebook, cls=NotebookSerialization)
     return SerializeResponse(source=MarimoConvert.from_ir(ir).to_py())
 
 
-async def deserialize(args: DeserializeRequest):
+@marimo_api("deserialize")
+async def deserialize(
+    _ctx: ApiContext,
+    args: DeserializeRequest,
+) -> dict[str, typing.Any]:
     converter = MarimoConvert.from_py(args.source)
     ir = converter.to_ir()
 
@@ -347,12 +467,13 @@ async def deserialize(args: DeserializeRequest):
     return dataclasses.asdict(ir)
 
 
+@marimo_api("get-configuration")
 async def get_configuration(
-    sessions: Sessions,
+    ctx: ApiContext,
     args: NotebookCommand[GetConfigurationRequest],
 ) -> GetConfigurationResponse:
     """Get the current marimo configuration."""
-    session = sessions.get(args.notebook_uri)
+    session = ctx.sessions.get(args.notebook_uri)
     if not session:
         logger.warning(f"No session found for {args.notebook_uri}")
         return GetConfigurationResponse(config=DEFAULT_CONFIG)
@@ -360,33 +481,29 @@ async def get_configuration(
     return GetConfigurationResponse(config=session.get_config())
 
 
+@marimo_api("update-configuration")
 async def update_configuration(
-    sessions: Sessions,
+    ctx: ApiContext,
     args: NotebookCommand[UpdateConfigurationRequest],
-) -> UpdateConfigurationResponse:
+) -> MarimoConfig:
     """Update the marimo user configuration."""
-    session = sessions.get(args.notebook_uri)
+    session = ctx.sessions.get(args.notebook_uri)
     if not session:
         logger.warning(f"No session found for {args.notebook_uri}")
-        return UpdateConfigurationResponse(success=False, error="No session found")
+        raise SessionNotFoundError(args.notebook_uri)
 
-    try:
-        updated_config = session.save_config(
-            cast("PartialMarimoConfig", args.inner.config),
-        )
-
-        return UpdateConfigurationResponse(success=True, config=updated_config)
-    except Exception as e:
-        logger.exception(f"Error updating configuration for {args.notebook_uri}")
-        return UpdateConfigurationResponse(success=False, error=str(e))
+    return session.save_config(
+        cast("PartialMarimoConfig", args.inner.config),
+    )
 
 
+@marimo_api("set-display-theme")
 async def set_display_theme(
-    sessions: Sessions,
+    ctx: ApiContext,
     args: SetDisplayThemeRequest,
 ) -> SetDisplayThemeResponse:
     """Set the display theme in all kernels without persisting to disk."""
-    for session in sessions:
+    for session in ctx.sessions:
         config = session.get_config(hide_secrets=False)
         display = _get_display_config(config)
         updated = cast(
@@ -396,13 +513,14 @@ async def set_display_theme(
     return SetDisplayThemeResponse(success=True)
 
 
+@marimo_api("export-as-html")
 async def export_as_html(
-    sessions: Sessions,
+    ctx: ApiContext,
     args: NotebookCommand[ExportAsHTMLRequest],
-):
+) -> str:
     """Export the notebook as HTML with current outputs."""
     logger.info(f"export_as_html for {args.notebook_uri}")
-    session = sessions.get(args.notebook_uri)
+    session = ctx.sessions.get(args.notebook_uri)
     assert session, f"No session in workspace for {args.notebook_uri}"
 
     # Export the notebook with current outputs using the Exporter
@@ -428,13 +546,14 @@ async def export_as_html(
     return html
 
 
+@marimo_api("export-as-ipynb")
 async def export_as_ipynb(
-    sessions: Sessions,
+    ctx: ApiContext,
     args: NotebookCommand[ExportAsIpynbRequest],
 ) -> str:
     """Export the notebook as ipynb with current outputs."""
     logger.info(f"export_as_ipynb for {args.notebook_uri}")
-    session = sessions.get(args.notebook_uri)
+    session = ctx.sessions.get(args.notebook_uri)
     assert session, f"No session in workspace for {args.notebook_uri}"
 
     ipynb_str = Exporter().export_as_ipynb(
@@ -457,152 +576,7 @@ async def export_as_ipynb(
     return json.dumps(ipynb)
 
 
-@dataclasses.dataclass(frozen=True)
-class ApiContext:
-    """Server-side dependencies a handler can reach for."""
-
-    ls: LanguageServer
-    sessions: Sessions
-
-
-@dataclasses.dataclass(frozen=True)
-class ApiMethod[Req, Res]:
-    """One ``marimo.api`` method: the single source of truth for its wire contract.
-
-    The server dispatches and validates wire values from this table. Genericity
-    ties each entry's handler to its request/response annotations, so a
-    mismatched handler fails type-checking at table construction.
-    """
-
-    name: str
-    """Wire method name (kebab-case)."""
-
-    request: TypeForm[Req]
-    """msgspec annotation the incoming ``params`` must convert to."""
-
-    response: TypeForm[Res] | None
-    """msgspec annotation the handler's return value is validated against.
-
-    ``None`` marks a fire-and-forget method whose response is always ``null``.
-    """
-
-    handler: Callable[[ApiContext, Req], typing.Awaitable[Res]]
-
-
-API_METHODS: tuple[ApiMethod[typing.Any, typing.Any], ...] = (
-    ApiMethod(
-        "execute-cells",
-        SessionCommand[ExecuteCellsRequest],
-        None,
-        lambda ctx, args: run(ctx.sessions, args),
-    ),
-    ApiMethod(
-        "send-stdin",
-        NotebookCommand[StdinRequest],
-        None,
-        lambda ctx, args: send_stdin(ctx.sessions, args),
-    ),
-    ApiMethod(
-        "interrupt",
-        NotebookCommand[InterruptRequest],
-        None,
-        lambda ctx, args: interrupt(ctx.sessions, args),
-    ),
-    ApiMethod(
-        "delete-cell",
-        NotebookCommand[DeleteCellRequest],
-        None,
-        lambda ctx, args: delete_cell(ctx.sessions, args),
-    ),
-    ApiMethod(
-        "update-ui-element",
-        NotebookCommand[UpdateUIElementRequest],
-        None,
-        lambda ctx, args: set_ui_element_value(ctx.sessions, args),
-    ),
-    ApiMethod(
-        "set-model-value",
-        NotebookCommand[ModelRequest],
-        None,
-        lambda ctx, args: set_model_value(ctx.sessions, args),
-    ),
-    ApiMethod(
-        "invoke-function",
-        NotebookCommand[InvokeFunctionCommand],
-        None,
-        lambda ctx, args: function_call_request(ctx.sessions, args),
-    ),
-    ApiMethod(
-        "close-session",
-        NotebookCommand[CloseSessionRequest],
-        None,
-        lambda ctx, args: close_session(ctx.sessions, args),
-    ),
-    ApiMethod(
-        "serialize",
-        SerializeRequest,
-        SerializeResponse,
-        lambda _ctx, args: serialize(args),
-    ),
-    # NOTE: the deserialize payload is marimo's `NotebookSerialization`, which
-    # msgspec cannot introspect (it embeds `ast` nodes), so the response stays
-    # opaque on the wire. The client parses it with its hand-written
-    # `SerializedNotebook` schema (`extension/src/schemas/SerializedNotebook.ts`).
-    ApiMethod(
-        "deserialize",
-        DeserializeRequest,
-        dict[str, typing.Any],
-        lambda _ctx, args: deserialize(args),
-    ),
-    ApiMethod(
-        "get-package-list",
-        PackageCommand[ListPackagesRequest],
-        ListPackagesResponse,
-        lambda _ctx, args: get_package_list(args),
-    ),
-    ApiMethod(
-        "get-dependency-tree",
-        PackageCommand[DependencyTreeRequest],
-        DependencyTreeResponse,
-        lambda _ctx, args: get_dependency_tree(args),
-    ),
-    ApiMethod(
-        "get-configuration",
-        NotebookCommand[GetConfigurationRequest],
-        GetConfigurationResponse,
-        lambda ctx, args: get_configuration(ctx.sessions, args),
-    ),
-    ApiMethod(
-        "update-configuration",
-        NotebookCommand[UpdateConfigurationRequest],
-        UpdateConfigurationResponse,
-        lambda ctx, args: update_configuration(ctx.sessions, args),
-    ),
-    ApiMethod(
-        "set-display-theme",
-        SetDisplayThemeRequest,
-        SetDisplayThemeResponse,
-        lambda ctx, args: set_display_theme(ctx.sessions, args),
-    ),
-    ApiMethod(
-        "export-as-html",
-        NotebookCommand[ExportAsHTMLRequest],
-        str,
-        lambda ctx, args: export_as_html(ctx.sessions, args),
-    ),
-    ApiMethod(
-        "export-as-ipynb",
-        NotebookCommand[ExportAsIpynbRequest],
-        str,
-        lambda ctx, args: export_as_ipynb(ctx.sessions, args),
-    ),
-    ApiMethod(
-        "execute-scratchpad",
-        SessionCommand[ExecuteScratchRequest],
-        None,
-        lambda ctx, args: execute_scratch(ctx.ls, ctx.sessions, args),
-    ),
-)
+API_METHODS = marimo_api.build()
 
 _API_BY_NAME = {method.name: method for method in API_METHODS}
 
@@ -623,9 +597,6 @@ async def handle_api_command(
 
     request = msgspec.convert(params, type=spec.request)
     result = await spec.handler(ApiContext(ls=ls, sessions=sessions), request)
-
-    if spec.response is None:
-        return None
 
     payload = msgspec.to_builtins(result)
     validated = msgspec.convert(payload, type=spec.response)

--- a/src/marimo_lsp/api.py
+++ b/src/marimo_lsp/api.py
@@ -6,9 +6,14 @@ from __future__ import annotations
 
 import dataclasses
 import json
+import typing
 from typing import TYPE_CHECKING, cast
 
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
 import msgspec
+from marimo._config.config import DEFAULT_CONFIG
 from marimo._convert.converters import MarimoConvert
 from marimo._export.exporter import Exporter
 from marimo._export.requests import HTMLExportRequest, IPYNBExportRequest
@@ -17,6 +22,7 @@ from marimo._runtime.commands import (
     ExecuteScratchpadCommand,
     InvokeFunctionCommand,
 )
+from marimo._runtime.packages.package_manager import PackageDescription
 from marimo._runtime.packages.package_managers import create_package_manager
 from marimo._schemas.export import ExportAsHTMLRequest, to_html_export_options
 from marimo._schemas.export_options import IPYNBExportOptions
@@ -25,6 +31,7 @@ from marimo._session.requests import InstantiateNotebookRequest
 from marimo._session.state.serialize import serialize_session_view
 from marimo._utils.parse_dataclass import parse_raw
 from pygls.uris import to_fs_path
+from typing_extensions import TypeForm
 
 from marimo_lsp.app_file_manager import find_notebook_document, snapshot_for_scratchpad
 from marimo_lsp.loggers import get_logger
@@ -32,22 +39,28 @@ from marimo_lsp.models import (
     CloseSessionRequest,
     DeleteCellRequest,
     DependencyTreeRequest,
+    DependencyTreeResponse,
     DeserializeRequest,
     ExecuteCellsRequest,
     ExecuteScratchRequest,
     ExportAsIpynbRequest,
     GetConfigurationRequest,
+    GetConfigurationResponse,
     InterruptRequest,
     ListPackagesRequest,
+    ListPackagesResponse,
     ModelRequest,
     NotebookCommand,
     PackageCommand,
     ScriptSource,
     SerializeRequest,
+    SerializeResponse,
     SessionCommand,
     SetDisplayThemeRequest,
+    SetDisplayThemeResponse,
     StdinRequest,
     UpdateConfigurationRequest,
+    UpdateConfigurationResponse,
     UpdateUIElementRequest,
     VenvSource,
 )
@@ -65,7 +78,7 @@ if TYPE_CHECKING:
     from marimo_lsp.sessions import Sessions
 
 
-__all__ = ["handle_api_command"]
+__all__ = ["API_METHODS", "ApiMethod", "handle_api_command"]
 
 logger = get_logger()
 
@@ -220,12 +233,12 @@ async def execute_scratch(
 
 async def get_package_list(
     args: PackageCommand[ListPackagesRequest],
-):
+) -> ListPackagesResponse:
     logger.info(f"get_package_list for {args.notebook_uri}")
     package_manager = _package_manager_for(args.source)
     if not package_manager.is_manager_installed():
         logger.warning(f"Package manager not installed for {args.notebook_uri}")
-        return {"packages": []}
+        return ListPackagesResponse(packages=[])
 
     if isinstance(args.source, ScriptSource):
         # No bound venv to `uv pip list` against; flatten `uv tree --script`
@@ -234,17 +247,16 @@ async def get_package_list(
         # script's.
         filename = _script_filename(args.notebook_uri)
         if filename is None:
-            return {"packages": []}
+            return ListPackagesResponse(packages=[])
         tree = package_manager.dependency_tree(filename)
-        return msgspec.to_builtins({"packages": _flatten_tree(tree)})
+        return ListPackagesResponse(packages=_flatten_tree(tree))
 
-    packages = package_manager.list_packages()
-    return msgspec.to_builtins({"packages": packages})
+    return ListPackagesResponse(packages=package_manager.list_packages())
 
 
 async def get_dependency_tree(
     args: PackageCommand[DependencyTreeRequest],
-):
+) -> DependencyTreeResponse:
     logger.info(f"get_dependency_tree for {args.notebook_uri}")
     package_manager = _package_manager_for(args.source)
 
@@ -253,12 +265,12 @@ async def get_dependency_tree(
         # and let `uv tree --script <file>` resolve the env.
         filename = _script_filename(args.notebook_uri)
         if filename is None:
-            return {"tree": None}
+            return DependencyTreeResponse(tree=None)
         tree = package_manager.dependency_tree(filename)
     else:
         tree = package_manager.dependency_tree()
 
-    return msgspec.to_builtins({"tree": tree})
+    return DependencyTreeResponse(tree=tree)
 
 
 def _script_filename(notebook_uri: str) -> str | None:
@@ -278,7 +290,7 @@ def _script_filename(notebook_uri: str) -> str | None:
     return filename
 
 
-def _flatten_tree(tree: object) -> list[dict[str, str]]:
+def _flatten_tree(tree: object) -> list[PackageDescription]:
     """Walk a `uv tree` result and return a deduplicated list of packages.
 
     Mirrors marimo's own `UvPackageManager.list_packages` flattening so that
@@ -288,7 +300,7 @@ def _flatten_tree(tree: object) -> list[dict[str, str]]:
     if tree is None:
         return []
     seen: set[str] = set()
-    packages: list[dict[str, str]] = []
+    packages: list[PackageDescription] = []
     stack: list[object] = list(getattr(tree, "dependencies", []))
     while stack:
         node = stack.pop()
@@ -297,9 +309,9 @@ def _flatten_tree(tree: object) -> list[dict[str, str]]:
             continue
         seen.add(name)
         version = getattr(node, "version", None) or ""
-        packages.append({"name": name, "version": version})
+        packages.append(PackageDescription(name=name, version=version))
         stack.extend(getattr(node, "dependencies", []))
-    return sorted(packages, key=lambda p: p["name"])
+    return sorted(packages, key=lambda p: p.name)
 
 
 def _package_manager_for(source: VenvSource | ScriptSource) -> LspPackageManager:
@@ -317,9 +329,9 @@ def _package_manager_for(source: VenvSource | ScriptSource) -> LspPackageManager
     )
 
 
-async def serialize(args: SerializeRequest):
+async def serialize(args: SerializeRequest) -> SerializeResponse:
     ir = parse_raw(args.notebook, cls=NotebookSerialization)
-    return {"source": MarimoConvert.from_ir(ir).to_py()}
+    return SerializeResponse(source=MarimoConvert.from_ir(ir).to_py())
 
 
 async def deserialize(args: DeserializeRequest):
@@ -338,42 +350,41 @@ async def deserialize(args: DeserializeRequest):
 async def get_configuration(
     sessions: Sessions,
     args: NotebookCommand[GetConfigurationRequest],
-):
+) -> GetConfigurationResponse:
     """Get the current marimo configuration."""
     session = sessions.get(args.notebook_uri)
     if not session:
         logger.warning(f"No session found for {args.notebook_uri}")
-        return {"config": {}}
+        return GetConfigurationResponse(config=DEFAULT_CONFIG)
 
-    config = session.get_config()
-    return msgspec.to_builtins({"config": config})
+    return GetConfigurationResponse(config=session.get_config())
 
 
 async def update_configuration(
     sessions: Sessions,
     args: NotebookCommand[UpdateConfigurationRequest],
-):
+) -> UpdateConfigurationResponse:
     """Update the marimo user configuration."""
     session = sessions.get(args.notebook_uri)
     if not session:
         logger.warning(f"No session found for {args.notebook_uri}")
-        return {"success": False, "error": "No session found"}
+        return UpdateConfigurationResponse(success=False, error="No session found")
 
     try:
         updated_config = session.save_config(
             cast("PartialMarimoConfig", args.inner.config),
         )
 
-        return msgspec.to_builtins({"success": True, "config": updated_config})
+        return UpdateConfigurationResponse(success=True, config=updated_config)
     except Exception as e:
         logger.exception(f"Error updating configuration for {args.notebook_uri}")
-        return {"success": False, "error": str(e)}
+        return UpdateConfigurationResponse(success=False, error=str(e))
 
 
 async def set_display_theme(
     sessions: Sessions,
     args: SetDisplayThemeRequest,
-):
+) -> SetDisplayThemeResponse:
     """Set the display theme in all kernels without persisting to disk."""
     for session in sessions:
         config = session.get_config(hide_secrets=False)
@@ -382,7 +393,7 @@ async def set_display_theme(
             "MarimoConfig", {**config, "display": {**display, "theme": args.theme}}
         )
         session.update_runtime_config(updated)
-    return {"success": True}
+    return SetDisplayThemeResponse(success=True)
 
 
 async def export_as_html(
@@ -446,107 +457,176 @@ async def export_as_ipynb(
     return json.dumps(ipynb)
 
 
-async def handle_api_command(  # noqa: C901, PLR0911, PLR0912
+@dataclasses.dataclass(frozen=True)
+class ApiContext:
+    """Server-side dependencies a handler can reach for."""
+
+    ls: LanguageServer
+    sessions: Sessions
+
+
+@dataclasses.dataclass(frozen=True)
+class ApiMethod[Req, Res]:
+    """One ``marimo.api`` method: the single source of truth for its wire contract.
+
+    The server dispatches and validates wire values from this table. Genericity
+    ties each entry's handler to its request/response annotations, so a
+    mismatched handler fails type-checking at table construction.
+    """
+
+    name: str
+    """Wire method name (kebab-case)."""
+
+    request: TypeForm[Req]
+    """msgspec annotation the incoming ``params`` must convert to."""
+
+    response: TypeForm[Res] | None
+    """msgspec annotation the handler's return value is validated against.
+
+    ``None`` marks a fire-and-forget method whose response is always ``null``.
+    """
+
+    handler: Callable[[ApiContext, Req], typing.Awaitable[Res]]
+
+
+API_METHODS: tuple[ApiMethod[typing.Any, typing.Any], ...] = (
+    ApiMethod(
+        "execute-cells",
+        SessionCommand[ExecuteCellsRequest],
+        None,
+        lambda ctx, args: run(ctx.sessions, args),
+    ),
+    ApiMethod(
+        "send-stdin",
+        NotebookCommand[StdinRequest],
+        None,
+        lambda ctx, args: send_stdin(ctx.sessions, args),
+    ),
+    ApiMethod(
+        "interrupt",
+        NotebookCommand[InterruptRequest],
+        None,
+        lambda ctx, args: interrupt(ctx.sessions, args),
+    ),
+    ApiMethod(
+        "delete-cell",
+        NotebookCommand[DeleteCellRequest],
+        None,
+        lambda ctx, args: delete_cell(ctx.sessions, args),
+    ),
+    ApiMethod(
+        "update-ui-element",
+        NotebookCommand[UpdateUIElementRequest],
+        None,
+        lambda ctx, args: set_ui_element_value(ctx.sessions, args),
+    ),
+    ApiMethod(
+        "set-model-value",
+        NotebookCommand[ModelRequest],
+        None,
+        lambda ctx, args: set_model_value(ctx.sessions, args),
+    ),
+    ApiMethod(
+        "invoke-function",
+        NotebookCommand[InvokeFunctionCommand],
+        None,
+        lambda ctx, args: function_call_request(ctx.sessions, args),
+    ),
+    ApiMethod(
+        "close-session",
+        NotebookCommand[CloseSessionRequest],
+        None,
+        lambda ctx, args: close_session(ctx.sessions, args),
+    ),
+    ApiMethod(
+        "serialize",
+        SerializeRequest,
+        SerializeResponse,
+        lambda _ctx, args: serialize(args),
+    ),
+    # NOTE: the deserialize payload is marimo's `NotebookSerialization`, which
+    # msgspec cannot introspect (it embeds `ast` nodes), so the response stays
+    # opaque on the wire. The client parses it with its hand-written
+    # `SerializedNotebook` schema (`extension/src/schemas/SerializedNotebook.ts`).
+    ApiMethod(
+        "deserialize",
+        DeserializeRequest,
+        dict[str, typing.Any],
+        lambda _ctx, args: deserialize(args),
+    ),
+    ApiMethod(
+        "get-package-list",
+        PackageCommand[ListPackagesRequest],
+        ListPackagesResponse,
+        lambda _ctx, args: get_package_list(args),
+    ),
+    ApiMethod(
+        "get-dependency-tree",
+        PackageCommand[DependencyTreeRequest],
+        DependencyTreeResponse,
+        lambda _ctx, args: get_dependency_tree(args),
+    ),
+    ApiMethod(
+        "get-configuration",
+        NotebookCommand[GetConfigurationRequest],
+        GetConfigurationResponse,
+        lambda ctx, args: get_configuration(ctx.sessions, args),
+    ),
+    ApiMethod(
+        "update-configuration",
+        NotebookCommand[UpdateConfigurationRequest],
+        UpdateConfigurationResponse,
+        lambda ctx, args: update_configuration(ctx.sessions, args),
+    ),
+    ApiMethod(
+        "set-display-theme",
+        SetDisplayThemeRequest,
+        SetDisplayThemeResponse,
+        lambda ctx, args: set_display_theme(ctx.sessions, args),
+    ),
+    ApiMethod(
+        "export-as-html",
+        NotebookCommand[ExportAsHTMLRequest],
+        str,
+        lambda ctx, args: export_as_html(ctx.sessions, args),
+    ),
+    ApiMethod(
+        "export-as-ipynb",
+        NotebookCommand[ExportAsIpynbRequest],
+        str,
+        lambda ctx, args: export_as_ipynb(ctx.sessions, args),
+    ),
+    ApiMethod(
+        "execute-scratchpad",
+        SessionCommand[ExecuteScratchRequest],
+        None,
+        lambda ctx, args: execute_scratch(ctx.ls, ctx.sessions, args),
+    ),
+)
+
+_API_BY_NAME = {method.name: method for method in API_METHODS}
+
+
+async def handle_api_command(
     ls: LanguageServer, sessions: Sessions, method: str, params: dict
 ) -> object:
-    """Unified API endpoint for all marimo internal methods."""
-    if method == "execute-cells":
-        return await run(
-            sessions,
-            msgspec.convert(params, type=SessionCommand[ExecuteCellsRequest]),
-        )
+    """Unified API endpoint for all marimo internal methods.
 
-    if method == "send-stdin":
-        return await send_stdin(
-            sessions, msgspec.convert(params, type=NotebookCommand[StdinRequest])
-        )
+    Converts ``params`` into the method's request type, runs the handler, and
+    validates the result against the declared response annotation so the wire
+    always matches the generated client schemas.
+    """
+    spec = _API_BY_NAME.get(method)
+    if spec is None:
+        logger.warning(f"Unknown API method: {method}")
+        raise ValueError(method)
 
-    if method == "interrupt":
-        return await interrupt(
-            sessions, msgspec.convert(params, type=NotebookCommand[InterruptRequest])
-        )
+    request = msgspec.convert(params, type=spec.request)
+    result = await spec.handler(ApiContext(ls=ls, sessions=sessions), request)
 
-    if method == "delete-cell":
-        return await delete_cell(
-            sessions, msgspec.convert(params, type=NotebookCommand[DeleteCellRequest])
-        )
+    if spec.response is None:
+        return None
 
-    if method == "update-ui-element":
-        return await set_ui_element_value(
-            sessions,
-            msgspec.convert(params, type=NotebookCommand[UpdateUIElementRequest]),
-        )
-
-    if method == "set-model-value":
-        return await set_model_value(
-            sessions,
-            msgspec.convert(params, type=NotebookCommand[ModelRequest]),
-        )
-
-    if method == "invoke-function":
-        return await function_call_request(
-            sessions,
-            msgspec.convert(params, type=NotebookCommand[InvokeFunctionCommand]),
-        )
-
-    if method == "close-session":
-        return await close_session(
-            sessions,
-            msgspec.convert(params, type=NotebookCommand[CloseSessionRequest]),
-        )
-
-    if method == "serialize":
-        return await serialize(msgspec.convert(params, type=SerializeRequest))
-
-    if method == "deserialize":
-        return await deserialize(msgspec.convert(params, type=DeserializeRequest))
-
-    if method == "get-package-list":
-        return await get_package_list(
-            msgspec.convert(params, type=PackageCommand[ListPackagesRequest]),
-        )
-
-    if method == "get-dependency-tree":
-        return await get_dependency_tree(
-            msgspec.convert(params, type=PackageCommand[DependencyTreeRequest]),
-        )
-
-    if method == "get-configuration":
-        return await get_configuration(
-            sessions,
-            msgspec.convert(params, type=NotebookCommand[GetConfigurationRequest]),
-        )
-
-    if method == "update-configuration":
-        return await update_configuration(
-            sessions,
-            msgspec.convert(params, type=NotebookCommand[UpdateConfigurationRequest]),
-        )
-
-    if method == "set-display-theme":
-        return await set_display_theme(
-            sessions,
-            msgspec.convert(params, type=SetDisplayThemeRequest),
-        )
-
-    if method == "export-as-html":
-        return await export_as_html(
-            sessions,
-            msgspec.convert(params, type=NotebookCommand[ExportAsHTMLRequest]),
-        )
-
-    if method == "export-as-ipynb":
-        return await export_as_ipynb(
-            sessions,
-            msgspec.convert(params, type=NotebookCommand[ExportAsIpynbRequest]),
-        )
-
-    if method == "execute-scratchpad":
-        return await execute_scratch(
-            ls,
-            sessions,
-            msgspec.convert(params, type=SessionCommand[ExecuteScratchRequest]),
-        )
-
-    logger.warning(f"Unknown API method: {method}")
-    raise ValueError(method)
+    payload = msgspec.to_builtins(result)
+    validated = msgspec.convert(payload, type=spec.response)
+    return msgspec.to_builtins(validated)

--- a/src/marimo_lsp/models.py
+++ b/src/marimo_lsp/models.py
@@ -8,7 +8,14 @@ import typing
 
 import marimo._server.models.models as core
 import msgspec
+
+# These stay runtime imports (noqa: TC002) even though they only appear in
+# annotations: msgspec resolves the stringified annotations when the structs
+# are first encoded/inspected, which fails under TYPE_CHECKING-only imports.
+from marimo._config.config import MarimoConfig  # noqa: TC002
 from marimo._convert.common.format import DEFAULT_MARKDOWN_PREFIX
+from marimo._runtime.packages.package_manager import PackageDescription  # noqa: TC002
+from marimo._server.models.packages import DependencyTreeNode  # noqa: TC002
 
 # NOTE: the generic structs below use the legacy TypeVar spelling (noqa: UP046)
 # because msgspec's annotation resolver cannot see PEP 695 type parameters —
@@ -218,6 +225,51 @@ class ApiRequest(msgspec.Struct, rename="camel"):
 
     params: dict[str, typing.Any]
     """The parameters for the method."""
+
+
+class ListPackagesResponse(msgspec.Struct, rename="camel"):
+    """Response for ``get-package-list``."""
+
+    packages: list[PackageDescription]
+    """Installed packages in the notebook's environment."""
+
+
+class DependencyTreeResponse(msgspec.Struct, rename="camel"):
+    """Response for ``get-dependency-tree``."""
+
+    tree: DependencyTreeNode | None = None
+    """The environment's dependency tree, or ``None`` when unresolvable."""
+
+
+class SerializeResponse(msgspec.Struct, rename="camel"):
+    """Response for ``serialize``."""
+
+    source: str
+    """The notebook rendered as Python source."""
+
+
+class GetConfigurationResponse(msgspec.Struct, rename="camel"):
+    """Response for ``get-configuration``."""
+
+    config: MarimoConfig
+    """The resolved marimo configuration (defaults when no session exists)."""
+
+
+class UpdateConfigurationResponse(msgspec.Struct, rename="camel"):
+    """Response for ``update-configuration``."""
+
+    success: bool
+    config: MarimoConfig | None = None
+    """The updated configuration on success."""
+
+    error: str | None = None
+    """Human-readable failure reason when ``success`` is ``False``."""
+
+
+class SetDisplayThemeResponse(msgspec.Struct, rename="camel"):
+    """Response for ``set-display-theme``."""
+
+    success: bool
 
 
 ExecuteCellsRequest = core.ExecuteCellsRequest

--- a/src/marimo_lsp/models.py
+++ b/src/marimo_lsp/models.py
@@ -255,17 +255,6 @@ class GetConfigurationResponse(msgspec.Struct, rename="camel"):
     """The resolved marimo configuration (defaults when no session exists)."""
 
 
-class UpdateConfigurationResponse(msgspec.Struct, rename="camel"):
-    """Response for ``update-configuration``."""
-
-    success: bool
-    config: MarimoConfig | None = None
-    """The updated configuration on success."""
-
-    error: str | None = None
-    """Human-readable failure reason when ``success`` is ``False``."""
-
-
 class SetDisplayThemeResponse(msgspec.Struct, rename="camel"):
     """Response for ``set-display-theme``."""
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,103 @@
+# Copyright 2026 Marimo. All rights reserved.
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from marimo._config.config import DEFAULT_CONFIG
+
+from marimo_lsp.api import (
+    ApiBuilder,
+    ApiContext,
+    SessionNotFoundError,
+    update_configuration,
+)
+from marimo_lsp.models import NotebookCommand, UpdateConfigurationRequest
+
+
+def _context(sessions: MagicMock) -> ApiContext:
+    return ApiContext(ls=MagicMock(), sessions=sessions)
+
+
+def test_api_builder_infers_contract_from_handler() -> None:
+    builder = ApiBuilder()
+
+    @builder("example")
+    async def handler(
+        _ctx: ApiContext,
+        request: UpdateConfigurationRequest,
+    ) -> str:
+        return str(request.config)
+
+    (method,) = builder.build()
+
+    assert method.name == "example"
+    assert method.request is UpdateConfigurationRequest
+    assert method.response is str
+    assert method.handler is handler
+
+
+def test_api_builder_rejects_duplicate_methods() -> None:
+    builder = ApiBuilder()
+
+    @builder("duplicate")
+    async def first(_ctx: ApiContext, _request: UpdateConfigurationRequest) -> None:
+        pass
+
+    @builder("duplicate")
+    async def second(_ctx: ApiContext, _request: UpdateConfigurationRequest) -> None:
+        pass
+
+    with pytest.raises(ValueError, match="duplicate API method"):
+        builder.build()
+
+
+@pytest.mark.asyncio
+async def test_update_configuration_returns_saved_config() -> None:
+    session = MagicMock()
+    session.save_config.return_value = DEFAULT_CONFIG
+    sessions = MagicMock()
+    sessions.get.return_value = session
+
+    result = await update_configuration(
+        _context(sessions),
+        NotebookCommand(
+            notebook_uri="file:///notebook.py",
+            inner=UpdateConfigurationRequest(config={}),
+        ),
+    )
+
+    assert result == DEFAULT_CONFIG
+
+
+@pytest.mark.asyncio
+async def test_update_configuration_raises_without_session() -> None:
+    sessions = MagicMock()
+    sessions.get.return_value = None
+
+    with pytest.raises(SessionNotFoundError):
+        await update_configuration(
+            _context(sessions),
+            NotebookCommand(
+                notebook_uri="file:///notebook.py",
+                inner=UpdateConfigurationRequest(config={}),
+            ),
+        )
+
+
+@pytest.mark.asyncio
+async def test_update_configuration_propagates_save_errors() -> None:
+    session = MagicMock()
+    session.save_config.side_effect = OSError("config is read-only")
+    sessions = MagicMock()
+    sessions.get.return_value = session
+
+    with pytest.raises(OSError, match="config is read-only"):
+        await update_configuration(
+            _context(sessions),
+            NotebookCommand(
+                notebook_uri="file:///notebook.py",
+                inner=UpdateConfigurationRequest(config={}),
+            ),
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -454,6 +454,7 @@ dependencies = [
     { name = "lsprotocol" },
     { name = "marimo" },
     { name = "pygls" },
+    { name = "typing-extensions" },
 ]
 
 [package.dev-dependencies]
@@ -473,6 +474,7 @@ requires-dist = [
     { name = "lsprotocol", specifier = "==2025.0.0" },
     { name = "marimo", specifier = "==0.23.16" },
     { name = "pygls", specifier = "==2.1.1" },
+    { name = "typing-extensions", specifier = ">=4.15.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
`marimo.api` methods were previously dispatched through a manually maintained chain, while their request and response contracts lived elsewhere. That made the boundary easy to drift and left handler signatures weakly connected to the wire types.

Methods are now authored as typed Python handlers. `ApiBuilder` infers the contract from each handler and builds the dispatch table:

```python
marimo_api = ApiBuilder()

@marimo_api("serialize")
async def serialize(
    _ctx: ApiContext,
    request: SerializeRequest,
) -> SerializeResponse:
    ...

API_METHODS = marimo_api.build()
```

Requests and responses are validated at the boundary, and the resulting table becomes the source for generated client contracts later in the stack.
