### PR TITLE
Upgrade @vscode/test-electron to 3.1.0

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -46,7 +46,7 @@
     "@vscode/debugprotocol": "^1.68.0",
     "@vscode/python-extension": "^1.0.6",
     "@vscode/test-cli": "^0.0.12",
-    "@vscode/test-electron": "^2.5.2",
+    "@vscode/test-electron": "^3.1.0",
     "effect": "^3.19.19",
     "esbuild": "^0.28.0",
     "happy-dom": "^20.8.9",

--- a/extension/pnpm-lock.yaml
+++ b/extension/pnpm-lock.yaml
@@ -76,8 +76,8 @@ importers:
         specifier: ^0.0.12
         version: 0.0.12
       '@vscode/test-electron':
-        specifier: ^2.5.2
-        version: 2.5.2(supports-color@8.1.1)
+        specifier: ^3.1.0
+        version: 3.1.0(supports-color@8.1.1)
       effect:
         specifier: ^3.19.19
         version: 3.21.3
@@ -1440,9 +1440,9 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  '@vscode/test-electron@2.5.2':
-    resolution: {integrity: sha512-8ukpxv4wYe0iWMRQU18jhzJOHkeGKbnw7xWRX3Zw1WJA4cEKbHcmmLPdPrPtL6rhDcrlCZN+xKRpv09n4gRHYg==}
-    engines: {node: '>=16'}
+  '@vscode/test-electron@3.1.0':
+    resolution: {integrity: sha512-CRqv5u+YYoseuNVJ6Tyo4k0sF0mx4qnKMihRB0PjsUF8Dc0WKtCXo6CNL6nWWm5esfFQsQA/pejMj4ZbpJVLTw==}
+    engines: {node: '>=22'}
 
   '@yuku-codegen/binding-darwin-arm64@0.5.48':
     resolution: {integrity: sha512-yo96Oef12WzqnphInfz/eexVse3+kWgfGS5g2S3rFS3dcGn1ENW9xLFDZUP9rh+yP76DOq38wBoFi1+I9+6qBg==}
@@ -3820,7 +3820,7 @@ snapshots:
     transitivePeerDependencies:
       - monocart-coverage-reports
 
-  '@vscode/test-electron@2.5.2(supports-color@8.1.1)':
+  '@vscode/test-electron@3.1.0(supports-color@8.1.1)':
     dependencies:
       http-proxy-agent: 7.0.2(supports-color@8.1.1)
       https-proxy-agent: 7.0.6(supports-color@8.1.1)


### PR DESCRIPTION
Upgrade `@vscode/test-electron` from 2.5.2 to 3.1.0.

Current VS Code macOS bundles no longer expose the historical `Contents/MacOS/Electron` executable. Version 3.1.0 includes [the upstream fix](https://github.com/microsoft/vscode-test/pull/350) that resolves the executable from the app bundle metadata, preventing `just test-vscode` from failing with `ENOENT` on current Stable and Insiders builds.

The new major version requires Node.js 22 or newer; this repository uses Node.js 24 in CI.
