### PR TITLE
Generate Effect Schemas and a typed api client from msgspec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,13 @@ jobs:
           node scripts/codegen.mjs
           pnpm turbo typecheck-ci
 
+      - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+
+      - name: Check generated Effect Schemas are up to date
+        run: |
+          cd marimo-lsp
+          uv run scripts/generate_effect_schemas.py --check
+
       - name: Validate marimo CSS variable overrides
         run: node marimo-lsp/extension/scripts/check-css-variables.mjs
 

--- a/extension/src/notebook/NotebookSerializer.ts
+++ b/extension/src/notebook/NotebookSerializer.ts
@@ -19,7 +19,7 @@ import {
   type CellMetadata,
   decodeCellMetadata,
 } from "../schemas/CellMetadata.ts";
-import { SerializedNotebook } from "../schemas/SerializedNotebook.ts";
+import * as Api from "../schemas/Models.gen.ts";
 import { classifyCellCode } from "./classifyCellCode.ts";
 import { pickLiveNotebook } from "./pickLiveNotebook.ts";
 
@@ -49,12 +49,9 @@ export class NotebookSerializer extends Effect.Service<NotebookSerializer>()(
         function* (notebook: vscode.NotebookData) {
           yield* Effect.annotateCurrentSpan("cellCount", notebook.cells.length);
 
-          const resp = yield* marimo.serialize({
-            notebook: yield* notebookDataToSerializedNotebook(
-              notebook,
-              constants,
-            ),
-          });
+          const resp = yield* marimo.serialize(
+            yield* notebookDataToNotebookDocument(notebook, constants),
+          );
           const result = yield* decodeSerializeResponse(resp);
           return new TextEncoder().encode(result.source);
         },
@@ -66,15 +63,23 @@ export class NotebookSerializer extends Effect.Service<NotebookSerializer>()(
           const resp = yield* marimo.deserialize({
             source: new TextDecoder().decode(bytes),
           });
-          const { cells, ...metadata } = yield* decodeDeserializeResponse(resp);
+          const {
+            notebook: document,
+            appConfig,
+            header,
+          } = yield* decodeDeserializeResponse(resp);
 
           const notebook = {
-            metadata: metadata,
-            cells: cells.map((cell) => {
+            metadata: {
+              appConfig,
+              header,
+              notebookMetadata: document.metadata,
+            } satisfies NotebookDocumentMetadata,
+            cells: document.cells.map((cell) => {
               // Same classification the live transaction path uses, so a file
               // open and a code-mode commit agree on markdown/sql vs python.
               const classified = classifyCellCode(
-                cell.code,
+                cell.code ?? "",
                 constants.LanguageId,
               );
               return {
@@ -82,12 +87,12 @@ export class NotebookSerializer extends Effect.Service<NotebookSerializer>()(
                 value: classified.code,
                 languageId: classified.languageId,
                 metadata: {
-                  name: cell.name,
-                  options: cell.options,
+                  name: cell.name ?? DEFAULT_CELL_NAME,
+                  options: cell.config,
                   ...(classified.languageMetadata
                     ? { languageMetadata: classified.languageMetadata }
                     : {}),
-                  stableId: crypto.randomUUID(),
+                  stableId: cell.id ?? crypto.randomUUID(),
                 } satisfies CellMetadata,
               };
             }),
@@ -188,15 +193,10 @@ export class NotebookSerializer extends Effect.Service<NotebookSerializer>()(
               options: false,
             } satisfies BooleanMap<CellMetadata>,
             transientDocumentMetadata: {
-              app: false,
+              appConfig: false,
               header: false,
-              version: false,
-              cells: true,
-              // Violations and valid are computed during deserialization
-              // and don't affect the serialized .py output.
-              violations: true,
-              valid: true,
-            } satisfies BooleanMap<SerializedNotebook>,
+              notebookMetadata: false,
+            } satisfies BooleanMap<NotebookDocumentMetadata>,
           },
         );
       }
@@ -210,9 +210,17 @@ export class NotebookSerializer extends Effect.Service<NotebookSerializer>()(
   },
 ) {}
 
-const decodeDeserializeResponse = Schema.decodeUnknown(SerializedNotebook);
-const decodeSerializeResponse = Schema.decodeUnknown(
-  Schema.Struct({ source: Schema.String }),
+const decodeSerializeResponse = Schema.decodeUnknown(Api.SerializeResponse);
+const decodeDeserializeResponse = Schema.decodeUnknown(Api.NotebookDocument);
+
+const NotebookDocumentMetadata = Schema.Struct({
+  appConfig: Schema.optional(Api._AppConfig),
+  header: Schema.optional(Schema.NullOr(Schema.String)),
+  notebookMetadata: Schema.optional(Api.NotebookMetadata),
+});
+type NotebookDocumentMetadata = typeof NotebookDocumentMetadata.Type;
+const decodeNotebookDocumentMetadata = Schema.decodeUnknown(
+  NotebookDocumentMetadata,
 );
 
 function hasStringTag(value: unknown): value is { _tag: string } {
@@ -237,78 +245,100 @@ function causeTag(cause: Cause.Cause<unknown>): string {
 
 const DEFAULT_CELL_NAME = "_";
 
-function notebookDataToSerializedNotebook(
+function notebookDataToNotebookDocument(
   notebook: vscode.NotebookData,
   {
     LanguageId,
   }: {
     LanguageId: Constants["LanguageId"];
   },
-): Effect.Effect<typeof SerializedNotebook.Type, ParseResult.ParseError> {
+): Effect.Effect<typeof Api.SerializePayload.Encoded, ParseResult.ParseError> {
   const { cells, metadata = {} } = notebook;
   const sqlParser = new SQLParser();
   const markdownParser = new MarkdownParser();
+  return Effect.gen(function* () {
+    const documentMetadata = yield* decodeNotebookDocumentMetadata(metadata);
 
-  // Deserialize response is just the IR for our notebook
-  return decodeDeserializeResponse({
-    app: metadata.app ?? { options: {} },
-    header: metadata.header ?? null,
-    version: metadata.version ?? null,
-    violations: metadata.violations ?? [],
-    valid: metadata.valid ?? true,
-    cells: cells.map((cell) => {
-      const cellMeta = decodeCellMetadata(cell.metadata);
-
-      // oxlint-disable-next-line typescript/no-unsafe-enum-comparison
-      if (cell.kind === NotebookCellKind.Markup) {
-        // Check if this is a markdown cell with metadata
-        if (cell.languageId === LanguageId.Markdown) {
-          const result = markdownParser.transformOut(
-            cell.value,
-            cellMeta.pipe(
-              Option.flatMap((x) =>
-                Option.fromNullable(x.languageMetadata?.markdown),
-              ),
-              Option.getOrElse(() => markdownParser.defaultMetadata),
-            ),
+    return {
+      notebook: {
+        version: "1",
+        metadata: documentMetadata.notebookMetadata ?? {},
+        cells: cells.map((cell) => {
+          const cellMeta = decodeCellMetadata(cell.metadata);
+          const name = cellMeta.pipe(
+            Option.flatMap((value) => Option.fromNullable(value.name)),
+            Option.getOrElse(() => DEFAULT_CELL_NAME),
           );
+          const config = (fallback: typeof Api.NotebookCellConfig.Type) =>
+            cellMeta.pipe(
+              Option.flatMap((value) => Option.fromNullable(value.options)),
+              Option.getOrElse(() => fallback),
+            );
+
+          // oxlint-disable-next-line typescript/no-unsafe-enum-comparison
+          if (cell.kind === NotebookCellKind.Markup) {
+            // Check if this is a markdown cell with metadata
+            if (cell.languageId === LanguageId.Markdown) {
+              const result = markdownParser.transformOut(
+                cell.value,
+                cellMeta.pipe(
+                  Option.flatMap((x) =>
+                    Option.fromNullable(x.languageMetadata?.markdown),
+                  ),
+                  Option.getOrElse(() => markdownParser.defaultMetadata),
+                ),
+              );
+              return {
+                id: null,
+                code: result.code,
+                code_hash: null,
+                name,
+                config: config({ hide_code: true }),
+              };
+            }
+            // Otherwise use the default wrapInMarkdown
+            return {
+              id: null,
+              code: wrapInMarkdown(cell.value),
+              code_hash: null,
+              name,
+              config: config({ hide_code: true }),
+            };
+          }
+
+          // Handle SQL cells - transform back to Python mo.sql() wrapper
+          if (cell.languageId === LanguageId.Sql) {
+            const result = sqlParser.transformOut(
+              cell.value,
+              cellMeta.pipe(
+                Option.flatMap((x) =>
+                  Option.fromNullable(x.languageMetadata?.sql),
+                ),
+                Option.getOrElse(() => sqlParser.defaultMetadata),
+              ),
+            );
+            return {
+              id: null,
+              code: result.code,
+              code_hash: null,
+              name,
+              config: config({}),
+            };
+          }
+
+          // Default Python cells
           return {
-            code: result.code,
-            name: cell.metadata?.name ?? DEFAULT_CELL_NAME,
-            options: cell.metadata?.options ?? { hide_code: true },
+            id: null,
+            code: cell.value,
+            code_hash: null,
+            name,
+            config: config({}),
           };
-        }
-        // Otherwise use the default wrapInMarkdown
-        return {
-          code: wrapInMarkdown(cell.value),
-          name: cell.metadata?.name ?? DEFAULT_CELL_NAME,
-          options: cell.metadata?.options ?? { hide_code: true },
-        };
-      }
-
-      // Handle SQL cells - transform back to Python mo.sql() wrapper
-      if (cell.languageId === LanguageId.Sql) {
-        const result = sqlParser.transformOut(
-          cell.value,
-          cellMeta.pipe(
-            Option.flatMap((x) => Option.fromNullable(x.languageMetadata?.sql)),
-            Option.getOrElse(() => sqlParser.defaultMetadata),
-          ),
-        );
-        return {
-          code: result.code,
-          name: cell.metadata?.name ?? DEFAULT_CELL_NAME,
-          options: cell.metadata?.options ?? {},
-        };
-      }
-
-      // Default Python cells
-      return {
-        code: cell.value,
-        name: cell.metadata?.name ?? DEFAULT_CELL_NAME,
-        options: cell.metadata?.options ?? {},
-      };
-    }),
+        }),
+      },
+      appConfig: documentMetadata.appConfig,
+      header: documentMetadata.header ?? null,
+    };
   });
 }
 

--- a/extension/src/schemas/CellMetadata.ts
+++ b/extension/src/schemas/CellMetadata.ts
@@ -1,6 +1,7 @@
 import { Schema } from "effect";
 
 import { CellState } from "./CellState.ts";
+import { NotebookCellConfig } from "./Models.gen.ts";
 
 /**
  * Cell language
@@ -35,7 +36,6 @@ export const LanguageMetadata = Schema.partial(
 );
 export type LanguageMetadata = typeof LanguageMetadata.Type;
 
-// TODO: passthrough unknown fields
 /**
  * VS Code notebook cell metadata (runtime state)
  */
@@ -48,10 +48,7 @@ export const CellMetadata = Schema.partial(
     name: Schema.String,
 
     // Cell configuration options
-    options: Schema.Record({
-      key: Schema.String,
-      value: Schema.Unknown,
-    }),
+    options: NotebookCellConfig,
 
     // Language-specific metadata (e.g., SQL engine, output flag)
     languageMetadata: LanguageMetadata,

--- a/extension/src/schemas/Models.gen.ts
+++ b/extension/src/schemas/Models.gen.ts
@@ -1,0 +1,1495 @@
+// AUTO-GENERATED FILE — DO NOT EDIT.
+//
+// Generated from `src/marimo_lsp/models.py` and the `marimo.api` registry
+// (`API_METHODS` in `src/marimo_lsp/api.py`) by `scripts/generate_effect_schemas.py`.
+// Regenerate with `just generate-schemas`.
+import { Effect, ParseResult, Schema } from "effect";
+
+/**
+ * The notebook's environment is a concrete venv with a known python executable.
+ */
+export const VenvSource = Schema.Struct({
+  kind: Schema.optionalWith(Schema.Literal("venv"), { default: () => "venv" }),
+  executable: Schema.String,
+}).annotations({ identifier: "VenvSource" });
+export type VenvSource = typeof VenvSource.Type;
+
+/**
+ * The notebook's environment is a PEP 723 sandbox script.
+ *
+ * The server resolves the script filename from the notebook URI; `uv`
+ * derives the venv from the script's inline metadata.
+ */
+export const ScriptSource = Schema.Struct({
+  kind: Schema.optionalWith(Schema.Literal("script"), {
+    default: () => "script",
+  }),
+}).annotations({ identifier: "ScriptSource" });
+export type ScriptSource = typeof ScriptSource.Type;
+
+export const PackageSource = Schema.Union(VenvSource, ScriptSource).annotations(
+  { identifier: "PackageSource" },
+);
+export type PackageSource = typeof PackageSource.Type;
+
+/**
+ * Smart-cell metadata for a markdown cell (mirrors the frontend shape).
+ */
+export const MarkdownCellMetadata = Schema.Struct({
+  quotePrefix: Schema.optionalWith(Schema.String, { default: () => "r" }),
+}).annotations({ identifier: "MarkdownCellMetadata" });
+export type MarkdownCellMetadata = typeof MarkdownCellMetadata.Type;
+
+/**
+ * Smart-cell metadata for a SQL cell (mirrors the frontend shape).
+ */
+export const SqlCellMetadata = Schema.Struct({
+  dataframeName: Schema.optionalWith(Schema.String, { default: () => "_df" }),
+  showOutput: Schema.optionalWith(Schema.Boolean, { default: () => true }),
+  engine: Schema.optionalWith(Schema.NullOr(Schema.String), {
+    default: () => null,
+  }),
+}).annotations({ identifier: "SqlCellMetadata" });
+export type SqlCellMetadata = typeof SqlCellMetadata.Type;
+
+/**
+ * Language-specific smart-cell metadata needed to re-wrap display source.
+ *
+ * Only one of these is set, matching the cell's language. Absent when the
+ * client didn't sync it, in which case the per-language defaults apply.
+ */
+export const CellLanguageMetadata = Schema.Struct({
+  markdown: Schema.optionalWith(Schema.NullOr(MarkdownCellMetadata), {
+    default: () => null,
+  }),
+  sql: Schema.optionalWith(Schema.NullOr(SqlCellMetadata), {
+    default: () => null,
+  }),
+}).annotations({ identifier: "CellLanguageMetadata" });
+export type CellLanguageMetadata = typeof CellLanguageMetadata.Type;
+
+/**
+ * marimo-specific fields synced on a VS Code notebook cell's metadata.
+ */
+export const CellMetadata = Schema.Struct({
+  stableId: Schema.optionalWith(Schema.NullOr(Schema.String), {
+    default: () => null,
+  }),
+  name: Schema.optionalWith(Schema.String, { default: () => "_" }),
+  options: Schema.optionalWith(
+    Schema.Record({ key: Schema.String, value: Schema.Unknown }),
+    { default: () => ({}) },
+  ),
+  languageMetadata: Schema.optionalWith(Schema.NullOr(CellLanguageMetadata), {
+    default: () => null,
+  }),
+}).annotations({ identifier: "CellMetadata" });
+export type CellMetadata = typeof CellMetadata.Type;
+
+/**
+ * A request to serialize a notebook to Python source.
+ *
+ * Contains the notebook data to be serialized.
+ */
+export const SerializeRequest = Schema.Struct({
+  notebook: Schema.Record({ key: Schema.String, value: Schema.Unknown }),
+}).annotations({ identifier: "SerializeRequest" });
+export type SerializeRequest = typeof SerializeRequest.Type;
+
+/**
+ * A request to deserialize Python source to notebook format.
+ *
+ * Contains the source code to be parsed.
+ */
+export const DeserializeRequest = Schema.Struct({
+  source: Schema.String,
+}).annotations({ identifier: "DeserializeRequest" });
+export type DeserializeRequest = typeof DeserializeRequest.Type;
+
+/**
+ * A request to convert a file source a marimo notebook.
+ */
+export const ConvertRequest = Schema.Struct({
+  uri: Schema.String,
+}).annotations({ identifier: "ConvertRequest" });
+export type ConvertRequest = typeof ConvertRequest.Type;
+
+/**
+ * A request to interrupt the kernel execution.
+ */
+export const InterruptRequest = Schema.Struct({}).annotations({
+  identifier: "InterruptRequest",
+});
+export type InterruptRequest = typeof InterruptRequest.Type;
+
+/**
+ * A request to list installed packages in the kernel environment.
+ */
+export const ListPackagesRequest = Schema.Struct({}).annotations({
+  identifier: "ListPackagesRequest",
+});
+export type ListPackagesRequest = typeof ListPackagesRequest.Type;
+
+/**
+ * A request to get the dependency tree of installed packages.
+ */
+export const DependencyTreeRequest = Schema.Struct({}).annotations({
+  identifier: "DependencyTreeRequest",
+});
+export type DependencyTreeRequest = typeof DependencyTreeRequest.Type;
+
+/**
+ * A request to get the current configuration.
+ */
+export const GetConfigurationRequest = Schema.Struct({}).annotations({
+  identifier: "GetConfigurationRequest",
+});
+export type GetConfigurationRequest = typeof GetConfigurationRequest.Type;
+
+/**
+ * A request to close the current session.
+ */
+export const CloseSessionRequest = Schema.Struct({}).annotations({
+  identifier: "CloseSessionRequest",
+});
+export type CloseSessionRequest = typeof CloseSessionRequest.Type;
+
+/**
+ * A request to export the notebook as ipynb.
+ */
+export const ExportAsIpynbRequest = Schema.Struct({}).annotations({
+  identifier: "ExportAsIpynbRequest",
+});
+export type ExportAsIpynbRequest = typeof ExportAsIpynbRequest.Type;
+
+/**
+ * Execute arbitrary Python code outside the dependency graph.
+ */
+export const ExecuteScratchRequest = Schema.Struct({
+  code: Schema.String,
+  runId: Schema.optionalWith(Schema.NullOr(Schema.String), {
+    default: () => null,
+  }),
+}).annotations({ identifier: "ExecuteScratchRequest" });
+export type ExecuteScratchRequest = typeof ExecuteScratchRequest.Type;
+
+/**
+ * A request to update the user configuration.
+ */
+export const UpdateConfigurationRequest = Schema.Struct({
+  config: Schema.Record({ key: Schema.String, value: Schema.Unknown }),
+}).annotations({ identifier: "UpdateConfigurationRequest" });
+export type UpdateConfigurationRequest = typeof UpdateConfigurationRequest.Type;
+
+/**
+ * A request to set the display theme without persisting to disk.
+ */
+export const SetDisplayThemeRequest = Schema.Struct({
+  theme: Schema.String,
+}).annotations({ identifier: "SetDisplayThemeRequest" });
+export type SetDisplayThemeRequest = typeof SetDisplayThemeRequest.Type;
+
+/**
+ * Wraps a marimo command with its target notebook context.
+ *
+ * Associates any marimo command/request with the specific notebook
+ * it should operate on, enabling proper routing in multi-notebook
+ * environments.
+ */
+export const NotebookCommand = <S extends Schema.Schema.Any>(inner: S) =>
+  Schema.Struct({
+    notebookUri: Schema.String,
+    inner,
+  });
+
+/**
+ * A notebook command that is further routed to a specific runtime/session.
+ */
+export const SessionCommand = <S extends Schema.Schema.Any>(inner: S) =>
+  Schema.Struct({
+    notebookUri: Schema.String,
+    inner,
+    executable: Schema.String,
+  });
+
+/**
+ * A notebook command that describes its python environment via a `PackageSource`.
+ *
+ * Distinct from `SessionCommand`: package endpoints don't talk to a live
+ * marimo kernel — they shell out to `uv` — and sandbox notebooks have no
+ * pre-resolved python executable for the client to send.
+ */
+export const PackageCommand = <S extends Schema.Schema.Any>(inner: S) =>
+  Schema.Struct({
+    notebookUri: Schema.String,
+    inner,
+    source: PackageSource,
+  });
+
+/**
+ * Serializable HTTP request representation.
+ *
+ * Mimics Starlette/FastAPI Request but is pickle-able and contains only a safe
+ * subset of data. Excludes session and auth to prevent exposing sensitive data.
+ *
+ * Attributes:
+ *     url: Serialized URL with path, port, scheme, netloc, query, hostname.
+ *     base_url: Serialized base URL.
+ *     headers: Request headers (marimo-specific headers excluded).
+ *     query_params: Query parameters mapped to lists of values.
+ *     path_params: Path parameters from the URL route.
+ *     cookies: Request cookies.
+ *     meta: User-defined storage for custom data.
+ *     user: User info from authentication middleware (e.g., is_authenticated, username).
+ */
+export const HTTPRequest = Schema.Struct({
+  url: Schema.Record({ key: Schema.String, value: Schema.Unknown }),
+  base_url: Schema.Record({ key: Schema.String, value: Schema.Unknown }),
+  headers: Schema.Record({ key: Schema.String, value: Schema.String }),
+  query_params: Schema.Record({
+    key: Schema.String,
+    value: Schema.Array(Schema.String),
+  }),
+  path_params: Schema.Record({ key: Schema.String, value: Schema.Unknown }),
+  cookies: Schema.Record({ key: Schema.String, value: Schema.String }),
+  meta: Schema.Record({ key: Schema.String, value: Schema.Unknown }),
+  user: Schema.Unknown,
+}).annotations({ identifier: "HTTPRequest" });
+export type HTTPRequest = typeof HTTPRequest.Type;
+
+export const ExecuteCellsRequest = Schema.Struct({
+  cellIds: Schema.Array(Schema.String),
+  codes: Schema.Array(Schema.String),
+  request: Schema.optionalWith(Schema.NullOr(HTTPRequest), {
+    default: () => null,
+  }),
+}).annotations({ identifier: "ExecuteCellsRequest" });
+export type ExecuteCellsRequest = typeof ExecuteCellsRequest.Type;
+
+export const ExecuteCellsPayload = Schema.Struct({
+  notebookUri: Schema.String,
+  inner: ExecuteCellsRequest,
+  executable: Schema.String,
+});
+
+export class ExecuteCells extends Schema.TaggedRequest<ExecuteCells>()(
+  "execute-cells",
+  {
+    failure: Schema.Never,
+    success: Schema.Union(Schema.Null, Schema.Undefined),
+    payload: ExecuteCellsPayload.fields,
+  },
+) {}
+
+export const StdinRequest = Schema.Struct({
+  text: Schema.String,
+}).annotations({ identifier: "StdinRequest" });
+export type StdinRequest = typeof StdinRequest.Type;
+
+export const SendStdinPayload = Schema.Struct({
+  notebookUri: Schema.String,
+  inner: StdinRequest,
+});
+
+export class SendStdin extends Schema.TaggedRequest<SendStdin>()("send-stdin", {
+  failure: Schema.Never,
+  success: Schema.Union(Schema.Null, Schema.Undefined),
+  payload: SendStdinPayload.fields,
+}) {}
+
+export const InterruptPayload = Schema.Struct({
+  notebookUri: Schema.String,
+  inner: InterruptRequest,
+});
+
+export class Interrupt extends Schema.TaggedRequest<Interrupt>()("interrupt", {
+  failure: Schema.Never,
+  success: Schema.Union(Schema.Null, Schema.Undefined),
+  payload: InterruptPayload.fields,
+}) {}
+
+export const DeleteCellRequest = Schema.Struct({
+  cellId: Schema.String,
+}).annotations({ identifier: "DeleteCellRequest" });
+export type DeleteCellRequest = typeof DeleteCellRequest.Type;
+
+export const DeleteCellPayload = Schema.Struct({
+  notebookUri: Schema.String,
+  inner: DeleteCellRequest,
+});
+
+export class DeleteCell extends Schema.TaggedRequest<DeleteCell>()(
+  "delete-cell",
+  {
+    failure: Schema.Never,
+    success: Schema.Union(Schema.Null, Schema.Undefined),
+    payload: DeleteCellPayload.fields,
+  },
+) {}
+
+export const UpdateUIElementRequest = Schema.Struct({
+  objectIds: Schema.Array(Schema.String),
+  values: Schema.Array(Schema.Unknown),
+  request: Schema.optionalWith(Schema.NullOr(HTTPRequest), {
+    default: () => null,
+  }),
+  token: Schema.optional(Schema.String),
+}).annotations({ identifier: "UpdateUIElementRequest" });
+export type UpdateUIElementRequest = typeof UpdateUIElementRequest.Type;
+
+export const UpdateUiElementPayload = Schema.Struct({
+  notebookUri: Schema.String,
+  inner: UpdateUIElementRequest,
+});
+
+export class UpdateUiElement extends Schema.TaggedRequest<UpdateUiElement>()(
+  "update-ui-element",
+  {
+    failure: Schema.Never,
+    success: Schema.Union(Schema.Null, Schema.Undefined),
+    payload: UpdateUiElementPayload.fields,
+  },
+) {}
+
+/**
+ * Widget model state update message.
+ *
+ * Attributes:
+ *     state: Model state updates.
+ *     buffer_paths: Paths within state dict pointing to binary buffers.
+ */
+export const ModelUpdateMessage = Schema.Struct({
+  method: Schema.optionalWith(Schema.Literal("update"), {
+    default: () => "update",
+  }),
+  state: Schema.Record({ key: Schema.String, value: Schema.Unknown }),
+  bufferPaths: Schema.Array(
+    Schema.Array(Schema.Union(Schema.String, Schema.Int)),
+  ),
+}).annotations({ identifier: "ModelUpdateMessage" });
+export type ModelUpdateMessage = typeof ModelUpdateMessage.Type;
+
+/**
+ * Custom widget message.
+ *
+ * Attributes:
+ *     content: Arbitrary content for the custom message.
+ */
+export const ModelCustomMessage = Schema.Struct({
+  method: Schema.optionalWith(Schema.Literal("custom"), {
+    default: () => "custom",
+  }),
+  content: Schema.Unknown,
+}).annotations({ identifier: "ModelCustomMessage" });
+export type ModelCustomMessage = typeof ModelCustomMessage.Type;
+
+/**
+ * Base64-encoded bytes on the msgspec JSON wire.
+ *
+ * Matches the compile-time `TypedString<"Base64String">` brand emitted
+ * by `@marimo-team/openapi`. Decode with `Schema.Uint8ArrayFromBase64`
+ * where actual bytes are needed.
+ */
+export const Base64String = Schema.String.pipe(Schema.brand("Base64String"));
+export type Base64String = typeof Base64String.Type;
+
+export const ModelRequest = Schema.Struct({
+  modelId: Schema.String,
+  message: Schema.Union(ModelUpdateMessage, ModelCustomMessage),
+  buffers: Schema.Array(Base64String),
+  token: Schema.optional(Schema.String),
+}).annotations({ identifier: "ModelRequest" });
+export type ModelRequest = typeof ModelRequest.Type;
+
+export const SetModelValuePayload = Schema.Struct({
+  notebookUri: Schema.String,
+  inner: ModelRequest,
+});
+
+export class SetModelValue extends Schema.TaggedRequest<SetModelValue>()(
+  "set-model-value",
+  {
+    failure: Schema.Never,
+    success: Schema.Union(Schema.Null, Schema.Undefined),
+    payload: SetModelValuePayload.fields,
+  },
+) {}
+
+/**
+ * Invoke a function from a UI element.
+ *
+ * Called when a UI element needs to invoke a Python function.
+ *
+ * Attributes:
+ *     function_call_id: Unique identifier for this call.
+ *     namespace: Namespace where the function is registered.
+ *     function_name: Function to invoke.
+ *     args: Keyword arguments for the function.
+ */
+export const InvokeFunctionCommand = Schema.Struct({
+  type: Schema.optionalWith(Schema.Literal("invoke-function"), {
+    default: () => "invoke-function",
+  }),
+  functionCallId: Schema.String,
+  namespace: Schema.String,
+  functionName: Schema.String,
+  args: Schema.Record({ key: Schema.String, value: Schema.Unknown }),
+}).annotations({ identifier: "InvokeFunctionCommand" });
+export type InvokeFunctionCommand = typeof InvokeFunctionCommand.Type;
+
+export const InvokeFunctionPayload = Schema.Struct({
+  notebookUri: Schema.String,
+  inner: InvokeFunctionCommand,
+});
+
+export class InvokeFunction extends Schema.TaggedRequest<InvokeFunction>()(
+  "invoke-function",
+  {
+    failure: Schema.Never,
+    success: Schema.Union(Schema.Null, Schema.Undefined),
+    payload: InvokeFunctionPayload.fields,
+  },
+) {}
+
+export const CloseSessionPayload = Schema.Struct({
+  notebookUri: Schema.String,
+  inner: CloseSessionRequest,
+});
+
+export class CloseSession extends Schema.TaggedRequest<CloseSession>()(
+  "close-session",
+  {
+    failure: Schema.Never,
+    success: Schema.Union(Schema.Null, Schema.Undefined),
+    payload: CloseSessionPayload.fields,
+  },
+) {}
+
+/**
+ * Response for ``serialize``.
+ */
+export const SerializeResponse = Schema.Struct({
+  source: Schema.String,
+}).annotations({ identifier: "SerializeResponse" });
+export type SerializeResponse = typeof SerializeResponse.Type;
+
+export const SerializePayload = Schema.Struct({
+  notebook: Schema.Record({ key: Schema.String, value: Schema.Unknown }),
+});
+
+export class Serialize extends Schema.TaggedRequest<Serialize>()("serialize", {
+  failure: Schema.Never,
+  success: SerializeResponse,
+  payload: SerializePayload.fields,
+}) {}
+
+export const DeserializePayload = Schema.Struct({
+  source: Schema.String,
+});
+
+export class Deserialize extends Schema.TaggedRequest<Deserialize>()(
+  "deserialize",
+  {
+    failure: Schema.Never,
+    success: Schema.Record({ key: Schema.String, value: Schema.Unknown }),
+    payload: DeserializePayload.fields,
+  },
+) {}
+
+export const PackageDescription = Schema.Struct({
+  name: Schema.String,
+  version: Schema.String,
+}).annotations({ identifier: "PackageDescription" });
+export type PackageDescription = typeof PackageDescription.Type;
+
+/**
+ * Response for ``get-package-list``.
+ */
+export const ListPackagesResponse = Schema.Struct({
+  packages: Schema.Array(PackageDescription),
+}).annotations({ identifier: "ListPackagesResponse" });
+export type ListPackagesResponse = typeof ListPackagesResponse.Type;
+
+export const GetPackageListPayload = Schema.Struct({
+  notebookUri: Schema.String,
+  inner: ListPackagesRequest,
+  source: PackageSource,
+});
+
+export class GetPackageList extends Schema.TaggedRequest<GetPackageList>()(
+  "get-package-list",
+  {
+    failure: Schema.Never,
+    success: ListPackagesResponse,
+    payload: GetPackageListPayload.fields,
+  },
+) {}
+
+export const DependencyTag = Schema.Struct({
+  kind: Schema.String,
+  value: Schema.String,
+}).annotations({ identifier: "DependencyTag" });
+export type DependencyTag = typeof DependencyTag.Type;
+
+export interface DependencyTreeNode {
+  readonly name: string;
+  readonly version: string | null;
+  readonly tags: ReadonlyArray<DependencyTag>;
+  readonly dependencies: ReadonlyArray<DependencyTreeNode>;
+}
+export const DependencyTreeNode: Schema.Schema<DependencyTreeNode> =
+  Schema.Struct({
+    name: Schema.String,
+    version: Schema.NullOr(Schema.String),
+    tags: Schema.Array(DependencyTag),
+    dependencies: Schema.Array(
+      Schema.suspend(
+        (): Schema.Schema<DependencyTreeNode> => DependencyTreeNode,
+      ),
+    ),
+  }).annotations({ identifier: "DependencyTreeNode" });
+
+/**
+ * Response for ``get-dependency-tree``.
+ */
+export const DependencyTreeResponse = Schema.Struct({
+  tree: Schema.optionalWith(Schema.NullOr(DependencyTreeNode), {
+    default: () => null,
+  }),
+}).annotations({ identifier: "DependencyTreeResponse" });
+export type DependencyTreeResponse = typeof DependencyTreeResponse.Type;
+
+export const GetDependencyTreePayload = Schema.Struct({
+  notebookUri: Schema.String,
+  inner: DependencyTreeRequest,
+  source: PackageSource,
+});
+
+export class GetDependencyTree extends Schema.TaggedRequest<GetDependencyTree>()(
+  "get-dependency-tree",
+  {
+    failure: Schema.Never,
+    success: DependencyTreeResponse,
+    payload: GetDependencyTreePayload.fields,
+  },
+) {}
+
+/**
+ * Configuration options for Anthropic.
+ *
+ * **Keys.**
+ *
+ * - `api_key`: the Anthropic API key
+ */
+export const AnthropicConfig = Schema.Struct({
+  api_key: Schema.optional(Schema.String),
+}).annotations({ identifier: "AnthropicConfig" });
+export type AnthropicConfig = typeof AnthropicConfig.Type;
+
+/**
+ * Configuration options for OpenAI or OpenAI-compatible services.
+ *
+ * **Keys.**
+ *
+ * - `api_key`: the OpenAI API key
+ * - `base_url`: the base URL for the API
+ * - `project`: the project ID for the OpenAI API
+ * - `ssl_verify` : Boolean argument for httpx passed to open ai client. httpx defaults to true, but some use cases to let users override to False in some testing scenarios
+ * - `ca_bundle_path`: custom ca bundle to be used for verifying SSL certificates. Used to create custom SSL context for httpx client
+ * - `client_pem` : custom path of a client .pem cert used for verifying identity of client server
+ * - `extra_headers`: extra headers to be passed to the OpenAI client
+ */
+export const OpenAiConfig = Schema.Struct({
+  api_key: Schema.optional(Schema.String),
+  base_url: Schema.optional(Schema.String),
+  ca_bundle_path: Schema.optional(Schema.String),
+  client_pem: Schema.optional(Schema.String),
+  extra_headers: Schema.optional(
+    Schema.Record({ key: Schema.String, value: Schema.String }),
+  ),
+  model: Schema.optional(Schema.String),
+  project: Schema.optional(Schema.String),
+  ssl_verify: Schema.optional(Schema.Boolean),
+}).annotations({ identifier: "OpenAiConfig" });
+export type OpenAiConfig = typeof OpenAiConfig.Type;
+
+/**
+ * Configuration options for Bedrock.
+ *
+ * **Keys.**
+ *
+ * - `profile_name`: the AWS profile to use
+ * - `region_name`: the AWS region to use
+ * - `aws_access_key_id`: the AWS access key ID
+ * - `aws_secret_access_key`: the AWS secret access key
+ */
+export const BedrockConfig = Schema.Struct({
+  aws_access_key_id: Schema.optional(Schema.String),
+  aws_secret_access_key: Schema.optional(Schema.String),
+  profile_name: Schema.optional(Schema.String),
+  region_name: Schema.optional(Schema.String),
+}).annotations({ identifier: "BedrockConfig" });
+export type BedrockConfig = typeof BedrockConfig.Type;
+
+/**
+ * Configuration options for GitHub.
+ *
+ * **Keys.**
+ *
+ * - `api_key`: the GitHub API token
+ * - `base_url`: the base URL for the API
+ * - `copilot_settings`: configuration settings for GitHub Copilot LSP.
+ *     Supports settings like `http` (proxy configuration), `telemetry`,
+ *     and `github-enterprise` (enterprise URI).
+ */
+export const GitHubConfig = Schema.Struct({
+  api_key: Schema.optional(Schema.String),
+  base_url: Schema.optional(Schema.String),
+  copilot_settings: Schema.optional(
+    Schema.Record({ key: Schema.String, value: Schema.Unknown }),
+  ),
+}).annotations({ identifier: "GitHubConfig" });
+export type GitHubConfig = typeof GitHubConfig.Type;
+
+/**
+ * Configuration options for Google AI.
+ *
+ * **Keys.**
+ *
+ * - `api_key`: the Google AI API key
+ */
+export const GoogleAiConfig = Schema.Struct({
+  api_key: Schema.optional(Schema.String),
+}).annotations({ identifier: "GoogleAiConfig" });
+export type GoogleAiConfig = typeof GoogleAiConfig.Type;
+
+/**
+ * Configuration options for an AI model.
+ *
+ * **Keys.**
+ *
+ * - `chat_model`: the model to use for chat completions
+ * - `edit_model`: the model to use for edit completions
+ * - `autocomplete_model`: the model to use for code completion/autocomplete
+ * - `displayed_models`: a list of models to display in the UI
+ * - `custom_models`: a list of custom models to use that are not from the default list
+ */
+export const AiModelConfig = Schema.Struct({
+  autocomplete_model: Schema.optional(Schema.String),
+  chat_model: Schema.optional(Schema.String),
+  custom_models: Schema.Array(Schema.String),
+  displayed_models: Schema.Array(Schema.String),
+  edit_model: Schema.optional(Schema.String),
+}).annotations({ identifier: "AiModelConfig" });
+export type AiModelConfig = typeof AiModelConfig.Type;
+
+/**
+ * Configuration options for AI.
+ *
+ * **Keys.**
+ *
+ * - `enabled`: if `False`, hide AI actions and panels in the marimo UI
+ * - `rules`: custom rules to include in all AI completion prompts
+ * - `max_tokens`: the maximum number of tokens to use in AI completions
+ * - `mode`: the mode to use for AI completions. Can be one of: `"ask"` or `"manual"`
+ * - `inline_tooltip`: if `True`, enable inline AI tooltip suggestions
+ * - `models`: the models to use for AI completions
+ * - `open_ai`: the OpenAI config
+ * - `anthropic`: the Anthropic config
+ * - `google`: the Google AI config
+ * - `bedrock`: the Bedrock config
+ * - `azure`: the Azure config
+ * - `ollama`: the Ollama config
+ * - `github`: the GitHub config
+ * - `openrouter`: the OpenRouter config
+ * - `wandb`: the Weights & Biases config
+ * - `opencode_go`: the OpenCode Go config
+ * - `custom_providers`: a dict of custom OpenAI-compatible providers
+ * - `open_ai_compatible`: the OpenAI-compatible config (deprecated, use custom_providers)
+ */
+export const AiConfig = Schema.Struct({
+  anthropic: Schema.optional(AnthropicConfig),
+  azure: Schema.optional(OpenAiConfig),
+  bedrock: Schema.optional(BedrockConfig),
+  custom_providers: Schema.optional(
+    Schema.Record({ key: Schema.String, value: OpenAiConfig }),
+  ),
+  enabled: Schema.optional(Schema.Boolean),
+  github: Schema.optional(GitHubConfig),
+  google: Schema.optional(GoogleAiConfig),
+  inline_tooltip: Schema.optional(Schema.Boolean),
+  max_tokens: Schema.optional(Schema.Int),
+  mode: Schema.optional(Schema.Literal("agent", "ask", "code_mode", "manual")),
+  models: Schema.optional(AiModelConfig),
+  ollama: Schema.optional(OpenAiConfig),
+  open_ai: Schema.optional(OpenAiConfig),
+  open_ai_compatible: Schema.optional(OpenAiConfig),
+  opencode_go: Schema.optional(OpenAiConfig),
+  openrouter: Schema.optional(OpenAiConfig),
+  rules: Schema.optional(Schema.String),
+  wandb: Schema.optional(OpenAiConfig),
+}).annotations({ identifier: "AiConfig" });
+export type AiConfig = typeof AiConfig.Type;
+
+/**
+ * Configuration for code completion.
+ *
+ * A dict with key/value pairs configuring code completion in the marimo
+ * editor.
+ *
+ * **Keys.**
+ *
+ * - `activate_on_typing`: if `False`, completion won't activate
+ * until the completion hotkey is entered
+ * - `signature_hint_on_typing`: if `False`, signature hint won't be shown when typing
+ * - `copilot`: one of `"github"`, `"codeium"`, or `"custom"`
+ * - `codeium_api_key`: the Codeium API key
+ * - `auto_close_pairs`: if `False`, typing an opening bracket, parenthesis,
+ * or quote will not automatically insert the closing character
+ */
+export const CompletionConfig = Schema.Struct({
+  activate_on_typing: Schema.Boolean,
+  api_key: Schema.optional(Schema.NullOr(Schema.String)),
+  auto_close_pairs: Schema.optional(Schema.Boolean),
+  base_url: Schema.optional(Schema.NullOr(Schema.String)),
+  codeium_api_key: Schema.optional(Schema.NullOr(Schema.String)),
+  copilot: Schema.Union(
+    Schema.Boolean,
+    Schema.Literal("codeium", "custom", "github"),
+  ),
+  model: Schema.optional(Schema.NullOr(Schema.String)),
+  signature_hint_on_typing: Schema.Boolean,
+}).annotations({ identifier: "CompletionConfig" });
+export type CompletionConfig = typeof CompletionConfig.Type;
+
+/**
+ * Configuration for datasources panel.
+ *
+ * **Keys.**
+ *
+ * - `auto_discover_schemas`: if `True`, include schemas in the datasource
+ * - `auto_discover_tables`: if `True`, include tables in the datasource
+ * - `auto_discover_columns`: if `True`, include columns & table metadata in the datasource
+ */
+export const DatasourcesConfig = Schema.Struct({
+  auto_discover_columns: Schema.optional(
+    Schema.Union(Schema.Boolean, Schema.Literal("auto")),
+  ),
+  auto_discover_schemas: Schema.optional(
+    Schema.Union(Schema.Boolean, Schema.Literal("auto")),
+  ),
+  auto_discover_tables: Schema.optional(
+    Schema.Union(Schema.Boolean, Schema.Literal("auto")),
+  ),
+}).annotations({ identifier: "DatasourcesConfig" });
+export type DatasourcesConfig = typeof DatasourcesConfig.Type;
+
+/**
+ * Configuration options for diagnostics.
+ *
+ * **Keys.**
+ *
+ * - `enabled`: if `True`, diagnostics will be shown in the editor
+ * - `sql_linter`: if `True`, SQL cells will have linting enabled
+ */
+export const DiagnosticsConfig = Schema.Struct({
+  enabled: Schema.optional(Schema.Boolean),
+  sql_linter: Schema.optional(Schema.Boolean),
+}).annotations({ identifier: "DiagnosticsConfig" });
+export type DiagnosticsConfig = typeof DiagnosticsConfig.Type;
+
+/**
+ * Configuration for display.
+ *
+ * **Keys.**
+ *
+ * - `theme`: `"light"`, `"dark"`, or `"system"`
+ * - `code_editor_font_size`: font size for the code editor
+ * - `cell_output`: `"above"` or `"below"`
+ * - `dataframes`: `"rich"` or `"plain"`
+ * - `custom_css`: list of paths to custom CSS files
+ * - `default_table_page_size`: default number of rows to display in tables
+ * - `default_table_max_columns`: default maximum number of columns to display in tables
+ * - `reference_highlighting`: if `True`, highlight reactive variable references
+ * - `locale`: locale for date formatting and internationalization (e.g., "en-US", "en-GB", "de-DE")
+ */
+export const DisplayConfig = Schema.Struct({
+  cell_output: Schema.Literal("above", "below"),
+  code_editor_font_size: Schema.Int,
+  custom_css: Schema.optional(Schema.Array(Schema.String)),
+  dataframes: Schema.Literal("plain", "rich"),
+  default_table_max_columns: Schema.Int,
+  default_table_page_size: Schema.Int,
+  default_width: Schema.Literal(
+    "columns",
+    "compact",
+    "full",
+    "medium",
+    "normal",
+  ),
+  locale: Schema.optional(Schema.NullOr(Schema.String)),
+  reference_highlighting: Schema.optional(Schema.Boolean),
+  theme: Schema.Literal("dark", "light", "system"),
+}).annotations({ identifier: "DisplayConfig" });
+export type DisplayConfig = typeof DisplayConfig.Type;
+
+/**
+ * Configuration for code formatting.
+ *
+ * **Keys.**
+ *
+ * - `line_length`: max line length
+ */
+export const FormattingConfig = Schema.Struct({
+  line_length: Schema.Int,
+}).annotations({ identifier: "FormattingConfig" });
+export type FormattingConfig = typeof FormattingConfig.Type;
+
+/**
+ * Configuration for keymaps.
+ *
+ * **Keys.**
+ *
+ * - `preset`: one of `"default"` or `"vim"`
+ * - `overrides`: a dict of keymap actions to their keymap override
+ * - `vimrc`: path to a vimrc file to load keymaps from
+ * - `destructive_delete`: if `True`, allows deleting cells with content.
+ */
+export const KeymapConfig = Schema.Struct({
+  destructive_delete: Schema.optional(Schema.Boolean),
+  overrides: Schema.optional(
+    Schema.Record({ key: Schema.String, value: Schema.String }),
+  ),
+  preset: Schema.Literal("default", "vim"),
+  vimrc: Schema.optional(Schema.NullOr(Schema.String)),
+}).annotations({ identifier: "KeymapConfig" });
+export type KeymapConfig = typeof KeymapConfig.Type;
+
+/**
+ * Configuration options for basedpyright Language Server.
+ *
+ * basedpyright handles completion, hover, go-to-definition, and diagnostics,
+ * but we only use it for diagnostics.
+ */
+export const BasedpyrightServerConfig = Schema.Struct({
+  enabled: Schema.optional(Schema.Boolean),
+}).annotations({ identifier: "BasedpyrightServerConfig" });
+export type BasedpyrightServerConfig = typeof BasedpyrightServerConfig.Type;
+
+/**
+ * Configuration options for Python Language Server.
+ *
+ * pylsp handles completion, hover, go-to-definition, and diagnostics.
+ */
+export const PythonLanguageServerConfig = Schema.Struct({
+  enable_flake8: Schema.optional(Schema.Boolean),
+  enable_mypy: Schema.optional(Schema.Boolean),
+  enable_pydocstyle: Schema.optional(Schema.Boolean),
+  enable_pyflakes: Schema.optional(Schema.Boolean),
+  enable_pylint: Schema.optional(Schema.Boolean),
+  enable_ruff: Schema.optional(Schema.Boolean),
+  enabled: Schema.optional(Schema.Boolean),
+}).annotations({ identifier: "PythonLanguageServerConfig" });
+export type PythonLanguageServerConfig = typeof PythonLanguageServerConfig.Type;
+
+/**
+ * Configuration options for Pyrefly Language Server.
+ *
+ * Pyrefly handles completion, hover, go-to-definition, and diagnostics.
+ */
+export const PyreflyLanguageServerConfig = Schema.Struct({
+  enabled: Schema.optional(Schema.Boolean),
+}).annotations({ identifier: "PyreflyLanguageServerConfig" });
+export type PyreflyLanguageServerConfig =
+  typeof PyreflyLanguageServerConfig.Type;
+
+/**
+ * Configuration options for Ty Language Server.
+ *
+ * ty handles completion, hover, go-to-definition, and diagnostics,
+ * but we only use it for diagnostics.
+ */
+export const TyLanguageServerConfig = Schema.Struct({
+  enabled: Schema.optional(Schema.Boolean),
+}).annotations({ identifier: "TyLanguageServerConfig" });
+export type TyLanguageServerConfig = typeof TyLanguageServerConfig.Type;
+
+/**
+ * Configuration options for language servers.
+ *
+ * **Keys.**
+ *
+ * - `pylsp`: the pylsp config
+ * - `basedpyright`: the basedpyright config
+ * - `ty`: the ty config
+ * - `pyrefly`: the pyrefly config
+ */
+export const LanguageServersConfig = Schema.Struct({
+  basedpyright: Schema.optional(BasedpyrightServerConfig),
+  pylsp: Schema.optional(PythonLanguageServerConfig),
+  pyrefly: Schema.optional(PyreflyLanguageServerConfig),
+  ty: Schema.optional(TyLanguageServerConfig),
+}).annotations({ identifier: "LanguageServersConfig" });
+export type LanguageServersConfig = typeof LanguageServersConfig.Type;
+
+/**
+ * Configuration for lint rule selection.
+ *
+ * Follows ruff-inspired semantics for selecting which rules to run
+ * during `marimo check`.
+ *
+ * **Keys.**
+ *
+ * - `select`: list of rule code prefixes that replaces the default
+ *   enabled set. Use `"ALL"` to select all rules.
+ *   Example: `["MB", "MR001"]`
+ * - `ignore`: list of rule code prefixes to remove from the
+ *   enabled set.
+ */
+export const LintConfig = Schema.Struct({
+  ignore: Schema.optional(Schema.Array(Schema.String)),
+  select: Schema.optional(Schema.Array(Schema.String)),
+}).annotations({ identifier: "LintConfig" });
+export type LintConfig = typeof LintConfig.Type;
+
+/**
+ * Configuration for MCP servers
+ *
+ * Note: the field name `mcpServers` is camelCased to match MCP server
+ * config conventions used by popular AI applications (e.g. Cursor, Claude Desktop, etc.)
+ */
+export const MCPConfig = Schema.Struct({
+  mcpServers: Schema.Record({
+    key: Schema.String,
+    value: Schema.Record({ key: Schema.String, value: Schema.Unknown }),
+  }),
+  presets: Schema.optional(Schema.Array(Schema.Literal("context7", "marimo"))),
+}).annotations({ identifier: "MCPConfig" });
+export type MCPConfig = typeof MCPConfig.Type;
+
+/**
+ * Configuration options for package management.
+ *
+ * **Keys.**
+ *
+ * - `manager`: the package manager to use
+ */
+export const PackageManagementConfig = Schema.Struct({
+  manager: Schema.Literal("pip", "pixi", "poetry", "rye", "uv"),
+}).annotations({ identifier: "PackageManagementConfig" });
+export type PackageManagementConfig = typeof PackageManagementConfig.Type;
+
+/**
+ * Configuration for runtime.
+ *
+ * **Keys.**
+ *
+ * - `auto_instantiate`: if `False`, cells won't automatically
+ *     run on startup. This only applies when editing a notebook,
+ *     and not when running as an application.
+ *     The default is `True`.
+ * - `auto_reload`: if `lazy`, cells importing modified modules will marked
+ *   as stale; if `autorun`, affected cells will be automatically run. similar
+ *   to IPython's %autoreload extension but with more code intelligence.
+ * - `reactive_tests`: if `True`, marimo will automatically run pytest on cells containing only test functions and test classes.
+ *   execution.
+ * - `on_cell_change`: if `lazy`, cells will be marked stale when their
+ *   ancestors run but won't autorun; if `autorun`, cells will automatically
+ *   run when their ancestors run.
+ * - `execution_type`: if `relaxed`, marimo will not clone cell declarations;
+ *   if `strict` marimo will clone cell declarations by default, avoiding
+ *   hidden potential state build up.
+ * - `watcher_on_save`: how to handle file changes when saving. `"lazy"` marks
+ *     affected cells as stale, `"autorun"` automatically runs affected cells.
+ * - `output_max_bytes`: the maximum size in bytes of cell outputs; larger
+ *     values may affect frontend performance
+ * - `serve_cached_sessions_in_apps`: if `True`, initialize applications with session cache.
+ *     The default is `False`.
+ * - `std_stream_max_bytes`: the maximum size in bytes of console outputs;
+ *   larger values may affect frontend performance
+ * - `pythonpath`: a list of directories to add to the Python search path.
+ *     Directories will be added to the head of sys.path. Similar to the
+ *     `PYTHONPATH` environment variable, the directories will be included in
+ *     where Python will look for imported modules.
+ * - `dotenv`: a list of paths to `.env` files to load.
+ *     If the file does not exist, it will be silently ignored.
+ *     The default is `[".env"]` if a pyproject.toml is found, otherwise `[]`.
+ * - `default_sql_output`: the default output format for SQL queries. Can be one of:
+ *     `"auto"`, `"native"`, `"polars"`, `"lazy-polars"`, or `"pandas"`.
+ *     The default is `"auto"`.
+ * - `default_auto_download`: an Optional list of export types to automatically snapshot your notebook as:
+ *    `html`, `markdown`, `ipynb`.
+ *    The default is None.
+ * - `default_csv_encoding`: the default encoding for CSV exports.
+ *     The default is `"utf-8"`.
+ * - `show_tracebacks`: if `True`, show detailed error tracebacks in run mode.
+ *     When enabled, exceptions will display a clickable toast that opens a modal with the full traceback.
+ *     The default is `False`.
+ */
+export const RuntimeConfig = Schema.Struct({
+  auto_instantiate: Schema.Boolean,
+  auto_reload: Schema.Literal("autorun", "lazy", "off"),
+  default_auto_download: Schema.optional(
+    Schema.Array(Schema.Literal("html", "ipynb", "markdown")),
+  ),
+  default_csv_encoding: Schema.optional(Schema.String),
+  default_sql_output: Schema.Literal(
+    "auto",
+    "lazy-polars",
+    "native",
+    "pandas",
+    "polars",
+  ),
+  dotenv: Schema.optional(Schema.Array(Schema.String)),
+  on_cell_change: Schema.Literal("autorun", "lazy"),
+  output_max_bytes: Schema.Int,
+  pythonpath: Schema.optional(Schema.Array(Schema.String)),
+  reactive_tests: Schema.Boolean,
+  serve_cached_sessions_in_apps: Schema.optional(Schema.Boolean),
+  show_tracebacks: Schema.optional(Schema.Boolean),
+  std_stream_max_bytes: Schema.Int,
+  watcher_on_save: Schema.Literal("autorun", "lazy"),
+}).annotations({ identifier: "RuntimeConfig" });
+export type RuntimeConfig = typeof RuntimeConfig.Type;
+
+/**
+ * Configuration for saving.
+ *
+ * **Keys.**
+ *
+ * - `autosave`: one of `"off"` or `"after_delay"`
+ * - `delay`: number of milliseconds to wait before autosaving
+ * - `format_on_save`: if `True`, format the code on save
+ */
+export const SaveConfig = Schema.Struct({
+  autosave: Schema.Literal("after_delay", "off"),
+  autosave_delay: Schema.Int,
+  format_on_save: Schema.Boolean,
+}).annotations({ identifier: "SaveConfig" });
+export type SaveConfig = typeof SaveConfig.Type;
+
+/**
+ * Configuration for the server.
+ *
+ * **Keys.**
+ *
+ * - `browser`: the web browser to use. `"default"` or a browser registered
+ *     with Python's webbrowser module (eg, `"firefox"` or `"chrome"`)
+ * - `follow_symlink`: if true, the server will follow symlinks it finds
+ *     inside its static assets directory.
+ * - `disable_file_downloads`: if true, the file download button will be
+ *     hidden in the file explorer.
+ * - `transport`: experimental. The transport used to stream kernel
+ *     messages to the frontend, typically set with the
+ *     `MARIMO_SERVER_TRANSPORT` environment variable. `"websocket"`
+ *     (default) uses the `/ws` WebSocket endpoint; `"sse"` uses
+ *     server-sent events over HTTP, for deployments behind proxies or
+ *     services that do not support WebSockets. Terminal, LSP, and
+ *     real-time collaboration still require WebSockets; RTC is disabled
+ *     when using `"sse"`.
+ */
+export const ServerConfig = Schema.Struct({
+  browser: Schema.Union(Schema.Literal("default"), Schema.String),
+  disable_file_downloads: Schema.optional(Schema.Boolean),
+  follow_symlink: Schema.Boolean,
+  transport: Schema.optional(Schema.Literal("sse", "websocket")),
+}).annotations({ identifier: "ServerConfig" });
+export type ServerConfig = typeof ServerConfig.Type;
+
+/**
+ * Configuration for sharing features.
+ *
+ * **Keys.**
+ *
+ * - `html`: if `False`, HTML sharing options will be hidden from the UI
+ * - `wasm`: if `False`, WebAssembly sharing options will be hidden from the UI
+ * - `molab`: if `False`, molab sharing options will be hidden from the UI
+ */
+export const SharingConfig = Schema.Struct({
+  html: Schema.optional(Schema.Boolean),
+  molab: Schema.optional(Schema.Boolean),
+  wasm: Schema.optional(Schema.Boolean),
+}).annotations({ identifier: "SharingConfig" });
+export type SharingConfig = typeof SharingConfig.Type;
+
+/**
+ * Configuration for snippets.
+ *
+ * **Keys.**
+ *
+ * - `custom_path`: the path to the custom snippets directory
+ */
+export const SnippetsConfig = Schema.Struct({
+  custom_paths: Schema.optional(Schema.Array(Schema.String)),
+  include_default_snippets: Schema.optional(Schema.Boolean),
+}).annotations({ identifier: "SnippetsConfig" });
+export type SnippetsConfig = typeof SnippetsConfig.Type;
+
+/**
+ * Configuration for external Python environment in home sandbox mode.
+ *
+ * Allows specifying an existing virtualenv to use instead of creating
+ * ephemeral sandboxes per notebook. Only applies in home sandbox mode.
+ *
+ * **Keys.**
+ *
+ * - `path`: path to a virtualenv directory (absolute or relative to
+ *   pyproject.toml)
+ * - `writable`: if true, marimo will manage script metadata (inline
+ *   dependencies). Defaults to false.
+ */
+export const VenvConfig = Schema.Struct({
+  path: Schema.optional(Schema.String),
+  writable: Schema.optional(Schema.Boolean),
+}).annotations({ identifier: "VenvConfig" });
+export type VenvConfig = typeof VenvConfig.Type;
+
+/**
+ * Configuration for the marimo editor
+ */
+export const MarimoConfig = Schema.Struct({
+  ai: Schema.optional(AiConfig),
+  completion: CompletionConfig,
+  datasources: Schema.optional(DatasourcesConfig),
+  diagnostics: Schema.optional(DiagnosticsConfig),
+  display: DisplayConfig,
+  experimental: Schema.optional(
+    Schema.Record({ key: Schema.String, value: Schema.Unknown }),
+  ),
+  formatting: FormattingConfig,
+  keymap: KeymapConfig,
+  language_servers: Schema.optional(LanguageServersConfig),
+  lint: Schema.optional(LintConfig),
+  mcp: Schema.optional(MCPConfig),
+  package_management: PackageManagementConfig,
+  runtime: RuntimeConfig,
+  save: SaveConfig,
+  server: ServerConfig,
+  sharing: Schema.optional(SharingConfig),
+  snippets: Schema.optional(SnippetsConfig),
+  venv: Schema.optional(VenvConfig),
+}).annotations({ identifier: "MarimoConfig" });
+export type MarimoConfig = typeof MarimoConfig.Type;
+
+/**
+ * Response for ``get-configuration``.
+ */
+export const GetConfigurationResponse = Schema.Struct({
+  config: MarimoConfig,
+}).annotations({ identifier: "GetConfigurationResponse" });
+export type GetConfigurationResponse = typeof GetConfigurationResponse.Type;
+
+export const GetConfigurationPayload = Schema.Struct({
+  notebookUri: Schema.String,
+  inner: GetConfigurationRequest,
+});
+
+export class GetConfiguration extends Schema.TaggedRequest<GetConfiguration>()(
+  "get-configuration",
+  {
+    failure: Schema.Never,
+    success: GetConfigurationResponse,
+    payload: GetConfigurationPayload.fields,
+  },
+) {}
+
+/**
+ * Response for ``update-configuration``.
+ */
+export const UpdateConfigurationResponse = Schema.Struct({
+  success: Schema.Boolean,
+  config: Schema.optionalWith(Schema.NullOr(MarimoConfig), {
+    default: () => null,
+  }),
+  error: Schema.optionalWith(Schema.NullOr(Schema.String), {
+    default: () => null,
+  }),
+}).annotations({ identifier: "UpdateConfigurationResponse" });
+export type UpdateConfigurationResponse =
+  typeof UpdateConfigurationResponse.Type;
+
+export const UpdateConfigurationPayload = Schema.Struct({
+  notebookUri: Schema.String,
+  inner: UpdateConfigurationRequest,
+});
+
+export class UpdateConfiguration extends Schema.TaggedRequest<UpdateConfiguration>()(
+  "update-configuration",
+  {
+    failure: Schema.Never,
+    success: UpdateConfigurationResponse,
+    payload: UpdateConfigurationPayload.fields,
+  },
+) {}
+
+/**
+ * Response for ``set-display-theme``.
+ */
+export const SetDisplayThemeResponse = Schema.Struct({
+  success: Schema.Boolean,
+}).annotations({ identifier: "SetDisplayThemeResponse" });
+export type SetDisplayThemeResponse = typeof SetDisplayThemeResponse.Type;
+
+export const SetDisplayThemePayload = Schema.Struct({
+  theme: Schema.String,
+});
+
+export class SetDisplayTheme extends Schema.TaggedRequest<SetDisplayTheme>()(
+  "set-display-theme",
+  {
+    failure: Schema.Never,
+    success: SetDisplayThemeResponse,
+    payload: SetDisplayThemePayload.fields,
+  },
+) {}
+
+export const ExportAsHTMLRequest = Schema.Struct({
+  download: Schema.Boolean,
+  files: Schema.Array(Schema.String),
+  includeCode: Schema.Boolean,
+  assetUrl: Schema.optionalWith(Schema.NullOr(Schema.String), {
+    default: () => null,
+  }),
+}).annotations({ identifier: "ExportAsHTMLRequest" });
+export type ExportAsHTMLRequest = typeof ExportAsHTMLRequest.Type;
+
+export const ExportAsHtmlPayload = Schema.Struct({
+  notebookUri: Schema.String,
+  inner: ExportAsHTMLRequest,
+});
+
+export class ExportAsHtml extends Schema.TaggedRequest<ExportAsHtml>()(
+  "export-as-html",
+  {
+    failure: Schema.Never,
+    success: Schema.String,
+    payload: ExportAsHtmlPayload.fields,
+  },
+) {}
+
+export const ExportAsIpynbPayload = Schema.Struct({
+  notebookUri: Schema.String,
+  inner: ExportAsIpynbRequest,
+});
+
+export class ExportAsIpynb extends Schema.TaggedRequest<ExportAsIpynb>()(
+  "export-as-ipynb",
+  {
+    failure: Schema.Never,
+    success: Schema.String,
+    payload: ExportAsIpynbPayload.fields,
+  },
+) {}
+
+export const ExecuteScratchpadPayload = Schema.Struct({
+  notebookUri: Schema.String,
+  inner: ExecuteScratchRequest,
+  executable: Schema.String,
+});
+
+export class ExecuteScratchpad extends Schema.TaggedRequest<ExecuteScratchpad>()(
+  "execute-scratchpad",
+  {
+    failure: Schema.Never,
+    success: Schema.Union(Schema.Null, Schema.Undefined),
+    payload: ExecuteScratchpadPayload.fields,
+  },
+) {}
+
+/**
+ * Every `marimo.api` request; `_tag` is the wire method name.
+ *
+ * Generated from the `API_METHODS` registry in `src/marimo_lsp/api.py`,
+ * which is also what the server dispatches and validates against.
+ */
+export const ApiRequest = Schema.Union(
+  ExecuteCells,
+  SendStdin,
+  Interrupt,
+  DeleteCell,
+  UpdateUiElement,
+  SetModelValue,
+  InvokeFunction,
+  CloseSession,
+  Serialize,
+  Deserialize,
+  GetPackageList,
+  GetDependencyTree,
+  GetConfiguration,
+  UpdateConfiguration,
+  SetDisplayTheme,
+  ExportAsHtml,
+  ExportAsIpynb,
+  ExecuteScratchpad,
+);
+export type ApiRequest = typeof ApiRequest.Type;
+
+type Execute<E, R> = (call: {
+  readonly method: string;
+  readonly params: unknown;
+}) => Effect.Effect<unknown, E, R>;
+
+/**
+ * Validate the outgoing params against the payload schema (the wire/Encoded
+ * side, so defaulted fields stay omittable), send them verbatim, and parse
+ * the response against the method's success schema.
+ */
+const dispatch = <PA, PI, PR, A, I, R2, E, R>(
+  execute: Execute<E, R>,
+  method: string,
+  payload: Schema.Schema<PA, PI, PR>,
+  success: Schema.Schema<A, I, R2>,
+  params: PI,
+): Effect.Effect<A, E | ParseResult.ParseError, R | PR | R2> =>
+  Effect.zipRight(
+    Schema.decode(payload)(params),
+    Effect.flatMap(execute({ method, params }), Schema.decodeUnknown(success)),
+  );
+
+/**
+ * Typed `marimo.api` client surface: one method per registry entry.
+ *
+ * Each method encodes its payload, dispatches `{ method, params }` over
+ * `execute`, and parses the response against the method's success schema —
+ * both sides of the wire are earned, not asserted.
+ */
+export const makeApiClient = <E, R>(execute: Execute<E, R>) => ({
+  executeCells: (params: typeof ExecuteCellsPayload.Encoded) =>
+    dispatch(
+      execute,
+      "execute-cells",
+      ExecuteCellsPayload,
+      Schema.Union(Schema.Null, Schema.Undefined),
+      params,
+    ),
+  sendStdin: (params: typeof SendStdinPayload.Encoded) =>
+    dispatch(
+      execute,
+      "send-stdin",
+      SendStdinPayload,
+      Schema.Union(Schema.Null, Schema.Undefined),
+      params,
+    ),
+  interrupt: (params: typeof InterruptPayload.Encoded) =>
+    dispatch(
+      execute,
+      "interrupt",
+      InterruptPayload,
+      Schema.Union(Schema.Null, Schema.Undefined),
+      params,
+    ),
+  deleteCell: (params: typeof DeleteCellPayload.Encoded) =>
+    dispatch(
+      execute,
+      "delete-cell",
+      DeleteCellPayload,
+      Schema.Union(Schema.Null, Schema.Undefined),
+      params,
+    ),
+  updateUiElement: (params: typeof UpdateUiElementPayload.Encoded) =>
+    dispatch(
+      execute,
+      "update-ui-element",
+      UpdateUiElementPayload,
+      Schema.Union(Schema.Null, Schema.Undefined),
+      params,
+    ),
+  setModelValue: (params: typeof SetModelValuePayload.Encoded) =>
+    dispatch(
+      execute,
+      "set-model-value",
+      SetModelValuePayload,
+      Schema.Union(Schema.Null, Schema.Undefined),
+      params,
+    ),
+  invokeFunction: (params: typeof InvokeFunctionPayload.Encoded) =>
+    dispatch(
+      execute,
+      "invoke-function",
+      InvokeFunctionPayload,
+      Schema.Union(Schema.Null, Schema.Undefined),
+      params,
+    ),
+  closeSession: (params: typeof CloseSessionPayload.Encoded) =>
+    dispatch(
+      execute,
+      "close-session",
+      CloseSessionPayload,
+      Schema.Union(Schema.Null, Schema.Undefined),
+      params,
+    ),
+  serialize: (params: typeof SerializePayload.Encoded) =>
+    dispatch(execute, "serialize", SerializePayload, SerializeResponse, params),
+  deserialize: (params: typeof DeserializePayload.Encoded) =>
+    dispatch(
+      execute,
+      "deserialize",
+      DeserializePayload,
+      Schema.Record({ key: Schema.String, value: Schema.Unknown }),
+      params,
+    ),
+  getPackageList: (params: typeof GetPackageListPayload.Encoded) =>
+    dispatch(
+      execute,
+      "get-package-list",
+      GetPackageListPayload,
+      ListPackagesResponse,
+      params,
+    ),
+  getDependencyTree: (params: typeof GetDependencyTreePayload.Encoded) =>
+    dispatch(
+      execute,
+      "get-dependency-tree",
+      GetDependencyTreePayload,
+      DependencyTreeResponse,
+      params,
+    ),
+  getConfiguration: (params: typeof GetConfigurationPayload.Encoded) =>
+    dispatch(
+      execute,
+      "get-configuration",
+      GetConfigurationPayload,
+      GetConfigurationResponse,
+      params,
+    ),
+  updateConfiguration: (params: typeof UpdateConfigurationPayload.Encoded) =>
+    dispatch(
+      execute,
+      "update-configuration",
+      UpdateConfigurationPayload,
+      UpdateConfigurationResponse,
+      params,
+    ),
+  setDisplayTheme: (params: typeof SetDisplayThemePayload.Encoded) =>
+    dispatch(
+      execute,
+      "set-display-theme",
+      SetDisplayThemePayload,
+      SetDisplayThemeResponse,
+      params,
+    ),
+  exportAsHtml: (params: typeof ExportAsHtmlPayload.Encoded) =>
+    dispatch(
+      execute,
+      "export-as-html",
+      ExportAsHtmlPayload,
+      Schema.String,
+      params,
+    ),
+  exportAsIpynb: (params: typeof ExportAsIpynbPayload.Encoded) =>
+    dispatch(
+      execute,
+      "export-as-ipynb",
+      ExportAsIpynbPayload,
+      Schema.String,
+      params,
+    ),
+  executeScratchpad: (params: typeof ExecuteScratchpadPayload.Encoded) =>
+    dispatch(
+      execute,
+      "execute-scratchpad",
+      ExecuteScratchpadPayload,
+      Schema.Union(Schema.Null, Schema.Undefined),
+      params,
+    ),
+});

--- a/extension/src/schemas/Models.gen.ts
+++ b/extension/src/schemas/Models.gen.ts
@@ -9,7 +9,7 @@ import { Effect, ParseResult, Schema } from "effect";
  * The notebook's environment is a concrete venv with a known python executable.
  */
 export const VenvSource = Schema.Struct({
-  kind: Schema.optionalWith(Schema.Literal("venv"), { default: () => "venv" }),
+  kind: Schema.Literal("venv"),
   executable: Schema.String,
 }).annotations({ identifier: "VenvSource" });
 export type VenvSource = typeof VenvSource.Type;
@@ -21,9 +21,7 @@ export type VenvSource = typeof VenvSource.Type;
  * derives the venv from the script's inline metadata.
  */
 export const ScriptSource = Schema.Struct({
-  kind: Schema.optionalWith(Schema.Literal("script"), {
-    default: () => "script",
-  }),
+  kind: Schema.Literal("script"),
 }).annotations({ identifier: "ScriptSource" });
 export type ScriptSource = typeof ScriptSource.Type;
 

--- a/extension/src/schemas/Models.gen.ts
+++ b/extension/src/schemas/Models.gen.ts
@@ -31,6 +31,16 @@ export const PackageSource = Schema.Union(VenvSource, ScriptSource).annotations(
 export type PackageSource = typeof PackageSource.Type;
 
 /**
+ * Configuration for a notebook cell
+ */
+export const NotebookCellConfig = Schema.Struct({
+  column: Schema.optional(Schema.NullOr(Schema.Int)),
+  disabled: Schema.optional(Schema.NullOr(Schema.Boolean)),
+  hide_code: Schema.optional(Schema.NullOr(Schema.Boolean)),
+}).annotations({ identifier: "NotebookCellConfig" });
+export type NotebookCellConfig = typeof NotebookCellConfig.Type;
+
+/**
  * Smart-cell metadata for a markdown cell (mirrors the frontend shape).
  */
 export const MarkdownCellMetadata = Schema.Struct({
@@ -74,10 +84,7 @@ export const CellMetadata = Schema.Struct({
     default: () => null,
   }),
   name: Schema.optionalWith(Schema.String, { default: () => "_" }),
-  options: Schema.optionalWith(
-    Schema.Record({ key: Schema.String, value: Schema.Unknown }),
-    { default: () => ({}) },
-  ),
+  options: Schema.optionalWith(NotebookCellConfig, { default: () => ({}) }),
   languageMetadata: Schema.optionalWith(Schema.NullOr(CellLanguageMetadata), {
     default: () => null,
   }),
@@ -85,14 +92,80 @@ export const CellMetadata = Schema.Struct({
 export type CellMetadata = typeof CellMetadata.Type;
 
 /**
- * A request to serialize a notebook to Python source.
- *
- * Contains the notebook data to be serialized.
+ * Code cell specific structure
  */
-export const SerializeRequest = Schema.Struct({
-  notebook: Schema.Record({ key: Schema.String, value: Schema.Unknown }),
-}).annotations({ identifier: "SerializeRequest" });
-export type SerializeRequest = typeof SerializeRequest.Type;
+export const NotebookCell = Schema.Struct({
+  code: Schema.NullOr(Schema.String),
+  code_hash: Schema.NullOr(Schema.String),
+  config: NotebookCellConfig,
+  id: Schema.NullOr(Schema.String),
+  name: Schema.NullOr(Schema.String),
+}).annotations({ identifier: "NotebookCell" });
+export type NotebookCell = typeof NotebookCell.Type;
+
+/**
+ * Metadata about the notebook
+ */
+export const NotebookMetadata = Schema.Struct({
+  marimo_version: Schema.optional(Schema.NullOr(Schema.String)),
+}).annotations({ identifier: "NotebookMetadata" });
+export type NotebookMetadata = typeof NotebookMetadata.Type;
+
+/**
+ * Main notebook structure
+ */
+export const NotebookV1 = Schema.Struct({
+  cells: Schema.Array(NotebookCell),
+  metadata: NotebookMetadata,
+  version: Schema.Literal("1"),
+}).annotations({ identifier: "NotebookV1" });
+export type NotebookV1 = typeof NotebookV1.Type;
+
+/**
+ * Program-specific configuration.
+ *
+ * Configuration for frontends or runtimes that is specific to
+ * a single marimo program.
+ */
+export const _AppConfig = Schema.Struct({
+  width: Schema.optionalWith(
+    Schema.Literal("columns", "compact", "full", "medium", "normal"),
+    { default: () => "compact" },
+  ),
+  app_title: Schema.optionalWith(Schema.NullOr(Schema.String), {
+    default: () => null,
+  }),
+  layout_file: Schema.optionalWith(Schema.NullOr(Schema.String), {
+    default: () => null,
+  }),
+  css_file: Schema.optionalWith(Schema.NullOr(Schema.String), {
+    default: () => null,
+  }),
+  html_head_file: Schema.optionalWith(Schema.NullOr(Schema.String), {
+    default: () => null,
+  }),
+  auto_download: Schema.optionalWith(
+    Schema.Array(Schema.Literal("html", "ipynb", "markdown")),
+    { default: () => [] },
+  ),
+  sql_output: Schema.optionalWith(
+    Schema.Literal("auto", "lazy-polars", "native", "pandas", "polars"),
+    { default: () => "auto" },
+  ),
+}).annotations({ identifier: "_AppConfig" });
+export type _AppConfig = typeof _AppConfig.Type;
+
+/**
+ * Strict JSON notebook data plus source-level application metadata.
+ */
+export const NotebookDocument = Schema.Struct({
+  notebook: NotebookV1,
+  appConfig: Schema.optional(_AppConfig),
+  header: Schema.optionalWith(Schema.NullOr(Schema.String), {
+    default: () => null,
+  }),
+}).annotations({ identifier: "NotebookDocument" });
+export type NotebookDocument = typeof NotebookDocument.Type;
 
 /**
  * A request to deserialize Python source to notebook format.
@@ -183,7 +256,7 @@ export type UpdateConfigurationRequest = typeof UpdateConfigurationRequest.Type;
  * A request to set the display theme without persisting to disk.
  */
 export const SetDisplayThemeRequest = Schema.Struct({
-  theme: Schema.String,
+  theme: Schema.Literal("dark", "light"),
 }).annotations({ identifier: "SetDisplayThemeRequest" });
 export type SetDisplayThemeRequest = typeof SetDisplayThemeRequest.Type;
 
@@ -270,61 +343,6 @@ export const ExecuteCellsPayload = Schema.Struct({
   executable: Schema.String,
 });
 
-export class ExecuteCells extends Schema.TaggedRequest<ExecuteCells>()(
-  "execute-cells",
-  {
-    failure: Schema.Never,
-    success: Schema.Union(Schema.Null, Schema.Undefined),
-    payload: ExecuteCellsPayload.fields,
-  },
-) {}
-
-export const StdinRequest = Schema.Struct({
-  text: Schema.String,
-}).annotations({ identifier: "StdinRequest" });
-export type StdinRequest = typeof StdinRequest.Type;
-
-export const SendStdinPayload = Schema.Struct({
-  notebookUri: Schema.String,
-  inner: StdinRequest,
-});
-
-export class SendStdin extends Schema.TaggedRequest<SendStdin>()("send-stdin", {
-  failure: Schema.Never,
-  success: Schema.Union(Schema.Null, Schema.Undefined),
-  payload: SendStdinPayload.fields,
-}) {}
-
-export const InterruptPayload = Schema.Struct({
-  notebookUri: Schema.String,
-  inner: InterruptRequest,
-});
-
-export class Interrupt extends Schema.TaggedRequest<Interrupt>()("interrupt", {
-  failure: Schema.Never,
-  success: Schema.Union(Schema.Null, Schema.Undefined),
-  payload: InterruptPayload.fields,
-}) {}
-
-export const DeleteCellRequest = Schema.Struct({
-  cellId: Schema.String,
-}).annotations({ identifier: "DeleteCellRequest" });
-export type DeleteCellRequest = typeof DeleteCellRequest.Type;
-
-export const DeleteCellPayload = Schema.Struct({
-  notebookUri: Schema.String,
-  inner: DeleteCellRequest,
-});
-
-export class DeleteCell extends Schema.TaggedRequest<DeleteCell>()(
-  "delete-cell",
-  {
-    failure: Schema.Never,
-    success: Schema.Union(Schema.Null, Schema.Undefined),
-    payload: DeleteCellPayload.fields,
-  },
-) {}
-
 export const UpdateUIElementRequest = Schema.Struct({
   objectIds: Schema.Array(Schema.String),
   values: Schema.Array(Schema.Unknown),
@@ -340,15 +358,6 @@ export const UpdateUiElementPayload = Schema.Struct({
   inner: UpdateUIElementRequest,
 });
 
-export class UpdateUiElement extends Schema.TaggedRequest<UpdateUiElement>()(
-  "update-ui-element",
-  {
-    failure: Schema.Never,
-    success: Schema.Union(Schema.Null, Schema.Undefined),
-    payload: UpdateUiElementPayload.fields,
-  },
-) {}
-
 /**
  * Widget model state update message.
  *
@@ -357,9 +366,7 @@ export class UpdateUiElement extends Schema.TaggedRequest<UpdateUiElement>()(
  *     buffer_paths: Paths within state dict pointing to binary buffers.
  */
 export const ModelUpdateMessage = Schema.Struct({
-  method: Schema.optionalWith(Schema.Literal("update"), {
-    default: () => "update",
-  }),
+  method: Schema.Literal("update"),
   state: Schema.Record({ key: Schema.String, value: Schema.Unknown }),
   bufferPaths: Schema.Array(
     Schema.Array(Schema.Union(Schema.String, Schema.Int)),
@@ -374,9 +381,7 @@ export type ModelUpdateMessage = typeof ModelUpdateMessage.Type;
  *     content: Arbitrary content for the custom message.
  */
 export const ModelCustomMessage = Schema.Struct({
-  method: Schema.optionalWith(Schema.Literal("custom"), {
-    default: () => "custom",
-  }),
+  method: Schema.Literal("custom"),
   content: Schema.Unknown,
 }).annotations({ identifier: "ModelCustomMessage" });
 export type ModelCustomMessage = typeof ModelCustomMessage.Type;
@@ -404,15 +409,6 @@ export const SetModelValuePayload = Schema.Struct({
   inner: ModelRequest,
 });
 
-export class SetModelValue extends Schema.TaggedRequest<SetModelValue>()(
-  "set-model-value",
-  {
-    failure: Schema.Never,
-    success: Schema.Union(Schema.Null, Schema.Undefined),
-    payload: SetModelValuePayload.fields,
-  },
-) {}
-
 /**
  * Invoke a function from a UI element.
  *
@@ -425,9 +421,7 @@ export class SetModelValue extends Schema.TaggedRequest<SetModelValue>()(
  *     args: Keyword arguments for the function.
  */
 export const InvokeFunctionCommand = Schema.Struct({
-  type: Schema.optionalWith(Schema.Literal("invoke-function"), {
-    default: () => "invoke-function",
-  }),
+  type: Schema.Literal("invoke-function"),
   functionCallId: Schema.String,
   namespace: Schema.String,
   functionName: Schema.String,
@@ -440,59 +434,41 @@ export const InvokeFunctionPayload = Schema.Struct({
   inner: InvokeFunctionCommand,
 });
 
-export class InvokeFunction extends Schema.TaggedRequest<InvokeFunction>()(
-  "invoke-function",
-  {
-    failure: Schema.Never,
-    success: Schema.Union(Schema.Null, Schema.Undefined),
-    payload: InvokeFunctionPayload.fields,
-  },
-) {}
+export const InterruptPayload = Schema.Struct({
+  notebookUri: Schema.String,
+  inner: InterruptRequest,
+});
+
+export const DeleteCellRequest = Schema.Struct({
+  cellId: Schema.String,
+}).annotations({ identifier: "DeleteCellRequest" });
+export type DeleteCellRequest = typeof DeleteCellRequest.Type;
+
+export const DeleteCellPayload = Schema.Struct({
+  notebookUri: Schema.String,
+  inner: DeleteCellRequest,
+});
+
+export const StdinRequest = Schema.Struct({
+  text: Schema.String,
+}).annotations({ identifier: "StdinRequest" });
+export type StdinRequest = typeof StdinRequest.Type;
+
+export const SendStdinPayload = Schema.Struct({
+  notebookUri: Schema.String,
+  inner: StdinRequest,
+});
 
 export const CloseSessionPayload = Schema.Struct({
   notebookUri: Schema.String,
   inner: CloseSessionRequest,
 });
 
-export class CloseSession extends Schema.TaggedRequest<CloseSession>()(
-  "close-session",
-  {
-    failure: Schema.Never,
-    success: Schema.Union(Schema.Null, Schema.Undefined),
-    payload: CloseSessionPayload.fields,
-  },
-) {}
-
-/**
- * Response for ``serialize``.
- */
-export const SerializeResponse = Schema.Struct({
-  source: Schema.String,
-}).annotations({ identifier: "SerializeResponse" });
-export type SerializeResponse = typeof SerializeResponse.Type;
-
-export const SerializePayload = Schema.Struct({
-  notebook: Schema.Record({ key: Schema.String, value: Schema.Unknown }),
+export const ExecuteScratchpadPayload = Schema.Struct({
+  notebookUri: Schema.String,
+  inner: ExecuteScratchRequest,
+  executable: Schema.String,
 });
-
-export class Serialize extends Schema.TaggedRequest<Serialize>()("serialize", {
-  failure: Schema.Never,
-  success: SerializeResponse,
-  payload: SerializePayload.fields,
-}) {}
-
-export const DeserializePayload = Schema.Struct({
-  source: Schema.String,
-});
-
-export class Deserialize extends Schema.TaggedRequest<Deserialize>()(
-  "deserialize",
-  {
-    failure: Schema.Never,
-    success: Schema.Record({ key: Schema.String, value: Schema.Unknown }),
-    payload: DeserializePayload.fields,
-  },
-) {}
 
 export const PackageDescription = Schema.Struct({
   name: Schema.String,
@@ -513,15 +489,6 @@ export const GetPackageListPayload = Schema.Struct({
   inner: ListPackagesRequest,
   source: PackageSource,
 });
-
-export class GetPackageList extends Schema.TaggedRequest<GetPackageList>()(
-  "get-package-list",
-  {
-    failure: Schema.Never,
-    success: ListPackagesResponse,
-    payload: GetPackageListPayload.fields,
-  },
-) {}
 
 export const DependencyTag = Schema.Struct({
   kind: Schema.String,
@@ -563,14 +530,25 @@ export const GetDependencyTreePayload = Schema.Struct({
   source: PackageSource,
 });
 
-export class GetDependencyTree extends Schema.TaggedRequest<GetDependencyTree>()(
-  "get-dependency-tree",
-  {
-    failure: Schema.Never,
-    success: DependencyTreeResponse,
-    payload: GetDependencyTreePayload.fields,
-  },
-) {}
+/**
+ * Response for ``serialize``.
+ */
+export const SerializeResponse = Schema.Struct({
+  source: Schema.String,
+}).annotations({ identifier: "SerializeResponse" });
+export type SerializeResponse = typeof SerializeResponse.Type;
+
+export const SerializePayload = Schema.Struct({
+  notebook: NotebookV1,
+  appConfig: Schema.optional(_AppConfig),
+  header: Schema.optionalWith(Schema.NullOr(Schema.String), {
+    default: () => null,
+  }),
+});
+
+export const DeserializePayload = Schema.Struct({
+  source: Schema.String,
+});
 
 /**
  * Configuration options for Anthropic.
@@ -1182,26 +1160,11 @@ export const GetConfigurationPayload = Schema.Struct({
   inner: GetConfigurationRequest,
 });
 
-export class GetConfiguration extends Schema.TaggedRequest<GetConfiguration>()(
-  "get-configuration",
-  {
-    failure: Schema.Never,
-    success: GetConfigurationResponse,
-    payload: GetConfigurationPayload.fields,
-  },
-) {}
-
 /**
  * Response for ``update-configuration``.
  */
 export const UpdateConfigurationResponse = Schema.Struct({
-  success: Schema.Boolean,
-  config: Schema.optionalWith(Schema.NullOr(MarimoConfig), {
-    default: () => null,
-  }),
-  error: Schema.optionalWith(Schema.NullOr(Schema.String), {
-    default: () => null,
-  }),
+  config: MarimoConfig,
 }).annotations({ identifier: "UpdateConfigurationResponse" });
 export type UpdateConfigurationResponse =
   typeof UpdateConfigurationResponse.Type;
@@ -1210,15 +1173,6 @@ export const UpdateConfigurationPayload = Schema.Struct({
   notebookUri: Schema.String,
   inner: UpdateConfigurationRequest,
 });
-
-export class UpdateConfiguration extends Schema.TaggedRequest<UpdateConfiguration>()(
-  "update-configuration",
-  {
-    failure: Schema.Never,
-    success: UpdateConfigurationResponse,
-    payload: UpdateConfigurationPayload.fields,
-  },
-) {}
 
 /**
  * Response for ``set-display-theme``.
@@ -1229,17 +1183,8 @@ export const SetDisplayThemeResponse = Schema.Struct({
 export type SetDisplayThemeResponse = typeof SetDisplayThemeResponse.Type;
 
 export const SetDisplayThemePayload = Schema.Struct({
-  theme: Schema.String,
+  theme: Schema.Literal("dark", "light"),
 });
-
-export class SetDisplayTheme extends Schema.TaggedRequest<SetDisplayTheme>()(
-  "set-display-theme",
-  {
-    failure: Schema.Never,
-    success: SetDisplayThemeResponse,
-    payload: SetDisplayThemePayload.fields,
-  },
-) {}
 
 export const ExportAsHTMLRequest = Schema.Struct({
   download: Schema.Boolean,
@@ -1256,76 +1201,92 @@ export const ExportAsHtmlPayload = Schema.Struct({
   inner: ExportAsHTMLRequest,
 });
 
-export class ExportAsHtml extends Schema.TaggedRequest<ExportAsHtml>()(
-  "export-as-html",
-  {
-    failure: Schema.Never,
-    success: Schema.String,
-    payload: ExportAsHtmlPayload.fields,
-  },
-) {}
-
 export const ExportAsIpynbPayload = Schema.Struct({
   notebookUri: Schema.String,
   inner: ExportAsIpynbRequest,
 });
 
-export class ExportAsIpynb extends Schema.TaggedRequest<ExportAsIpynb>()(
-  "export-as-ipynb",
-  {
-    failure: Schema.Never,
-    success: Schema.String,
-    payload: ExportAsIpynbPayload.fields,
-  },
-) {}
-
-export const ExecuteScratchpadPayload = Schema.Struct({
-  notebookUri: Schema.String,
-  inner: ExecuteScratchRequest,
-  executable: Schema.String,
-});
-
-export class ExecuteScratchpad extends Schema.TaggedRequest<ExecuteScratchpad>()(
-  "execute-scratchpad",
-  {
-    failure: Schema.Never,
-    success: Schema.Union(Schema.Null, Schema.Undefined),
-    payload: ExecuteScratchpadPayload.fields,
-  },
-) {}
-
 /**
- * Every `marimo.api` request; `_tag` is the wire method name.
+ * Every command accepted by the `marimo.api` transport.
  *
  * Generated from the `API_METHODS` registry in `src/marimo_lsp/api.py`,
  * which is also what the server dispatches and validates against.
  */
-export const ApiRequest = Schema.Union(
-  ExecuteCells,
-  SendStdin,
-  Interrupt,
-  DeleteCell,
-  UpdateUiElement,
-  SetModelValue,
-  InvokeFunction,
-  CloseSession,
-  Serialize,
-  Deserialize,
-  GetPackageList,
-  GetDependencyTree,
-  GetConfiguration,
-  UpdateConfiguration,
-  SetDisplayTheme,
-  ExportAsHtml,
-  ExportAsIpynb,
-  ExecuteScratchpad,
-);
-export type ApiRequest = typeof ApiRequest.Type;
+export type MarimoApiCall =
+  | {
+      readonly method: "execute-cells";
+      readonly params: typeof ExecuteCellsPayload.Encoded;
+    }
+  | {
+      readonly method: "update-ui-element";
+      readonly params: typeof UpdateUiElementPayload.Encoded;
+    }
+  | {
+      readonly method: "set-model-value";
+      readonly params: typeof SetModelValuePayload.Encoded;
+    }
+  | {
+      readonly method: "invoke-function";
+      readonly params: typeof InvokeFunctionPayload.Encoded;
+    }
+  | {
+      readonly method: "interrupt";
+      readonly params: typeof InterruptPayload.Encoded;
+    }
+  | {
+      readonly method: "delete-cell";
+      readonly params: typeof DeleteCellPayload.Encoded;
+    }
+  | {
+      readonly method: "send-stdin";
+      readonly params: typeof SendStdinPayload.Encoded;
+    }
+  | {
+      readonly method: "close-session";
+      readonly params: typeof CloseSessionPayload.Encoded;
+    }
+  | {
+      readonly method: "execute-scratchpad";
+      readonly params: typeof ExecuteScratchpadPayload.Encoded;
+    }
+  | {
+      readonly method: "get-package-list";
+      readonly params: typeof GetPackageListPayload.Encoded;
+    }
+  | {
+      readonly method: "get-dependency-tree";
+      readonly params: typeof GetDependencyTreePayload.Encoded;
+    }
+  | {
+      readonly method: "serialize";
+      readonly params: typeof SerializePayload.Encoded;
+    }
+  | {
+      readonly method: "deserialize";
+      readonly params: typeof DeserializePayload.Encoded;
+    }
+  | {
+      readonly method: "get-configuration";
+      readonly params: typeof GetConfigurationPayload.Encoded;
+    }
+  | {
+      readonly method: "update-configuration";
+      readonly params: typeof UpdateConfigurationPayload.Encoded;
+    }
+  | {
+      readonly method: "set-display-theme";
+      readonly params: typeof SetDisplayThemePayload.Encoded;
+    }
+  | {
+      readonly method: "export-as-html";
+      readonly params: typeof ExportAsHtmlPayload.Encoded;
+    }
+  | {
+      readonly method: "export-as-ipynb";
+      readonly params: typeof ExportAsIpynbPayload.Encoded;
+    };
 
-type Execute<E, R> = (call: {
-  readonly method: string;
-  readonly params: unknown;
-}) => Effect.Effect<unknown, E, R>;
+type Execute<E, R> = (call: MarimoApiCall) => Effect.Effect<unknown, E, R>;
 
 /**
  * Validate the outgoing params against the payload schema (the wire/Encoded
@@ -1334,14 +1295,13 @@ type Execute<E, R> = (call: {
  */
 const dispatch = <PA, PI, PR, A, I, R2, E, R>(
   execute: Execute<E, R>,
-  method: string,
+  call: MarimoApiCall & { readonly params: PI },
   payload: Schema.Schema<PA, PI, PR>,
   success: Schema.Schema<A, I, R2>,
-  params: PI,
 ): Effect.Effect<A, E | ParseResult.ParseError, R | PR | R2> =>
   Effect.zipRight(
-    Schema.decode(payload)(params),
-    Effect.flatMap(execute({ method, params }), Schema.decodeUnknown(success)),
+    Schema.decode(payload)(call.params),
+    Effect.flatMap(execute(call), Schema.decodeUnknown(success)),
   );
 
 /**
@@ -1355,139 +1315,127 @@ export const makeApiClient = <E, R>(execute: Execute<E, R>) => ({
   executeCells: (params: typeof ExecuteCellsPayload.Encoded) =>
     dispatch(
       execute,
-      "execute-cells",
+      { method: "execute-cells", params },
       ExecuteCellsPayload,
-      Schema.Union(Schema.Null, Schema.Undefined),
-      params,
-    ),
-  sendStdin: (params: typeof SendStdinPayload.Encoded) =>
-    dispatch(
-      execute,
-      "send-stdin",
-      SendStdinPayload,
-      Schema.Union(Schema.Null, Schema.Undefined),
-      params,
-    ),
-  interrupt: (params: typeof InterruptPayload.Encoded) =>
-    dispatch(
-      execute,
-      "interrupt",
-      InterruptPayload,
-      Schema.Union(Schema.Null, Schema.Undefined),
-      params,
-    ),
-  deleteCell: (params: typeof DeleteCellPayload.Encoded) =>
-    dispatch(
-      execute,
-      "delete-cell",
-      DeleteCellPayload,
-      Schema.Union(Schema.Null, Schema.Undefined),
-      params,
+      Schema.Null,
     ),
   updateUiElement: (params: typeof UpdateUiElementPayload.Encoded) =>
     dispatch(
       execute,
-      "update-ui-element",
+      { method: "update-ui-element", params },
       UpdateUiElementPayload,
-      Schema.Union(Schema.Null, Schema.Undefined),
-      params,
+      Schema.Null,
     ),
   setModelValue: (params: typeof SetModelValuePayload.Encoded) =>
     dispatch(
       execute,
-      "set-model-value",
+      { method: "set-model-value", params },
       SetModelValuePayload,
-      Schema.Union(Schema.Null, Schema.Undefined),
-      params,
+      Schema.Null,
     ),
   invokeFunction: (params: typeof InvokeFunctionPayload.Encoded) =>
     dispatch(
       execute,
-      "invoke-function",
+      { method: "invoke-function", params },
       InvokeFunctionPayload,
-      Schema.Union(Schema.Null, Schema.Undefined),
-      params,
+      Schema.Null,
+    ),
+  interrupt: (params: typeof InterruptPayload.Encoded) =>
+    dispatch(
+      execute,
+      { method: "interrupt", params },
+      InterruptPayload,
+      Schema.Null,
+    ),
+  deleteCell: (params: typeof DeleteCellPayload.Encoded) =>
+    dispatch(
+      execute,
+      { method: "delete-cell", params },
+      DeleteCellPayload,
+      Schema.Null,
+    ),
+  sendStdin: (params: typeof SendStdinPayload.Encoded) =>
+    dispatch(
+      execute,
+      { method: "send-stdin", params },
+      SendStdinPayload,
+      Schema.Null,
     ),
   closeSession: (params: typeof CloseSessionPayload.Encoded) =>
     dispatch(
       execute,
-      "close-session",
+      { method: "close-session", params },
       CloseSessionPayload,
-      Schema.Union(Schema.Null, Schema.Undefined),
-      params,
-    ),
-  serialize: (params: typeof SerializePayload.Encoded) =>
-    dispatch(execute, "serialize", SerializePayload, SerializeResponse, params),
-  deserialize: (params: typeof DeserializePayload.Encoded) =>
-    dispatch(
-      execute,
-      "deserialize",
-      DeserializePayload,
-      Schema.Record({ key: Schema.String, value: Schema.Unknown }),
-      params,
-    ),
-  getPackageList: (params: typeof GetPackageListPayload.Encoded) =>
-    dispatch(
-      execute,
-      "get-package-list",
-      GetPackageListPayload,
-      ListPackagesResponse,
-      params,
-    ),
-  getDependencyTree: (params: typeof GetDependencyTreePayload.Encoded) =>
-    dispatch(
-      execute,
-      "get-dependency-tree",
-      GetDependencyTreePayload,
-      DependencyTreeResponse,
-      params,
-    ),
-  getConfiguration: (params: typeof GetConfigurationPayload.Encoded) =>
-    dispatch(
-      execute,
-      "get-configuration",
-      GetConfigurationPayload,
-      GetConfigurationResponse,
-      params,
-    ),
-  updateConfiguration: (params: typeof UpdateConfigurationPayload.Encoded) =>
-    dispatch(
-      execute,
-      "update-configuration",
-      UpdateConfigurationPayload,
-      UpdateConfigurationResponse,
-      params,
-    ),
-  setDisplayTheme: (params: typeof SetDisplayThemePayload.Encoded) =>
-    dispatch(
-      execute,
-      "set-display-theme",
-      SetDisplayThemePayload,
-      SetDisplayThemeResponse,
-      params,
-    ),
-  exportAsHtml: (params: typeof ExportAsHtmlPayload.Encoded) =>
-    dispatch(
-      execute,
-      "export-as-html",
-      ExportAsHtmlPayload,
-      Schema.String,
-      params,
-    ),
-  exportAsIpynb: (params: typeof ExportAsIpynbPayload.Encoded) =>
-    dispatch(
-      execute,
-      "export-as-ipynb",
-      ExportAsIpynbPayload,
-      Schema.String,
-      params,
+      Schema.Null,
     ),
   executeScratchpad: (params: typeof ExecuteScratchpadPayload.Encoded) =>
     dispatch(
       execute,
-      "execute-scratchpad",
+      { method: "execute-scratchpad", params },
       ExecuteScratchpadPayload,
-      Schema.Union(Schema.Null, Schema.Undefined),
-      params,
+      Schema.Null,
+    ),
+  getPackageList: (params: typeof GetPackageListPayload.Encoded) =>
+    dispatch(
+      execute,
+      { method: "get-package-list", params },
+      GetPackageListPayload,
+      ListPackagesResponse,
+    ),
+  getDependencyTree: (params: typeof GetDependencyTreePayload.Encoded) =>
+    dispatch(
+      execute,
+      { method: "get-dependency-tree", params },
+      GetDependencyTreePayload,
+      DependencyTreeResponse,
+    ),
+  serialize: (params: typeof SerializePayload.Encoded) =>
+    dispatch(
+      execute,
+      { method: "serialize", params },
+      SerializePayload,
+      SerializeResponse,
+    ),
+  deserialize: (params: typeof DeserializePayload.Encoded) =>
+    dispatch(
+      execute,
+      { method: "deserialize", params },
+      DeserializePayload,
+      NotebookDocument,
+    ),
+  getConfiguration: (params: typeof GetConfigurationPayload.Encoded) =>
+    dispatch(
+      execute,
+      { method: "get-configuration", params },
+      GetConfigurationPayload,
+      GetConfigurationResponse,
+    ),
+  updateConfiguration: (params: typeof UpdateConfigurationPayload.Encoded) =>
+    dispatch(
+      execute,
+      { method: "update-configuration", params },
+      UpdateConfigurationPayload,
+      UpdateConfigurationResponse,
+    ),
+  setDisplayTheme: (params: typeof SetDisplayThemePayload.Encoded) =>
+    dispatch(
+      execute,
+      { method: "set-display-theme", params },
+      SetDisplayThemePayload,
+      SetDisplayThemeResponse,
+    ),
+  exportAsHtml: (params: typeof ExportAsHtmlPayload.Encoded) =>
+    dispatch(
+      execute,
+      { method: "export-as-html", params },
+      ExportAsHtmlPayload,
+      Schema.String,
+    ),
+  exportAsIpynb: (params: typeof ExportAsIpynbPayload.Encoded) =>
+    dispatch(
+      execute,
+      { method: "export-as-ipynb", params },
+      ExportAsIpynbPayload,
+      Schema.String,
     ),
 });

--- a/extension/src/schemas/__tests__/Models.gen.test.ts
+++ b/extension/src/schemas/__tests__/Models.gen.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "@effect/vitest";
-import { Either, Schema } from "effect";
+import { Effect, Either, Schema } from "effect";
 
 import {
   CellMetadata,
   ExecuteScratchRequest,
+  makeApiClient,
+  NotebookDocument,
   PackageCommand,
   PackageSource,
   VenvSource,
@@ -84,4 +86,37 @@ describe("Models.gen (msgspec → Effect Schema codegen)", () => {
       }
     `);
   });
+
+  it("models the notebook wire document without an opaque record", () => {
+    const decoded = Schema.decodeUnknownSync(NotebookDocument)({
+      notebook: {
+        version: "1",
+        metadata: { marimo_version: "0.23.15" },
+        cells: [
+          {
+            id: "cell-id",
+            code: "x = 1",
+            code_hash: null,
+            name: "cell",
+            config: { hide_code: true },
+          },
+        ],
+      },
+      appConfig: { width: "full" },
+      header: null,
+    });
+
+    expect(decoded.notebook.cells[0]?.config.hide_code).toBe(true);
+    expect(decoded.appConfig?.width).toBe("full");
+  });
+
+  it.effect("requires JSON null for fire-and-forget responses", () =>
+    Effect.gen(function* () {
+      const api = makeApiClient(() => Effect.succeed(undefined));
+      const result = yield* Effect.either(
+        api.interrupt({ notebookUri: "file:///nb.py", inner: {} }),
+      );
+      expect(Either.isLeft(result)).toBe(true);
+    }),
+  );
 });

--- a/extension/src/schemas/__tests__/Models.gen.test.ts
+++ b/extension/src/schemas/__tests__/Models.gen.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Either, Schema } from "effect";
+
+import {
+  CellMetadata,
+  ExecuteScratchRequest,
+  PackageCommand,
+  PackageSource,
+  VenvSource,
+} from "../Models.gen.ts";
+
+describe("Models.gen (msgspec → Effect Schema codegen)", () => {
+  it("fills omitted fields with msgspec defaults on decode", () => {
+    const decoded = Schema.decodeUnknownSync(CellMetadata)({});
+    expect(decoded).toMatchInlineSnapshot(`
+      {
+        "languageMetadata": null,
+        "name": "_",
+        "options": {},
+        "stableId": null,
+      }
+    `);
+  });
+
+  it("decodes tagged unions by their msgspec tag field", () => {
+    const venv = Schema.decodeUnknownSync(PackageSource)({
+      kind: "venv",
+      executable: "/usr/bin/python3",
+    });
+    expect(venv).toEqual({ kind: "venv", executable: "/usr/bin/python3" });
+
+    const bad = Schema.decodeUnknownEither(PackageSource)({ kind: "conda" });
+    expect(Either.isLeft(bad)).toBe(true);
+  });
+
+  it("rejects payloads msgspec would reject", () => {
+    const missingCode = Schema.decodeUnknownEither(ExecuteScratchRequest)({
+      runId: "abc",
+    });
+    expect(Either.isLeft(missingCode)).toBe(true);
+  });
+
+  it("composes generic command wrappers around an inner schema", () => {
+    const command = PackageCommand(Schema.Struct({ query: Schema.String }));
+    const decoded = Schema.decodeUnknownSync(command)({
+      notebookUri: "file:///nb.py",
+      source: { kind: "script" },
+      inner: { query: "polars" },
+    });
+    expect(decoded.inner.query).toBe("polars");
+    expect(decoded.source).toEqual({ kind: "script" });
+  });
+
+  it("names structs in parse errors via identifier annotations", () => {
+    const result = Schema.decodeUnknownEither(VenvSource)({ kind: "venv" });
+    expect(Either.isLeft(result)).toBe(true);
+    if (Either.isLeft(result)) {
+      expect(String(result.left)).toContain("VenvSource");
+    }
+  });
+
+  it("round-trips through encode to the wire shape msgspec expects", () => {
+    const encoded = Schema.encodeSync(CellMetadata)({
+      stableId: "abc",
+      name: "my_cell",
+      options: { hide_code: true },
+      languageMetadata: null,
+    });
+    expect(encoded).toMatchInlineSnapshot(`
+      {
+        "languageMetadata": null,
+        "name": "my_cell",
+        "options": {
+          "hide_code": true,
+        },
+        "stableId": "abc",
+      }
+    `);
+  });
+});

--- a/extension/src/schemas/__tests__/Models.gen.test.ts
+++ b/extension/src/schemas/__tests__/Models.gen.test.ts
@@ -31,6 +31,13 @@ describe("Models.gen (msgspec → Effect Schema codegen)", () => {
 
     const bad = Schema.decodeUnknownEither(PackageSource)({ kind: "conda" });
     expect(Either.isLeft(bad)).toBe(true);
+
+    // msgspec accepts an omitted tag when decoding a concrete struct, but
+    // requires it when decoding the tagged union used at this wire boundary.
+    const missing = Schema.decodeUnknownEither(PackageSource)({
+      executable: "/usr/bin/python3",
+    });
+    expect(Either.isLeft(missing)).toBe(true);
   });
 
   it("rejects payloads msgspec would reject", () => {

--- a/extension/src/types.ts
+++ b/extension/src/types.ts
@@ -5,7 +5,7 @@ import type {
   NotebookCellId,
   NotebookId,
 } from "./schemas/MarimoNotebookDocument.ts";
-import type { SerializedNotebook } from "./schemas/SerializedNotebook.ts";
+import type * as Gen from "./schemas/Models.gen.ts";
 
 export type { CellRuntimeState } from "@marimo-team/frontend/unstable_internal/core/cells/types.ts";
 
@@ -65,12 +65,6 @@ type ModelRequest = Schemas["ModelRequest"];
 type InvokeFunctionRequest = Schemas["InvokeFunctionRequest"];
 type DeleteCellRequest = Schemas["DeleteCellRequest"];
 type ExportAsHtmlRequest = Schemas["ExportAsHTMLRequest"];
-interface DeserializeRequest {
-  source: string;
-}
-interface SerializeRequest {
-  notebook: typeof SerializedNotebook.Type;
-}
 type InterruptRequest = {};
 type ListPackagesRequest = {};
 type DependencyTreeRequest = {};
@@ -113,8 +107,8 @@ type MarimoApiMethodMap = {
   interrupt: NotebookScoped<InterruptRequest>;
   "send-stdin": NotebookScoped<SendStdinRequest>;
   // marimo-lsp API
-  serialize: SerializeRequest;
-  deserialize: DeserializeRequest;
+  serialize: typeof Gen.SerializePayload.Encoded;
+  deserialize: typeof Gen.DeserializePayload.Encoded;
   "set-display-theme": SetDisplayThemeRequest;
 };
 

--- a/justfile
+++ b/justfile
@@ -56,6 +56,11 @@ build:
     pnpm -C extension build
     pnpm -C extension embed-sdist
 
+# Regenerate Effect Schemas in extension/src from msgspec models
+[group('build')]
+generate-schemas:
+    uv run scripts/generate_effect_schemas.py
+
 # setup --------------------------------------------------------------
 
 [group('setup')]

--- a/scripts/generate_effect_schemas.py
+++ b/scripts/generate_effect_schemas.py
@@ -62,7 +62,7 @@ class _Inner(msgspec.Struct):
 CONCRETE: list[tuple[str, type | object]] = [
     ("PackageSource", models.PackageSource),
     ("CellMetadata", models.CellMetadata),
-    ("SerializeRequest", models.SerializeRequest),
+    ("NotebookDocument", models.NotebookDocument),
     ("DeserializeRequest", models.DeserializeRequest),
     ("ConvertRequest", models.ConvertRequest),
     ("InterruptRequest", models.InterruptRequest),
@@ -151,6 +151,8 @@ class Emitter:
         """Render a msgspec IR node as an Effect Schema expression."""
         match t:
             case mi.AnyType() | mi.RawType():
+                return "Schema.Unknown"
+            case mi.CustomType(cls=cls) if cls is object:
                 return "Schema.Unknown"
             case mi.NoneType():
                 return "Schema.Null"
@@ -355,7 +357,9 @@ class Emitter:
         if field.default is not msgspec.NODEFAULT:
             return _ts_literal(field.default)
         if field.default_factory is not msgspec.NODEFAULT:
-            if field.default_factory is dict:
+            if field.default_factory is dict or isinstance(
+                field.type, mi.TypedDictType
+            ):
                 return "({})"
             if field.default_factory is list:
                 return "[]"
@@ -389,9 +393,9 @@ class Emitter:
         )
 
     def emit_api_method(self, method: ApiMethod) -> tuple[str, str]:
-        """Emit a `Schema.TaggedRequest` class for one registry entry.
+        """Emit the payload schema for one registry entry.
 
-        Returns the emitted class name and its success schema expression (the
+        Returns the method's PascalCase name and success schema expression (the
         client factory references the success schema statically per method).
         """
         class_name = _pascal(method.name)
@@ -400,34 +404,15 @@ class Emitter:
             msg = f"api method {method.name!r} request must be struct-like"
             raise TypeError(msg)
         payload = self.fields_src(info, indent="  ")
-        # Fire-and-forget methods respond `null` over JSON-RPC, but in-memory
-        # test transports naturally produce `undefined`; accept both while
-        # still rejecting any substantive payload (contract drift).
-        success = (
-            "Schema.Union(Schema.Null, Schema.Undefined)"
-            if method.response is None
-            else self.type_expr(mi.type_info(method.response))
-        )
+        success = self.type_expr(mi.type_info(method.response))
         self.definitions.append(
             f"export const {class_name}Payload = Schema.Struct({{\n{payload}}});\n"
-            "\n"
-            f"export class {class_name} extends Schema.TaggedRequest<{class_name}>()(\n"
-            f"  {_ts_string(method.name)},\n"
-            "  {\n"
-            "    failure: Schema.Never,\n"
-            f"    success: {success},\n"
-            f"    payload: {class_name}Payload.fields,\n"
-            "  },\n"
-            ") {}\n"
         )
         return class_name, success
 
 
 _DISPATCH_HELPER = """\
-type Execute<E, R> = (call: {
-  readonly method: string;
-  readonly params: unknown;
-}) => Effect.Effect<unknown, E, R>;
+type Execute<E, R> = (call: MarimoApiCall) => Effect.Effect<unknown, E, R>;
 
 /**
  * Validate the outgoing params against the payload schema (the wire/Encoded
@@ -436,15 +421,14 @@ type Execute<E, R> = (call: {
  */
 const dispatch = <PA, PI, PR, A, I, R2, E, R>(
   execute: Execute<E, R>,
-  method: string,
+  call: MarimoApiCall & { readonly params: PI },
   payload: Schema.Schema<PA, PI, PR>,
   success: Schema.Schema<A, I, R2>,
-  params: PI,
 ): Effect.Effect<A, E | ParseResult.ParseError, R | PR | R2> =>
   Effect.zipRight(
-    Schema.decode(payload)(params),
+    Schema.decode(payload)(call.params),
     Effect.flatMap(
-      execute({ method, params }),
+      execute(call),
       Schema.decodeUnknown(success),
     ),
   );
@@ -458,16 +442,19 @@ def generate() -> str:
     for cls, parameterized in GENERIC:
         emitter.emit_generic(cls, parameterized)
     api = [emitter.emit_api_method(method) for method in API_METHODS]
-    members = ",\n  ".join(class_name for class_name, _ in api)
+    members = "\n".join(
+        f"  | {{ readonly method: {_ts_string(method.name)}; "
+        f"readonly params: typeof {class_name}Payload.Encoded }}"
+        for (class_name, _), method in zip(api, API_METHODS, strict=True)
+    )
     emitter.definitions.append(
         "/**\n"
-        " * Every `marimo.api` request; `_tag` is the wire method name.\n"
+        " * Every command accepted by the `marimo.api` transport.\n"
         " *\n"
         " * Generated from the `API_METHODS` registry in `src/marimo_lsp/api.py`,\n"
         " * which is also what the server dispatches and validates against.\n"
         " */\n"
-        f"export const ApiRequest = Schema.Union(\n  {members},\n);\n"
-        "export type ApiRequest = typeof ApiRequest.Type;\n"
+        f"export type MarimoApiCall =\n{members};\n"
     )
     emitter.definitions.append(_DISPATCH_HELPER)
     methods = "\n".join(
@@ -476,10 +463,9 @@ def generate() -> str:
         f"  ) =>\n"
         f"    dispatch(\n"
         f"      execute,\n"
-        f"      {_ts_string(method.name)},\n"
+        f"      {{ method: {_ts_string(method.name)}, params }},\n"
         f"      {class_name}Payload,\n"
         f"      {success},\n"
-        f"      params,\n"
         f"    ),"
         for (class_name, success), method in zip(api, API_METHODS, strict=True)
     )

--- a/scripts/generate_effect_schemas.py
+++ b/scripts/generate_effect_schemas.py
@@ -1,0 +1,542 @@
+# Copyright 2026 Marimo. All rights reserved.
+
+"""Generate Effect `Schema` definitions from `marimo_lsp.models` msgspec Structs.
+
+Walks msgspec's introspection IR (`msgspec.inspect`) directly — no JSON Schema
+round-trip — and emits `extension/src/schemas/Models.gen.ts` so the TypeScript
+side *parses* our own wire types instead of assuming them.
+
+Only types owned by marimo-lsp are emitted. Types re-exported from marimo core
+(`ExecuteCellsRequest`, ...) stay on the `@marimo-team/openapi` path.
+
+Usage:
+    uv run scripts/generate_effect_schemas.py          # write the file
+    uv run scripts/generate_effect_schemas.py --check  # exit 1 on drift
+"""
+
+from __future__ import annotations
+
+import inspect as pyinspect
+import json
+import pathlib
+import subprocess
+import sys
+import tempfile
+
+import msgspec
+import msgspec.inspect as mi
+
+from marimo_lsp import models
+from marimo_lsp.api import API_METHODS, ApiMethod
+
+OUTPUT = (
+    pathlib.Path(__file__).parent.parent
+    / "extension"
+    / "src"
+    / "schemas"
+    / "Models.gen.ts"
+)
+
+HEADER = """\
+// AUTO-GENERATED FILE — DO NOT EDIT.
+//
+// Generated from `src/marimo_lsp/models.py` and the `marimo.api` registry
+// (`API_METHODS` in `src/marimo_lsp/api.py`) by `scripts/generate_effect_schemas.py`.
+// Regenerate with `just generate-schemas`.
+import { Effect, ParseResult, Schema } from "effect";
+"""
+
+
+_StructLike = mi.StructType | mi.DataclassType | mi.TypedDictType
+"""IR nodes with a `cls` and `fields` that emit as `Schema.Struct`."""
+
+
+class _Inner(msgspec.Struct):
+    """Placeholder substituted for generic type parameters.
+
+    Fields typed as `_Inner` are emitted as the TS generic parameter `inner`.
+    """
+
+
+# (exported name, type) pairs. The emitter topologically orders dependencies.
+CONCRETE: list[tuple[str, type | object]] = [
+    ("PackageSource", models.PackageSource),
+    ("CellMetadata", models.CellMetadata),
+    ("SerializeRequest", models.SerializeRequest),
+    ("DeserializeRequest", models.DeserializeRequest),
+    ("ConvertRequest", models.ConvertRequest),
+    ("InterruptRequest", models.InterruptRequest),
+    ("ListPackagesRequest", models.ListPackagesRequest),
+    ("DependencyTreeRequest", models.DependencyTreeRequest),
+    ("GetConfigurationRequest", models.GetConfigurationRequest),
+    ("CloseSessionRequest", models.CloseSessionRequest),
+    ("ExportAsIpynbRequest", models.ExportAsIpynbRequest),
+    ("ExecuteScratchRequest", models.ExecuteScratchRequest),
+    ("UpdateConfigurationRequest", models.UpdateConfigurationRequest),
+    ("SetDisplayThemeRequest", models.SetDisplayThemeRequest),
+]
+
+# Generic wrappers become TS functions of the `inner` schema. Parameterized
+# with the `_Inner` placeholder so msgspec resolves the type variable to a
+# marker the emitter can recognize.
+GENERIC: list[tuple[type, type]] = [
+    (models.NotebookCommand, models.NotebookCommand[_Inner]),
+    (models.SessionCommand, models.SessionCommand[_Inner]),
+    (models.PackageCommand, models.PackageCommand[_Inner]),
+]
+
+
+def _ts_string(value: str) -> str:
+    return json.dumps(value)
+
+
+def _pascal(name: str) -> str:
+    """Convert a kebab-case wire method name to a PascalCase class name."""
+    return "".join(part.capitalize() for part in name.split("-"))
+
+
+def _camel(name: str) -> str:
+    """Convert a kebab-case wire method name to a camelCase client method."""
+    pascal = _pascal(name)
+    return pascal[0].lower() + pascal[1:]
+
+
+def _prop(name: str) -> str:
+    """Render an object property key, quoting when not a valid identifier."""
+    if name.isidentifier():
+        return name
+    return _ts_string(name)
+
+
+def _ts_literal(value: object) -> str:
+    """Render a Python default value as a TS expression."""
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, str):
+        return _ts_string(value)
+    if isinstance(value, (int, float)):
+        return repr(value)
+    msg = f"unsupported default value: {value!r}"
+    raise NotImplementedError(msg)
+
+
+def _jsdoc(doc: str | None, indent: str = "") -> str:
+    if not doc:
+        return ""
+    lines = pyinspect.cleandoc(doc).splitlines()
+    body = "\n".join(f"{indent} * {line}".rstrip() for line in lines)
+    return f"{indent}/**\n{body}\n{indent} */\n"
+
+
+def _identifier(name: str) -> str:
+    """Annotate a schema with its name so parse errors read `Expected <name>`."""
+    return f".annotations({{ identifier: {_ts_string(name)} }})"
+
+
+class Emitter:
+    """Accumulates TS definitions while resolving msgspec type IR."""
+
+    def __init__(self) -> None:
+        self.definitions: list[str] = []
+        self.emitted: dict[type, str] = {}
+        self.alias_by_expr: dict[str, str] = {}
+        self.in_flight: set[type] = set()
+        self.recursive: set[type] = set()
+
+    # Exhaustive dispatch over msgspec's IR node types is a flat switch by
+    # design; splitting it up would hide the one-to-one mapping this encodes.
+    def type_expr(self, t: mi.Type) -> str:  # noqa: C901, PLR0911, PLR0912
+        """Render a msgspec IR node as an Effect Schema expression."""
+        match t:
+            case mi.AnyType() | mi.RawType():
+                return "Schema.Unknown"
+            case mi.NoneType():
+                return "Schema.Null"
+            case mi.BoolType():
+                return "Schema.Boolean"
+            case mi.IntType():
+                return "Schema.Int"
+            case mi.FloatType():
+                return "Schema.Number"
+            case mi.StrType():
+                return "Schema.String"
+            case mi.BytesType() | mi.ByteArrayType():
+                return self.base64_ref()
+            case mi.LiteralType(values=values):
+                args = ", ".join(_ts_string(str(v)) for v in values)
+                return f"Schema.Literal({args})"
+            case mi.EnumType(cls=cls):
+                args = ", ".join(_ts_string(member.value) for member in cls)
+                return f"Schema.Literal({args})"
+            case mi.DictType(key_type=key, value_type=value):
+                return (
+                    "Schema.Record({ "
+                    f"key: {self.type_expr(key)}, value: {self.type_expr(value)}"
+                    " })"
+                )
+            case (
+                mi.ListType(item_type=item)
+                | mi.SetType(item_type=item)
+                | mi.VarTupleType(item_type=item)
+            ):
+                return f"Schema.Array({self.type_expr(item)})"
+            case mi.TupleType(item_types=items):
+                args = ", ".join(self.type_expr(i) for i in items)
+                return f"Schema.Tuple({args})"
+            case mi.Metadata(type=inner):
+                # `typing.Annotated[..., msgspec.Meta(...)]`; constraints are
+                # already folded into the inner node.
+                return self.type_expr(inner)
+            case mi.UnionType(types=types):
+                return self.union_expr(list(types))
+            case mi.StructType() | mi.DataclassType() | mi.TypedDictType():
+                return self.struct_ref(t)
+            case _:
+                msg = f"no Effect Schema mapping for {type(t).__name__}"
+                raise NotImplementedError(msg)
+
+    def union_expr(self, types: list[mi.Type]) -> str:
+        rest = [t for t in types if not isinstance(t, mi.NoneType)]
+        nullable = len(rest) != len(types)
+        inner = (
+            self.type_expr(rest[0])
+            if len(rest) == 1
+            else f"Schema.Union({', '.join(self.type_expr(t) for t in rest)})"
+        )
+        inner = self.alias_by_expr.get(inner, inner)
+        return f"Schema.NullOr({inner})" if nullable else inner
+
+    def base64_ref(self) -> str:
+        """Emit the shared brand for msgspec `bytes` fields (base64 on the JSON wire)."""
+        name = "Base64String"
+        if bytes not in self.emitted:
+            self.emitted[bytes] = name
+            self.definitions.append(
+                "/**\n"
+                " * Base64-encoded bytes on the msgspec JSON wire.\n"
+                " *\n"
+                ' * Matches the compile-time `TypedString<"Base64String">` brand emitted\n'
+                " * by `@marimo-team/openapi`. Decode with `Schema.Uint8ArrayFromBase64`\n"
+                " * where actual bytes are needed.\n"
+                " */\n"
+                f'export const {name} = Schema.String.pipe(Schema.brand("{name}"));\n'
+                f"export type {name} = typeof {name}.Type;\n"
+            )
+        return name
+
+    def struct_ref(self, t: _StructLike) -> str:
+        """Emit a struct/dataclass/TypedDict definition (once); return its name."""
+        cls = t.cls
+        if cls is _Inner:
+            return "inner"
+        if cls in self.emitted:
+            name = self.emitted[cls]
+            if cls in self.in_flight:
+                # A cycle back into a definition we're still emitting: defer
+                # the reference so the const can close over itself.
+                self.recursive.add(cls)
+                return f"Schema.suspend((): Schema.Schema<{name}> => {name})"
+            return name
+        name = cls.__name__
+        self.emitted[cls] = name
+        self.in_flight.add(cls)
+        try:
+            fields = self.fields_src(t, indent="  ")
+        finally:
+            self.in_flight.discard(cls)
+        struct = f"Schema.Struct({{\n{fields}}})" if fields else "Schema.Struct({})"
+        identifier = _identifier(name)
+        if cls in self.recursive:
+            # Recursive schemas need an explicit type: `typeof X.Type` cannot
+            # refer to itself, so emit a structural interface alongside.
+            self.definitions.append(
+                f"{_jsdoc(cls.__doc__)}"
+                f"export interface {name} {{\n{self.interface_fields(t)}}}\n"
+                f"export const {name}: Schema.Schema<{name}> = {struct}{identifier};\n"
+            )
+        else:
+            self.definitions.append(
+                f"{_jsdoc(cls.__doc__)}"
+                f"export const {name} = {struct}{identifier};\n"
+                f"export type {name} = typeof {name}.Type;\n"
+            )
+        return name
+
+    def interface_fields(self, t: _StructLike) -> str:
+        """Render a recursive struct's fields as TS interface members.
+
+        Only the `Type == Encoded` case is supported: a recursive struct with
+        renamed, optional, or defaulted fields would need distinct Type and
+        Encoded interfaces (`Schema.Schema<A, I>`).
+        """
+        lines: list[str] = []
+        for field in t.fields:
+            if not field.required or field.name != field.encode_name:
+                msg = (
+                    f"recursive type {t.cls.__name__} has optional/renamed field "
+                    f"{field.name!r}; Type/Encoded diverge (unsupported)"
+                )
+                raise NotImplementedError(msg)
+            lines.append(
+                f"  readonly {_prop(field.encode_name)}: {self.ts_type(field.type)};"
+            )
+        return "\n".join(lines) + "\n" if lines else ""
+
+    # Same shape as `type_expr` — the TS-type mirror of each IR node.
+    def ts_type(self, t: mi.Type) -> str:  # noqa: C901, PLR0911, PLR0912
+        """Render a msgspec IR node as a TS *type* (for recursive interfaces)."""
+        match t:
+            case mi.AnyType() | mi.RawType():
+                return "unknown"
+            case mi.NoneType():
+                return "null"
+            case mi.BoolType():
+                return "boolean"
+            case mi.IntType() | mi.FloatType():
+                return "number"
+            case mi.StrType():
+                return "string"
+            case mi.BytesType() | mi.ByteArrayType():
+                return self.base64_ref()
+            case mi.LiteralType(values=values):
+                return " | ".join(_ts_string(str(v)) for v in values)
+            case mi.EnumType(cls=cls):
+                return " | ".join(_ts_string(member.value) for member in cls)
+            case mi.DictType(key_type=key, value_type=value):
+                return (
+                    f"{{ readonly [key: {self.ts_type(key)}]: {self.ts_type(value)} }}"
+                )
+            case (
+                mi.ListType(item_type=item)
+                | mi.SetType(item_type=item)
+                | mi.VarTupleType(item_type=item)
+            ):
+                return f"ReadonlyArray<{self.ts_type(item)}>"
+            case mi.TupleType(item_types=items):
+                return f"readonly [{', '.join(self.ts_type(i) for i in items)}]"
+            case mi.Metadata(type=inner):
+                return self.ts_type(inner)
+            case mi.UnionType(types=types):
+                return " | ".join(self.ts_type(x) for x in types)
+            case mi.StructType() | mi.DataclassType() | mi.TypedDictType():
+                # `struct_ref` is memoized; recursive members resolve to the
+                # interface name being emitted.
+                return self.emitted.get(t.cls) or self.struct_ref(t)
+            case _:
+                msg = f"no TS type mapping for {type(t).__name__}"
+                raise NotImplementedError(msg)
+
+    def fields_src(self, t: _StructLike, indent: str) -> str:
+        lines: list[str] = []
+        if isinstance(t, mi.StructType) and t.tag_field is not None:
+            # msgspec always encodes the tag but tolerates its absence when
+            # decoding into the concrete struct; optionalWith mirrors that.
+            tag = _ts_string(str(t.tag))
+            lines.append(
+                f"{indent}{_prop(t.tag_field)}: "
+                f"Schema.optionalWith(Schema.Literal({tag}), {{ default: () => {tag} }}),"
+            )
+        for field in t.fields:
+            expr = self.type_expr(field.type)
+            prop = _prop(field.encode_name)
+            if field.required:
+                rendered = expr if prop == expr else f"{prop}: {expr}"
+            else:
+                default = self.default_expr(field)
+                if default is None:
+                    rendered = f"{prop}: Schema.optional({expr})"
+                else:
+                    rendered = f"{prop}: Schema.optionalWith({expr}, {{ default: () => {default} }})"
+            lines.append(f"{indent}{rendered},")
+        return "\n".join(lines) + "\n" if lines else ""
+
+    def default_expr(self, field: mi.Field) -> str | None:
+        """Render the field default so decode fills omitted fields, like msgspec."""
+        if field.default is not msgspec.NODEFAULT:
+            return _ts_literal(field.default)
+        if field.default_factory is not msgspec.NODEFAULT:
+            if field.default_factory is dict:
+                return "({})"
+            if field.default_factory is list:
+                return "[]"
+        return None
+
+    def emit_named(self, name: str, t: type | object) -> None:
+        info = mi.type_info(t)
+        if isinstance(info, mi.StructType):
+            emitted = self.struct_ref(info)
+            if emitted != name:
+                msg = f"manifest name {name!r} does not match struct name {emitted!r}"
+                raise ValueError(msg)
+            return
+        expr = self.type_expr(info)
+        self.alias_by_expr[expr] = name
+        self.definitions.append(
+            f"export const {name} = {expr}{_identifier(name)};\n"
+            f"export type {name} = typeof {name}.Type;\n"
+        )
+
+    def emit_generic(self, cls: type, parameterized: type) -> None:
+        info = mi.type_info(parameterized)
+        if not isinstance(info, mi.StructType):
+            msg = f"expected a struct, got {type(info).__name__}"
+            raise TypeError(msg)
+        fields = self.fields_src(info, indent="    ")
+        self.definitions.append(
+            f"{_jsdoc(cls.__doc__)}"
+            f"export const {cls.__name__} = <S extends Schema.Schema.Any>(inner: S) =>\n"
+            f"  Schema.Struct({{\n{fields}  }});\n"
+        )
+
+    def emit_api_method(self, method: ApiMethod) -> tuple[str, str]:
+        """Emit a `Schema.TaggedRequest` class for one registry entry.
+
+        Returns the emitted class name and its success schema expression (the
+        client factory references the success schema statically per method).
+        """
+        class_name = _pascal(method.name)
+        info = mi.type_info(method.request)
+        if not isinstance(info, _StructLike):
+            msg = f"api method {method.name!r} request must be struct-like"
+            raise TypeError(msg)
+        payload = self.fields_src(info, indent="  ")
+        # Fire-and-forget methods respond `null` over JSON-RPC, but in-memory
+        # test transports naturally produce `undefined`; accept both while
+        # still rejecting any substantive payload (contract drift).
+        success = (
+            "Schema.Union(Schema.Null, Schema.Undefined)"
+            if method.response is None
+            else self.type_expr(mi.type_info(method.response))
+        )
+        self.definitions.append(
+            f"export const {class_name}Payload = Schema.Struct({{\n{payload}}});\n"
+            "\n"
+            f"export class {class_name} extends Schema.TaggedRequest<{class_name}>()(\n"
+            f"  {_ts_string(method.name)},\n"
+            "  {\n"
+            "    failure: Schema.Never,\n"
+            f"    success: {success},\n"
+            f"    payload: {class_name}Payload.fields,\n"
+            "  },\n"
+            ") {}\n"
+        )
+        return class_name, success
+
+
+_DISPATCH_HELPER = """\
+type Execute<E, R> = (call: {
+  readonly method: string;
+  readonly params: unknown;
+}) => Effect.Effect<unknown, E, R>;
+
+/**
+ * Validate the outgoing params against the payload schema (the wire/Encoded
+ * side, so defaulted fields stay omittable), send them verbatim, and parse
+ * the response against the method's success schema.
+ */
+const dispatch = <PA, PI, PR, A, I, R2, E, R>(
+  execute: Execute<E, R>,
+  method: string,
+  payload: Schema.Schema<PA, PI, PR>,
+  success: Schema.Schema<A, I, R2>,
+  params: PI,
+): Effect.Effect<A, E | ParseResult.ParseError, R | PR | R2> =>
+  Effect.zipRight(
+    Schema.decode(payload)(params),
+    Effect.flatMap(
+      execute({ method, params }),
+      Schema.decodeUnknown(success),
+    ),
+  );
+"""
+
+
+def generate() -> str:
+    emitter = Emitter()
+    for name, t in CONCRETE:
+        emitter.emit_named(name, t)
+    for cls, parameterized in GENERIC:
+        emitter.emit_generic(cls, parameterized)
+    api = [emitter.emit_api_method(method) for method in API_METHODS]
+    members = ",\n  ".join(class_name for class_name, _ in api)
+    emitter.definitions.append(
+        "/**\n"
+        " * Every `marimo.api` request; `_tag` is the wire method name.\n"
+        " *\n"
+        " * Generated from the `API_METHODS` registry in `src/marimo_lsp/api.py`,\n"
+        " * which is also what the server dispatches and validates against.\n"
+        " */\n"
+        f"export const ApiRequest = Schema.Union(\n  {members},\n);\n"
+        "export type ApiRequest = typeof ApiRequest.Type;\n"
+    )
+    emitter.definitions.append(_DISPATCH_HELPER)
+    methods = "\n".join(
+        f"  {_camel(method.name)}: (\n"
+        f"    params: typeof {class_name}Payload.Encoded,\n"
+        f"  ) =>\n"
+        f"    dispatch(\n"
+        f"      execute,\n"
+        f"      {_ts_string(method.name)},\n"
+        f"      {class_name}Payload,\n"
+        f"      {success},\n"
+        f"      params,\n"
+        f"    ),"
+        for (class_name, success), method in zip(api, API_METHODS, strict=True)
+    )
+    emitter.definitions.append(
+        "/**\n"
+        " * Typed `marimo.api` client surface: one method per registry entry.\n"
+        " *\n"
+        " * Each method encodes its payload, dispatches `{ method, params }` over\n"
+        " * `execute`, and parses the response against the method's success schema —\n"
+        " * both sides of the wire are earned, not asserted.\n"
+        " */\n"
+        "export const makeApiClient = <E, R>(execute: Execute<E, R>) => ({\n"
+        f"{methods}\n"
+        "});\n"
+    )
+    return HEADER + "\n" + "\n".join(emitter.definitions)
+
+
+def _format(path: pathlib.Path) -> None:
+    """Run the extension's formatter so output is byte-stable under `just fix-ts`."""
+    extension = OUTPUT.parents[2]
+    subprocess.run(  # noqa: S603
+        ["pnpm", "exec", "vp", "fmt", str(path.relative_to(extension))],  # noqa: S607
+        cwd=extension,
+        check=True,
+        capture_output=True,
+    )
+
+
+def main() -> int:
+    source = generate()
+    if "--check" in sys.argv[1:]:
+        # Format a sibling temp copy (same dir, so formatter config applies)
+        # and compare against the checked-in file.
+        with tempfile.NamedTemporaryFile(
+            mode="w", dir=OUTPUT.parent, suffix=".check.gen.ts", delete=False
+        ) as f:
+            tmp = pathlib.Path(f.name)
+            f.write(source)
+        try:
+            _format(tmp)
+            drifted = OUTPUT.read_text() != tmp.read_text()
+        finally:
+            tmp.unlink()
+        if drifted:
+            print(
+                f"{OUTPUT} is out of date; run `just generate-schemas`", file=sys.stderr
+            )
+            return 1
+        return 0
+    OUTPUT.write_text(source)
+    _format(OUTPUT)
+    print(f"wrote {OUTPUT}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/generate_effect_schemas.py
+++ b/scripts/generate_effect_schemas.py
@@ -335,10 +335,7 @@ class Emitter:
             # tolerates an omitted tag when decoding a concrete struct, it
             # requires the discriminator when decoding a tagged union.
             tag = _ts_string(str(t.tag))
-            lines.append(
-                f"{indent}{_prop(t.tag_field)}: "
-                f"Schema.Literal({tag}),"
-            )
+            lines.append(f"{indent}{_prop(t.tag_field)}: Schema.Literal({tag}),")
         for field in t.fields:
             expr = self.type_expr(field.type)
             prop = _prop(field.encode_name)

--- a/scripts/generate_effect_schemas.py
+++ b/scripts/generate_effect_schemas.py
@@ -331,12 +331,13 @@ class Emitter:
     def fields_src(self, t: _StructLike, indent: str) -> str:
         lines: list[str] = []
         if isinstance(t, mi.StructType) and t.tag_field is not None:
-            # msgspec always encodes the tag but tolerates its absence when
-            # decoding into the concrete struct; optionalWith mirrors that.
+            # This schema describes the encoded wire shape. Although msgspec
+            # tolerates an omitted tag when decoding a concrete struct, it
+            # requires the discriminator when decoding a tagged union.
             tag = _ts_string(str(t.tag))
             lines.append(
                 f"{indent}{_prop(t.tag_field)}: "
-                f"Schema.optionalWith(Schema.Literal({tag}), {{ default: () => {tag} }}),"
+                f"Schema.Literal({tag}),"
             )
         for field in t.fields:
             expr = self.type_expr(field.type)

--- a/src/marimo_lsp/api.py
+++ b/src/marimo_lsp/api.py
@@ -11,6 +11,7 @@ import typing
 from typing import TYPE_CHECKING, cast
 
 import msgspec
+from marimo._ast.app_config import _AppConfig
 from marimo._config.config import DEFAULT_CONFIG, MarimoConfig
 from marimo._convert.converters import MarimoConvert
 from marimo._export.exporter import Exporter
@@ -24,10 +25,12 @@ from marimo._runtime.packages.package_manager import PackageDescription
 from marimo._runtime.packages.package_managers import create_package_manager
 from marimo._schemas.export import ExportAsHTMLRequest, to_html_export_options
 from marimo._schemas.export_options import IPYNBExportOptions
-from marimo._schemas.serialization import NotebookSerialization
+from marimo._schemas.serialization import (
+    AppInstantiation,
+    Header,
+)
 from marimo._session.requests import InstantiateNotebookRequest
 from marimo._session.state.serialize import serialize_session_view
-from marimo._utils.parse_dataclass import parse_raw
 from pygls.uris import to_fs_path
 from typing_extensions import TypeForm
 
@@ -49,15 +52,16 @@ from marimo_lsp.models import (
     ListPackagesResponse,
     ModelRequest,
     NotebookCommand,
+    NotebookDocument,
     PackageCommand,
     ScriptSource,
-    SerializeRequest,
     SerializeResponse,
     SessionCommand,
     SetDisplayThemeRequest,
     SetDisplayThemeResponse,
     StdinRequest,
     UpdateConfigurationRequest,
+    UpdateConfigurationResponse,
     UpdateUIElementRequest,
     VenvSource,
 )
@@ -445,8 +449,13 @@ def _package_manager_for(source: VenvSource | ScriptSource) -> LspPackageManager
 
 
 @marimo_api("serialize")
-async def serialize(_ctx: ApiContext, args: SerializeRequest) -> SerializeResponse:
-    ir = parse_raw(args.notebook, cls=NotebookSerialization)
+async def serialize(_ctx: ApiContext, args: NotebookDocument) -> SerializeResponse:
+    ir = MarimoConvert.from_notebook_v1(args.notebook).to_ir()
+    ir = dataclasses.replace(
+        ir,
+        app=AppInstantiation(options=args.app_config.asdict()),
+        header=Header(value=args.header) if args.header is not None else None,
+    )
     return SerializeResponse(source=MarimoConvert.from_ir(ir).to_py())
 
 
@@ -454,17 +463,14 @@ async def serialize(_ctx: ApiContext, args: SerializeRequest) -> SerializeRespon
 async def deserialize(
     _ctx: ApiContext,
     args: DeserializeRequest,
-) -> dict[str, typing.Any]:
+) -> NotebookDocument:
     converter = MarimoConvert.from_py(args.source)
     ir = converter.to_ir()
-
-    # The `_ast` field on each `CellDef` holds a parsed Python AST, which isn't
-    # serializable. Since the AST isn't used on the other side of the wire,
-    # we can safely drop it before serialization.
-    for cell in ir.cells:
-        cell._ast = None  # noqa: SLF001
-
-    return dataclasses.asdict(ir)
+    return NotebookDocument(
+        notebook=converter.to_notebook_v1(),
+        app_config=_AppConfig.from_untrusted_dict(ir.app.options),
+        header=ir.header.value if ir.header is not None else None,
+    )
 
 
 @marimo_api("get-configuration")
@@ -485,15 +491,17 @@ async def get_configuration(
 async def update_configuration(
     ctx: ApiContext,
     args: NotebookCommand[UpdateConfigurationRequest],
-) -> MarimoConfig:
+) -> UpdateConfigurationResponse:
     """Update the marimo user configuration."""
     session = ctx.sessions.get(args.notebook_uri)
     if not session:
         logger.warning(f"No session found for {args.notebook_uri}")
         raise SessionNotFoundError(args.notebook_uri)
 
-    return session.save_config(
-        cast("PartialMarimoConfig", args.inner.config),
+    # PartialMarimoConfig is only shallow-partial, while config updates are
+    # intentionally deep patches (for example, just runtime.on_cell_change).
+    return UpdateConfigurationResponse(
+        config=session.save_config(cast("PartialMarimoConfig", args.inner.config))
     )
 
 
@@ -582,7 +590,10 @@ _API_BY_NAME = {method.name: method for method in API_METHODS}
 
 
 async def handle_api_command(
-    ls: LanguageServer, sessions: Sessions, method: str, params: dict
+    ls: LanguageServer,
+    sessions: Sessions,
+    method: str,
+    params: dict[str, object],
 ) -> object:
     """Unified API endpoint for all marimo internal methods.
 

--- a/src/marimo_lsp/api.py
+++ b/src/marimo_lsp/api.py
@@ -100,7 +100,7 @@ type ApiHandler[Req, Res] = typing.Callable[
 
 @dataclasses.dataclass(frozen=True)
 class ApiMethod[Req, Res]:
-    """One ``marimo.api`` method and its wire contract."""
+    """One ``marimo.api`` method consumed by dispatch and schema generation."""
 
     name: str
     request: TypeForm[Req]

--- a/src/marimo_lsp/app_file_manager.py
+++ b/src/marimo_lsp/app_file_manager.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
 
     import lsprotocol.types as lsp
     from lsprotocol.types import NotebookDocument
+    from marimo._schemas.notebook import NotebookCellConfig
     from pygls.lsp.server import LanguageServer
     from pygls.workspace import Workspace
 
@@ -148,7 +149,7 @@ def find_notebook_document(
 def _iter_notebook_cells(
     workspace: Workspace,
     notebook: NotebookDocument,
-) -> Generator[tuple[CellId_t, str, str, dict[str, Any]]]:
+) -> Generator[tuple[CellId_t, str, str, NotebookCellConfig]]:
     """Yield (cell_id, code, name, config) for each valid cell in a notebook."""
     for cell in notebook.cells:
         meta = decode_cell_metadata(cell)
@@ -187,7 +188,7 @@ def sync_app_with_workspace(
         codes.append(code)
         # Must be a CellConfig, not a dict: code mode reads attributes like
         # `config.column` off these (a dict raises AttributeError).
-        configs.append(CellConfig.from_dict(config))
+        configs.append(CellConfig.from_dict(dict(config)))
         names.append(name)
 
     return app.with_data(
@@ -208,7 +209,7 @@ def _snapshot_notebook_cells(
             id=cell_id,
             code=code,
             name=name,
-            config=CellConfig.from_dict(config),
+            config=CellConfig.from_dict(dict(config)),
         )
         for cell_id, code, name, config in _iter_notebook_cells(workspace, notebook)
     )

--- a/src/marimo_lsp/models.py
+++ b/src/marimo_lsp/models.py
@@ -12,9 +12,11 @@ import msgspec
 # These stay runtime imports (noqa: TC002) even though they only appear in
 # annotations: msgspec resolves the stringified annotations when the structs
 # are first encoded/inspected, which fails under TYPE_CHECKING-only imports.
+from marimo._ast.app_config import _AppConfig
 from marimo._config.config import MarimoConfig  # noqa: TC002
 from marimo._convert.common.format import DEFAULT_MARKDOWN_PREFIX
 from marimo._runtime.packages.package_manager import PackageDescription  # noqa: TC002
+from marimo._schemas.notebook import NotebookCellConfig, NotebookV1
 from marimo._server.models.packages import DependencyTreeNode  # noqa: TC002
 
 # NOTE: the generic structs below use the legacy TypeVar spelling (noqa: UP046)
@@ -123,8 +125,11 @@ class CellMetadata(msgspec.Struct, rename="camel"):
     name: str = "_"
     """The marimo cell name."""
 
-    config: dict[str, typing.Any] = msgspec.field(default_factory=dict, name="options")
-    """The marimo `CellConfig` as a plain dict.
+    config: NotebookCellConfig = msgspec.field(
+        default_factory=NotebookCellConfig,
+        name="options",
+    )
+    """The marimo `NotebookCellConfig`.
 
     Synced on the wire as ``options`` (VS Code's notebook cell config key); we
     expose it as ``config`` to match marimo's downstream vocabulary
@@ -135,15 +140,12 @@ class CellMetadata(msgspec.Struct, rename="camel"):
     """Smart-cell metadata for markdown/SQL cells; absent for Python cells."""
 
 
-class SerializeRequest(msgspec.Struct, rename="camel"):
-    """
-    A request to serialize a notebook to Python source.
+class NotebookDocument(msgspec.Struct, rename="camel"):
+    """Strict JSON notebook data plus source-level application metadata."""
 
-    Contains the notebook data to be serialized.
-    """
-
-    notebook: dict[str, typing.Any]
-    """The notebook data in marimo's internal format."""
+    notebook: NotebookV1
+    app_config: _AppConfig = msgspec.field(default_factory=_AppConfig)
+    header: str | None = None
 
 
 class DeserializeRequest(msgspec.Struct, rename="camel"):
@@ -206,14 +208,14 @@ class ExecuteScratchRequest(msgspec.Struct, rename="camel"):
 class UpdateConfigurationRequest(msgspec.Struct, rename="camel"):
     """A request to update the user configuration."""
 
-    config: dict[str, typing.Any]
+    config: dict[str, object]
     """The partial configuration to merge with the current config."""
 
 
 class SetDisplayThemeRequest(msgspec.Struct, rename="camel"):
     """A request to set the display theme without persisting to disk."""
 
-    theme: str
+    theme: typing.Literal["light", "dark"]
     """The theme to set ('light' or 'dark')."""
 
 
@@ -223,7 +225,7 @@ class ApiRequest(msgspec.Struct, rename="camel"):
     method: str
     """The API method to call (e.g., 'run', 'interrupt', 'serialize')."""
 
-    params: dict[str, typing.Any]
+    params: dict[str, object]
     """The parameters for the method."""
 
 
@@ -253,6 +255,13 @@ class GetConfigurationResponse(msgspec.Struct, rename="camel"):
 
     config: MarimoConfig
     """The resolved marimo configuration (defaults when no session exists)."""
+
+
+class UpdateConfigurationResponse(msgspec.Struct, rename="camel"):
+    """Response for ``update-configuration``."""
+
+    config: MarimoConfig
+    """The resolved configuration after the update."""
 
 
 class SetDisplayThemeResponse(msgspec.Struct, rename="camel"):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
+import msgspec
 import pytest
 from marimo._config.config import DEFAULT_CONFIG
 
@@ -13,7 +14,11 @@ from marimo_lsp.api import (
     SessionNotFoundError,
     update_configuration,
 )
-from marimo_lsp.models import NotebookCommand, UpdateConfigurationRequest
+from marimo_lsp.models import (
+    NotebookCommand,
+    SetDisplayThemeRequest,
+    UpdateConfigurationRequest,
+)
 
 
 def _context(sessions: MagicMock) -> ApiContext:
@@ -68,7 +73,7 @@ async def test_update_configuration_returns_saved_config() -> None:
         ),
     )
 
-    assert result == DEFAULT_CONFIG
+    assert result.config == DEFAULT_CONFIG
 
 
 @pytest.mark.asyncio
@@ -101,3 +106,8 @@ async def test_update_configuration_propagates_save_errors() -> None:
                 inner=UpdateConfigurationRequest(config={}),
             ),
         )
+
+
+def test_display_theme_rejects_unresolved_theme() -> None:
+    with pytest.raises(msgspec.ValidationError):
+        msgspec.convert({"theme": "system"}, type=SetDisplayThemeRequest)

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -8,6 +8,8 @@ from typing import cast
 from unittest.mock import MagicMock, patch
 
 import lsprotocol.types as lsp
+import msgspec
+import pytest
 from inline_snapshot import snapshot
 from marimo._types.ids import CellId_t
 
@@ -436,6 +438,19 @@ class TestCellMetadataHelpers:
 
         meta = decode_cell_metadata(cell)
         assert meta.stable_id == "abc-123"
+
+    def test_decode_cell_metadata_rejects_invalid_config(self) -> None:
+        cell = lsp.NotebookCell(
+            kind=lsp.NotebookCellKind.Code,
+            document="file:///test.py#cell1",
+            metadata=cast(
+                "lsp.LSPObject",
+                {"options": {"disabled": "yes"}},
+            ),
+        )
+
+        with pytest.raises(msgspec.ValidationError):
+            decode_cell_metadata(cell)
 
 
 class TestNormalizeCellCode:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -266,25 +266,28 @@ async def test_file_notebook_did_close_detaches_session() -> None:
 async def test_marimo_serialize_command(client: LanguageClient) -> None:
     """Test the marimo.serialize command."""
     notebook = {
-        "app": {
-            "options": {},
-        },
-        "header": {"value": "marimo app"},
+        "version": "1",
+        "metadata": {},
         "cells": [
             {
+                "id": None,
                 "code": "import marimo as mo",
+                "code_hash": None,
                 "name": "cell1",
-                "options": {},
+                "config": {},
             }
         ],
-        "violations": [],
-        "valid": True,
     }
 
     result = await client.workspace_execute_command_async(
         lsp.ExecuteCommandParams(
             command="marimo.api",
-            arguments=[{"method": "serialize", "params": {"notebook": notebook}}],
+            arguments=[
+                {
+                    "method": "serialize",
+                    "params": {"notebook": notebook, "header": "marimo app"},
+                }
+            ],
         )
     )
 
@@ -337,36 +340,33 @@ if __name__ == "__main__":
 
     assert result == snapshot(
         {
-            "app": {
-                "lineno": 0,
-                "col_offset": 0,
-                "end_lineno": 0,
-                "end_col_offset": 0,
-                "options": {},
+            "notebook": {
+                "version": "1",
+                "cells": [
+                    {
+                        "id": "Hbol",
+                        "code": "import marimo as mo",
+                        "code_hash": "1d0db38904205bec4d6f6f6a1f6cec3e",
+                        "name": "__",
+                        "config": {
+                            "column": None,
+                            "disabled": False,
+                            "hide_code": False,
+                        },
+                    }
+                ],
+                "metadata": {"marimo_version": "0.23.16"},
             },
-            "header": {
-                "lineno": 0,
-                "col_offset": 0,
-                "end_lineno": 0,
-                "end_col_offset": 0,
-                "value": "",
+            "appConfig": {
+                "width": "compact",
+                "app_title": None,
+                "layout_file": None,
+                "css_file": None,
+                "html_head_file": None,
+                "auto_download": [],
+                "sql_output": "auto",
             },
-            "version": "0.14.17",
-            "cells": [
-                {
-                    "lineno": 7,
-                    "col_offset": 0,
-                    "end_lineno": 17,
-                    "end_col_offset": 38,
-                    "code": "import marimo as mo",
-                    "name": "__",
-                    "options": {},
-                    "_ast": None,
-                }
-            ],
-            "violations": [],
-            "valid": True,
-            "filename": "notebook.py",
+            "header": "",
         }
     )
 


### PR DESCRIPTION
The `marimo.api` contract was manually maintained across Python handlers, TypeScript method maps, and response schemas. Those parallel definitions could drift, and many methods crossed the boundary without strict request or response types.

This PR generates the corresponding Effect schemas and typed TypeScript client from the Python method table:

```bash
uv run scripts/generate_effect_schemas.py
```

A typed Python handler:

```python
@marimo_api("serialize")
async def serialize(
    _ctx: ApiContext,
    request: NotebookDocument,
) -> SerializeResponse:
    ...
```

generates a client where both the parameters and result are inferred:

```typescript
const result = yield* api.serialize(params);
// result: SerializeResponse
```

The server and client now share one contract, and CI checks the generated output for drift.
