### PR TITLE
Give editor-created setup cells the reserved id

### DIFF
--- a/extension/src/commands/createSetupCell.ts
+++ b/extension/src/commands/createSetupCell.ts
@@ -1,6 +1,7 @@
 import { Effect, Option } from "effect";
 
 import { SETUP_CELL_NAME } from "../constants.ts";
+import { Constants } from "../platform/Constants.ts";
 import { VsCode } from "../platform/VsCode.ts";
 import {
   MarimoNotebookCell,
@@ -9,6 +10,7 @@ import {
 
 export const createSetupCell = Effect.fn(function* () {
   const code = yield* VsCode;
+  const { LanguageId } = yield* Constants;
   const notebook = Option.filterMap(
     yield* code.window.getActiveNotebookEditor(),
     (editor) => MarimoNotebookDocument.tryFrom(editor.notebook),
@@ -47,10 +49,15 @@ export const createSetupCell = Effect.fn(function* () {
     const cell = new code.NotebookCellData(
       code.NotebookCellKind.Code,
       "# Initialization code that runs before all other cells",
-      "python",
+      LanguageId.Python,
     );
     cell.metadata = MarimoNotebookCell.createMetadata({
       marimo: { name: SETUP_CELL_NAME },
+      // marimo reserves the cell id "setup" for the setup cell: file
+      // deserialization assigns it, and the kernel keys its setup-cell
+      // semantics (auto-run-as-root when stale) on that exact id. A random
+      // UUID here would leave the cell an ordinary cell until reopen.
+      marimoRuntime: { stableId: SETUP_CELL_NAME },
     });
     edit.set(notebook.value.uri, [code.NotebookEdit.insertCells(0, [cell])]);
     yield* code.workspace.applyEdit(edit);

--- a/extension/src/kernel/NotebookRuntime.ts
+++ b/extension/src/kernel/NotebookRuntime.ts
@@ -18,7 +18,7 @@ import type * as vscode from "vscode";
 
 import { unreachable } from "../assert.ts";
 import { Config } from "../config/Config.ts";
-import { SCRATCH_CELL_ID } from "../constants.ts";
+import { SCRATCH_CELL_ID, SETUP_CELL_NAME } from "../constants.ts";
 import { showErrorAndPromptLogs } from "../lib/showErrorAndPromptLogs.ts";
 import {
   MarimoClient,
@@ -990,11 +990,16 @@ function syncCellIdentity(
         if (Option.isSome(cell.id)) {
           addedCellIds.add(cell.id.value);
         } else {
+          // marimo reserves the cell id "setup" for the setup cell: the
+          // kernel keys its setup-cell semantics on that exact id, and file
+          // deserialization assigns it. Any other cell gets a fresh UUID.
+          const isSetupCell =
+            Option.isSome(cell.name) && cell.name.value === SETUP_CELL_NAME;
           edits.push(
             options.code.NotebookEdit.updateCellMetadata(
               cell.index,
               cell.buildRuntimeMetadataForInsertion({
-                stableId: crypto.randomUUID(),
+                stableId: isSetupCell ? SETUP_CELL_NAME : crypto.randomUUID(),
               }),
             ),
           );


### PR DESCRIPTION
Closes #625

marimo reserves the cell id "setup" and keys its setup-cell semantics on it, but the extension gave UI-created setup cells a random UUID. The kernel treated them as ordinary cells, and their identity silently changed when the file was reopened, so the setup cell only started behaving correctly after a kernel restart. Setup cells now always get the reserved id (and the extension cell language id) wherever they are created, matching setup cells loaded from a file.