### PR TITLE
Automatically export configured notebooks

### DIFF
--- a/extension/src/__mocks__/TestVsCode.ts
+++ b/extension/src/__mocks__/TestVsCode.ts
@@ -1909,6 +1909,9 @@ export class TestVsCode extends Data.TaggedClass("TestVsCode")<{
         }),
         workspace: Workspace.make({
           fs: {
+            createDirectory() {
+              return Effect.void;
+            },
             readFile(uri: vscode.Uri) {
               const fileSystem: Map<string, Uint8Array | Error> =
                 options.fileSystem ?? new Map();

--- a/extension/src/features/AutoExport.ts
+++ b/extension/src/features/AutoExport.ts
@@ -1,0 +1,259 @@
+import * as NodePath from "node:path";
+
+import { Effect, HashMap, Layer, Option, Ref, Schema, Stream } from "effect";
+import type * as vscode from "vscode";
+
+import { NotebookRuntime } from "../kernel/NotebookRuntime.ts";
+import { MarimoClient } from "../lsp/MarimoClient.ts";
+import { VsCode } from "../platform/VsCode.ts";
+import {
+  MarimoNotebookDocument,
+  type NotebookId,
+} from "../schemas/MarimoNotebookDocument.ts";
+
+export const AUTO_EXPORT_INTERVAL = "5 seconds";
+
+export type AutoExportFormat = "html" | "ipynb";
+
+interface AutoExportState {
+  readonly incarnation: object;
+  readonly generation: number;
+  readonly exported: Readonly<Record<AutoExportFormat, number>>;
+}
+
+const initialState = (): AutoExportState => ({
+  incarnation: {},
+  generation: 0,
+  exported: { html: -1, ipynb: -1 },
+});
+
+export function autoExportUri(
+  code: VsCode,
+  notebook: MarimoNotebookDocument,
+  format: AutoExportFormat,
+) {
+  const basename = NodePath.posix.basename(notebook.uri.path);
+  const extension = NodePath.posix.extname(basename);
+  const stem =
+    extension.length > 0 ? basename.slice(0, -extension.length) : basename;
+  return code.Uri.joinPath(
+    notebook.uri,
+    "..",
+    "__marimo__",
+    `${stem}.${format}`,
+  );
+}
+
+function marimoNotebooks(editors: ReadonlyArray<vscode.NotebookEditor>) {
+  const notebooks = editors.flatMap((editor) =>
+    Option.toArray(MarimoNotebookDocument.tryFrom(editor.notebook)),
+  );
+  return [
+    ...new Map(notebooks.map((notebook) => [notebook.id, notebook])).values(),
+  ];
+}
+
+export const AutoExportLive = Layer.scopedDiscard(
+  Effect.gen(function* () {
+    const code = yield* VsCode;
+    const marimo = yield* MarimoClient;
+    const runtime = yield* NotebookRuntime;
+    const states = yield* Ref.make(
+      HashMap.empty<NotebookId, AutoExportState>(),
+    );
+
+    const getOrCreateState = (notebookId: NotebookId) =>
+      Ref.modify(states, (current) =>
+        Option.match(HashMap.get(current, notebookId), {
+          onNone: () => {
+            const state = initialState();
+            return [state, HashMap.set(current, notebookId, state)];
+          },
+          onSome: (state) => [state, current],
+        }),
+      );
+
+    const markDirty = (notebookId: NotebookId) =>
+      Ref.update(states, (current) =>
+        HashMap.modifyAt(current, notebookId, (state) => {
+          const value = Option.getOrElse(state, initialState);
+          return Option.some({ ...value, generation: value.generation + 1 });
+        }),
+      );
+
+    const markExported = (
+      notebookId: NotebookId,
+      format: AutoExportFormat,
+      exportedState: AutoExportState,
+    ) =>
+      Ref.update(states, (current) =>
+        HashMap.modifyAt(current, notebookId, (state) =>
+          Option.filter(state, (value) =>
+            Object.is(value.incarnation, exportedState.incarnation),
+          ).pipe(
+            Option.map((value) => ({
+              ...value,
+              exported: {
+                ...value.exported,
+                [format]: exportedState.generation,
+              },
+            })),
+          ),
+        ),
+      );
+
+    const visibleNotebooks = Stream.concat(
+      Stream.fromEffect(code.window.getVisibleNotebookEditors()),
+      code.window.visibleNotebookEditorsChanges(),
+    ).pipe(Stream.map(marimoNotebooks));
+
+    yield* Effect.forkScoped(
+      visibleNotebooks.pipe(
+        Stream.runForEach((notebooks) =>
+          Effect.forEach(notebooks, (notebook) => markDirty(notebook.id), {
+            discard: true,
+          }),
+        ),
+      ),
+    );
+
+    yield* Effect.forkScoped(
+      marimo
+        .operations()
+        .pipe(Stream.runForEach((message) => markDirty(message.notebookUri))),
+    );
+
+    yield* Effect.forkScoped(
+      code.workspace.notebookDocumentChanges().pipe(
+        Stream.filterMap((event) =>
+          MarimoNotebookDocument.tryFrom(event.notebook),
+        ),
+        Stream.runForEach((notebook) => markDirty(notebook.id)),
+      ),
+    );
+
+    yield* Effect.forkScoped(
+      code.workspace.notebookDocumentClosed().pipe(
+        Stream.filterMap((document) =>
+          MarimoNotebookDocument.tryFrom(document),
+        ),
+        Stream.runForEach((notebook) =>
+          Ref.update(states, HashMap.remove(notebook.id)),
+        ),
+      ),
+    );
+
+    yield* Effect.forkScoped(
+      Stream.tick(AUTO_EXPORT_INTERVAL).pipe(
+        Stream.runForEach(() =>
+          Effect.gen(function* () {
+            const editors = yield* code.window.getVisibleNotebookEditors();
+            yield* Effect.forEach(marimoNotebooks(editors), exportNotebook, {
+              concurrency: "unbounded",
+              discard: true,
+            });
+          }),
+        ),
+      ),
+    );
+
+    function exportNotebook(notebook: MarimoNotebookDocument) {
+      return Effect.gen(function* () {
+        if (notebook.isUntitled) return;
+
+        const metadata = yield* notebook.parseMetadata();
+        const enabled = metadata.appConfig.auto_download;
+        const formats = (["html", "ipynb"] as const).filter((format) =>
+          enabled.includes(format),
+        );
+        if (formats.length === 0) return;
+
+        const controller = yield* runtime
+          .forNotebook(notebook.id)
+          .getController();
+        if (Option.isNone(controller)) return;
+
+        const state = yield* getOrCreateState(notebook.id);
+        const pendingFormats = formats.filter((format) => {
+          if (state.exported[format] >= state.generation) return false;
+          return (
+            format !== "html" ||
+            notebook.getCells().some((cell) => cell.outputs.length > 0)
+          );
+        });
+        if (pendingFormats.length === 0) return;
+
+        const outputDirectory = code.Uri.joinPath(
+          notebook.uri,
+          "..",
+          "__marimo__",
+        );
+        yield* code.workspace.fs.createDirectory(outputDirectory);
+        yield* Effect.forEach(
+          pendingFormats,
+          (format) => {
+            return exportFormat(notebook, format).pipe(
+              Effect.andThen(markExported(notebook.id, format, state)),
+              Effect.catchAll((error) =>
+                Effect.logWarning(
+                  "Failed to automatically export notebook",
+                ).pipe(
+                  Effect.annotateLogs({
+                    error,
+                    format,
+                    notebook: notebook.id,
+                  }),
+                ),
+              ),
+            );
+          },
+          { discard: true },
+        );
+      }).pipe(
+        Effect.catchAll((error) =>
+          Effect.logWarning("Failed to process notebook for auto-export").pipe(
+            Effect.annotateLogs({ error, notebook: notebook.id }),
+          ),
+        ),
+      );
+    }
+
+    function exportFormat(
+      notebook: MarimoNotebookDocument,
+      format: AutoExportFormat,
+    ) {
+      const content =
+        format === "html"
+          ? marimo.exportAsHtml({
+              notebookUri: notebook.id,
+              inner: {
+                download: false,
+                files: [],
+                includeCode: true,
+                assetUrl: null,
+              },
+            })
+          : marimo.exportAsIpynb({
+              notebookUri: notebook.id,
+              inner: {},
+            });
+
+      const uri = autoExportUri(code, notebook, format);
+      return content.pipe(
+        Effect.andThen(Schema.decodeUnknown(Schema.String)),
+        Effect.flatMap((value) =>
+          code.workspace.fs.writeFile(uri, new TextEncoder().encode(value)),
+        ),
+        Effect.tap(() =>
+          Effect.logInfo("Automatically exported notebook").pipe(
+            Effect.annotateLogs({
+              format,
+              notebook: notebook.id,
+              output: uri.toString(),
+            }),
+          ),
+        ),
+      );
+    }
+  }),
+);

--- a/extension/src/features/Main.ts
+++ b/extension/src/features/Main.ts
@@ -47,6 +47,7 @@ import { StatusBar } from "../statusbar/StatusBar.ts";
 import { HealthService } from "../telemetry/HealthService.ts";
 import type { Sentry } from "../telemetry/Sentry.ts";
 import type { Telemetry } from "../telemetry/Telemetry.ts";
+import { AutoExportLive } from "./AutoExport.ts";
 import { CellMetadataBindingsLive } from "./CellMetadataBindings.ts";
 import { CellStatusBarProviderLive } from "./CellStatusBarProvider.ts";
 import { DebugLayerLive } from "./DebugLayer.ts";
@@ -76,6 +77,7 @@ const MainLive = Layer.empty
     Layer.merge(PackagesViewLive),
     Layer.merge(CellStatusBarProviderLive),
     Layer.merge(CellMetadataBindingsLive),
+    Layer.merge(AutoExportLive),
     Layer.merge(ReloadOnConfigChangeLive),
     Layer.merge(ThemeSyncLive),
     Layer.merge(HideCodeSyncLive),

--- a/extension/src/features/__tests__/AutoExport.test.ts
+++ b/extension/src/features/__tests__/AutoExport.test.ts
@@ -1,0 +1,297 @@
+import { describe, expect, it } from "@effect/vitest";
+import {
+  Deferred,
+  Effect,
+  Fiber,
+  Layer,
+  Option,
+  PubSub,
+  Ref,
+  Stream,
+  TestClock,
+} from "effect";
+
+import { TestVsCode } from "../../__mocks__/TestVsCode.ts";
+import { makeTestNotebookRuntime } from "../../__tests__/__utils__/TestMarimoClient.ts";
+import type { NotebookController } from "../../kernel/NotebookRuntime.ts";
+import { FileSystemError, VsCode } from "../../platform/VsCode.ts";
+import {
+  MarimoNotebookCell,
+  MarimoNotebookDocument,
+} from "../../schemas/MarimoNotebookDocument.ts";
+import type { MarimoApiCall, MarimoOperation } from "../../types.ts";
+import {
+  AUTO_EXPORT_INTERVAL,
+  AutoExportLive,
+  autoExportUri,
+} from "../AutoExport.ts";
+
+const controller: NotebookController = {
+  id: "test-controller",
+  createNotebookCellExecution() {
+    throw new Error("not used");
+  },
+  resolveExecutable: () => Effect.succeed("/usr/bin/python"),
+};
+
+const withTestCtx = Effect.fn(function* (
+  options: {
+    readonly execute?: (request: MarimoApiCall) => Effect.Effect<string>;
+    readonly hasOutputs?: boolean;
+  } = {},
+) {
+  const calls = yield* Ref.make<ReadonlyArray<MarimoApiCall>>([]);
+  const writes = yield* Ref.make<ReadonlyMap<string, string>>(new Map());
+  const directories = yield* Ref.make<ReadonlyArray<string>>([]);
+  const operations = yield* PubSub.unbounded<MarimoOperation>();
+
+  const output = {
+    items: [
+      {
+        data: new TextEncoder().encode("2"),
+        mime: "text/plain",
+      },
+    ],
+  };
+  const cellOutputs = options.hasOutputs === false ? [] : [output];
+  const editor = TestVsCode.makeNotebookEditor("/test/report.py", {
+    data: {
+      metadata: MarimoNotebookDocument.createMetadata({
+        appConfig: { auto_download: ["html", "ipynb"] },
+      }),
+      cells: [
+        {
+          kind: 2,
+          value: "1 + 1",
+          languageId: "python",
+          metadata: MarimoNotebookCell.createMetadata({
+            marimoRuntime: { stableId: "cell-1" },
+          }),
+          outputs: cellOutputs,
+        },
+      ],
+    },
+  });
+  const notebook = MarimoNotebookDocument.from(editor.notebook);
+
+  const vscode = yield* TestVsCode.make({
+    initialDocuments: [editor.notebook],
+    workspace: {
+      fs: {
+        createDirectory: (uri) =>
+          Ref.update(directories, (current) => [...current, uri.toString()]),
+        readFile: (uri) =>
+          Effect.fail(
+            new FileSystemError({
+              cause: new Error(`ENOENT: ${uri.toString()}`),
+            }),
+          ),
+        writeFile: (uri, contents) =>
+          Ref.update(writes, (current) => {
+            const next = new Map(current);
+            next.set(uri.toString(), new TextDecoder().decode(contents));
+            return next;
+          }),
+      },
+    },
+  });
+
+  const runtime = makeTestNotebookRuntime({
+    initialControllers: [{ notebookUri: notebook.id, controller }],
+    operations: () => Stream.fromPubSub(operations),
+    execute: (request) =>
+      Ref.update(calls, (current) => [...current, request]).pipe(
+        Effect.andThen(
+          options.execute?.(request) ??
+            Effect.succeed(
+              request.method === "export-as-html"
+                ? "<html>report</html>"
+                : "{}",
+            ),
+        ),
+      ),
+  });
+
+  const layer = AutoExportLive.pipe(
+    Layer.provide(runtime),
+    Layer.provide(vscode.layer),
+  );
+
+  return {
+    calls,
+    cellOutputs,
+    directories,
+    editor,
+    layer,
+    notebook,
+    operations,
+    vscode,
+    writes,
+  };
+});
+
+describe("autoExportUri", () => {
+  it.scoped(
+    "writes beside the notebook under __marimo__",
+    Effect.fn(function* () {
+      const ctx = yield* withTestCtx();
+      const uri = yield* Effect.gen(function* () {
+        const code = yield* VsCode;
+        return autoExportUri(code, ctx.notebook, "html");
+      }).pipe(Effect.provide(ctx.vscode.layer));
+
+      expect(uri.path).toBe("/test/__marimo__/report.html");
+    }),
+  );
+});
+
+describe("AutoExport", () => {
+  it.scoped(
+    "exports enabled formats once per live-session generation",
+    Effect.fn(function* () {
+      const ctx = yield* withTestCtx();
+
+      yield* Effect.gen(function* () {
+        yield* ctx.vscode.setActiveNotebookEditor(Option.some(ctx.editor));
+        yield* TestClock.adjust(AUTO_EXPORT_INTERVAL);
+
+        expect((yield* ctx.calls).map((call) => call.method)).toEqual([
+          "export-as-html",
+          "export-as-ipynb",
+        ]);
+        expect(Object.fromEntries(yield* ctx.writes)).toEqual({
+          "file:///test/__marimo__/report.html": "<html>report</html>",
+          "file:///test/__marimo__/report.ipynb": "{}",
+        });
+        expect(yield* ctx.directories).toEqual(["file:///test/__marimo__"]);
+
+        yield* TestClock.adjust(AUTO_EXPORT_INTERVAL);
+        expect(yield* ctx.calls).toHaveLength(2);
+
+        yield* PubSub.publish(ctx.operations, {
+          notebookUri: ctx.notebook.id,
+          operation: { op: "completed-run", run_id: null },
+        });
+        yield* TestClock.adjust(AUTO_EXPORT_INTERVAL);
+        expect((yield* ctx.calls).map((call) => call.method)).toEqual([
+          "export-as-html",
+          "export-as-ipynb",
+          "export-as-html",
+          "export-as-ipynb",
+        ]);
+      }).pipe(Effect.provide(ctx.layer));
+    }),
+  );
+
+  it.scoped(
+    "exports a notebook once when it has multiple visible editors",
+    Effect.fn(function* () {
+      const ctx = yield* withTestCtx();
+
+      yield* Effect.gen(function* () {
+        yield* ctx.vscode.setActiveNotebookEditor(Option.some(ctx.editor));
+        yield* ctx.vscode.setActiveNotebookEditor(Option.some(ctx.editor));
+        yield* TestClock.adjust(AUTO_EXPORT_INTERVAL);
+
+        expect((yield* ctx.calls).map((call) => call.method)).toEqual([
+          "export-as-html",
+          "export-as-ipynb",
+        ]);
+      }).pipe(Effect.provide(ctx.layer));
+    }),
+  );
+
+  it.scoped(
+    "waits for cell output before exporting HTML",
+    Effect.fn(function* () {
+      const ctx = yield* withTestCtx({ hasOutputs: false });
+
+      yield* Effect.gen(function* () {
+        yield* ctx.vscode.setActiveNotebookEditor(Option.some(ctx.editor));
+        yield* TestClock.adjust(AUTO_EXPORT_INTERVAL);
+        expect((yield* ctx.calls).map((call) => call.method)).toEqual([
+          "export-as-ipynb",
+        ]);
+
+        ctx.cellOutputs.push({
+          items: [
+            {
+              data: new TextEncoder().encode("2"),
+              mime: "text/plain",
+            },
+          ],
+        });
+        yield* PubSub.publish(ctx.operations, {
+          notebookUri: ctx.notebook.id,
+          operation: { op: "completed-run", run_id: null },
+        });
+        yield* TestClock.adjust(AUTO_EXPORT_INTERVAL);
+
+        expect((yield* ctx.calls).map((call) => call.method)).toEqual([
+          "export-as-ipynb",
+          "export-as-html",
+          "export-as-ipynb",
+        ]);
+      }).pipe(Effect.provide(ctx.layer));
+    }),
+  );
+
+  it.scoped(
+    "does not credit an in-flight export to a reopened notebook",
+    Effect.fn(function* () {
+      const exportStarted = yield* Deferred.make<void>();
+      const releaseExport = yield* Deferred.make<void>();
+      const ctx = yield* withTestCtx({
+        execute: (request) =>
+          request.method === "export-as-html"
+            ? Deferred.succeed(exportStarted, undefined).pipe(
+                Effect.andThen(Deferred.await(releaseExport)),
+                Effect.as("<html>old report</html>"),
+              )
+            : Effect.succeed("{}"),
+      });
+
+      yield* Effect.gen(function* () {
+        yield* ctx.vscode.setActiveNotebookEditor(Option.some(ctx.editor));
+        const firstTick = yield* Effect.fork(
+          TestClock.adjust(AUTO_EXPORT_INTERVAL),
+        );
+        yield* Deferred.await(exportStarted);
+
+        yield* ctx.vscode.closeNotebook(ctx.editor.notebook);
+        yield* Effect.yieldNow();
+        const reopened = TestVsCode.makeNotebookEditor("/test/report.py", {
+          data: {
+            metadata: MarimoNotebookDocument.createMetadata({
+              appConfig: { auto_download: ["html", "ipynb"] },
+            }),
+            cells: [
+              {
+                kind: 2,
+                value: "2 + 2",
+                languageId: "python",
+                metadata: MarimoNotebookCell.createMetadata({
+                  marimoRuntime: { stableId: "cell-1" },
+                }),
+                outputs: ctx.cellOutputs,
+              },
+            ],
+          },
+        });
+        yield* ctx.vscode.setActiveNotebookEditor(Option.some(reopened));
+        yield* Effect.yieldNow();
+
+        yield* Deferred.succeed(releaseExport, undefined);
+        yield* Fiber.join(firstTick);
+        yield* TestClock.adjust(AUTO_EXPORT_INTERVAL);
+
+        expect((yield* ctx.calls).map((call) => call.method)).toEqual([
+          "export-as-html",
+          "export-as-ipynb",
+          "export-as-html",
+          "export-as-ipynb",
+        ]);
+      }).pipe(Effect.provide(ctx.layer));
+    }),
+  );
+});

--- a/extension/src/lsp/MarimoClient.ts
+++ b/extension/src/lsp/MarimoClient.ts
@@ -2,7 +2,7 @@ import * as NodeChildProcess from "node:child_process";
 import * as NodeFs from "node:fs";
 import * as NodePath from "node:path";
 
-import { Cause, Data, Effect, Option, Stream } from "effect";
+import { Cause, Data, Effect, Option, PubSub, Stream } from "effect";
 import * as lsp from "vscode-languageclient/node";
 
 import { Config } from "../config/Config.ts";
@@ -58,6 +58,25 @@ export function makeMarimoCommands<Error>(transport: MarimoTransport<Error>) {
     ...Api.makeApiClient(transport.execute),
   };
 }
+
+export const makeMarimoOperationStream = Effect.fn(function* (
+  register: (handler: (message: MarimoOperation) => void) => {
+    readonly dispose: () => void;
+  },
+) {
+  const operationPubSub = yield* PubSub.unbounded<MarimoOperation>();
+  yield* Effect.addFinalizer(() => PubSub.shutdown(operationPubSub));
+
+  // vscode-languageclient stores one notification handler per method, so
+  // register once and fan out to every operations() consumer.
+  yield* acquireDisposable(() =>
+    register((message) => {
+      Effect.runSync(PubSub.publish(operationPubSub, message));
+    }),
+  );
+
+  return () => Stream.fromPubSub(operationPubSub);
+});
 
 /**
  * Communication with marimo-lsp.
@@ -191,6 +210,12 @@ export class MarimoClient extends Effect.Service<MarimoClient>()(
 
       yield* Effect.addFinalizer(() => Effect.promise(() => client.dispose()));
 
+      const operations = yield* makeMarimoOperationStream((handler) =>
+        client.onNotification("marimo/operation", (message) => {
+          handler(message);
+        }),
+      );
+
       const restart = () =>
         code.window.withProgress(
           {
@@ -250,14 +275,7 @@ export class MarimoClient extends Effect.Service<MarimoClient>()(
             }),
           );
         }),
-        operations: () =>
-          Stream.asyncPush<MarimoOperation>((emit) =>
-            acquireDisposable(() =>
-              client.onNotification("marimo/operation", (message) => {
-                emit.single(message);
-              }),
-            ),
-          ),
+        operations,
       };
 
       return {

--- a/extension/src/lsp/__tests__/MarimoClient.test.ts
+++ b/extension/src/lsp/__tests__/MarimoClient.test.ts
@@ -3,13 +3,14 @@ import * as NodeOs from "node:os";
 import * as NodePath from "node:path";
 
 import { assert, describe, expect, it } from "@effect/vitest";
-import { Effect, Exit, Ref, Stream } from "effect";
+import { Effect, Exit, Option, Ref, Stream } from "effect";
 
 import { notebookId } from "../../lib/__tests__/branded.ts";
-import type { MarimoApiCall } from "../../types.ts";
+import type { MarimoApiCall, MarimoOperation } from "../../types.ts";
 import {
   findMarimoLspExecutable,
   makeMarimoCommands,
+  makeMarimoOperationStream,
 } from "../MarimoClient.ts";
 
 const notebook = notebookId("notebook-a");
@@ -194,5 +195,39 @@ it.scoped(
     yield* marimo.operations().pipe(Stream.runDrain);
 
     assert.strictEqual(requestedNotification, "marimo/operation");
+  }),
+);
+
+it.scoped(
+  "broadcasts marimo operations without replacing the transport handler",
+  Effect.fn(function* () {
+    let registrations = 0;
+    let notify: ((message: MarimoOperation) => void) | undefined;
+    const operations = yield* makeMarimoOperationStream((handler) => {
+      registrations += 1;
+      notify = handler;
+      return { dispose() {} };
+    });
+
+    const message = {
+      notebookUri: notebook,
+      operation: { op: "completed-run", run_id: null },
+    } as const;
+    const [first, second] = yield* Effect.all(
+      [
+        operations().pipe(Stream.take(1), Stream.runHead),
+        operations().pipe(Stream.take(1), Stream.runHead),
+        Effect.gen(function* () {
+          yield* Effect.yieldNow();
+          assert.ok(notify);
+          notify(message);
+        }),
+      ],
+      { concurrency: "unbounded" },
+    );
+
+    assert.strictEqual(registrations, 1);
+    assert.deepStrictEqual(first, Option.some(message));
+    assert.deepStrictEqual(second, Option.some(message));
   }),
 );

--- a/extension/src/platform/VsCode.ts
+++ b/extension/src/platform/VsCode.ts
@@ -403,6 +403,12 @@ export class Workspace extends Effect.Service<Workspace>()("Workspace", {
     const api = vscode.workspace;
     return {
       fs: {
+        createDirectory(uri: vscode.Uri) {
+          return Effect.tryPromise({
+            try: () => api.fs.createDirectory(uri),
+            catch: (cause) => new FileSystemError({ cause }),
+          });
+        },
         readFile(uri: vscode.Uri) {
           return Effect.tryPromise({
             try: () => api.fs.readFile(uri),


### PR DESCRIPTION
Add an extension service that reads marimo’s `auto_download` notebook metadata and exports the enabled HTML and IPYNB formats from the live kernel.

The service tracks kernel operations, notebook edits, and visible-editor changes as generations. Every five seconds it exports each dirty format once for visible, file-backed notebooks with a running controller. HTML waits for cell output, while IPYNB can be written immediately.

Exports are saved beside the notebook under `__marimo__`, for example `__marimo__/report.html` and `__marimo__/report.ipynb`. The directory is created as needed. Failed exports are logged and remain eligible for a later retry.

This PR does not add configuration UI. It consumes the same notebook metadata written by marimo; the next PR adds the VS Code command for editing it.

Closes #181.
