### PR TITLE
Configure automatic notebook exports

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -303,6 +303,14 @@
         "enablement": "notebookType == 'marimo-notebook'"
       },
       {
+        "command": "marimo.configureAutoExport",
+        "title": "Configure automatic exports",
+        "shortTitle": "Automatic exports",
+        "category": "marimo",
+        "icon": "$(save-all)",
+        "enablement": "notebookType == 'marimo-notebook'"
+      },
+      {
         "command": "marimo.publishMarimoNotebookGist",
         "title": "Publish notebook as Gist",
         "shortTitle": "Publish Gist",
@@ -536,6 +544,11 @@
           "command": "marimo.openOutlineView",
           "when": "notebookType == 'marimo-notebook'",
           "group": "navigation@5"
+        },
+        {
+          "command": "marimo.configureAutoExport",
+          "when": "notebookType == 'marimo-notebook'",
+          "group": "navigation@6"
         }
       ],
       "editor/title": [

--- a/extension/src/__mocks__/TestVsCode.ts
+++ b/extension/src/__mocks__/TestVsCode.ts
@@ -746,6 +746,10 @@ class WorkspaceEdit implements vscode.WorkspaceEdit {
     const edits = this.#edits.get(uri.toString()) || [];
     return edits.filter((e) => e instanceof TextEdit);
   }
+  getNotebookEdits(uri: Uri): readonly NotebookEdit[] {
+    const edits = this.#edits.get(uri.toString()) || [];
+    return edits.filter((edit) => edit instanceof NotebookEdit);
+  }
   createFile(_uri: Uri): void {
     this.#fileOperationCount += 1;
   }
@@ -763,6 +767,13 @@ class WorkspaceEdit implements vscode.WorkspaceEdit {
     }
     return result;
   }
+}
+
+export function getNotebookEdits(edit: vscode.WorkspaceEdit, uri: vscode.Uri) {
+  if (!(edit instanceof WorkspaceEdit)) {
+    throw new Error("Expected test WorkspaceEdit");
+  }
+  return edit.getNotebookEdits(uri);
 }
 
 class EventEmitter<T> implements vscode.EventEmitter<T> {
@@ -1712,6 +1723,9 @@ export class TestVsCode extends Data.TaggedClass("TestVsCode")<{
             return Effect.succeed(Option.none());
           },
           showQuickPickItems() {
+            return Effect.succeed(Option.none());
+          },
+          showQuickPickItemsMany() {
             return Effect.succeed(Option.none());
           },
           createOutputChannel(name) {

--- a/extension/src/commands/MarimoCommands.gen.ts
+++ b/extension/src/commands/MarimoCommands.gen.ts
@@ -19,6 +19,7 @@ export const GeneratedMarimoCommands = {
   configToggleOnCellChangeLazy: marimoCommand(
     "marimo.config.toggleOnCellChangeLazy",
   ),
+  configureAutoExport: marimoCommand("marimo.configureAutoExport"),
   createSetupCell: marimoCommand("marimo.createSetupCell"),
   debugCell: marimoCommand("marimo.debugCell"),
   exportStaticHTML: marimoCommand("marimo.exportStaticHTML"),

--- a/extension/src/commands/__tests__/configureAutoExport.test.ts
+++ b/extension/src/commands/__tests__/configureAutoExport.test.ts
@@ -1,0 +1,270 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Option, Ref } from "effect";
+
+import { getNotebookEdits, TestVsCode } from "../../__mocks__/TestVsCode.ts";
+import {
+  MarimoNotebookCell,
+  MarimoNotebookDocument,
+} from "../../schemas/MarimoNotebookDocument.ts";
+import {
+  configureAutoExport,
+  mergeAutoDownloadFormats,
+} from "../configureAutoExport.ts";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+describe("mergeAutoDownloadFormats", () => {
+  it("updates HTML and IPYNB without removing latent Markdown export", () => {
+    expect(mergeAutoDownloadFormats(["html", "markdown"], ["ipynb"])).toEqual([
+      "markdown",
+      "ipynb",
+    ]);
+  });
+
+  it("uses stable format ordering", () => {
+    expect(mergeAutoDownloadFormats([], ["ipynb", "html"])).toEqual([
+      "html",
+      "ipynb",
+    ]);
+  });
+
+  it("preserves the order of existing formats", () => {
+    expect(mergeAutoDownloadFormats(["markdown", "html"], ["html"])).toEqual([
+      "markdown",
+      "html",
+    ]);
+  });
+});
+
+it.effect(
+  "applies and saves selected automatic export formats",
+  Effect.fn(function* () {
+    const applied = yield* Ref.make(false);
+    const information = yield* Ref.make(Option.none<string>());
+    const editor = TestVsCode.makeNotebookEditor("/test/report.py", {
+      data: {
+        metadata: MarimoNotebookDocument.createMetadata({
+          appConfig: { auto_download: ["html"] },
+        }),
+        cells: [
+          {
+            kind: 2,
+            value: "1 + 1",
+            languageId: "python",
+            metadata: MarimoNotebookCell.createMetadata({
+              marimoRuntime: { stableId: "cell-1" },
+            }),
+          },
+        ],
+      },
+    });
+    const vscode = yield* TestVsCode.make({
+      initialDocuments: [editor.notebook],
+      window: {
+        showQuickPickItemsMany: (items) =>
+          Effect.succeed(
+            Option.some(items.filter((item) => item.label === "IPYNB")),
+          ),
+        showInformationMessage: (message) =>
+          Ref.set(information, Option.some(message)).pipe(
+            Effect.as(Option.none()),
+          ),
+      },
+      workspace: {
+        applyEdit: () => Ref.set(applied, true).pipe(Effect.as(true)),
+      },
+    });
+
+    yield* vscode.setActiveNotebookEditor(Option.some(editor));
+    yield* configureAutoExport().pipe(Effect.provide(vscode.layer));
+
+    expect(yield* applied).toBe(true);
+    expect(yield* information).toEqual(
+      Option.some("Automatic exports enabled for IPYNB."),
+    );
+  }),
+);
+
+it.effect(
+  "does not save when the selected formats are unchanged",
+  Effect.fn(function* () {
+    const applied = yield* Ref.make(false);
+    const editor = TestVsCode.makeNotebookEditor("/test/report.py", {
+      data: {
+        cells: [],
+        metadata: MarimoNotebookDocument.createMetadata({
+          appConfig: { auto_download: ["markdown", "html"] },
+        }),
+      },
+    });
+    const vscode = yield* TestVsCode.make({
+      initialDocuments: [editor.notebook],
+      window: {
+        showQuickPickItemsMany: (items) =>
+          Effect.succeed(
+            Option.some(items.filter((item) => item.label === "HTML")),
+          ),
+      },
+      workspace: {
+        applyEdit: () => Ref.set(applied, true).pipe(Effect.as(true)),
+      },
+    });
+
+    yield* vscode.setActiveNotebookEditor(Option.some(editor));
+    yield* configureAutoExport().pipe(Effect.provide(vscode.layer));
+
+    expect(yield* applied).toBe(false);
+  }),
+);
+
+it.effect(
+  "merges the selection into metadata changed while the picker is open",
+  Effect.fn(function* () {
+    const updatedMetadata = yield* Ref.make(
+      Option.none<Record<string, unknown>>(),
+    );
+    const editor = TestVsCode.makeNotebookEditor("/test/report.py", {
+      data: {
+        cells: [],
+        metadata: MarimoNotebookDocument.createMetadata({
+          appConfig: { auto_download: ["html"] },
+        }),
+      },
+    });
+    const vscode = yield* TestVsCode.make({
+      initialDocuments: [editor.notebook],
+      window: {
+        showQuickPickItemsMany: (items) =>
+          Effect.sync(() => {
+            const marimo = editor.notebook.metadata.marimo;
+            if (!isRecord(marimo)) {
+              throw new Error("Expected marimo notebook metadata");
+            }
+            const appConfig = marimo.appConfig;
+            if (!isRecord(appConfig)) {
+              throw new Error("Expected marimo app config");
+            }
+            marimo.appConfig = {
+              ...appConfig,
+              width: "full",
+            };
+            return Option.some(items.filter((item) => item.label === "IPYNB"));
+          }),
+      },
+      workspace: {
+        applyEdit: (edit) => {
+          const notebookEdits = getNotebookEdits(edit, editor.notebook.uri);
+          return Ref.set(
+            updatedMetadata,
+            Option.fromNullable(notebookEdits[0]?.newNotebookMetadata),
+          ).pipe(Effect.as(true));
+        },
+      },
+    });
+
+    yield* vscode.setActiveNotebookEditor(Option.some(editor));
+    yield* configureAutoExport().pipe(Effect.provide(vscode.layer));
+
+    const metadata = Option.getOrThrow(yield* updatedMetadata);
+    const updated = TestVsCode.makeNotebookEditor("/test/report.py", {
+      data: { cells: [], metadata },
+    });
+    const parsed = yield* MarimoNotebookDocument.from(
+      updated.notebook,
+    ).parseMetadata();
+    expect(parsed.appConfig.width).toBe("full");
+    expect(parsed.appConfig.auto_download).toEqual(["ipynb"]);
+  }),
+);
+
+it.effect(
+  "reports an error instead of success when the notebook cannot be saved",
+  Effect.fn(function* () {
+    const information = yield* Ref.make(Option.none<string>());
+    const error = yield* Ref.make(Option.none<string>());
+    const editor = TestVsCode.makeNotebookEditor("/test/report.py", {
+      data: {
+        cells: [],
+        metadata: MarimoNotebookDocument.createMetadata({
+          appConfig: { auto_download: ["html"] },
+        }),
+      },
+    });
+    Object.defineProperty(editor.notebook, "save", {
+      value: () => Promise.resolve(false),
+    });
+    const vscode = yield* TestVsCode.make({
+      initialDocuments: [editor.notebook],
+      window: {
+        showQuickPickItemsMany: (items) =>
+          Effect.succeed(
+            Option.some(items.filter((item) => item.label === "IPYNB")),
+          ),
+        showInformationMessage: (message) =>
+          Ref.set(information, Option.some(message)).pipe(
+            Effect.as(Option.none()),
+          ),
+        showErrorMessage: (message) =>
+          Ref.set(error, Option.some(message)).pipe(Effect.as(Option.none())),
+      },
+      workspace: {
+        applyEdit: () => Effect.succeed(true),
+      },
+    });
+
+    yield* vscode.setActiveNotebookEditor(Option.some(editor));
+    yield* configureAutoExport().pipe(Effect.provide(vscode.layer));
+
+    expect(yield* information).toEqual(Option.none());
+    expect(yield* error).toEqual(
+      Option.some("Automatic export settings could not be saved."),
+    );
+  }),
+);
+
+it.effect(
+  "reports an error instead of failing when saving rejects",
+  Effect.fn(function* () {
+    const information = yield* Ref.make(Option.none<string>());
+    const error = yield* Ref.make(Option.none<string>());
+    const editor = TestVsCode.makeNotebookEditor("/test/report.py", {
+      data: {
+        cells: [],
+        metadata: MarimoNotebookDocument.createMetadata({
+          appConfig: { auto_download: ["html"] },
+        }),
+      },
+    });
+    Object.defineProperty(editor.notebook, "save", {
+      value: () => Promise.reject(new Error("disk full")),
+    });
+    const vscode = yield* TestVsCode.make({
+      initialDocuments: [editor.notebook],
+      window: {
+        showQuickPickItemsMany: (items) =>
+          Effect.succeed(
+            Option.some(items.filter((item) => item.label === "IPYNB")),
+          ),
+        showInformationMessage: (message) =>
+          Ref.set(information, Option.some(message)).pipe(
+            Effect.as(Option.none()),
+          ),
+        showErrorMessage: (message) =>
+          Ref.set(error, Option.some(message)).pipe(Effect.as(Option.none())),
+      },
+      workspace: {
+        applyEdit: () => Effect.succeed(true),
+      },
+    });
+
+    yield* vscode.setActiveNotebookEditor(Option.some(editor));
+    yield* configureAutoExport().pipe(Effect.provide(vscode.layer));
+
+    expect(yield* information).toEqual(Option.none());
+    expect(yield* error).toEqual(
+      Option.some("Automatic export settings could not be saved."),
+    );
+  }),
+);

--- a/extension/src/commands/configureAutoExport.ts
+++ b/extension/src/commands/configureAutoExport.ts
@@ -1,0 +1,124 @@
+import { Effect, Option } from "effect";
+
+import type { AutoExportFormat } from "../features/AutoExport.ts";
+import { VsCode } from "../platform/VsCode.ts";
+import { MarimoNotebookDocument } from "../schemas/MarimoNotebookDocument.ts";
+import type { _AppConfig } from "../schemas/Models.gen.ts";
+
+const FORMATS = ["html", "ipynb"] as const;
+
+const isManagedFormat = (format: string): format is AutoExportFormat =>
+  format === "html" || format === "ipynb";
+
+export function mergeAutoDownloadFormats(
+  current: _AppConfig["auto_download"],
+  selected: ReadonlyArray<AutoExportFormat>,
+): _AppConfig["auto_download"] {
+  const retained = current.filter(
+    (format) => !isManagedFormat(format) || selected.includes(format),
+  );
+  return [
+    ...retained,
+    ...FORMATS.filter(
+      (format) => selected.includes(format) && !retained.includes(format),
+    ),
+  ];
+}
+
+export const configureAutoExport = Effect.fn("command.configureAutoExport")(
+  function* () {
+    const code = yield* VsCode;
+    const notebook = Option.filterMap(
+      yield* code.window.getActiveNotebookEditor(),
+      (editor) => MarimoNotebookDocument.tryFrom(editor.notebook),
+    );
+
+    if (Option.isNone(notebook)) {
+      yield* code.window.showWarningMessage(
+        "Must have an open marimo notebook to configure automatic exports.",
+      );
+      return;
+    }
+
+    const metadata = yield* notebook.value.parseMetadata();
+    const current = metadata.appConfig.auto_download;
+    const selected = yield* code.window.showQuickPickItemsMany(
+      [
+        {
+          label: "HTML",
+          detail: "Save a static HTML snapshot with current outputs",
+          value: "html" as const,
+          picked: current.includes("html"),
+        },
+        {
+          label: "IPYNB",
+          detail: "Save a Jupyter notebook with current outputs",
+          value: "ipynb" as const,
+          picked: current.includes("ipynb"),
+        },
+      ],
+      {
+        placeHolder: "Select formats to save under __marimo__",
+        title: "Automatic exports",
+      },
+    );
+    if (Option.isNone(selected)) return;
+
+    // The picker can stay open while another command updates notebook metadata.
+    // Merge into the latest app config so those concurrent changes survive.
+    const latestMetadata = yield* notebook.value.parseMetadata();
+    const latest = latestMetadata.appConfig.auto_download;
+    const next = mergeAutoDownloadFormats(
+      latest,
+      selected.value.map((item) => item.value),
+    );
+    if (
+      latest.length === next.length &&
+      latest.every((format, index) => format === next[index])
+    ) {
+      return;
+    }
+
+    const nextMetadata = notebook.value.buildMetadataUpdate({
+      appConfig: { ...latestMetadata.appConfig, auto_download: next },
+    });
+    const edit = new code.WorkspaceEdit();
+    edit.set(notebook.value.uri, [
+      code.NotebookEdit.updateNotebookMetadata(nextMetadata),
+    ]);
+    const applied = yield* code.workspace.applyEdit(edit);
+    if (!applied) {
+      yield* code.window.showErrorMessage(
+        "Could not update automatic export settings.",
+      );
+      return;
+    }
+
+    const saved = yield* notebook.value
+      .save()
+      .pipe(
+        Effect.catchAllCause((cause) =>
+          Effect.logError("Failed to save automatic export settings").pipe(
+            Effect.annotateLogs({ cause, notebook: notebook.value.id }),
+            Effect.as(false),
+          ),
+        ),
+      );
+    if (!saved) {
+      yield* code.window.showErrorMessage(
+        "Automatic export settings could not be saved.",
+      );
+      return;
+    }
+
+    const label = next
+      .filter(isManagedFormat)
+      .map((format) => format.toUpperCase())
+      .join(", ");
+    yield* code.window.showInformationMessage(
+      label.length > 0
+        ? `Automatic exports enabled for ${label}.`
+        : "Automatic HTML and IPYNB exports disabled.",
+    );
+  },
+);

--- a/extension/src/features/AutoExport.ts
+++ b/extension/src/features/AutoExport.ts
@@ -168,10 +168,8 @@ export const AutoExportLive = Layer.scopedDiscard(
         );
         if (formats.length === 0) return;
 
-        const controller = yield* runtime
-          .forNotebook(notebook.id)
-          .getController();
-        if (Option.isNone(controller)) return;
+        const session = yield* runtime.getRuntimeSession(notebook.id);
+        if (Option.isNone(session)) return;
 
         const state = yield* getOrCreateState(notebook.id);
         const pendingFormats = formats.filter((format) => {

--- a/extension/src/features/RegisterCommands.ts
+++ b/extension/src/features/RegisterCommands.ts
@@ -1,5 +1,6 @@
 import { Effect, Either, Layer, Stream } from "effect";
 
+import { configureAutoExport } from "../commands/configureAutoExport.ts";
 import { createSetupCell } from "../commands/createSetupCell.ts";
 import { debugCell } from "../commands/debugCell.ts";
 import { exportNotebookAsHtml } from "../commands/exportNotebookAsHtml.ts";
@@ -36,6 +37,11 @@ export const RegisterCommandsLive = Layer.scopedDiscard(
     yield* code.commands.register(
       MarimoCommands.createSetupCell,
       createSetupCell,
+    );
+
+    yield* code.commands.register(
+      MarimoCommands.configureAutoExport,
+      configureAutoExport,
     );
 
     yield* code.commands.register(

--- a/extension/src/features/__tests__/AutoExport.test.ts
+++ b/extension/src/features/__tests__/AutoExport.test.ts
@@ -38,6 +38,7 @@ const withTestCtx = Effect.fn(function* (
   options: {
     readonly execute?: (request: MarimoApiCall) => Effect.Effect<string>;
     readonly hasOutputs?: boolean;
+    readonly hasRuntimeSession?: boolean;
   } = {},
 ) {
   const calls = yield* Ref.make<ReadonlyArray<MarimoApiCall>>([]);
@@ -98,6 +99,10 @@ const withTestCtx = Effect.fn(function* (
 
   const runtime = makeTestNotebookRuntime({
     initialControllers: [{ notebookUri: notebook.id, controller }],
+    runtimeSession:
+      options.hasRuntimeSession === false
+        ? undefined
+        : { executable: "/usr/bin/python", workingDirectory: "/test" },
     operations: () => Stream.fromPubSub(operations),
     execute: (request) =>
       Ref.update(calls, (current) => [...current, request]).pipe(
@@ -146,6 +151,22 @@ describe("autoExportUri", () => {
 });
 
 describe("AutoExport", () => {
+  it.scoped(
+    "waits for a live runtime session before creating exports",
+    Effect.fn(function* () {
+      const ctx = yield* withTestCtx({ hasRuntimeSession: false });
+
+      yield* Effect.gen(function* () {
+        yield* ctx.vscode.setActiveNotebookEditor(Option.some(ctx.editor));
+        yield* TestClock.adjust(AUTO_EXPORT_INTERVAL);
+
+        expect(yield* ctx.calls).toEqual([]);
+        expect(yield* ctx.directories).toEqual([]);
+        expect(yield* ctx.writes).toEqual(new Map());
+      }).pipe(Effect.provide(ctx.layer));
+    }),
+  );
+
   it.scoped(
     "exports enabled formats once per live-session generation",
     Effect.fn(function* () {

--- a/extension/src/platform/VsCode.ts
+++ b/extension/src/platform/VsCode.ts
@@ -154,6 +154,21 @@ export class Window extends Effect.Service<Window>()("Window", {
           Option.fromNullable,
         );
       },
+      showQuickPickItemsMany<T extends vscode.QuickPickItem>(
+        items: readonly T[],
+        options: Omit<vscode.QuickPickOptions, "canPickMany"> = {},
+      ) {
+        return Effect.map(
+          Effect.promise((signal) =>
+            api.showQuickPick(
+              items,
+              { ...options, canPickMany: true },
+              tokenFromSignal(signal),
+            ),
+          ),
+          Option.fromNullable,
+        );
+      },
       createOutputChannel(name: string) {
         return acquireDisposable(() => api.createOutputChannel(name));
       },

--- a/src/marimo_lsp/sessions.py
+++ b/src/marimo_lsp/sessions.py
@@ -13,6 +13,7 @@ from uuid import uuid4
 from marimo._config.manager import get_default_config_manager
 from marimo._ipc import QueueManager as IpcQueues
 from marimo._runtime.commands import (
+    CodeCompletionCommand,
     CommandMessage,
     CreateNotebookCommand,
     ExecuteCellCommand,
@@ -204,7 +205,8 @@ class Session:
     ) -> None:
         """Send a command to the kernel."""
         del from_consumer_id
-        self.session_view.add_control_request(request)
+        if not isinstance(request, CodeCompletionCommand):
+            self.session_view.add_control_request(request)
         self._queue_manager.put_control_request(request)
 
     def _effective_runtime(self, config: MarimoConfig) -> MarimoConfig:

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -67,6 +67,7 @@ def test_regular_commands_are_routed_to_control_queue_only() -> None:
 
 def test_out_of_band_commands_are_routed_to_completion_queue() -> None:
     session, queue_manager = _make_session()
+    session.session_view.mark_auto_export_html()
     command = CodeCompletionCommand(
         id=RequestId("request"), document="mo.", cell_id=CellId_t("cell")
     )
@@ -76,6 +77,7 @@ def test_out_of_band_commands_are_routed_to_completion_queue() -> None:
     queue_manager.completion_queue.put.assert_called_once_with(command)
     queue_manager.control_queue.put.assert_not_called()
     queue_manager.set_ui_element_queue.put.assert_not_called()
+    assert not session.session_view.needs_export("html")
 
 
 def test_detach_only_overrides_auto_reload() -> None:


### PR DESCRIPTION
Add a notebook toolbar command for selecting automatic HTML and IPYNB exports. The command starts from the notebook’s current marimo configuration, writes the selected formats back to `auto_download`, and saves the notebook.

The picker preserves export formats it does not manage, including the existing Markdown value, so editing the VS Code choices does not discard configuration written elsewhere. Selecting no formats disables automatic HTML and IPYNB exports.

The runtime from the previous PR observes the saved metadata and writes live exports under `__marimo__`. This keeps marimo notebook metadata as the shared source of truth instead of adding a separate VS Code setting.

Closes #181.
