### PR TITLE
Organize marimo notebook actions

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -363,7 +363,7 @@
       {
         "command": "marimo.config.toggleOnCellChangeAutoRun",
         "title": "Configure behavior after cell changes",
-        "shortTitle": "Cell changes: Automatic",
+        "shortTitle": "Cell changes: Auto-run",
         "category": "marimo",
         "icon": "$(zap)",
         "enablement": "notebookType == 'marimo-notebook'"
@@ -371,7 +371,7 @@
       {
         "command": "marimo.config.toggleOnCellChangeLazy",
         "title": "Configure behavior after cell changes",
-        "shortTitle": "Cell changes: Mark stale",
+        "shortTitle": "Cell changes: Lazy",
         "category": "marimo",
         "icon": "$(history)",
         "enablement": "notebookType == 'marimo-notebook'"
@@ -387,7 +387,7 @@
       {
         "command": "marimo.config.toggleAutoReloadLazy",
         "title": "Configure behavior after module changes",
-        "shortTitle": "Module changes: Mark stale",
+        "shortTitle": "Module changes: Lazy",
         "category": "marimo",
         "icon": "$(history)",
         "enablement": "notebookType == 'marimo-notebook'"
@@ -395,7 +395,7 @@
       {
         "command": "marimo.config.toggleAutoReloadAutorun",
         "title": "Configure behavior after module changes",
-        "shortTitle": "Module changes: Automatic",
+        "shortTitle": "Module changes: Auto-run",
         "category": "marimo",
         "icon": "$(zap)",
         "enablement": "notebookType == 'marimo-notebook'"

--- a/extension/package.json
+++ b/extension/package.json
@@ -304,8 +304,8 @@
       },
       {
         "command": "marimo.configureAutoExport",
-        "title": "Configure automatic exports",
-        "shortTitle": "Automatic exports",
+        "title": "Configure export formats",
+        "shortTitle": "Export formats…",
         "category": "marimo",
         "icon": "$(save-all)",
         "enablement": "notebookType == 'marimo-notebook'"
@@ -354,40 +354,40 @@
       },
       {
         "command": "marimo.config.toggleOnCellChangeAutoRun",
-        "title": "Toggle on-cell-change mode",
-        "shortTitle": "On cell change: Auto-Run",
+        "title": "Configure behavior after cell changes",
+        "shortTitle": "Cell changes: Automatic",
         "category": "marimo",
         "icon": "$(zap)",
         "enablement": "notebookType == 'marimo-notebook'"
       },
       {
         "command": "marimo.config.toggleOnCellChangeLazy",
-        "title": "Toggle on-cell-change mode",
-        "shortTitle": "On cell change: Lazy",
+        "title": "Configure behavior after cell changes",
+        "shortTitle": "Cell changes: Mark stale",
         "category": "marimo",
-        "icon": "$(symbol-interface)",
+        "icon": "$(history)",
         "enablement": "notebookType == 'marimo-notebook'"
       },
       {
         "command": "marimo.config.toggleAutoReloadOff",
-        "title": "Toggle auto-reload mode",
-        "shortTitle": "Auto-reload: Off",
+        "title": "Configure behavior after module changes",
+        "shortTitle": "Module changes: Off",
         "category": "marimo",
-        "icon": "$(sync-ignored)",
+        "icon": "$(circle-slash)",
         "enablement": "notebookType == 'marimo-notebook'"
       },
       {
         "command": "marimo.config.toggleAutoReloadLazy",
-        "title": "Toggle auto-reload mode",
-        "shortTitle": "Auto-reload: Lazy",
+        "title": "Configure behavior after module changes",
+        "shortTitle": "Module changes: Mark stale",
         "category": "marimo",
-        "icon": "$(symbol-interface)",
+        "icon": "$(history)",
         "enablement": "notebookType == 'marimo-notebook'"
       },
       {
         "command": "marimo.config.toggleAutoReloadAutorun",
-        "title": "Toggle auto-reload mode",
-        "shortTitle": "Auto-reload: Auto-Run",
+        "title": "Configure behavior after module changes",
+        "shortTitle": "Module changes: Automatic",
         "category": "marimo",
         "icon": "$(zap)",
         "enablement": "notebookType == 'marimo-notebook'"
@@ -445,7 +445,7 @@
       },
       {
         "id": "marimo.runtimeActions",
-        "label": "Runtime",
+        "label": "Reactivity",
         "icon": "$(zap)"
       }
     ],

--- a/extension/package.json
+++ b/extension/package.json
@@ -278,6 +278,14 @@
         "category": "marimo"
       },
       {
+        "command": "marimo.showNotebookActions",
+        "title": "Show notebook actions",
+        "shortTitle": "marimo",
+        "category": "marimo",
+        "icon": "images/small-icon.png",
+        "enablement": "notebookType == 'marimo-notebook'"
+      },
+      {
         "command": "marimo.newMarimoNotebook",
         "title": "New marimo notebook",
         "shortTitle": "Marimo notebook",
@@ -434,21 +442,6 @@
         "enablement": "notebookType == 'marimo-notebook'"
       }
     ],
-    "submenus": [
-      {
-        "id": "marimo.notebookActions",
-        "label": "marimo",
-        "icon": {
-          "light": "icons/marimo-icon-light.svg",
-          "dark": "icons/marimo-icon-dark.svg"
-        }
-      },
-      {
-        "id": "marimo.runtimeActions",
-        "label": "Reactivity",
-        "icon": "$(zap)"
-      }
-    ],
     "viewsContainers": {
       "panel": [
         {
@@ -519,48 +512,6 @@
           "group": "navigation"
         }
       ],
-      "marimo.notebookActions": [
-        {
-          "submenu": "marimo.runtimeActions",
-          "group": "navigation@1"
-        },
-        {
-          "command": "marimo.configureAutoExport",
-          "group": "notebook@1"
-        }
-      ],
-      "marimo.runtimeActions": [
-        {
-          "command": "marimo.runStale",
-          "when": "marimo.notebook.hasStaleCells",
-          "group": "navigation@1"
-        },
-        {
-          "command": "marimo.config.toggleOnCellChangeAutoRun",
-          "when": "marimo.notebook.hasKernel && marimo.config.runtime.on_cell_change != 'lazy'",
-          "group": "runtime@1"
-        },
-        {
-          "command": "marimo.config.toggleOnCellChangeLazy",
-          "when": "marimo.notebook.hasKernel && marimo.config.runtime.on_cell_change == 'lazy'",
-          "group": "runtime@1"
-        },
-        {
-          "command": "marimo.config.toggleAutoReloadOff",
-          "when": "marimo.notebook.hasKernel && marimo.config.runtime.auto_reload == 'off'",
-          "group": "runtime@2"
-        },
-        {
-          "command": "marimo.config.toggleAutoReloadLazy",
-          "when": "marimo.notebook.hasKernel && marimo.config.runtime.auto_reload == 'lazy'",
-          "group": "runtime@2"
-        },
-        {
-          "command": "marimo.config.toggleAutoReloadAutorun",
-          "when": "marimo.notebook.hasKernel && marimo.config.runtime.auto_reload == 'autorun'",
-          "group": "runtime@2"
-        }
-      ],
       "notebook/toolbar": [
         {
           "command": "marimo.runStale",
@@ -578,7 +529,7 @@
           "group": "navigation@3"
         },
         {
-          "submenu": "marimo.notebookActions",
+          "command": "marimo.showNotebookActions",
           "when": "notebookType == 'marimo-notebook'",
           "group": "navigation@4"
         }

--- a/extension/package.json
+++ b/extension/package.json
@@ -434,6 +434,18 @@
         "enablement": "notebookType == 'marimo-notebook'"
       }
     ],
+    "submenus": [
+      {
+        "id": "marimo.notebookActions",
+        "label": "marimo",
+        "icon": "images/small-icon.png"
+      },
+      {
+        "id": "marimo.runtimeActions",
+        "label": "Runtime",
+        "icon": "$(zap)"
+      }
+    ],
     "viewsContainers": {
       "panel": [
         {
@@ -502,6 +514,44 @@
           "command": "marimo.refreshPackages",
           "when": "view == marimo-explorer-packages",
           "group": "navigation"
+        }
+      ],
+      "marimo.notebookActions": [
+        {
+          "submenu": "marimo.runtimeActions",
+          "group": "navigation@1"
+        }
+      ],
+      "marimo.runtimeActions": [
+        {
+          "command": "marimo.runStale",
+          "when": "marimo.notebook.hasStaleCells",
+          "group": "navigation@1"
+        },
+        {
+          "command": "marimo.config.toggleOnCellChangeAutoRun",
+          "when": "marimo.notebook.hasKernel && marimo.config.runtime.on_cell_change != 'lazy'",
+          "group": "runtime@1"
+        },
+        {
+          "command": "marimo.config.toggleOnCellChangeLazy",
+          "when": "marimo.notebook.hasKernel && marimo.config.runtime.on_cell_change == 'lazy'",
+          "group": "runtime@1"
+        },
+        {
+          "command": "marimo.config.toggleAutoReloadOff",
+          "when": "marimo.notebook.hasKernel && marimo.config.runtime.auto_reload == 'off'",
+          "group": "runtime@2"
+        },
+        {
+          "command": "marimo.config.toggleAutoReloadLazy",
+          "when": "marimo.notebook.hasKernel && marimo.config.runtime.auto_reload == 'lazy'",
+          "group": "runtime@2"
+        },
+        {
+          "command": "marimo.config.toggleAutoReloadAutorun",
+          "when": "marimo.notebook.hasKernel && marimo.config.runtime.auto_reload == 'autorun'",
+          "group": "runtime@2"
         }
       ],
       "notebook/toolbar": [

--- a/extension/package.json
+++ b/extension/package.json
@@ -520,6 +520,10 @@
         {
           "submenu": "marimo.runtimeActions",
           "group": "navigation@1"
+        },
+        {
+          "command": "marimo.configureAutoExport",
+          "group": "notebook@1"
         }
       ],
       "marimo.runtimeActions": [
@@ -566,39 +570,14 @@
           "group": "navigation@2"
         },
         {
-          "command": "marimo.config.toggleOnCellChangeAutoRun",
-          "when": "notebookType == 'marimo-notebook' && marimo.notebook.hasKernel && marimo.config.runtime.on_cell_change != 'lazy'",
-          "group": "navigation@3"
-        },
-        {
-          "command": "marimo.config.toggleOnCellChangeLazy",
-          "when": "notebookType == 'marimo-notebook' && marimo.notebook.hasKernel && marimo.config.runtime.on_cell_change == 'lazy'",
-          "group": "navigation@3"
-        },
-        {
-          "command": "marimo.config.toggleAutoReloadOff",
-          "when": "notebookType == 'marimo-notebook' && marimo.notebook.hasKernel && marimo.config.runtime.auto_reload == 'off'",
-          "group": "navigation@4"
-        },
-        {
-          "command": "marimo.config.toggleAutoReloadLazy",
-          "when": "notebookType == 'marimo-notebook' && marimo.notebook.hasKernel && marimo.config.runtime.auto_reload == 'lazy'",
-          "group": "navigation@4"
-        },
-        {
-          "command": "marimo.config.toggleAutoReloadAutorun",
-          "when": "notebookType == 'marimo-notebook' && marimo.notebook.hasKernel && marimo.config.runtime.auto_reload == 'autorun'",
-          "group": "navigation@4"
-        },
-        {
           "command": "marimo.openOutlineView",
           "when": "notebookType == 'marimo-notebook'",
-          "group": "navigation@5"
+          "group": "navigation@3"
         },
         {
-          "command": "marimo.configureAutoExport",
+          "submenu": "marimo.notebookActions",
           "when": "notebookType == 'marimo-notebook'",
-          "group": "navigation@6"
+          "group": "navigation@4"
         }
       ],
       "editor/title": [

--- a/extension/package.json
+++ b/extension/package.json
@@ -438,7 +438,10 @@
       {
         "id": "marimo.notebookActions",
         "label": "marimo",
-        "icon": "images/small-icon.png"
+        "icon": {
+          "light": "icons/marimo-icon-light.svg",
+          "dark": "icons/marimo-icon-dark.svg"
+        }
       },
       {
         "id": "marimo.runtimeActions",

--- a/extension/src/commands.ts
+++ b/extension/src/commands.ts
@@ -1,4 +1,5 @@
 import { Effect, ParseResult, Schema } from "effect";
+import type * as vscode from "vscode";
 
 const MarimoCommandTypeId: unique symbol = Symbol("MarimoCommand");
 
@@ -29,6 +30,27 @@ export function marimoCommand(id: string): MarimoCommand<[], void> {
   };
 }
 
+export const VscodeUriSchema = Schema.declare<vscode.Uri>(
+  (value): value is vscode.Uri =>
+    typeof value === "object" &&
+    value !== null &&
+    "scheme" in value &&
+    typeof value.scheme === "string" &&
+    "path" in value &&
+    typeof value.path === "string" &&
+    "with" in value &&
+    typeof value.with === "function" &&
+    "toString" in value &&
+    typeof value.toString === "function",
+  { identifier: "vscode.Uri" },
+);
+
+const NotebookCommandContextSchema = Schema.Struct({
+  notebookEditor: Schema.Struct({ notebookUri: VscodeUriSchema }),
+});
+
+export type NotebookCommandContext = typeof NotebookCommandContextSchema.Type;
+
 export function withFirstArgument<A>(
   command: MarimoCommand,
   schema: Schema.Schema<A>,
@@ -39,6 +61,25 @@ export function withFirstArgument<A>(
       decodeArguments: (args) =>
         Schema.decodeUnknown(schema)(args[0]).pipe(
           Effect.map((argument) => [argument]),
+        ),
+      decodeResult: Schema.decodeUnknown(Schema.Void),
+    },
+  };
+}
+
+export function withOptionalNotebookContext(
+  command: MarimoCommand,
+): MarimoCommand<[context?: NotebookCommandContext], void> {
+  return {
+    [MarimoCommandTypeId]: {
+      id: commandId(command),
+      decodeArguments: (args) =>
+        Schema.decodeUnknown(Schema.UndefinedOr(NotebookCommandContextSchema))(
+          args[0],
+        ).pipe(
+          Effect.map((context): [context?: NotebookCommandContext] =>
+            context === undefined ? [] : [context],
+          ),
         ),
       decodeResult: Schema.decodeUnknown(Schema.Void),
     },

--- a/extension/src/commands.ts
+++ b/extension/src/commands.ts
@@ -22,7 +22,11 @@ export function marimoCommand(id: string): MarimoCommand<[], void> {
     [MarimoCommandTypeId]: {
       id,
       decodeArguments: (args) =>
-        Schema.decodeUnknown(Schema.Tuple())(args).pipe(Effect.as([])),
+        Schema.decodeUnknown(
+          Schema.Array(Schema.Unknown).pipe(
+            Schema.filter((args) => args.length === 0),
+          ),
+        )(args).pipe(Effect.as([])),
       decodeResult: Schema.decodeUnknown(Schema.Void),
     },
   };

--- a/extension/src/commands.ts
+++ b/extension/src/commands.ts
@@ -21,12 +21,9 @@ export function marimoCommand(id: string): MarimoCommand<[], void> {
   return {
     [MarimoCommandTypeId]: {
       id,
-      decodeArguments: (args) =>
-        Schema.decodeUnknown(
-          Schema.Array(Schema.Unknown).pipe(
-            Schema.filter((args) => args.length === 0),
-          ),
-        )(args).pipe(Effect.as([])),
+      // VS Code adds invocation context for commands launched from menus and
+      // toolbars. It is platform metadata, not part of the command contract.
+      decodeArguments: () => Effect.succeed([]),
       decodeResult: Schema.decodeUnknown(Schema.Void),
     },
   };

--- a/extension/src/commands/MarimoCommands.gen.ts
+++ b/extension/src/commands/MarimoCommands.gen.ts
@@ -36,6 +36,7 @@ export const GeneratedMarimoCommands = {
   runStale: marimoCommand("marimo.runStale"),
   showDiagnostics: marimoCommand("marimo.showDiagnostics"),
   showMarimoMenu: marimoCommand("marimo.showMarimoMenu"),
+  showNotebookActions: marimoCommand("marimo.showNotebookActions"),
   updateActivePythonEnvironment: marimoCommand(
     "marimo.updateActivePythonEnvironment",
   ),

--- a/extension/src/commands/MarimoCommands.ts
+++ b/extension/src/commands/MarimoCommands.ts
@@ -1,23 +1,36 @@
 import { Schema } from "effect";
-import type * as vscode from "vscode";
 
-import { withFirstArgument } from "../commands.ts";
+import {
+  withFirstArgument,
+  withOptionalNotebookContext,
+  VscodeUriSchema,
+} from "../commands.ts";
 import { GeneratedMarimoCommands } from "./MarimoCommands.gen.ts";
 
-const UriSchema = Schema.declare<vscode.Uri>(
-  (value): value is vscode.Uri =>
-    typeof value === "object" &&
-    value !== null &&
-    "scheme" in value &&
-    typeof value.scheme === "string" &&
-    "path" in value &&
-    typeof value.path === "string" &&
-    "with" in value &&
-    typeof value.with === "function" &&
-    "toString" in value &&
-    typeof value.toString === "function",
-  { identifier: "vscode.Uri" },
-);
+const notebookCommands = {
+  configToggleAutoReloadAutorun: withOptionalNotebookContext(
+    GeneratedMarimoCommands.configToggleAutoReloadAutorun,
+  ),
+  configToggleAutoReloadLazy: withOptionalNotebookContext(
+    GeneratedMarimoCommands.configToggleAutoReloadLazy,
+  ),
+  configToggleAutoReloadOff: withOptionalNotebookContext(
+    GeneratedMarimoCommands.configToggleAutoReloadOff,
+  ),
+  configToggleOnCellChangeAutoRun: withOptionalNotebookContext(
+    GeneratedMarimoCommands.configToggleOnCellChangeAutoRun,
+  ),
+  configToggleOnCellChangeLazy: withOptionalNotebookContext(
+    GeneratedMarimoCommands.configToggleOnCellChangeLazy,
+  ),
+  configureAutoExport: withOptionalNotebookContext(
+    GeneratedMarimoCommands.configureAutoExport,
+  ),
+  restartKernel: withOptionalNotebookContext(
+    GeneratedMarimoCommands.restartKernel,
+  ),
+  runStale: withOptionalNotebookContext(GeneratedMarimoCommands.runStale),
+};
 
 /**
  * Commands contributed by this extension, with exceptional contracts refined
@@ -25,8 +38,9 @@ const UriSchema = Schema.declare<vscode.Uri>(
  */
 export const MarimoCommands = {
   ...GeneratedMarimoCommands,
+  ...notebookCommands,
   openAsMarimoNotebook: withFirstArgument(
     GeneratedMarimoCommands.openAsMarimoNotebook,
-    Schema.UndefinedOr(Schema.Union(Schema.String, UriSchema)),
+    Schema.UndefinedOr(Schema.Union(Schema.String, VscodeUriSchema)),
   ),
 } as const;

--- a/extension/src/commands/MarimoCommands.ts
+++ b/extension/src/commands/MarimoCommands.ts
@@ -30,6 +30,9 @@ const notebookCommands = {
     GeneratedMarimoCommands.restartKernel,
   ),
   runStale: withOptionalNotebookContext(GeneratedMarimoCommands.runStale),
+  showNotebookActions: withOptionalNotebookContext(
+    GeneratedMarimoCommands.showNotebookActions,
+  ),
 };
 
 /**

--- a/extension/src/commands/__tests__/MarimoCommands.test.ts
+++ b/extension/src/commands/__tests__/MarimoCommands.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "@effect/vitest";
-import { Effect, Either } from "effect";
+import { Effect } from "effect";
 
 import { commandId, decodeCommandArguments } from "../../commands.ts";
 import { GeneratedMarimoCommands } from "../MarimoCommands.gen.ts";
@@ -15,12 +15,16 @@ describe("MarimoCommands", () => {
     );
   });
 
-  it.effect("rejects arguments for a no-argument command", () =>
+  it.effect("ignores VS Code context for a no-argument command", () =>
     Effect.gen(function* () {
-      const result = yield* Effect.either(
-        decodeCommandArguments(MarimoCommands.restartKernel, ["unexpected"]),
-      );
-      expect(Either.isLeft(result)).toBe(true);
+      const args = yield* decodeCommandArguments(MarimoCommands.restartKernel, [
+        {
+          ui: true,
+          notebookEditor: { notebookUri: "file:///notebook.py" },
+          source: "notebookToolbar",
+        },
+      ]);
+      expect(args).toEqual([]);
     }),
   );
 

--- a/extension/src/commands/__tests__/MarimoCommands.test.ts
+++ b/extension/src/commands/__tests__/MarimoCommands.test.ts
@@ -15,9 +15,9 @@ describe("MarimoCommands", () => {
     );
   });
 
-  it.effect("ignores VS Code context for a no-argument command", () =>
+  it.effect("ignores VS Code context for a context-free command", () =>
     Effect.gen(function* () {
-      const args = yield* decodeCommandArguments(MarimoCommands.restartKernel, [
+      const args = yield* decodeCommandArguments(MarimoCommands.restartLsp, [
         {
           ui: true,
           notebookEditor: { notebookUri: "file:///notebook.py" },
@@ -29,6 +29,36 @@ describe("MarimoCommands", () => {
   );
 
   it.effect("accepts an empty argument list for a no-argument command", () =>
+    Effect.gen(function* () {
+      const args = yield* decodeCommandArguments(MarimoCommands.restartLsp, []);
+      expect(args).toEqual([]);
+    }),
+  );
+
+  it.effect("decodes optional notebook toolbar context", () =>
+    Effect.gen(function* () {
+      const notebookUri = {
+        scheme: "file",
+        path: "/notebook.py",
+        with() {
+          return this;
+        },
+        toString() {
+          return "file:///notebook.py";
+        },
+      };
+      const args = yield* decodeCommandArguments(MarimoCommands.restartKernel, [
+        {
+          ui: true,
+          notebookEditor: { notebookUri },
+          source: "notebookToolbar",
+        },
+      ]);
+      expect(args).toEqual([{ notebookEditor: { notebookUri } }]);
+    }),
+  );
+
+  it.effect("accepts no context for a notebook command", () =>
     Effect.gen(function* () {
       const args = yield* decodeCommandArguments(
         MarimoCommands.restartKernel,

--- a/extension/src/commands/__tests__/MarimoCommands.test.ts
+++ b/extension/src/commands/__tests__/MarimoCommands.test.ts
@@ -24,6 +24,16 @@ describe("MarimoCommands", () => {
     }),
   );
 
+  it.effect("accepts an empty argument list for a no-argument command", () =>
+    Effect.gen(function* () {
+      const args = yield* decodeCommandArguments(
+        MarimoCommands.restartKernel,
+        [],
+      );
+      expect(args).toEqual([]);
+    }),
+  );
+
   it.effect("decodes the first external argument for open-as-notebook", () =>
     Effect.gen(function* () {
       const args = yield* decodeCommandArguments(

--- a/extension/src/commands/__tests__/configureAutoExport.test.ts
+++ b/extension/src/commands/__tests__/configureAutoExport.test.ts
@@ -219,7 +219,9 @@ it.effect(
 
     expect(yield* information).toEqual(Option.none());
     expect(yield* error).toEqual(
-      Option.some("Automatic export settings could not be saved."),
+      Option.some(
+        "Export formats changed but the notebook could not be saved.",
+      ),
     );
   }),
 );
@@ -264,7 +266,9 @@ it.effect(
 
     expect(yield* information).toEqual(Option.none());
     expect(yield* error).toEqual(
-      Option.some("Automatic export settings could not be saved."),
+      Option.some(
+        "Export formats changed but the notebook could not be saved.",
+      ),
     );
   }),
 );

--- a/extension/src/commands/configureAutoExport.ts
+++ b/extension/src/commands/configureAutoExport.ts
@@ -1,6 +1,8 @@
 import { Effect, Option } from "effect";
 
+import type { NotebookCommandContext } from "../commands.ts";
 import type { AutoExportFormat } from "../features/AutoExport.ts";
+import { getNotebookCommandEditor } from "../lib/getNotebookCommandEditor.ts";
 import { VsCode } from "../platform/VsCode.ts";
 import { MarimoNotebookDocument } from "../schemas/MarimoNotebookDocument.ts";
 import type { _AppConfig } from "../schemas/Models.gen.ts";
@@ -26,10 +28,10 @@ export function mergeAutoDownloadFormats(
 }
 
 export const configureAutoExport = Effect.fn("command.configureAutoExport")(
-  function* () {
+  function* (context?: NotebookCommandContext) {
     const code = yield* VsCode;
     const notebook = Option.filterMap(
-      yield* code.window.getActiveNotebookEditor(),
+      yield* getNotebookCommandEditor(context),
       (editor) => MarimoNotebookDocument.tryFrom(editor.notebook),
     );
 

--- a/extension/src/commands/configureAutoExport.ts
+++ b/extension/src/commands/configureAutoExport.ts
@@ -35,7 +35,7 @@ export const configureAutoExport = Effect.fn("command.configureAutoExport")(
 
     if (Option.isNone(notebook)) {
       yield* code.window.showWarningMessage(
-        "Must have an open marimo notebook to configure automatic exports.",
+        "Open a marimo notebook to configure export formats.",
       );
       return;
     }
@@ -58,8 +58,8 @@ export const configureAutoExport = Effect.fn("command.configureAutoExport")(
         },
       ],
       {
-        placeHolder: "Select formats to save under __marimo__",
-        title: "Automatic exports",
+        placeHolder: "Choose formats; saved under __marimo__",
+        title: "Save copies automatically",
       },
     );
     if (Option.isNone(selected)) return;
@@ -88,9 +88,7 @@ export const configureAutoExport = Effect.fn("command.configureAutoExport")(
     ]);
     const applied = yield* code.workspace.applyEdit(edit);
     if (!applied) {
-      yield* code.window.showErrorMessage(
-        "Could not update automatic export settings.",
-      );
+      yield* code.window.showErrorMessage("Could not update export formats.");
       return;
     }
 
@@ -106,7 +104,7 @@ export const configureAutoExport = Effect.fn("command.configureAutoExport")(
       );
     if (!saved) {
       yield* code.window.showErrorMessage(
-        "Automatic export settings could not be saved.",
+        "Export formats changed but the notebook could not be saved.",
       );
       return;
     }

--- a/extension/src/commands/restartKernel.ts
+++ b/extension/src/commands/restartKernel.ts
@@ -1,17 +1,21 @@
 import { Effect, Either, Option } from "effect";
 
+import type { NotebookCommandContext } from "../commands.ts";
 import { CellExecutions } from "../kernel/CellExecutions.ts";
 import { NotebookRuntime } from "../kernel/NotebookRuntime.ts";
+import { getNotebookCommandEditor } from "../lib/getNotebookCommandEditor.ts";
 import { showErrorAndPromptLogs } from "../lib/showErrorAndPromptLogs.ts";
 import { VsCode } from "../platform/VsCode.ts";
 import { MarimoNotebookDocument } from "../schemas/MarimoNotebookDocument.ts";
 
-export const restartKernel = Effect.fn("command.restartKernel")(function* () {
+export const restartKernel = Effect.fn("command.restartKernel")(function* (
+  context?: NotebookCommandContext,
+) {
   const code = yield* VsCode;
   const notebooks = yield* NotebookRuntime;
   const executions = yield* CellExecutions;
 
-  const editor = yield* code.window.getActiveNotebookEditor();
+  const editor = yield* getNotebookCommandEditor(context);
   if (Option.isNone(editor)) {
     yield* code.window.showInformationMessage(
       "No notebook editor is currently open",

--- a/extension/src/commands/runStale.ts
+++ b/extension/src/commands/runStale.ts
@@ -1,16 +1,18 @@
 import { Effect, flow, Option } from "effect";
 
+import type { NotebookCommandContext } from "../commands.ts";
 import { CellExecutions } from "../kernel/CellExecutions.ts";
+import { getNotebookCommandEditor } from "../lib/getNotebookCommandEditor.ts";
 import { showErrorAndPromptLogs } from "../lib/showErrorAndPromptLogs.ts";
 import { VsCode } from "../platform/VsCode.ts";
 import { MarimoNotebookDocument } from "../schemas/MarimoNotebookDocument.ts";
 
 export const runStale = Effect.fn("command.runStale")(
-  function* () {
+  function* (context?: NotebookCommandContext) {
     const code = yield* VsCode;
     const executions = yield* CellExecutions;
     const notebook = Option.filterMap(
-      yield* code.window.getActiveNotebookEditor(),
+      yield* getNotebookCommandEditor(context),
       (editor) => MarimoNotebookDocument.tryFrom(editor.notebook),
     );
 

--- a/extension/src/commands/showNotebookActions.ts
+++ b/extension/src/commands/showNotebookActions.ts
@@ -16,12 +16,12 @@ export const showNotebookActions = Effect.fn("command.showNotebookActions")(
       [
         {
           label: "$(zap) Reactivity",
-          detail: "Choose what happens when cells or imported modules change",
+          detail: "Choose when dependent code runs",
           value: "reactivity" as const,
         },
         {
-          label: "$(save-all) Automatic exports",
-          detail: "Save HTML or IPYNB copies when the notebook changes",
+          label: "$(save-all) Exports",
+          detail: "Keep HTML or IPYNB copies up to date",
           value: "exports" as const,
         },
       ],
@@ -53,19 +53,27 @@ export const showNotebookActions = Effect.fn("command.showNotebookActions")(
       [
         {
           label: "Cell changes",
-          description: onCellChange === "autorun" ? "Automatic" : "Mark stale",
-          detail: "Control when dependent cells run",
+          description: onCellChange === "autorun" ? "Auto-run" : "Lazy",
+          detail:
+            onCellChange === "autorun"
+              ? "Run dependent cells after an upstream cell changes"
+              : "Mark dependent cells stale and run them only when needed",
           value: "cells" as const,
         },
         {
           label: "Module changes",
           description:
             autoReload === "autorun"
-              ? "Automatic"
+              ? "Auto-run"
               : autoReload === "lazy"
-                ? "Mark stale"
+                ? "Lazy"
                 : "Off",
-          detail: "Control what happens when imported modules change",
+          detail:
+            autoReload === "autorun"
+              ? "Reload edited modules and run affected cells automatically"
+              : autoReload === "lazy"
+                ? "Mark affected cells stale and run them only when needed"
+                : "Ignore edits to imported Python modules",
           value: "modules" as const,
         },
       ],

--- a/extension/src/commands/showNotebookActions.ts
+++ b/extension/src/commands/showNotebookActions.ts
@@ -1,0 +1,80 @@
+import { Effect, Option } from "effect";
+
+import type { NotebookCommandContext } from "../commands.ts";
+import { MarimoConfigurationService } from "../config/MarimoConfigurationService.ts";
+import { getNotebookCommandEditor } from "../lib/getNotebookCommandEditor.ts";
+import { VsCode } from "../platform/VsCode.ts";
+import { MarimoNotebookDocument } from "../schemas/MarimoNotebookDocument.ts";
+import { configureAutoExport } from "./configureAutoExport.ts";
+import { toggleAutoReload } from "./toggleAutoReload.ts";
+import { toggleOnCellChange } from "./toggleOnCellChange.ts";
+
+export const showNotebookActions = Effect.fn("command.showNotebookActions")(
+  function* (context?: NotebookCommandContext) {
+    const code = yield* VsCode;
+    const selection = yield* code.window.showQuickPickItems(
+      [
+        {
+          label: "$(zap) Reactivity",
+          detail: "Choose what happens when cells or imported modules change",
+          value: "reactivity" as const,
+        },
+        {
+          label: "$(save-all) Automatic exports",
+          detail: "Save HTML or IPYNB copies when the notebook changes",
+          value: "exports" as const,
+        },
+      ],
+      { title: "marimo notebook" },
+    );
+
+    if (Option.isNone(selection)) return;
+    if (selection.value.value === "exports") {
+      yield* configureAutoExport(context);
+      return;
+    }
+
+    const configService = yield* MarimoConfigurationService;
+    const notebook = Option.filterMap(
+      yield* getNotebookCommandEditor(context),
+      (editor) => MarimoNotebookDocument.tryFrom(editor.notebook),
+    );
+    if (Option.isNone(notebook)) {
+      yield* code.window.showWarningMessage(
+        "Open a marimo notebook to configure reactivity.",
+      );
+      return;
+    }
+
+    const config = yield* configService.getConfig(notebook.value.id);
+    const onCellChange = config.runtime?.on_cell_change ?? "autorun";
+    const autoReload = config.runtime?.auto_reload ?? "off";
+    const reactivity = yield* code.window.showQuickPickItems(
+      [
+        {
+          label: "Cell changes",
+          description: onCellChange === "autorun" ? "Automatic" : "Mark stale",
+          detail: "Control when dependent cells run",
+          value: "cells" as const,
+        },
+        {
+          label: "Module changes",
+          description:
+            autoReload === "autorun"
+              ? "Automatic"
+              : autoReload === "lazy"
+                ? "Mark stale"
+                : "Off",
+          detail: "Control what happens when imported modules change",
+          value: "modules" as const,
+        },
+      ],
+      { title: "Reactivity" },
+    );
+
+    if (Option.isNone(reactivity)) return;
+    yield* reactivity.value.value === "cells"
+      ? toggleOnCellChange(context)
+      : toggleAutoReload(context);
+  },
+);

--- a/extension/src/commands/toggleAutoReload.ts
+++ b/extension/src/commands/toggleAutoReload.ts
@@ -10,18 +10,18 @@ export const toggleAutoReload = (context?: NotebookCommandContext) =>
     getCurrentValue: (config) => config.runtime?.auto_reload ?? "off",
     choices: [
       {
-        label: "Ignore module changes",
-        detail: "Keep the notebook unchanged when imported modules are edited",
+        label: "Off",
+        detail: "Ignore edits to imported Python modules",
         value: "off" as const,
       },
       {
-        label: "Mark affected cells stale",
-        detail: "Wait to run affected cells until they are needed",
+        label: "Lazy",
+        detail: "Mark affected cells stale and run them only when needed",
         value: "lazy" as const,
       },
       {
-        label: "Reload and run affected cells",
-        detail: "Keep affected cells up to date automatically",
+        label: "Auto-run",
+        detail: "Reload edited modules and run affected cells automatically",
         value: "autorun" as const,
       },
     ],
@@ -30,9 +30,9 @@ export const toggleAutoReload = (context?: NotebookCommandContext) =>
         case "off":
           return "Off";
         case "lazy":
-          return "Mark stale";
+          return "Lazy";
         case "autorun":
-          return "Automatic";
+          return "Auto-run";
         default:
           return value;
       }

--- a/extension/src/commands/toggleAutoReload.ts
+++ b/extension/src/commands/toggleAutoReload.ts
@@ -3,21 +3,23 @@ import { createConfigToggle } from "../lib/createConfigToggle.ts";
 export const toggleAutoReload = () =>
   createConfigToggle({
     configPath: "runtime.auto_reload",
+    settingName: "Module changes",
+    pickerTitle: "Module changes",
     getCurrentValue: (config) => config.runtime?.auto_reload ?? "off",
     choices: [
       {
-        label: "Off",
-        detail: "Don't reload modules automatically",
+        label: "Ignore module changes",
+        detail: "Keep the notebook unchanged when imported modules are edited",
         value: "off" as const,
       },
       {
-        label: "Lazy",
-        detail: "Mark cells stale when modules change, don't autorun",
+        label: "Mark affected cells stale",
+        detail: "Wait to run affected cells until they are needed",
         value: "lazy" as const,
       },
       {
-        label: "Auto-Run",
-        detail: "Reload modules and automatically run affected cells",
+        label: "Reload and run affected cells",
+        detail: "Keep affected cells up to date automatically",
         value: "autorun" as const,
       },
     ],
@@ -26,9 +28,9 @@ export const toggleAutoReload = () =>
         case "off":
           return "Off";
         case "lazy":
-          return "Lazy";
+          return "Mark stale";
         case "autorun":
-          return "Auto-Run";
+          return "Automatic";
         default:
           return value;
       }

--- a/extension/src/commands/toggleAutoReload.ts
+++ b/extension/src/commands/toggleAutoReload.ts
@@ -1,7 +1,9 @@
+import type { NotebookCommandContext } from "../commands.ts";
 import { createConfigToggle } from "../lib/createConfigToggle.ts";
 
-export const toggleAutoReload = () =>
+export const toggleAutoReload = (context?: NotebookCommandContext) =>
   createConfigToggle({
+    context,
     configPath: "runtime.auto_reload",
     settingName: "Module changes",
     pickerTitle: "Module changes",

--- a/extension/src/commands/toggleOnCellChange.ts
+++ b/extension/src/commands/toggleOnCellChange.ts
@@ -10,16 +10,16 @@ export const toggleOnCellChange = (context?: NotebookCommandContext) =>
     getCurrentValue: (config) => config.runtime?.on_cell_change ?? "autorun",
     choices: [
       {
-        label: "Run dependent cells",
-        detail: "Keep dependent cells up to date automatically",
+        label: "Auto-run",
+        detail:
+          "Run dependent cells immediately after an upstream cell changes",
         value: "autorun" as const,
       },
       {
-        label: "Mark dependent cells stale",
-        detail: "Wait to run dependent cells until they are needed",
+        label: "Lazy",
+        detail: "Mark dependent cells stale and run them only when needed",
         value: "lazy" as const,
       },
     ],
-    getDisplayName: (value) =>
-      value === "autorun" ? "Automatic" : "Mark stale",
+    getDisplayName: (value) => (value === "autorun" ? "Auto-run" : "Lazy"),
   });

--- a/extension/src/commands/toggleOnCellChange.ts
+++ b/extension/src/commands/toggleOnCellChange.ts
@@ -1,7 +1,9 @@
+import type { NotebookCommandContext } from "../commands.ts";
 import { createConfigToggle } from "../lib/createConfigToggle.ts";
 
-export const toggleOnCellChange = () =>
+export const toggleOnCellChange = (context?: NotebookCommandContext) =>
   createConfigToggle({
+    context,
     configPath: "runtime.on_cell_change",
     settingName: "Cell changes",
     pickerTitle: "Cell changes",

--- a/extension/src/commands/toggleOnCellChange.ts
+++ b/extension/src/commands/toggleOnCellChange.ts
@@ -3,18 +3,21 @@ import { createConfigToggle } from "../lib/createConfigToggle.ts";
 export const toggleOnCellChange = () =>
   createConfigToggle({
     configPath: "runtime.on_cell_change",
+    settingName: "Cell changes",
+    pickerTitle: "Cell changes",
     getCurrentValue: (config) => config.runtime?.on_cell_change ?? "autorun",
     choices: [
       {
-        label: "Auto-Run",
-        detail: "Automatically run cells when their ancestors change",
+        label: "Run dependent cells",
+        detail: "Keep dependent cells up to date automatically",
         value: "autorun" as const,
       },
       {
-        label: "Lazy",
-        detail: "Mark cells stale when ancestors change, don't autorun",
+        label: "Mark dependent cells stale",
+        detail: "Wait to run dependent cells until they are needed",
         value: "lazy" as const,
       },
     ],
-    getDisplayName: (value) => (value === "autorun" ? "Auto-Run" : "Lazy"),
+    getDisplayName: (value) =>
+      value === "autorun" ? "Automatic" : "Mark stale",
   });

--- a/extension/src/features/RegisterCommands.ts
+++ b/extension/src/features/RegisterCommands.ts
@@ -15,6 +15,7 @@ import { restartKernel } from "../commands/restartKernel.ts";
 import { restartLsp } from "../commands/restartLsp.ts";
 import { runStale } from "../commands/runStale.ts";
 import { showDiagnostics } from "../commands/showDiagnostics.ts";
+import { showNotebookActions } from "../commands/showNotebookActions.ts";
 import { toggleAutoReload } from "../commands/toggleAutoReload.ts";
 import { toggleOnCellChange } from "../commands/toggleOnCellChange.ts";
 import { updateActivePythonEnvironment } from "../commands/updateActivePythonEnvironment.ts";
@@ -65,6 +66,10 @@ export const RegisterCommandsLive = Layer.scopedDiscard(
     );
 
     yield* code.commands.register(MarimoCommands.runStale, runStale);
+    yield* code.commands.register(
+      MarimoCommands.showNotebookActions,
+      showNotebookActions,
+    );
     yield* code.commands.register(MarimoCommands.debugCell, debugCell);
 
     for (const command of [

--- a/extension/src/lib/__tests__/getNotebookCommandEditor.test.ts
+++ b/extension/src/lib/__tests__/getNotebookCommandEditor.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Option } from "effect";
+
+import { TestVsCode } from "../../__mocks__/TestVsCode.ts";
+import { getNotebookCommandEditor } from "../getNotebookCommandEditor.ts";
+
+describe("getNotebookCommandEditor", () => {
+  it.effect("prefers the notebook referenced by toolbar context", () =>
+    Effect.gen(function* () {
+      const target = TestVsCode.makeNotebookEditor("/test/target.py");
+      const active = TestVsCode.makeNotebookEditor("/test/active.py");
+      const vscode = yield* TestVsCode.make({
+        initialDocuments: [target.notebook, active.notebook],
+      });
+
+      yield* vscode.setActiveNotebookEditor(Option.some(target));
+      yield* vscode.setActiveNotebookEditor(Option.some(active));
+
+      const editor = yield* getNotebookCommandEditor({
+        notebookEditor: { notebookUri: target.notebook.uri },
+      }).pipe(Effect.provide(vscode.layer));
+
+      expect(Option.getOrThrow(editor).notebook.uri.toString()).toBe(
+        target.notebook.uri.toString(),
+      );
+    }),
+  );
+
+  it.effect("falls back to the active notebook without toolbar context", () =>
+    Effect.gen(function* () {
+      const active = TestVsCode.makeNotebookEditor("/test/active.py");
+      const vscode = yield* TestVsCode.make({
+        initialDocuments: [active.notebook],
+      });
+      yield* vscode.setActiveNotebookEditor(Option.some(active));
+
+      const editor = yield* getNotebookCommandEditor().pipe(
+        Effect.provide(vscode.layer),
+      );
+
+      expect(Option.getOrThrow(editor)).toBe(active);
+    }),
+  );
+
+  it.effect(
+    "does not target the active notebook when context is unresolved",
+    () =>
+      Effect.gen(function* () {
+        const active = TestVsCode.makeNotebookEditor("/test/active.py");
+        const missing = TestVsCode.makeNotebookEditor("/test/missing.py");
+        const vscode = yield* TestVsCode.make({
+          initialDocuments: [active.notebook],
+        });
+        yield* vscode.setActiveNotebookEditor(Option.some(active));
+
+        const editor = yield* getNotebookCommandEditor({
+          notebookEditor: { notebookUri: missing.notebook.uri },
+        }).pipe(Effect.provide(vscode.layer));
+
+        expect(Option.isNone(editor)).toBe(true);
+      }),
+  );
+});

--- a/extension/src/lib/createConfigToggle.ts
+++ b/extension/src/lib/createConfigToggle.ts
@@ -12,11 +12,15 @@ import type { MarimoConfig } from "../types.ts";
  */
 export const createConfigToggle = <T extends string>({
   configPath,
+  settingName,
+  pickerTitle,
   getCurrentValue,
   choices,
   getDisplayName,
 }: {
   configPath: string;
+  settingName: string;
+  pickerTitle: string;
   getCurrentValue: (config: MarimoConfig) => T;
   choices: ReadonlyArray<{
     label: string;
@@ -37,7 +41,7 @@ export const createConfigToggle = <T extends string>({
 
     if (Option.isNone(notebook)) {
       yield* showErrorAndPromptLogs(
-        `Must have an open marimo notebook to toggle ${configPath}.`,
+        `Open a marimo notebook to configure ${settingName.toLowerCase()}.`,
       );
       return;
     }
@@ -54,6 +58,7 @@ export const createConfigToggle = <T extends string>({
         detail: c.detail,
         value: c.value,
       })),
+      { title: pickerTitle },
     );
 
     if (Option.isNone(choice)) {
@@ -88,11 +93,11 @@ export const createConfigToggle = <T extends string>({
     yield* configService.updateConfig(notebook.value.id, partialConfig);
 
     yield* code.window.showInformationMessage(
-      `${configPath} updated to: ${getDisplayName(newValue)}`,
+      `${settingName} set to ${getDisplayName(newValue)}.`,
     );
   }).pipe(
     Effect.tapErrorCause(Effect.logError),
     Effect.catchAllCause(() =>
-      showErrorAndPromptLogs(`Failed to toggle ${configPath}.`),
+      showErrorAndPromptLogs(`Could not update ${settingName.toLowerCase()}.`),
     ),
   );

--- a/extension/src/lib/createConfigToggle.ts
+++ b/extension/src/lib/createConfigToggle.ts
@@ -1,6 +1,8 @@
 import { Effect, Option } from "effect";
 
+import type { NotebookCommandContext } from "../commands.ts";
 import { MarimoConfigurationService } from "../config/MarimoConfigurationService.ts";
+import { getNotebookCommandEditor } from "../lib/getNotebookCommandEditor.ts";
 import { showErrorAndPromptLogs } from "../lib/showErrorAndPromptLogs.ts";
 import { VsCode } from "../platform/VsCode.ts";
 import { MarimoNotebookDocument } from "../schemas/MarimoNotebookDocument.ts";
@@ -11,6 +13,7 @@ import type { MarimoConfig } from "../types.ts";
  * Creates a handler that shows a quick pick dialog with all available options.
  */
 export const createConfigToggle = <T extends string>({
+  context,
   configPath,
   settingName,
   pickerTitle,
@@ -18,6 +21,7 @@ export const createConfigToggle = <T extends string>({
   choices,
   getDisplayName,
 }: {
+  context: NotebookCommandContext | undefined;
   configPath: string;
   settingName: string;
   pickerTitle: string;
@@ -33,9 +37,9 @@ export const createConfigToggle = <T extends string>({
     const code = yield* VsCode;
     const configService = yield* MarimoConfigurationService;
 
-    // Validate active notebook
+    // Validate the notebook that originated the command.
     const notebook = Option.filterMap(
-      yield* code.window.getActiveNotebookEditor(),
+      yield* getNotebookCommandEditor(context),
       (editor) => MarimoNotebookDocument.tryFrom(editor.notebook),
     );
 

--- a/extension/src/lib/getNotebookCommandEditor.ts
+++ b/extension/src/lib/getNotebookCommandEditor.ts
@@ -1,0 +1,24 @@
+import { Effect, Option } from "effect";
+
+import type { NotebookCommandContext } from "../commands.ts";
+import { VsCode } from "../platform/VsCode.ts";
+
+/**
+ * Resolve the notebook that originated a toolbar command. Commands launched
+ * elsewhere fall back to the active notebook.
+ */
+export const getNotebookCommandEditor = Effect.fn(
+  "command.getNotebookCommandEditor",
+)(function* (context?: NotebookCommandContext) {
+  const code = yield* VsCode;
+
+  if (context !== undefined) {
+    const target = context.notebookEditor.notebookUri.toString();
+    const editor = (yield* code.window.getVisibleNotebookEditors()).find(
+      (candidate) => candidate.notebook.uri.toString() === target,
+    );
+    return Option.fromNullable(editor);
+  }
+
+  return yield* code.window.getActiveNotebookEditor();
+});

--- a/src/marimo_lsp/api.py
+++ b/src/marimo_lsp/api.py
@@ -84,6 +84,17 @@ logger = get_logger()
 _API_HANDLER_PARAMETER_COUNT = 2
 
 
+def _as_partial_marimo_config(config: dict[str, object]) -> PartialMarimoConfig:
+    """Adapt a deep configuration patch to marimo's shallow partial type.
+
+    Python cannot derive a recursive partial ``TypedDict`` from
+    ``MarimoConfig``. Marimo accepts deep patches at runtime, even though its
+    ``PartialMarimoConfig`` annotation only describes a shallow partial.
+    Keep that typing assertion isolated at this API boundary.
+    """
+    return cast("PartialMarimoConfig", config)
+
+
 @dataclasses.dataclass(frozen=True)
 class ApiContext:
     """Server-side dependencies available to API handlers."""
@@ -490,14 +501,14 @@ async def update_configuration(
     args: NotebookCommand[UpdateConfigurationRequest],
 ) -> MarimoConfig:
     """Update the marimo user configuration."""
+    config = _as_partial_marimo_config(args.inner.config)
     session = ctx.sessions.get(args.notebook_uri)
     if not session:
         manager = get_default_config_manager(current_path=to_fs_path(args.notebook_uri))
-        return manager.save_config(cast("PartialMarimoConfig", args.inner.config))
+        manager.save_config(config)
+        return manager.get_config()
 
-    # PartialMarimoConfig is only shallow-partial, while config updates are
-    # intentionally deep patches (for example, just runtime.on_cell_change).
-    return session.save_config(cast("PartialMarimoConfig", args.inner.config))
+    return session.save_config(config)
 
 
 @marimo_api("set-display-theme")

--- a/src/marimo_lsp/api.py
+++ b/src/marimo_lsp/api.py
@@ -12,7 +12,8 @@ from typing import TYPE_CHECKING, cast
 
 import msgspec
 from marimo._ast.app_config import _AppConfig
-from marimo._config.config import DEFAULT_CONFIG, MarimoConfig
+from marimo._config.config import MarimoConfig  # noqa: TC002 - API introspection
+from marimo._config.manager import get_default_config_manager
 from marimo._convert.converters import MarimoConvert
 from marimo._export.exporter import Exporter
 from marimo._export.requests import HTMLExportRequest, IPYNBExportRequest
@@ -180,13 +181,6 @@ class ApiBuilder:
 
 
 marimo_api = ApiBuilder()
-
-
-class SessionNotFoundError(ValueError):
-    """Raised when an API command requires a live notebook session."""
-
-    def __init__(self, notebook_uri: str) -> None:
-        super().__init__(f"No session found for {notebook_uri}")
 
 
 def _get_display_config(config: MarimoConfig) -> DisplayConfig:
@@ -484,8 +478,8 @@ async def get_configuration(
     """Get the current marimo configuration."""
     session = ctx.sessions.get(args.notebook_uri)
     if not session:
-        logger.warning(f"No session found for {args.notebook_uri}")
-        return GetConfigurationResponse(config=DEFAULT_CONFIG)
+        manager = get_default_config_manager(current_path=to_fs_path(args.notebook_uri))
+        return GetConfigurationResponse(config=manager.get_config())
 
     return GetConfigurationResponse(config=session.get_config())
 
@@ -498,8 +492,8 @@ async def update_configuration(
     """Update the marimo user configuration."""
     session = ctx.sessions.get(args.notebook_uri)
     if not session:
-        logger.warning(f"No session found for {args.notebook_uri}")
-        raise SessionNotFoundError(args.notebook_uri)
+        manager = get_default_config_manager(current_path=to_fs_path(args.notebook_uri))
+        return manager.save_config(cast("PartialMarimoConfig", args.inner.config))
 
     # PartialMarimoConfig is only shallow-partial, while config updates are
     # intentionally deep patches (for example, just runtime.on_cell_change).

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import msgspec
 import pytest
@@ -11,10 +11,11 @@ from marimo._config.config import DEFAULT_CONFIG
 from marimo_lsp.api import (
     ApiBuilder,
     ApiContext,
-    SessionNotFoundError,
+    get_configuration,
     update_configuration,
 )
 from marimo_lsp.models import (
+    GetConfigurationRequest,
     NotebookCommand,
     SetDisplayThemeRequest,
     UpdateConfigurationRequest,
@@ -77,18 +78,49 @@ async def test_update_configuration_returns_saved_config() -> None:
 
 
 @pytest.mark.asyncio
-async def test_update_configuration_raises_without_session() -> None:
+async def test_update_configuration_saves_without_session() -> None:
     sessions = MagicMock()
     sessions.get.return_value = None
+    manager = MagicMock()
+    manager.save_config.return_value = DEFAULT_CONFIG
 
-    with pytest.raises(SessionNotFoundError):
-        await update_configuration(
+    with patch(
+        "marimo_lsp.api.get_default_config_manager", return_value=manager
+    ) as get_manager:
+        result = await update_configuration(
             _context(sessions),
             NotebookCommand(
                 notebook_uri="file:///notebook.py",
                 inner=UpdateConfigurationRequest(config={}),
             ),
         )
+
+    get_manager.assert_called_once_with(current_path="/notebook.py")
+    manager.save_config.assert_called_once_with({})
+    assert result == DEFAULT_CONFIG
+
+
+@pytest.mark.asyncio
+async def test_get_configuration_loads_without_session() -> None:
+    sessions = MagicMock()
+    sessions.get.return_value = None
+    manager = MagicMock()
+    manager.get_config.return_value = DEFAULT_CONFIG
+
+    with patch(
+        "marimo_lsp.api.get_default_config_manager", return_value=manager
+    ) as get_manager:
+        result = await get_configuration(
+            _context(sessions),
+            NotebookCommand(
+                notebook_uri="file:///notebook.py",
+                inner=GetConfigurationRequest(),
+            ),
+        )
+
+    get_manager.assert_called_once_with(current_path="/notebook.py")
+    manager.get_config.assert_called_once_with()
+    assert result.config == DEFAULT_CONFIG
 
 
 @pytest.mark.asyncio

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -78,11 +78,13 @@ async def test_update_configuration_returns_saved_config() -> None:
 
 
 @pytest.mark.asyncio
-async def test_update_configuration_saves_without_session() -> None:
+async def test_update_configuration_returns_effective_config_without_session() -> None:
     sessions = MagicMock()
     sessions.get.return_value = None
     manager = MagicMock()
-    manager.save_config.return_value = DEFAULT_CONFIG
+    manager.save_config.return_value = MagicMock(name="saved_user_config")
+    manager.get_config.return_value = DEFAULT_CONFIG
+    partial_config: dict[str, object] = {"runtime": {"on_cell_change": "lazy"}}
 
     with patch(
         "marimo_lsp.api.get_default_config_manager", return_value=manager
@@ -91,12 +93,13 @@ async def test_update_configuration_saves_without_session() -> None:
             _context(sessions),
             NotebookCommand(
                 notebook_uri="file:///notebook.py",
-                inner=UpdateConfigurationRequest(config={}),
+                inner=UpdateConfigurationRequest(config=partial_config),
             ),
         )
 
     get_manager.assert_called_once_with(current_path="/notebook.py")
-    manager.save_config.assert_called_once_with({})
+    manager.save_config.assert_called_once_with(partial_config)
+    manager.get_config.assert_called_once_with()
     assert result == DEFAULT_CONFIG
 
 


### PR DESCRIPTION
The notebook toolbar currently presents marimo-specific runtime and export controls alongside standard notebook actions. As the number of controls grows, related settings become harder to discover and the toolbar becomes harder to scan.

This PR keeps common notebook actions in the toolbar and moves marimo-specific controls behind a marimo menu. The menu groups Reactivity and Exports, uses consistent Auto-run, Lazy, and Off language, and keeps configuration available before a kernel starts. Toolbar actions continue to target the notebook that opened the menu.

### Screenshots

**Notebook toolbar and marimo menu**

<img width="500" alt="image" src="https://github.com/user-attachments/assets/efb07216-39f6-4e33-939c-0c1f2d337b4c" />


**Reactivity settings**

<img width="500" alt="image" src="https://github.com/user-attachments/assets/72599cb1-a07f-4ea7-9285-2d693fd3cd72" />

<img width="500" alt="image" src="https://github.com/user-attachments/assets/b634cb61-45a2-4fab-968c-4c5727e7569b" />

