### PR TITLE
Add notebook Outline shortcut

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -283,6 +283,14 @@
         "category": "marimo"
       },
       {
+        "command": "marimo.openOutlineView",
+        "title": "Show outline",
+        "shortTitle": "Outline",
+        "category": "marimo",
+        "icon": "$(list-unordered)",
+        "enablement": "notebookType == 'marimo-notebook'"
+      },
+      {
         "command": "marimo.createSetupCell",
         "title": "Create setup cell",
         "category": "marimo",
@@ -517,6 +525,11 @@
           "command": "marimo.config.toggleAutoReloadAutorun",
           "when": "notebookType == 'marimo-notebook' && marimo.notebook.hasKernel && marimo.config.runtime.auto_reload == 'autorun'",
           "group": "navigation@4"
+        },
+        {
+          "command": "marimo.openOutlineView",
+          "when": "notebookType == 'marimo-notebook'",
+          "group": "navigation@5"
         }
       ],
       "editor/title": [
@@ -524,6 +537,11 @@
           "command": "marimo.openAsMarimoNotebook",
           "when": "resourceLangId == python && !notebookType && marimo.isPythonFileMarimoNotebook",
           "group": "navigation"
+        },
+        {
+          "command": "marimo.openOutlineView",
+          "when": "notebookType == 'marimo-notebook' && config.notebook.globalToolbar != true",
+          "group": "navigation@5"
         }
       ]
     }

--- a/extension/src/commands.ts
+++ b/extension/src/commands.ts
@@ -6,6 +6,8 @@ export function dynamicCommand(command: string): DynamicCommand {
 
 // Pulled from https://code.visualstudio.com/api/references/commands
 export type VscodeBuiltinCommand =
+  // Focus the built-in Outline view.
+  | "outline.focus"
   // Invoke notebook serializer
   | "vscode.executeDataToNotebook"
   // Invoke notebook serializer

--- a/extension/src/commands/__tests__/openOutlineView.test.ts
+++ b/extension/src/commands/__tests__/openOutlineView.test.ts
@@ -1,0 +1,18 @@
+import { expect, it } from "@effect/vitest";
+import { Effect } from "effect";
+
+import { TestVsCode } from "../../__mocks__/TestVsCode.ts";
+import { openOutlineView } from "../openOutlineView.ts";
+
+it.effect(
+  "focuses the built-in VS Code Outline view",
+  Effect.fn(function* () {
+    const vscode = yield* TestVsCode.make();
+
+    yield* openOutlineView().pipe(Effect.provide(vscode.layer));
+
+    expect(yield* vscode.executions).toEqual([
+      { command: "outline.focus", args: [] },
+    ]);
+  }),
+);

--- a/extension/src/commands/openOutlineView.ts
+++ b/extension/src/commands/openOutlineView.ts
@@ -1,0 +1,8 @@
+import { Effect } from "effect";
+
+import { VsCode } from "../platform/VsCode.ts";
+
+export const openOutlineView = Effect.fn(function* () {
+  const code = yield* VsCode;
+  yield* code.commands.executeCommand("outline.focus");
+});

--- a/extension/src/commands/openOutlineView.ts
+++ b/extension/src/commands/openOutlineView.ts
@@ -2,7 +2,9 @@ import { Effect } from "effect";
 
 import { VsCode } from "../platform/VsCode.ts";
 
-export const openOutlineView = Effect.fn(function* () {
-  const code = yield* VsCode;
-  yield* code.commands.executeCommand("outline.focus");
-});
+export const openOutlineView = Effect.fn("command.openOutlineView")(
+  function* () {
+    const code = yield* VsCode;
+    yield* code.commands.executeCommand("outline.focus");
+  },
+);

--- a/extension/src/constants.ts
+++ b/extension/src/constants.ts
@@ -14,6 +14,7 @@ export type MarimoCommand =
   | "marimo.exportStaticHTML"
   | "marimo.newMarimoNotebook"
   | "marimo.openAsMarimoNotebook"
+  | "marimo.openOutlineView"
   | "marimo.openTutorial"
   | "marimo.publishMarimoNotebook"
   | "marimo.publishMarimoNotebookGist"

--- a/extension/src/features/RegisterCommands.ts
+++ b/extension/src/features/RegisterCommands.ts
@@ -5,6 +5,7 @@ import { debugCell } from "../commands/debugCell.ts";
 import { exportNotebookAsHtml } from "../commands/exportNotebookAsHtml.ts";
 import { newMarimoNotebook } from "../commands/newMarimoNotebook.ts";
 import { openAsMarimoNotebook } from "../commands/openAsMarimoNotebook.ts";
+import { openOutlineView } from "../commands/openOutlineView.ts";
 import { publishMarimoNotebook } from "../commands/publishMarimoNotebook.ts";
 import { publishMarimoNotebookGist } from "../commands/publishMarimoNotebookGist.ts";
 import { reportIssue } from "../commands/reportIssue.ts";
@@ -40,6 +41,11 @@ export const RegisterCommandsLive = Layer.scopedDiscard(
     yield* code.commands.registerCommand(
       "marimo.openAsMarimoNotebook",
       openAsMarimoNotebook,
+    );
+
+    yield* code.commands.registerCommand(
+      "marimo.openOutlineView",
+      openOutlineView,
     );
 
     yield* code.commands.registerCommand(


### PR DESCRIPTION
Add an Outline action to both notebook toolbar layouts and forward it to VS Code's built-in `outline.focus` command.

Closes #269