### PR TITLE
Add configurable notebook kernel working directory

### DIFF
--- a/extension/README.md
+++ b/extension/README.md
@@ -44,15 +44,18 @@ icon in the editor title bar to open it as a notebook (see image above).
 
 ## Configuration
 
-| Setting                                 | Type      | Default | Description                                                                                                                                                                                         |
-| --------------------------------------- | --------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `marimo.lsp.path`                       | `array`   | `[]`    | Path to a custom `marimo-lsp` executable, e.g., `["/path/to/marimo-lsp"]`. Leave empty to use the bundled version via `uvx`.                                                                        |
-| `marimo.uv.path`                        | `string`  |         | Path to the `uv` binary, e.g., `/Users/me/.local/bin/uv`. Leave empty to use `uv` from the system PATH.                                                                                             |
-| `marimo.ruff.path`                      | `string`  |         | Path to a custom `ruff` binary, e.g., `/usr/local/bin/ruff`. Useful for offline environments. Leave empty to auto-discover or install via uv.                                                       |
-| `marimo.ty.path`                        | `string`  |         | Path to a custom `ty` binary, e.g., `/usr/local/bin/ty`. Useful for offline environments. Leave empty to auto-discover or install via uv.                                                           |
-| `marimo.disableUvIntegration`           | `boolean` | `false` | Disable uv integration features such as automatic package installation prompts.                                                                                                                     |
-| `marimo.disableManagedLanguageFeatures` | `boolean` | `false` | Disable marimo's managed Python language features (completions, diagnostics, formatting). When enabled, notebook cells use the standard `python` language ID and rely on external language servers. |
-| `marimo.telemetry`                      | `boolean` | `true`  | Anonymous usage data. This helps us prioritize features for the marimo VSCode extension.                                                                                                            |
+| Setting                                 | Type      | Default          | Description                                                                                                                                                                                         |
+| --------------------------------------- | --------- | ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `marimo.lsp.path`                       | `array`   | `[]`             | Path to a custom `marimo-lsp` executable, e.g., `["/path/to/marimo-lsp"]`. Leave empty to use the bundled version via `uvx`.                                                                        |
+| `marimo.uv.path`                        | `string`  |                  | Path to the `uv` binary, e.g., `/Users/me/.local/bin/uv`. Leave empty to use `uv` from the system PATH.                                                                                             |
+| `marimo.ruff.path`                      | `string`  |                  | Path to a custom `ruff` binary, e.g., `/usr/local/bin/ruff`. Useful for offline environments. Leave empty to auto-discover or install via uv.                                                       |
+| `marimo.ty.path`                        | `string`  |                  | Path to a custom `ty` binary, e.g., `/usr/local/bin/ty`. Useful for offline environments. Leave empty to auto-discover or install via uv.                                                           |
+| `marimo.disableUvIntegration`           | `boolean` | `false`          | Disable uv integration features such as automatic package installation prompts.                                                                                                                     |
+| `marimo.disableManagedLanguageFeatures` | `boolean` | `false`          | Disable marimo's managed Python language features (completions, diagnostics, formatting). When enabled, notebook cells use the standard `python` language ID and rely on external language servers. |
+| `marimo.telemetry`                      | `boolean` | `true`           | Anonymous usage data. This helps us prioritize features for the marimo VSCode extension.                                                                                                            |
+| `marimo.notebookFileRoot`               | `string`  | `${fileDirname}` | Initial working directory for locally launched kernels. Supports the notebook directory, workspace folder, home-relative, absolute, and workspace-relative paths. Requires a kernel restart.        |
+
+`marimo.notebookFileRoot` controls process-relative behavior such as `Path.cwd()`, file access, and subprocesses. For paths that must remain portable across VS Code, CLI execution, exports, and deployment, prefer `mo.notebook_dir()`.
 
 ### Language Features
 

--- a/extension/package.json
+++ b/extension/package.json
@@ -114,6 +114,12 @@
           "default": false,
           "markdownDescription": "Disable marimo's managed Python language features (completions, diagnostics, formatting). When enabled, notebook cells use the standard `python` language ID and rely on external language servers.",
           "scope": "resource"
+        },
+        "marimo.notebookFileRoot": {
+          "type": "string",
+          "default": "${fileDirname}",
+          "markdownDescription": "Controls the initial working directory of locally launched marimo kernels. Supports `${fileDirname}`, `${workspaceFolder}`, `~/some/path`, absolute paths, and paths relative to the notebook's containing workspace folder. Requires a kernel restart to take effect.",
+          "scope": "resource"
         }
       }
     },

--- a/extension/src/__mocks__/TestVsCode.ts
+++ b/extension/src/__mocks__/TestVsCode.ts
@@ -1617,6 +1617,7 @@ export class TestVsCode extends Data.TaggedClass("TestVsCode")<{
       version?: string;
       fileSystem?: Map<string, Uint8Array | Error>;
       window?: Partial<Window>;
+      workspace?: Partial<Workspace>;
     } = {},
   ) {
     const activeTextEditor = yield* SubscriptionRef.make(
@@ -1869,6 +1870,7 @@ export class TestVsCode extends Data.TaggedClass("TestVsCode")<{
           withProgress() {
             return Effect.void;
           },
+          ...options.window,
         }),
         commands: Commands.make({
           subscribeToCommands() {
@@ -2000,6 +2002,7 @@ export class TestVsCode extends Data.TaggedClass("TestVsCode")<{
               ),
             );
           },
+          ...options.workspace,
         }),
         env: Env.make({
           appName: "Marimo Test",

--- a/extension/src/__tests__/__utils__/TestMarimoClient.ts
+++ b/extension/src/__tests__/__utils__/TestMarimoClient.ts
@@ -12,6 +12,8 @@ import {
   type NotebookControllerSelection,
   type NotebookHandle,
   NotebookRuntime,
+  type RuntimeSession,
+  type RuntimeSessionEntry,
 } from "../../kernel/NotebookRuntime.ts";
 import { makeMarimoCommands, MarimoClient } from "../../lsp/MarimoClient.ts";
 import type { NotebookId } from "../../schemas/MarimoNotebookDocument.ts";
@@ -23,6 +25,8 @@ interface Options {
   ) => Effect.Effect<unknown, ParseResult.ParseError>;
   readonly operations?: () => Stream.Stream<MarimoOperation>;
   readonly initialControllers?: ReadonlyArray<NotebookControllerSelection>;
+  readonly runtimeSession?: RuntimeSession;
+  readonly runtimeSessions?: ReadonlyArray<RuntimeSessionEntry>;
 }
 
 export function makeTestMarimoClient(options: Options = {}) {
@@ -60,6 +64,8 @@ export function makeTestNotebookRuntime(options: Options = {}) {
               client.executeCells({
                 notebookUri: notebookId,
                 executable,
+                workingDirectory:
+                  options.runtimeSession?.workingDirectory ?? process.cwd(),
                 inner,
               }),
             executeScratchpad: () => Stream.empty,
@@ -92,6 +98,12 @@ export function makeTestNotebookRuntime(options: Options = {}) {
               });
             }),
           controllerChanges: () => Stream.fromPubSub(selections),
+          getRuntimeSession: () =>
+            Effect.succeed(Option.fromNullable(options.runtimeSession)),
+          getRuntimeSessions: () =>
+            Effect.succeed([...(options.runtimeSessions ?? [])]),
+          activeRuntimeSession: () =>
+            Effect.succeed(Option.fromNullable(options.runtimeSession)),
           forNotebook,
         });
       }),

--- a/extension/src/config/Config.ts
+++ b/extension/src/config/Config.ts
@@ -1,5 +1,7 @@
 import { Effect, Option } from "effect";
+import type * as vscode from "vscode";
 
+import { DEFAULT_NOTEBOOK_FILE_ROOT } from "../kernel/NotebookFileRoot.ts";
 import { VsCode } from "../platform/VsCode.ts";
 
 /**
@@ -26,6 +28,9 @@ export class Config extends Effect.Service<Config>()("Config", {
         },
         lsp: {
           executable: Effect.succeed(Option.none()),
+        },
+        notebookFileRoot() {
+          return Effect.succeed(DEFAULT_NOTEBOOK_FILE_ROOT);
         },
         getManagedLanguageFeaturesEnabled() {
           return Effect.succeed(false);
@@ -87,6 +92,14 @@ export class Config extends Effect.Service<Config>()("Config", {
             );
           });
         },
+      },
+      notebookFileRoot(scope?: vscode.ConfigurationScope) {
+        return Effect.map(
+          code.value.workspace.getConfiguration("marimo", scope),
+          (config) =>
+            config.get<string>("notebookFileRoot") ??
+            DEFAULT_NOTEBOOK_FILE_ROOT,
+        );
       },
       getManagedLanguageFeaturesEnabled() {
         return Effect.andThen(

--- a/extension/src/features/ReloadOnConfigChange.ts
+++ b/extension/src/features/ReloadOnConfigChange.ts
@@ -1,36 +1,99 @@
-import { Effect, Layer, Option, Stream } from "effect";
+import { Effect, Either, Layer, Option, Stream } from "effect";
 
+import { NotebookRuntime } from "../kernel/NotebookRuntime.ts";
 import { VsCode } from "../platform/VsCode.ts";
+import { MarimoNotebookDocument } from "../schemas/MarimoNotebookDocument.ts";
 
-/**
- * Watches for changes to `marimo.disableManagedLanguageFeatures` and prompts
- * the user to reload the window, since this setting is read at startup and
- * baked into service initialization.
- */
-export const ReloadOnConfigChangeLive = Layer.scopedDiscard(
-  Effect.gen(function* () {
-    const code = yield* VsCode;
+export const promptToRestartKernelForFileRootChange = Effect.fn(function* () {
+  const code = yield* VsCode;
 
-    yield* Effect.forkScoped(
-      code.workspace.configurationChanges().pipe(
-        Stream.filter((event) =>
-          event.affectsConfiguration("marimo.disableManagedLanguageFeatures"),
-        ),
-        Stream.runForEach(() =>
-          Effect.gen(function* () {
-            const reload = yield* code.window.showInformationMessage(
-              "Changing managed language features requires reloading the window to take effect.",
-              { items: ["Reload Window"] },
-            );
+  const restart = yield* code.window.showInformationMessage(
+    "The notebook file root changed. Restart the marimo kernel to apply it.",
+    { items: ["Restart Kernel"] },
+  );
+  if (Option.isSome(restart) && restart.value === "Restart Kernel") {
+    yield* code.commands.executeCommand("marimo.restartKernel");
+  }
+});
 
-            if (Option.isSome(reload) && reload.value === "Reload Window") {
-              yield* code.commands.executeCommand(
-                "workbench.action.reloadWindow",
-              );
-            }
-          }),
-        ),
-      ),
+/** Watches configuration changes that require an explicit reload or restart. */
+export const watchForConfigurationChanges = Effect.fn(function* () {
+  const code = yield* VsCode;
+  const notebooks = yield* NotebookRuntime;
+  const pendingFileRootChanges = new Set<string>();
+
+  const promptForActiveAffectedSession = Effect.fn(function* () {
+    const activeNotebook = Option.filterMap(
+      yield* code.window.getActiveNotebookEditor(),
+      (editor) => MarimoNotebookDocument.tryFrom(editor.notebook),
     );
-  }),
+    if (
+      Option.isNone(activeNotebook) ||
+      !pendingFileRootChanges.has(activeNotebook.value.id)
+    ) {
+      return;
+    }
+
+    pendingFileRootChanges.delete(activeNotebook.value.id);
+    if (
+      Option.isNone(yield* notebooks.getRuntimeSession(activeNotebook.value.id))
+    ) {
+      return;
+    }
+    yield* promptToRestartKernelForFileRootChange();
+  });
+
+  yield* Effect.forkScoped(
+    code.workspace.configurationChanges().pipe(
+      Stream.filter((event) =>
+        event.affectsConfiguration("marimo.disableManagedLanguageFeatures"),
+      ),
+      Stream.runForEach(() =>
+        Effect.gen(function* () {
+          const reload = yield* code.window.showInformationMessage(
+            "Changing managed language features requires reloading the window to take effect.",
+            { items: ["Reload Window"] },
+          );
+
+          if (Option.isSome(reload) && reload.value === "Reload Window") {
+            yield* code.commands.executeCommand(
+              "workbench.action.reloadWindow",
+            );
+          }
+        }),
+      ),
+    ),
+  );
+
+  yield* Effect.forkScoped(
+    code.workspace.configurationChanges().pipe(
+      Stream.filter((event) =>
+        event.affectsConfiguration("marimo.notebookFileRoot"),
+      ),
+      Stream.runForEach((event) =>
+        Effect.gen(function* () {
+          for (const { notebookId } of yield* notebooks.getRuntimeSessions()) {
+            const uri = code.utils.parseUri(notebookId);
+            if (
+              Either.isRight(uri) &&
+              event.affectsConfiguration("marimo.notebookFileRoot", uri.right)
+            ) {
+              pendingFileRootChanges.add(notebookId);
+            }
+          }
+          yield* promptForActiveAffectedSession();
+        }),
+      ),
+    ),
+  );
+
+  yield* Effect.forkScoped(
+    code.window
+      .activeNotebookEditorChanges()
+      .pipe(Stream.runForEach(promptForActiveAffectedSession)),
+  );
+});
+
+export const ReloadOnConfigChangeLive = Layer.scopedDiscard(
+  watchForConfigurationChanges(),
 );

--- a/extension/src/features/__tests__/ReloadOnConfigChange.test.ts
+++ b/extension/src/features/__tests__/ReloadOnConfigChange.test.ts
@@ -1,0 +1,109 @@
+import { expect, it } from "@effect/vitest";
+import { Deferred, Effect, Layer, Option, Ref, Stream } from "effect";
+import type * as vscode from "vscode";
+
+import { TestVsCode } from "../../__mocks__/TestVsCode.ts";
+import { makeTestNotebookRuntime } from "../../__tests__/__utils__/TestMarimoClient.ts";
+import { notebookId } from "../../lib/__tests__/branded.ts";
+import {
+  promptToRestartKernelForFileRootChange,
+  watchForConfigurationChanges,
+} from "../ReloadOnConfigChange.ts";
+
+it.scoped("runs the restart command only when selected", () =>
+  Effect.gen(function* () {
+    let acceptRestart = true;
+    const vscode = yield* TestVsCode.make({
+      window: {
+        showInformationMessage: (_message, options = {}) =>
+          Effect.succeed(
+            acceptRestart
+              ? Option.fromNullable(
+                  options.items?.find((item) => item === "Restart Kernel"),
+                )
+              : Option.none(),
+          ),
+      },
+    });
+    yield* promptToRestartKernelForFileRootChange().pipe(
+      Effect.provide(vscode.layer),
+    );
+    expect(yield* Ref.get(vscode.executions)).toContainEqual({
+      command: "marimo.restartKernel",
+      args: [],
+    });
+
+    acceptRestart = false;
+    yield* promptToRestartKernelForFileRootChange().pipe(
+      Effect.provide(vscode.layer),
+    );
+    expect(yield* Ref.get(vscode.executions)).toHaveLength(1);
+  }),
+);
+
+it.scoped(
+  "prompts when an affected inactive RuntimeSession becomes active",
+  () =>
+    Effect.gen(function* () {
+      const editor = TestVsCode.makeNotebookEditor("/project/notebook.py");
+      const id = notebookId(editor.notebook.uri.toString());
+      const prompts = yield* Ref.make(0);
+      const prompted = yield* Deferred.make<void>();
+      const activeEditor = yield* Ref.make<
+        Option.Option<vscode.NotebookEditor>
+      >(Option.none());
+      let resolveResourceChecked: (() => void) | undefined;
+      const resourceChecked = new Promise<void>((resolve) => {
+        resolveResourceChecked = resolve;
+      });
+      const configurationChange: vscode.ConfigurationChangeEvent = {
+        affectsConfiguration: (section, resource) => {
+          const affected =
+            section === "marimo.notebookFileRoot" &&
+            (resource === undefined ||
+              ("scheme" in resource &&
+                resource.scheme === editor.notebook.uri.scheme &&
+                resource.path === editor.notebook.uri.path));
+          if (affected && resource !== undefined) {
+            resolveResourceChecked?.();
+          }
+          return affected;
+        },
+      };
+      const vscode = yield* TestVsCode.make({
+        window: {
+          getActiveNotebookEditor: () => Ref.get(activeEditor),
+          activeNotebookEditorChanges: () =>
+            Stream.fromEffect(
+              Effect.promise(() => resourceChecked).pipe(
+                Effect.andThen(Ref.set(activeEditor, Option.some(editor))),
+                Effect.as(Option.some(editor)),
+              ),
+            ),
+          showInformationMessage: <T extends string>() =>
+            Ref.update(prompts, (count) => count + 1).pipe(
+              Effect.andThen(Deferred.succeed(prompted, undefined)),
+              Effect.as(Option.none<T>()),
+            ),
+        },
+        workspace: {
+          configurationChanges: () => Stream.make(configurationChange),
+        },
+      });
+      const session = {
+        executable: "/python",
+        workingDirectory: "/project",
+      };
+      const services = Layer.merge(
+        vscode.layer,
+        makeTestNotebookRuntime({
+          runtimeSession: session,
+          runtimeSessions: [{ notebookId: id, session }],
+        }),
+      );
+      yield* watchForConfigurationChanges().pipe(Effect.provide(services));
+
+      yield* Deferred.await(prompted);
+      expect(yield* Ref.get(prompts)).toBe(1);
+    }),
+);

--- a/extension/src/kernel/NotebookFileRoot.ts
+++ b/extension/src/kernel/NotebookFileRoot.ts
@@ -1,0 +1,115 @@
+import * as NodeFs from "node:fs";
+import * as NodeOs from "node:os";
+import * as NodePath from "node:path";
+
+import { Data, Effect, Option } from "effect";
+import type * as vscode from "vscode";
+
+export const DEFAULT_NOTEBOOK_FILE_ROOT = "${fileDirname}";
+
+export class NotebookFileRootError extends Data.TaggedError(
+  "NotebookFileRootError",
+)<{ readonly configuredValue: string; readonly message: string }> {}
+
+export interface NotebookFileRootResolution {
+  readonly path: string;
+  readonly usedFirstWorkspaceFallback: boolean;
+}
+
+interface ResolveNotebookFileRootOptions {
+  readonly configuredValue: string;
+  readonly notebookUri: vscode.Uri;
+  readonly workspaceFolders: Option.Option<readonly vscode.WorkspaceFolder[]>;
+  readonly homeDirectory?: string;
+}
+
+/** Resolve and validate the initial working directory for a notebook kernel. */
+export const resolveNotebookFileRoot = Effect.fn("resolveNotebookFileRoot")(
+  function* ({
+    configuredValue,
+    notebookUri,
+    workspaceFolders,
+    homeDirectory = NodeOs.homedir(),
+  }: ResolveNotebookFileRootOptions) {
+    const fail = (message: string) =>
+      new NotebookFileRootError({ configuredValue, message });
+    const value = configuredValue;
+    if (value.trim().length === 0) {
+      return yield* fail("The notebook file root cannot be empty.");
+    }
+
+    const folders = Option.getOrElse(workspaceFolders, () => []);
+    const isSaved = notebookUri.scheme === "file";
+    const notebookPath = isSaved ? notebookUri.fsPath : undefined;
+    const containingWorkspace =
+      notebookPath === undefined
+        ? undefined
+        : folders
+            .filter((folder) => containsPath(folder.uri.fsPath, notebookPath))
+            .toSorted(
+              (left, right) => right.uri.fsPath.length - left.uri.fsPath.length,
+            )[0];
+
+    let resolved: string;
+    let usedFirstWorkspaceFallback = false;
+    if (value === DEFAULT_NOTEBOOK_FILE_ROOT) {
+      if (notebookPath !== undefined) {
+        resolved = NodePath.dirname(notebookPath);
+      } else if (folders.length === 1) {
+        resolved = folders[0].uri.fsPath;
+      } else if (folders.length > 1) {
+        resolved = folders[0].uri.fsPath;
+        usedFirstWorkspaceFallback = true;
+      } else {
+        resolved = homeDirectory;
+      }
+    } else if (value === "${workspaceFolder}") {
+      if (containingWorkspace === undefined) {
+        return yield* fail(
+          "${workspaceFolder} is unavailable because the notebook is not inside a workspace folder.",
+        );
+      }
+      resolved = containingWorkspace.uri.fsPath;
+    } else if (/\$\{[^}]+\}/.test(value)) {
+      const variable = value.match(/\$\{[^}]+\}/)?.[0] ?? value;
+      return yield* fail(`Unsupported variable ${variable}.`);
+    } else if (value === "~" || /^~[\\/]/.test(value)) {
+      resolved =
+        value === "~"
+          ? homeDirectory
+          : NodePath.join(homeDirectory, value.slice(2));
+    } else if (value.startsWith("~")) {
+      return yield* fail(
+        "Only '~' or paths beginning with '~/' can use home-directory expansion.",
+      );
+    } else if (NodePath.isAbsolute(value)) {
+      resolved = value;
+    } else {
+      if (containingWorkspace === undefined) {
+        return yield* fail(
+          "Relative notebook file roots require the notebook to be inside a workspace folder.",
+        );
+      }
+      resolved = NodePath.resolve(containingWorkspace.uri.fsPath, value);
+    }
+
+    resolved = NodePath.normalize(resolved);
+    const stat = yield* Effect.tryPromise({
+      try: () => NodeFs.promises.stat(resolved),
+      catch: () => fail(`Notebook file root does not exist: ${resolved}`),
+    });
+    if (!stat.isDirectory()) {
+      return yield* fail(`Notebook file root is not a directory: ${resolved}`);
+    }
+
+    return { path: resolved, usedFirstWorkspaceFallback };
+  },
+);
+
+function containsPath(parent: string, child: string): boolean {
+  const relative = NodePath.relative(parent, child);
+  return (
+    relative === "" ||
+    (!relative.startsWith("..") && !NodePath.isAbsolute(relative))
+  );
+}

--- a/extension/src/kernel/NotebookRuntime.ts
+++ b/extension/src/kernel/NotebookRuntime.ts
@@ -49,6 +49,10 @@ import type {
 } from "../types.ts";
 import { CellExecutions } from "./CellExecutions.ts";
 import { resolveImageDataUri, saveImageToDisk } from "./imageResolver.ts";
+import {
+  NotebookFileRootError,
+  resolveNotebookFileRoot,
+} from "./NotebookFileRoot.ts";
 import { handleMissingPackageAlert } from "./operations.ts";
 
 type InnerRequest<K extends keyof MarimoClient> = MarimoClient[K] extends (
@@ -104,7 +108,14 @@ export interface NotebookHandle {
   readonly executeCells: (
     request: InnerRequest<"executeCells">,
     executable: string,
-  ) => ReturnType<MarimoClient["executeCells"]>;
+  ) => Effect.Effect<
+    null,
+    | MarimoClientStartError
+    | MarimoCommandError
+    | NoActiveKernelError
+    | NotebookFileRootError
+    | ParseResult.ParseError
+  >;
   readonly executeScratchpad: (
     code: string,
   ) => Stream.Stream<
@@ -113,6 +124,7 @@ export interface NotebookHandle {
     | MarimoClientStartError
     | MarimoCommandError
     | NoActiveKernelError
+    | NotebookFileRootError
     | ParseResult.ParseError
     | UnsavedNotebookError
   >;
@@ -138,6 +150,16 @@ export interface NotebookHandle {
 interface NotebookState {
   readonly handle: NotebookHandle;
   readonly controller: Ref.Ref<Option.Option<NotebookController>>;
+}
+
+export interface RuntimeSession {
+  readonly executable: string;
+  readonly workingDirectory: string;
+}
+
+export interface RuntimeSessionEntry {
+  readonly notebookId: NotebookId;
+  readonly session: RuntimeSession;
 }
 
 function hasRunId<T extends { run_id?: string | null }>(
@@ -196,11 +218,13 @@ export class NotebookRuntime extends Effect.Service<NotebookRuntime>()(
     ],
     scoped: Effect.gen(function* () {
       const code = yield* VsCode;
+      const config = yield* Config;
       const marimo = yield* MarimoClient;
       const renderer = yield* NotebookRenderer;
       const executions = yield* CellExecutions;
       const operations = yield* PubSub.unbounded<MarimoOperation>();
       const notebooks = new Map<NotebookId, NotebookState>();
+      const runtimeSessions = new Map<NotebookId, RuntimeSession>();
       const controllerSelections =
         yield* PubSub.unbounded<NotebookControllerSelection>();
 
@@ -219,10 +243,22 @@ export class NotebookRuntime extends Effect.Service<NotebookRuntime>()(
         id: notebookId,
         getController: () => Ref.get(controller),
         executeCells: (request, executable) =>
-          marimo.executeCells({
-            notebookUri: notebookId,
-            executable,
-            inner: request,
+          Effect.gen(function* () {
+            const workingDirectory = yield* resolveWorkingDirectory(
+              notebookId,
+              executable,
+            );
+            const result = yield* marimo.executeCells({
+              notebookUri: notebookId,
+              executable,
+              workingDirectory,
+              inner: request,
+            });
+            runtimeSessions.set(notebookId, {
+              executable,
+              workingDirectory,
+            });
+            return result;
           }),
         executeScratchpad: (sourceCode) =>
           Stream.unwrapScoped(
@@ -239,13 +275,22 @@ export class NotebookRuntime extends Effect.Service<NotebookRuntime>()(
               const notebook = yield* findOpenNotebook(notebookId);
               const executable =
                 yield* selectedController.value.resolveExecutable(notebook);
+              const workingDirectory = yield* resolveWorkingDirectory(
+                notebookId,
+                executable,
+              );
               const subscription = yield* PubSub.subscribe(operations);
               const runId = crypto.randomUUID();
 
               yield* marimo.executeScratchpad({
                 notebookUri: notebookId,
                 executable,
+                workingDirectory,
                 inner: { code: sourceCode, runId },
+              });
+              runtimeSessions.set(notebookId, {
+                executable,
+                workingDirectory,
               });
 
               yield* Effect.addFinalizer((exit) =>
@@ -303,7 +348,13 @@ export class NotebookRuntime extends Effect.Service<NotebookRuntime>()(
         interrupt: () =>
           marimo.interrupt({ notebookUri: notebookId, inner: {} }),
         close: () =>
-          marimo.closeSession({ notebookUri: notebookId, inner: {} }),
+          marimo
+            .closeSession({ notebookUri: notebookId, inner: {} })
+            .pipe(
+              Effect.tap(() =>
+                Effect.sync(() => runtimeSessions.delete(notebookId)),
+              ),
+            ),
       });
 
       const makeState = (notebookId: NotebookId): NotebookState => {
@@ -518,6 +569,33 @@ export class NotebookRuntime extends Effect.Service<NotebookRuntime>()(
         controllerChanges() {
           return Stream.fromPubSub(controllerSelections);
         },
+        getRuntimeSession(notebookId: NotebookId) {
+          return Effect.sync(() =>
+            Option.fromNullable(runtimeSessions.get(notebookId)),
+          );
+        },
+        getRuntimeSessions() {
+          return Effect.sync(() =>
+            Array.from(runtimeSessions, ([notebookId, session]) => ({
+              notebookId,
+              session,
+            })),
+          );
+        },
+        activeRuntimeSession() {
+          return Effect.gen(function* () {
+            const activeNotebook = Option.filterMap(
+              yield* code.window.getActiveNotebookEditor(),
+              (editor) => MarimoNotebookDocument.tryFrom(editor.notebook),
+            );
+            if (Option.isNone(activeNotebook)) {
+              return Option.none<RuntimeSession>();
+            }
+            return Option.fromNullable(
+              runtimeSessions.get(activeNotebook.value.id),
+            );
+          });
+        },
         forNotebook,
       };
 
@@ -534,6 +612,32 @@ export class NotebookRuntime extends Effect.Service<NotebookRuntime>()(
             return yield* new NoActiveKernelError({ notebookUri: notebookId });
           }
           return notebook.value;
+        });
+      }
+
+      function resolveWorkingDirectory(
+        notebookId: NotebookId,
+        executable: string,
+      ) {
+        return Effect.gen(function* () {
+          const session = runtimeSessions.get(notebookId);
+          if (session?.executable === executable) {
+            return session.workingDirectory;
+          }
+
+          const notebook = yield* findOpenNotebook(notebookId);
+          const configuredValue = yield* config.notebookFileRoot(notebook.uri);
+          const resolution = yield* resolveNotebookFileRoot({
+            configuredValue,
+            notebookUri: notebook.uri,
+            workspaceFolders: yield* code.workspace.getWorkspaceFolders(),
+          });
+          if (resolution.usedFirstWorkspaceFallback) {
+            yield* Effect.logInfo(
+              "Untitled notebook has multiple workspace folders; using the first for ${fileDirname}",
+            ).pipe(Effect.annotateLogs({ workingDirectory: resolution.path }));
+          }
+          return resolution.path;
         });
       }
     }),

--- a/extension/src/kernel/PythonController.ts
+++ b/extension/src/kernel/PythonController.ts
@@ -87,6 +87,20 @@ export const createPythonController = Effect.fn("createPythonController")(
           }),
           // Known exceptions
           Effect.catchTags({
+            NotebookFileRootError: Effect.fn(function* (error) {
+              yield* Effect.logError(error.message).pipe(
+                Effect.annotateLogs({ configuredValue: error.configuredValue }),
+              );
+              yield* code.window.showErrorMessage(error.message, {
+                modal: true,
+              });
+            }),
+            NoActiveKernelError: Effect.fn(function* () {
+              yield* code.window.showErrorMessage(
+                "The notebook was closed before its kernel could start.",
+                { modal: true },
+              );
+            }),
             MarimoCommandError: Effect.fn(function* (error) {
               yield* Effect.logError("Failed to execute command").pipe(
                 Effect.annotateLogs({

--- a/extension/src/kernel/SandboxController.ts
+++ b/extension/src/kernel/SandboxController.ts
@@ -129,6 +129,15 @@ export const createSandboxController = Effect.fn("createSandboxController")(
               }
             }),
           ),
+          Effect.catchTag("NotebookFileRootError", (error) =>
+            code.window.showErrorMessage(error.message, { modal: true }),
+          ),
+          Effect.catchTag("NoActiveKernelError", () =>
+            code.window.showErrorMessage(
+              "The notebook was closed before its kernel could start.",
+              { modal: true },
+            ),
+          ),
           // Log everything else
           Effect.tapErrorCause(Effect.logError),
           Effect.catchTag("UvExecutionError", () =>

--- a/extension/src/kernel/__tests__/NotebookFileRoot.test.ts
+++ b/extension/src/kernel/__tests__/NotebookFileRoot.test.ts
@@ -1,0 +1,169 @@
+import * as NodeFs from "node:fs";
+import * as NodeOs from "node:os";
+import * as NodePath from "node:path";
+
+import { expect, it } from "@effect/vitest";
+import { Effect, Exit, Option } from "effect";
+import type * as vscode from "vscode";
+
+import { Uri } from "../../__mocks__/TestVsCode.ts";
+import { resolveNotebookFileRoot } from "../NotebookFileRoot.ts";
+
+const folder = (path: string) =>
+  ({
+    uri: Uri.file(path),
+    name: NodePath.basename(path),
+    index: 0,
+  }) satisfies vscode.WorkspaceFolder;
+
+const withTree = <A, E>(
+  run: (paths: {
+    root: string;
+    nested: string;
+    spaced: string;
+    notebook: Uri;
+    file: string;
+  }) => Effect.Effect<A, E>,
+) =>
+  Effect.acquireUseRelease(
+    Effect.sync(() =>
+      NodeFs.mkdtempDisposableSync(
+        NodePath.join(NodeOs.tmpdir(), "marimo-file-root-"),
+      ),
+    ),
+    (temporary) =>
+      Effect.sync(() => {
+        const nested = NodePath.join(temporary.path, "nested");
+        const spaced = NodePath.join(temporary.path, " spaced ");
+        const notebookPath = NodePath.join(nested, "notebook.py");
+        const file = NodePath.join(temporary.path, "plain-file");
+        NodeFs.mkdirSync(nested);
+        NodeFs.mkdirSync(spaced);
+        NodeFs.writeFileSync(notebookPath, "");
+        NodeFs.writeFileSync(file, "");
+        return {
+          root: temporary.path,
+          nested,
+          spaced,
+          notebook: Uri.file(notebookPath),
+          file,
+        };
+      }).pipe(Effect.flatMap(run)),
+    (temporary) => Effect.sync(() => temporary.remove()),
+  );
+
+it.scoped("resolves all supported saved-notebook forms", () =>
+  withTree(({ root, nested, spaced, notebook }) =>
+    Effect.gen(function* () {
+      for (const [configuredValue, expected] of [
+        ["${fileDirname}", nested],
+        ["${workspaceFolder}", root],
+        ["nested", nested],
+        [nested, nested],
+        [spaced, spaced],
+        ["~/nested", nested],
+      ] as const) {
+        const result = yield* resolveNotebookFileRoot({
+          configuredValue,
+          notebookUri: notebook,
+          workspaceFolders: Option.some([folder(root)]),
+          homeDirectory: root,
+        });
+        expect(result.path).toBe(expected);
+      }
+    }),
+  ),
+);
+
+it.scoped("uses the most specific containing workspace", () =>
+  withTree(({ root, nested, notebook }) =>
+    Effect.gen(function* () {
+      const result = yield* resolveNotebookFileRoot({
+        configuredValue: "${workspaceFolder}",
+        notebookUri: notebook,
+        workspaceFolders: Option.some([folder(root), folder(nested)]),
+      });
+      expect(result.path).toBe(nested);
+    }),
+  ),
+);
+
+it.scoped("rejects unsupported variables and invalid directories", () =>
+  withTree(({ root, notebook, file }) =>
+    Effect.gen(function* () {
+      for (const configuredValue of [
+        "${unknown}",
+        NodePath.join(root, "missing"),
+        file,
+      ]) {
+        expect(
+          Exit.isFailure(
+            yield* Effect.exit(
+              resolveNotebookFileRoot({
+                configuredValue,
+                notebookUri: notebook,
+                workspaceFolders: Option.some([folder(root)]),
+              }),
+            ),
+          ),
+        ).toBe(true);
+      }
+    }),
+  ),
+);
+
+it.scoped("handles saved notebooks outside workspace folders", () =>
+  withTree(({ root, nested, notebook }) =>
+    Effect.gen(function* () {
+      const workspaceFolders = Option.some([
+        folder(NodePath.join(root, "elsewhere")),
+      ]);
+      expect(
+        (yield* resolveNotebookFileRoot({
+          configuredValue: "${fileDirname}",
+          notebookUri: notebook,
+          workspaceFolders,
+        })).path,
+      ).toBe(nested);
+
+      for (const configuredValue of ["${workspaceFolder}", "relative"]) {
+        expect(
+          Exit.isFailure(
+            yield* Effect.exit(
+              resolveNotebookFileRoot({
+                configuredValue,
+                notebookUri: notebook,
+                workspaceFolders,
+              }),
+            ),
+          ),
+        ).toBe(true);
+      }
+    }),
+  ),
+);
+
+it.scoped("uses the documented untitled default fallbacks", () =>
+  withTree(({ root, nested }) =>
+    Effect.gen(function* () {
+      const untitled = Uri.from({ scheme: "untitled", path: "Untitled-1" });
+      const cases = [
+        [Option.some([folder(root)]), root, false],
+        [Option.some([folder(root), folder(nested)]), root, true],
+        [Option.none<readonly vscode.WorkspaceFolder[]>(), nested, false],
+      ] as const;
+      for (const [workspaceFolders, expected, usedFallback] of cases) {
+        const result = yield* resolveNotebookFileRoot({
+          configuredValue: "${fileDirname}",
+          notebookUri: untitled,
+          workspaceFolders,
+          homeDirectory: nested,
+        });
+        expect(result).toEqual({
+          path: expected,
+          usedFirstWorkspaceFallback: usedFallback,
+        });
+      }
+    }),
+  ),
+);

--- a/extension/src/kernel/__tests__/NotebookRuntime.test.ts
+++ b/extension/src/kernel/__tests__/NotebookRuntime.test.ts
@@ -1,3 +1,7 @@
+import * as NodeFs from "node:fs";
+import * as NodeOs from "node:os";
+import * as NodePath from "node:path";
+
 import { assert, expect, it } from "@effect/vitest";
 import { Effect, Layer, Option, Ref, Schedule, Stream } from "effect";
 
@@ -17,8 +21,9 @@ const notebook = notebookId("notebook-a");
 
 const makeTestLayer = Effect.fn(function* (
   options: Parameters<typeof makeTestMarimoClient>[0] = {},
+  vscodeOptions: Parameters<typeof TestVsCode.make>[0] = {},
 ) {
-  const vscode = yield* TestVsCode.make();
+  const vscode = yield* TestVsCode.make(vscodeOptions);
   return {
     vscode,
     layer: Layer.empty.pipe(
@@ -36,7 +41,7 @@ it.scoped(
   "returns a stable handle that binds the notebook ID",
   Effect.fn(function* () {
     const requests = yield* Ref.make<ReadonlyArray<MarimoApiCall>>([]);
-    const { layer } = yield* makeTestLayer({
+    const { layer, vscode } = yield* makeTestLayer({
       execute: (request) =>
         Ref.update(requests, (current) => [...current, request]).pipe(
           Effect.as(null),
@@ -45,8 +50,13 @@ it.scoped(
 
     yield* Effect.gen(function* () {
       const notebooks = yield* NotebookRuntime;
-      const first = notebooks.forNotebook(notebook);
-      const second = notebooks.forNotebook(notebook);
+      const editor = TestVsCode.makeNotebookEditor(
+        NodePath.join(process.cwd(), "notebook.py"),
+      );
+      const id = notebookId(editor.notebook.uri.toString());
+      yield* vscode.addNotebookDocument(editor.notebook);
+      const first = notebooks.forNotebook(id);
+      const second = notebooks.forNotebook(id);
 
       expect(first).toBe(second);
 
@@ -59,21 +69,119 @@ it.scoped(
         {
           method: "execute-cells",
           params: {
-            notebookUri: notebook,
+            notebookUri: id,
             executable: "/usr/bin/python",
+            workingDirectory: process.cwd(),
             inner: { cellIds: [], codes: [] },
           },
         },
         {
           method: "interrupt",
           params: {
-            notebookUri: notebook,
+            notebookUri: id,
             inner: {},
           },
         },
       ]);
     }).pipe(Effect.provide(layer));
   }),
+);
+
+it.scoped("tracks RuntimeSession until a successful kernel close", () =>
+  Effect.acquireUseRelease(
+    Effect.sync(() =>
+      NodeFs.mkdtempDisposableSync(
+        NodePath.join(NodeOs.tmpdir(), "marimo-runtime-session-"),
+      ),
+    ),
+    (temporary) =>
+      Effect.gen(function* () {
+        const firstRoot = NodePath.join(temporary.path, "first");
+        const secondRoot = NodePath.join(temporary.path, "second");
+        NodeFs.mkdirSync(firstRoot);
+        NodeFs.mkdirSync(secondRoot);
+        let configuredRoot = firstRoot;
+        const editor = TestVsCode.makeNotebookEditor(
+          NodePath.join(temporary.path, "notebook.py"),
+        );
+        const id = notebookId(editor.notebook.uri.toString());
+        const requests = yield* Ref.make<ReadonlyArray<MarimoApiCall>>([]);
+        const { layer, vscode } = yield* makeTestLayer(
+          {
+            execute: (request) =>
+              Ref.update(requests, (current) => [...current, request]).pipe(
+                Effect.as(null),
+              ),
+          },
+          {
+            initialDocuments: [editor.notebook],
+            workspace: {
+              getConfiguration: (section) =>
+                Effect.succeed({
+                  // oxlint-disable-next-line typescript/no-unnecessary-type-parameters
+                  get: <T>(key: string) => {
+                    // oxlint-disable-next-line typescript/no-unsafe-type-assertion
+                    return (
+                      section === "marimo" && key === "notebookFileRoot"
+                        ? configuredRoot
+                        : undefined
+                    ) as T;
+                  },
+                  has: (key: string) =>
+                    section === "marimo" && key === "notebookFileRoot",
+                  inspect: () => undefined,
+                  async update() {},
+                }),
+            },
+          },
+        );
+
+        yield* Effect.gen(function* () {
+          const runtime = yield* NotebookRuntime;
+          const handle = runtime.forNotebook(id);
+          yield* handle.executeCells({ cellIds: [], codes: [] }, "/python-one");
+
+          configuredRoot = secondRoot;
+          yield* handle.executeCells({ cellIds: [], codes: [] }, "/python-one");
+          expect(yield* runtime.getRuntimeSession(id)).toEqual(
+            Option.some({
+              executable: "/python-one",
+              workingDirectory: firstRoot,
+            }),
+          );
+
+          yield* vscode.closeNotebook(editor.notebook);
+          yield* Effect.yieldNow();
+          expect(yield* runtime.getRuntimeSession(id)).toEqual(
+            Option.some({
+              executable: "/python-one",
+              workingDirectory: firstRoot,
+            }),
+          );
+
+          yield* runtime
+            .forNotebook(id)
+            .executeCells({ cellIds: [], codes: [] }, "/python-two");
+          yield* runtime.forNotebook(id).close();
+          expect(Option.isNone(yield* runtime.getRuntimeSession(id))).toBe(
+            true,
+          );
+
+          configuredRoot = firstRoot;
+          yield* runtime
+            .forNotebook(id)
+            .executeCells({ cellIds: [], codes: [] }, "/python-two");
+
+          const launches = (yield* Ref.get(requests)).filter(
+            (request) => request.method === "execute-cells",
+          );
+          expect(
+            launches.map((request) => request.params.workingDirectory),
+          ).toEqual([firstRoot, firstRoot, secondRoot, firstRoot]);
+        }).pipe(Effect.provide(layer));
+      }),
+    (temporary) => Effect.sync(() => temporary.remove()),
+  ),
 );
 
 it.scoped(

--- a/extension/src/kernel/__tests__/NotebookRuntimeOperations.test.ts
+++ b/extension/src/kernel/__tests__/NotebookRuntimeOperations.test.ts
@@ -1,3 +1,5 @@
+import * as NodePath from "node:path";
+
 import { assert, describe, expect, it } from "@effect/vitest";
 import {
   Chunk,
@@ -10,6 +12,7 @@ import {
   Ref,
   Schema,
   Stream,
+  SubscriptionRef,
   TestClock,
 } from "effect";
 
@@ -43,26 +46,31 @@ const withTestCtx = Effect.fn(function* () {
   const inputQueue = yield* Queue.unbounded<Option.Option<string>>();
 
   // Capture executeCommand calls
-  const executions = yield* Ref.make<ReadonlyArray<MarimoApiCall>>([]);
+  const executions = yield* SubscriptionRef.make<ReadonlyArray<MarimoApiCall>>(
+    [],
+  );
 
   // PubSub to push operations into NotebookRuntime
   const operationsPubSub =
     yield* PubSub.unbounded<MarimoLspNotificationOf<"marimo/operation">>();
 
-  const editor = TestVsCode.makeNotebookEditor("/test/notebook_mo.py", {
-    data: {
-      cells: [
-        {
-          kind: 1, // Code
-          value: "name = input('Enter name: ')",
-          languageId: "python",
-          metadata: MarimoNotebookCell.createMetadata({
-            marimoRuntime: { stableId: "cell-1" },
-          }),
-        },
-      ],
+  const editor = TestVsCode.makeNotebookEditor(
+    NodePath.join(process.cwd(), "notebook_mo.py"),
+    {
+      data: {
+        cells: [
+          {
+            kind: 1, // Code
+            value: "name = input('Enter name: ')",
+            languageId: "python",
+            metadata: MarimoNotebookCell.createMetadata({
+              marimoRuntime: { stableId: "cell-1" },
+            }),
+          },
+        ],
+      },
     },
-  });
+  );
 
   const notebook = MarimoNotebookDocument.from(editor.notebook);
   const notebookUri = notebook.id;
@@ -576,7 +584,7 @@ describe("NotebookRuntime scratch stream", () => {
     Effect.fn(function* () {
       const ctx = yield* withTestCtx();
       const otherEditor = TestVsCode.makeNotebookEditor(
-        "/test/other_notebook_mo.py",
+        NodePath.join(process.cwd(), "other_notebook_mo.py"),
       );
       const otherNotebook = MarimoNotebookDocument.from(otherEditor.notebook);
 
@@ -598,13 +606,21 @@ describe("NotebookRuntime scratch stream", () => {
             .pipe(Stream.runDrain),
         );
 
-        yield* TestClock.adjust("1 millis");
+        const executions = yield* ctx.executions.changes.pipe(
+          Stream.filter(
+            (calls) =>
+              calls.filter((call) => call.method === "execute-scratchpad")
+                .length === 2,
+          ),
+          Stream.runHead,
+          Effect.map(Option.getOrThrow),
+        );
 
         const commands: Array<{
           notebookUri: NotebookId;
           runId: string;
         }> = [];
-        for (const command of yield* Ref.get(ctx.executions)) {
+        for (const command of executions) {
           if (command.method === "execute-scratchpad") {
             const params = Schema.decodeUnknownSync(
               Api.ExecuteScratchpadPayload,
@@ -769,15 +785,10 @@ describe("NotebookRuntime scratch stream", () => {
         // The finalizer should have sent an interrupt to the kernel.
         const interruptCmd = executions.find((c) => c.method === "interrupt");
 
-        expect(interruptCmd).toMatchInlineSnapshot(`
-        	{
-        	  "method": "interrupt",
-        	  "params": {
-        	    "inner": {},
-        	    "notebookUri": "file:///test/notebook_mo.py",
-        	  },
-        	}
-        `);
+        expect(interruptCmd).toMatchObject({
+          method: "interrupt",
+          params: { inner: {}, notebookUri: ctx.notebookUri },
+        });
       }).pipe(Effect.provide(ctx.layer));
     }),
   );

--- a/extension/src/schemas/Models.gen.ts
+++ b/extension/src/schemas/Models.gen.ts
@@ -364,6 +364,9 @@ export const SessionCommand = <S extends Schema.Schema.Any>(inner: S) =>
     notebookUri: Schema.String,
     inner,
     executable: Schema.String,
+    workingDirectory: Schema.optionalWith(Schema.NullOr(Schema.String), {
+      default: () => null,
+    }),
   });
 
 /**
@@ -424,6 +427,9 @@ export const ExecuteCellsPayload = Schema.Struct({
   notebookUri: Schema.String,
   inner: ExecuteCellsRequest,
   executable: Schema.String,
+  workingDirectory: Schema.optionalWith(Schema.NullOr(Schema.String), {
+    default: () => null,
+  }),
 });
 
 export const UpdateUIElementRequest = Schema.Struct({
@@ -551,6 +557,9 @@ export const ExecuteScratchpadPayload = Schema.Struct({
   notebookUri: Schema.String,
   inner: ExecuteScratchRequest,
   executable: Schema.String,
+  workingDirectory: Schema.optionalWith(Schema.NullOr(Schema.String), {
+    default: () => null,
+  }),
 });
 
 export const PackageDescription = Schema.Struct({

--- a/extension/src/schemas/__tests__/Models.gen.test.ts
+++ b/extension/src/schemas/__tests__/Models.gen.test.ts
@@ -9,6 +9,7 @@ import {
   NotebookDocumentMetadata,
   PackageCommand,
   PackageSource,
+  SessionCommand,
   VenvSource,
 } from "../Models.gen.ts";
 
@@ -92,6 +93,17 @@ describe("Models.gen (msgspec → Effect Schema codegen)", () => {
     });
     expect(decoded.inner.query).toBe("polars");
     expect(decoded.source).toEqual({ kind: "script" });
+  });
+
+  it("keeps workingDirectory optional for older session clients", () => {
+    const command = SessionCommand(Schema.Struct({ code: Schema.String }));
+    expect(
+      Schema.decodeUnknownSync(command)({
+        notebookUri: "file:///nb.py",
+        executable: "/usr/bin/python",
+        inner: { code: "print(1)" },
+      }),
+    ).toMatchObject({ workingDirectory: null });
   });
 
   it("names structs in parse errors via identifier annotations", () => {

--- a/extension/src/telemetry/HealthService.ts
+++ b/extension/src/telemetry/HealthService.ts
@@ -5,6 +5,7 @@ import { Effect, Option } from "effect";
 
 import { Config } from "../config/Config.ts";
 import { MINIMUM_MARIMO_KERNEL_VERSION } from "../constants.ts";
+import { NotebookRuntime } from "../kernel/NotebookRuntime.ts";
 import { BinarySource } from "../lib/binaryResolution.ts";
 import { getExtensionVersion } from "../lib/getExtensionVersion.ts";
 import {
@@ -30,6 +31,7 @@ export class HealthService extends Effect.Service<HealthService>()(
       const uv = yield* Uv;
       const code = yield* VsCode;
       const config = yield* Config;
+      const notebooks = yield* NotebookRuntime;
       const pyExt = yield* PythonExtension;
       const tyLsp = yield* TyLanguageServer;
       const ruffLsp = yield* RuffLanguageServer;
@@ -179,6 +181,22 @@ export class HealthService extends Effect.Service<HealthService>()(
             `\tVersion: ${Option.getOrElse(extVersion, () => "unknown")} `,
           );
           lines.push(`\tUV integration disabled: ${uvDisabled} `);
+          const activeEditor = yield* code.window.getActiveNotebookEditor();
+          const configuredRoot = yield* config.notebookFileRoot(
+            Option.isSome(activeEditor)
+              ? activeEditor.value.notebook.uri
+              : undefined,
+          );
+          const runtimeSession = yield* notebooks.activeRuntimeSession();
+          lines.push(
+            ...formatNotebookFileRootDiagnostics(
+              configuredRoot,
+              Option.map(
+                runtimeSession,
+                ({ workingDirectory }) => workingDirectory,
+              ),
+            ),
+          );
 
           lines.push("");
 
@@ -271,4 +289,14 @@ function formatBinarySource(source: BinarySource): string {
       `CompanionExtension/${kind} (${extensionId}, ${path})`,
     UvInstalled: ({ path }) => `UvInstalled (${path})`,
   });
+}
+
+function formatNotebookFileRootDiagnostics(
+  configuredRoot: string,
+  workingDirectory: Option.Option<string>,
+): readonly string[] {
+  return [
+    `\tNotebook file root: ${configuredRoot}`,
+    `\tResolved kernel working directory: ${Option.getOrElse(workingDirectory, () => "No active kernel")}`,
+  ];
 }

--- a/src/marimo_lsp/api.py
+++ b/src/marimo_lsp/api.py
@@ -203,7 +203,9 @@ async def run(
     args: SessionCommand[ExecuteCellsRequest],
 ) -> None:
     logger.info(f"run for {args.notebook_uri}")
-    session = ctx.sessions.start(args.notebook_uri, args.executable)
+    session = ctx.sessions.start(
+        args.notebook_uri, args.executable, args.working_directory
+    )
 
     session.instantiate(
         InstantiateNotebookRequest(auto_run=False, object_ids=[], values=[]),
@@ -320,7 +322,9 @@ async def execute_scratch(
         )
         return
 
-    session = ctx.sessions.start(args.notebook_uri, args.executable)
+    session = ctx.sessions.start(
+        args.notebook_uri, args.executable, args.working_directory
+    )
 
     session.instantiate(
         InstantiateNotebookRequest(auto_run=False, object_ids=[], values=[]),

--- a/src/marimo_lsp/kernel_manager.py
+++ b/src/marimo_lsp/kernel_manager.py
@@ -28,6 +28,23 @@ if typing.TYPE_CHECKING:
 logger = get_logger()
 
 
+class InvalidWorkingDirectoryError(ValueError):
+    """The requested kernel working directory is unsafe or unavailable."""
+
+    def __init__(self, path: Path, reason: str) -> None:
+        message = f"Kernel working directory {reason}: {path}"
+        super().__init__(message)
+
+
+def _validate_working_directory(path: Path) -> None:
+    if not path.is_absolute():
+        raise InvalidWorkingDirectoryError(path, "must be absolute")
+    if not path.exists():
+        raise InvalidWorkingDirectoryError(path, "does not exist")
+    if not path.is_dir():
+        raise InvalidWorkingDirectoryError(path, "is not a directory")
+
+
 def launch_kernel(
     executable: str,
     args: ipc.KernelArgs,
@@ -85,7 +102,7 @@ def launch_kernel(
 class LspKernelManager(KernelManagerImpl):
     """Kernel manager for marimo-lsp."""
 
-    def __init__(
+    def __init__(  # noqa: PLR0913
         self,
         *,
         executable: str,
@@ -93,6 +110,7 @@ class LspKernelManager(KernelManagerImpl):
         app_file_manager: LspAppFileManager,
         config_manager: MarimoConfigManager,
         connection_info: ConnectionInfo,
+        working_directory: str | None = None,
     ) -> None:
         super().__init__(
             # NB: Leaky abstraction. Mode affects internal behavior of
@@ -120,15 +138,23 @@ class LspKernelManager(KernelManagerImpl):
         )
         self.executable = executable
         self.connection_info = connection_info
+        self.working_directory = working_directory
 
     def start_kernel(self) -> None:
         """Start an instance of the marimo kernel using ZeroMQ IPC."""
-        # Set the working directory to the notebook's directory
         notebook_dir = (
             Path(self.app_metadata.filename).parent
             if self.app_metadata.filename
             else None
         )
+        working_directory = (
+            Path(self.working_directory)
+            if self.working_directory is not None
+            else notebook_dir
+        )
+        if working_directory is not None:
+            _validate_working_directory(working_directory)
+        logger.info(f"Kernel working directory: {working_directory}")
         self.kernel_task = launch_kernel(
             executable=self.executable,
             args=ipc.KernelArgs(
@@ -139,7 +165,7 @@ class LspKernelManager(KernelManagerImpl):
                 log_level=GLOBAL_SETTINGS.LOG_LEVEL,
                 profile_path=self.profile_path,
             ),
-            cwd=str(notebook_dir) if notebook_dir else None,
+            cwd=str(working_directory) if working_directory else None,
         )
 
 

--- a/src/marimo_lsp/models.py
+++ b/src/marimo_lsp/models.py
@@ -55,6 +55,9 @@ class SessionCommand(NotebookCommand[T]):
     executable: str
     """The target environment Python executable."""
 
+    working_directory: str | None = None
+    """Optional absolute working directory for a newly launched kernel."""
+
 
 class VenvSource(msgspec.Struct, tag="venv", tag_field="kind", rename="camel"):
     """The notebook's environment is a concrete venv with a known python executable."""

--- a/src/marimo_lsp/sessions.py
+++ b/src/marimo_lsp/sessions.py
@@ -293,7 +293,12 @@ class Sessions:
         """Return the live session for a notebook, if one exists."""
         return self._sessions.get(notebook_uri)
 
-    def start(self, notebook_uri: str, executable: str) -> Session:
+    def start(
+        self,
+        notebook_uri: str,
+        executable: str,
+        working_directory: str | None = None,
+    ) -> Session:
         """Start or reuse the notebook's session.
 
         A different executable replaces the existing session only after the
@@ -304,13 +309,18 @@ class Sessions:
             current.attach()
             return current
 
-        replacement = self._create(notebook_uri, executable)
+        replacement = self._create(notebook_uri, executable, working_directory)
         self._sessions[notebook_uri] = replacement
         if current is not None:
             self._close(current, notebook_uri)
         return replacement
 
-    def _create(self, notebook_uri: str, executable: str) -> Session:
+    def _create(
+        self,
+        notebook_uri: str,
+        executable: str,
+        working_directory: str | None = None,
+    ) -> Session:
         ipc_queues, connection_info = IpcQueues.create()
         queue_manager = IpcQueueManager.from_ipc(ipc_queues)
         app_file_manager = LspAppFileManager(
@@ -324,6 +334,7 @@ class Sessions:
             app_file_manager=app_file_manager,
             config_manager=config_manager,
             connection_info=connection_info,
+            working_directory=working_directory,
         )
 
         logger.info(f"Starting session for {notebook_uri}")

--- a/tests/test_kernel_manager.py
+++ b/tests/test_kernel_manager.py
@@ -1,0 +1,74 @@
+# Copyright 2026 Marimo. All rights reserved.
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+from unittest.mock import Mock
+
+import pytest
+
+from marimo_lsp.kernel_manager import LspKernelManager
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _manager(notebook: Path, working_directory: str | None) -> LspKernelManager:
+    manager = LspKernelManager.__new__(LspKernelManager)
+    manager.executable = "/usr/bin/python"
+    manager.connection_info = Mock()
+    manager.configs = {}
+    manager.app_metadata = SimpleNamespace(filename=str(notebook))
+    manager.config_manager = Mock()
+    manager.config_manager.get_config.return_value = {}
+    manager.working_directory = working_directory
+    return manager
+
+
+def test_supplied_working_directory_reaches_launch_kernel(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    launch = Mock(return_value=Mock())
+    monkeypatch.setattr("marimo_lsp.kernel_manager.launch_kernel", launch)
+    selected = tmp_path / "selected"
+    selected.mkdir()
+
+    manager = _manager(tmp_path / "notebook.py", str(selected))
+    manager.start_kernel()
+
+    assert launch.call_args.kwargs["cwd"] == str(selected)
+
+
+def test_omitted_working_directory_uses_notebook_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    launch = Mock(return_value=Mock())
+    monkeypatch.setattr("marimo_lsp.kernel_manager.launch_kernel", launch)
+
+    manager = _manager(tmp_path / "notebook.py", None)
+    manager.start_kernel()
+
+    assert launch.call_args.kwargs["cwd"] == str(tmp_path)
+
+
+@pytest.mark.parametrize("kind", ["relative", "missing", "file"])
+def test_invalid_working_directory_is_rejected(
+    kind: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    launch = Mock(return_value=Mock())
+    monkeypatch.setattr("marimo_lsp.kernel_manager.launch_kernel", launch)
+    if kind == "relative":
+        selected = "relative/path"
+    elif kind == "missing":
+        selected = str(tmp_path / "missing")
+    else:
+        file = tmp_path / "file"
+        file.write_text("")
+        selected = str(file)
+
+    manager = _manager(tmp_path / "notebook.py", selected)
+    with pytest.raises(ValueError, match="working directory"):
+        manager.start_kernel()
+
+    launch.assert_not_called()

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -185,6 +185,22 @@ def test_start_reuses_session_with_same_executable() -> None:
     sessions._create.assert_not_called()
 
 
+def test_start_reuses_same_executable_despite_new_working_directory() -> None:
+    sessions = Sessions(Mock())
+    current = Mock(spec=Session)
+    current.executable = "/usr/bin/python"
+    sessions._sessions["file:///test.py"] = current
+    sessions._create = Mock()
+
+    result = sessions.start(
+        "file:///test.py", "/usr/bin/python", "/new/working/directory"
+    )
+
+    assert result is current
+    current.attach.assert_called_once_with()
+    sessions._create.assert_not_called()
+
+
 def test_start_replaces_session_after_replacement_starts() -> None:
     sessions = Sessions(Mock())
     current = Mock(spec=Session)


### PR DESCRIPTION
Closes #343 

Adds `marimo.notebookFileRoot`:

```json
{
  "marimo.notebookFileRoot": "${workspaceFolder}"
}
```

This resource-scoped setting controls the initial working directory of locally launched marimo kernels. It supports `${fileDirname}`, `${workspaceFolder}`, home-relative paths, absolute paths, and paths relative to the notebook’s containing workspace folder. The default remains `${fileDirname}`, preserving the existing behavior.

The extension resolves and validates the directory when starting a runtime session, then keeps it fixed for that session. Changing the setting prompts the user to restart the kernel instead of silently replacing it or changing its working directory. The resolved directory is sent to marimo-lsp, validated again, and used as the kernel process cwd.