### PR TITLE
Track live control requests in session snapshots

### DIFF
--- a/src/marimo_lsp/sessions.py
+++ b/src/marimo_lsp/sessions.py
@@ -204,6 +204,7 @@ class Session:
     ) -> None:
         """Send a command to the kernel."""
         del from_consumer_id
+        self.session_view.add_control_request(request)
         self._queue_manager.put_control_request(request)
 
     def _effective_runtime(self, config: MarimoConfig) -> MarimoConfig:

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -18,6 +18,7 @@ from marimo._runtime.commands import (
     UpdateUserConfigCommand,
 )
 from marimo._session.managers import IPCQueueManagerImpl
+from marimo._session.state.session_view import SessionView
 from marimo._types.ids import CellId_t, RequestId, UIElementId
 
 from marimo_lsp.sessions import Session, Sessions, _OperationSink
@@ -27,6 +28,7 @@ def _make_session() -> tuple[Session, Mock]:
     session = Session.__new__(Session)
     ipc_queue_manager = Mock()
     session._queue_manager = IPCQueueManagerImpl.from_ipc(ipc_queue_manager)
+    session.session_view = SessionView()
     return session, ipc_queue_manager
 
 
@@ -39,6 +41,17 @@ def test_ui_element_updates_use_marimo_ipc_batching_route() -> None:
     queue_manager.control_queue.put.assert_called_once_with(command)
     queue_manager.set_ui_element_queue.put.assert_called_once_with(command)
     queue_manager.completion_queue.put.assert_not_called()
+
+
+def test_control_requests_update_live_session_snapshot() -> None:
+    session, _queue_manager = _make_session()
+    session.session_view.mark_auto_export_html()
+    command = UpdateUIElementCommand(object_ids=[UIElementId("slider")], values=[1])
+
+    session.put_control_request(command, from_consumer_id=None)
+
+    assert session.session_view.ui_values == {UIElementId("slider"): 1}
+    assert session.session_view.needs_export("html")
 
 
 def test_regular_commands_are_routed_to_control_queue_only() -> None:


### PR DESCRIPTION
Record each control request in `SessionView` before forwarding it to the kernel. This keeps the language server snapshot aligned with UI value changes and lets marimo mark configured automatic exports dirty through its existing session state.

The request still follows the normal IPC route. Tests cover the snapshot update and export invalidation without changing command delivery.

Fixes #181.
Fixes #540.
