### PR TITLE
Load datasource metadata on expansion

### DIFF
--- a/extension/src/features/__tests__/CellMetadataBindings.test.ts
+++ b/extension/src/features/__tests__/CellMetadataBindings.test.ts
@@ -8,6 +8,7 @@ import {
   createTestNotebookDocument,
   TestVsCode,
 } from "../../__mocks__/TestVsCode.ts";
+import { makeTestMarimoClient } from "../../__tests__/__utils__/TestMarimoClient.ts";
 import { CellMetadataUIBindingService } from "../../notebook/CellMetadataUIBindingService.ts";
 import { DatasourcesService } from "../../panel/datasources/DatasourcesService.ts";
 import { Constants } from "../../platform/Constants.ts";
@@ -24,6 +25,7 @@ const withTestCtx = Effect.gen(function* () {
     Layer.provideMerge(CellMetadataBindingsLive),
     Layer.provide(CellMetadataUIBindingService.Default),
     Layer.provide(DatasourcesService.Default),
+    Layer.provide(makeTestMarimoClient()),
     Layer.provide(Constants.Default),
     Layer.provide(vscode.layer),
   );

--- a/extension/src/kernel/NotebookRuntime.ts
+++ b/extension/src/kernel/NotebookRuntime.ts
@@ -816,6 +816,12 @@ function processOperation(
       case "datasets":
         yield* datasources.updateDatasets(notebookUri, operation);
         break;
+      case "sql-schema-list-preview":
+        yield* datasources.updateSchemaList(notebookUri, operation);
+        break;
+      case "sql-table-list-preview":
+        yield* datasources.updateTableList(notebookUri, operation);
+        break;
       case "notebook-document-transaction":
         yield* applyTransactionToEditor(
           notebookUri,
@@ -853,8 +859,6 @@ function processOperation(
       case "reconnected":
       case "reload":
       case "secret-keys-result":
-      case "sql-schema-list-preview":
-      case "sql-table-list-preview":
       case "sql-table-preview":
       case "startup-logs":
       case "storage-download-ready":

--- a/extension/src/kernel/__tests__/NotebookRuntimeOperations.test.ts
+++ b/extension/src/kernel/__tests__/NotebookRuntimeOperations.test.ts
@@ -734,10 +734,15 @@ describe("NotebookRuntime scratch stream", () => {
             .pipe(Stream.runCollect),
         );
 
-        // Let executeScratchpad enqueue marimo.api with its generated runId.
-        yield* TestClock.adjust("1 millis");
-
-        const executions = yield* Ref.get(ctx.executions);
+        // Wait for executeScratchpad to enqueue marimo.api with its generated
+        // runId instead of relying on a scheduler tick.
+        const executions = yield* ctx.executions.changes.pipe(
+          Stream.filter((calls) =>
+            calls.some((call) => call.method === "execute-scratchpad"),
+          ),
+          Stream.runHead,
+          Effect.map(Option.getOrThrow),
+        );
         const executeCmd = executions.find(
           (c) => c.method === "execute-scratchpad",
         );
@@ -829,9 +834,15 @@ describe("NotebookRuntime scratch stream", () => {
             .pipe(Stream.runCollect),
         );
 
-        // Let executeScratchpad send the command and arm the
-        // interrupt-on-abandon finalizer.
-        yield* TestClock.adjust("1 millis");
+        // Wait until executeScratchpad sends the command and arms the
+        // interrupt-on-abandon finalizer instead of relying on a scheduler
+        // tick.
+        yield* ctx.executions.changes.pipe(
+          Stream.filter((calls) =>
+            calls.some((call) => call.method === "execute-scratchpad"),
+          ),
+          Stream.runHead,
+        );
 
         // Abandon the stream before any completed-run arrives (mirrors a
         // cancelled tool invocation interrupting the fiber).

--- a/extension/src/panel/TreeView.ts
+++ b/extension/src/panel/TreeView.ts
@@ -92,6 +92,7 @@ export class TreeView extends Effect.Service<TreeView>()("TreeView", {
  * Configuration for a tree item.
  */
 export interface TreeItem {
+  id?: string;
   label: string;
   description?: string;
   tooltip?: string;
@@ -123,6 +124,10 @@ function toVSCodeTreeItem(vscode: VsCode, item: TreeItem): vscode.TreeItem {
         ? vscode.TreeItemCollapsibleState.Expanded
         : vscode.TreeItemCollapsibleState.None,
   );
+
+  if (item.id) {
+    treeItem.id = item.id;
+  }
 
   if (item.description) {
     treeItem.description = item.description;

--- a/extension/src/panel/datasources/DatasourcesService.ts
+++ b/extension/src/panel/datasources/DatasourcesService.ts
@@ -61,6 +61,8 @@ interface PendingExpansion {
   readonly deferred: Deferred.Deferred<void, DatasourceExpansionError>;
 }
 
+const EXPANSION_TIMEOUT = "30 seconds";
+
 /**
  * Manages datasource state across all notebooks.
  *
@@ -103,9 +105,22 @@ export class DatasourcesService extends Effect.Service<DatasourcesService>()(
         location: string,
         send: (requestId: string) => Effect.Effect<void, unknown>,
       ) {
+        const awaitExpansion = (
+          deferred: Deferred.Deferred<void, DatasourceExpansionError>,
+        ) =>
+          Deferred.await(deferred).pipe(
+            Effect.timeoutFail({
+              duration: EXPANSION_TIMEOUT,
+              onTimeout: () =>
+                new DatasourceExpansionError({
+                  message: "Timed out while loading datasource metadata",
+                }),
+            }),
+          );
+
         const current = pendingByLocation.get(location);
         if (current !== undefined) {
-          return yield* Deferred.await(current.deferred);
+          return yield* awaitExpansion(current.deferred);
         }
 
         const requestId = crypto.randomUUID();
@@ -123,7 +138,7 @@ export class DatasourcesService extends Effect.Service<DatasourcesService>()(
           ),
         );
 
-        return yield* Deferred.await(deferred).pipe(
+        return yield* awaitExpansion(deferred).pipe(
           Effect.ensuring(
             Effect.sync(() => {
               pendingByLocation.delete(location);

--- a/extension/src/panel/datasources/DatasourcesService.ts
+++ b/extension/src/panel/datasources/DatasourcesService.ts
@@ -159,6 +159,9 @@ export class DatasourcesService extends Effect.Service<DatasourcesService>()(
             );
       };
 
+      const isPendingExpansion = (notebookUri: NotebookId, requestId: string) =>
+        pendingByRequest.get(requestId)?.notebookUri === notebookUri;
+
       const convertTablesToMap = (tables: readonly DataTable[]) =>
         new Map(tables.map((table) => [table.name, table]));
 
@@ -313,6 +316,18 @@ export class DatasourcesService extends Effect.Service<DatasourcesService>()(
           operation: SqlSchemaListPreviewNotification,
         ) {
           return Effect.gen(function* () {
+            if (!isPendingExpansion(notebookUri, operation.request_id)) {
+              yield* Effect.logTrace(
+                "Ignored uncorrelated datasource schema response",
+              ).pipe(
+                Effect.annotateLogs({
+                  notebookUri,
+                  requestId: operation.request_id,
+                }),
+              );
+              return;
+            }
+
             if (operation.error != null) {
               yield* completeExpansion(operation.request_id, operation.error);
               yield* Effect.logWarning(
@@ -366,6 +381,18 @@ export class DatasourcesService extends Effect.Service<DatasourcesService>()(
           operation: SqlTableListPreviewNotification,
         ) {
           return Effect.gen(function* () {
+            if (!isPendingExpansion(notebookUri, operation.request_id)) {
+              yield* Effect.logTrace(
+                "Ignored uncorrelated datasource table response",
+              ).pipe(
+                Effect.annotateLogs({
+                  notebookUri,
+                  requestId: operation.request_id,
+                }),
+              );
+              return;
+            }
+
             if (operation.error != null) {
               yield* completeExpansion(operation.request_id, operation.error);
               yield* Effect.logWarning("Failed to list datasource tables").pipe(

--- a/extension/src/panel/datasources/DatasourcesService.ts
+++ b/extension/src/panel/datasources/DatasourcesService.ts
@@ -1,4 +1,11 @@
-import { Data, Deferred, Effect, HashMap, SubscriptionRef } from "effect";
+import {
+  Data,
+  Deferred,
+  Effect,
+  Fiber,
+  HashMap,
+  SubscriptionRef,
+} from "effect";
 
 import { MarimoClient } from "../../lsp/MarimoClient.ts";
 import type { NotebookId } from "../../schemas/MarimoNotebookDocument.ts";
@@ -57,8 +64,8 @@ export class DatasourceExpansionError extends Data.TaggedError(
 
 interface PendingExpansion {
   readonly notebookUri: NotebookId;
-  readonly requestId: string;
   readonly deferred: Deferred.Deferred<void, DatasourceExpansionError>;
+  readonly fiber: Fiber.RuntimeFiber<void, DatasourceExpansionError>;
 }
 
 const EXPANSION_TIMEOUT = "30 seconds";
@@ -78,6 +85,7 @@ export class DatasourcesService extends Effect.Service<DatasourcesService>()(
   {
     scoped: Effect.gen(function* () {
       const marimo = yield* MarimoClient;
+      const serviceScope = yield* Effect.scope;
 
       // Track data source connections: NotebookUri -> DataSourceConnectionMap
       const connectionsRef = yield* SubscriptionRef.make(
@@ -105,27 +113,38 @@ export class DatasourcesService extends Effect.Service<DatasourcesService>()(
         location: string,
         send: (requestId: string) => Effect.Effect<void, unknown>,
       ) {
-        const awaitExpansion = (
-          deferred: Deferred.Deferred<void, DatasourceExpansionError>,
-        ) =>
-          Deferred.await(deferred).pipe(
-            Effect.timeoutFail({
-              duration: EXPANSION_TIMEOUT,
-              onTimeout: () =>
-                new DatasourceExpansionError({
-                  message: "Timed out while loading datasource metadata",
-                }),
-            }),
-          );
-
         const current = pendingByLocation.get(location);
         if (current !== undefined) {
-          return yield* awaitExpansion(current.deferred);
+          return yield* Fiber.join(current.fiber);
         }
 
         const requestId = crypto.randomUUID();
         const deferred = yield* Deferred.make<void, DatasourceExpansionError>();
-        const pending = { notebookUri, requestId, deferred };
+        const fiber = yield* Deferred.await(deferred).pipe(
+          Effect.timeoutFail({
+            duration: EXPANSION_TIMEOUT,
+            onTimeout: () =>
+              new DatasourceExpansionError({
+                message: "Timed out while loading datasource metadata",
+              }),
+          }),
+          Effect.ensuring(
+            Effect.sync(() => {
+              const completed = pendingByRequest.get(requestId);
+              if (completed?.deferred !== deferred) return;
+              pendingByRequest.delete(requestId);
+              if (pendingByLocation.get(location) === completed) {
+                pendingByLocation.delete(location);
+              }
+            }),
+          ),
+          Effect.forkIn(serviceScope),
+        );
+        const pending = {
+          notebookUri,
+          deferred,
+          fiber,
+        };
         pendingByLocation.set(location, pending);
         pendingByRequest.set(requestId, pending);
 
@@ -138,25 +157,21 @@ export class DatasourcesService extends Effect.Service<DatasourcesService>()(
           ),
         );
 
-        return yield* awaitExpansion(deferred).pipe(
-          Effect.ensuring(
-            Effect.sync(() => {
-              pendingByLocation.delete(location);
-              pendingByRequest.delete(requestId);
-            }),
-          ),
-        );
+        return yield* Fiber.join(fiber);
       });
 
       const completeExpansion = (requestId: string, error?: string | null) => {
         const pending = pendingByRequest.get(requestId);
         if (pending === undefined) return Effect.void;
-        return error == null
-          ? Deferred.succeed(pending.deferred, undefined)
-          : Deferred.fail(
-              pending.deferred,
-              new DatasourceExpansionError({ message: error }),
-            );
+        return Effect.gen(function* () {
+          yield* error == null
+            ? Deferred.succeed(pending.deferred, undefined)
+            : Deferred.fail(
+                pending.deferred,
+                new DatasourceExpansionError({ message: error }),
+              );
+          yield* Fiber.await(pending.fiber);
+        });
       };
 
       const isPendingExpansion = (notebookUri: NotebookId, requestId: string) =>
@@ -544,6 +559,7 @@ export class DatasourcesService extends Effect.Service<DatasourcesService>()(
                     message: "Notebook closed",
                   }),
                 );
+                yield* Fiber.await(pending.fiber);
               }
             }
             yield* SubscriptionRef.update(connectionsRef, (map) =>

--- a/extension/src/panel/datasources/DatasourcesService.ts
+++ b/extension/src/panel/datasources/DatasourcesService.ts
@@ -2,62 +2,46 @@ import { Effect, HashMap, SubscriptionRef } from "effect";
 
 import type { NotebookId } from "../../schemas/MarimoNotebookDocument.ts";
 import type {
+  DataSourceConnection,
   DataSourceConnectionsNotification,
+  DatabaseSchema,
+  DataTable,
   DatasetsNotification,
+  SqlSchemaListPreviewNotification,
+  SqlTableListPreviewNotification,
 } from "../../types.ts";
 
 /**
  * Maps for efficient lookups in the datasource hierarchy:
- * Connection -> Database -> Schema -> Table
+ * Connection -> Database -> recursive Schema -> Table
  */
 
-interface DataSourceConnectionMap {
-  // connection name -> connection data
-  connections: Map<
-    string,
-    {
-      source: string;
-      dialect: string;
-      name: string;
-      display_name: string;
-      default_database: string | null;
-      default_schema: string | null;
-      databases: Map<
-        string,
-        {
-          name: string;
-          dialect: string;
-          engine: string | null;
-          schemas: Map<
-            string,
-            {
-              name: string;
-              tables: Map<string, DataTable>;
-            }
-          >;
-        }
-      >;
-    }
-  >;
+export interface DatasourceSchema {
+  readonly name: string;
+  readonly tables: ReadonlyMap<string, DataTable>;
+  readonly tablesResolved: boolean;
+  readonly childSchemas: ReadonlyMap<string, DatasourceSchema>;
+  readonly childSchemasResolved: boolean;
 }
 
-interface DataTable {
-  name: string;
-  source: string;
-  source_type: "catalog" | "connection" | "duckdb" | "local";
-  num_rows: number | null;
-  num_columns: number | null;
-  variable_name: string | null;
-  engine: string | null;
-  type: "table" | "view";
-  primary_keys: string[] | null;
-  indexes: string[] | null;
-  columns: Array<{
-    name: string;
-    type: string;
-    external_type: string;
-    sample_values: unknown[];
-  }>;
+export interface DatasourceDatabase {
+  readonly name: string;
+  readonly dialect: string;
+  readonly engine: string | null;
+  readonly schemas: ReadonlyMap<string, DatasourceSchema>;
+  readonly schemasResolved: boolean;
+}
+
+export interface DatasourceConnection extends Omit<
+  DataSourceConnection,
+  "databases"
+> {
+  readonly databases: ReadonlyMap<string, DatasourceDatabase>;
+}
+
+export interface DataSourceConnectionMap {
+  // connection name -> connection data
+  readonly connections: ReadonlyMap<string, DatasourceConnection>;
 }
 
 interface DatasetsMap {
@@ -90,6 +74,78 @@ export class DatasourcesService extends Effect.Service<DatasourcesService>()(
         HashMap.empty<NotebookId, DatasetsMap>(),
       );
 
+      const convertTablesToMap = (tables: readonly DataTable[]) =>
+        new Map(tables.map((table) => [table.name, table]));
+
+      const convertSchemaToMap = (
+        schema: DatabaseSchema,
+      ): DatasourceSchema => ({
+        name: schema.name,
+        tables: convertTablesToMap(schema.tables),
+        tablesResolved: schema.tables_resolved ?? true,
+        childSchemas: new Map(
+          (schema.child_schemas ?? []).map((child) => [
+            child.name,
+            convertSchemaToMap(child),
+          ]),
+        ),
+        childSchemasResolved: schema.child_schemas_resolved ?? true,
+      });
+
+      const convertSchemasToMap = (schemas: readonly DatabaseSchema[]) =>
+        new Map(
+          schemas.map((schema) => [schema.name, convertSchemaToMap(schema)]),
+        );
+
+      const updateSchemaAtPath = (
+        schemas: ReadonlyMap<string, DatasourceSchema>,
+        path: readonly string[],
+        update: (schema: DatasourceSchema) => DatasourceSchema,
+      ): ReadonlyMap<string, DatasourceSchema> => {
+        const [name, ...rest] = path;
+        if (name === undefined) return schemas;
+        const schema = schemas.get(name);
+        if (schema === undefined) return schemas;
+
+        const updated =
+          rest.length === 0
+            ? update(schema)
+            : {
+                ...schema,
+                childSchemas: updateSchemaAtPath(
+                  schema.childSchemas,
+                  rest,
+                  update,
+                ),
+              };
+        return new Map(schemas).set(name, updated);
+      };
+
+      const updateDatabase = (
+        state: DataSourceConnectionMap,
+        connectionName: string,
+        databaseName: string,
+        update: (database: DatasourceDatabase) => DatasourceDatabase,
+      ): DataSourceConnectionMap => {
+        const connection = state.connections.get(connectionName);
+        const database = connection?.databases.get(databaseName);
+        if (connection === undefined || database === undefined) return state;
+
+        const nextConnection = {
+          ...connection,
+          databases: new Map(connection.databases).set(
+            databaseName,
+            update(database),
+          ),
+        };
+        return {
+          connections: new Map(state.connections).set(
+            connectionName,
+            nextConnection,
+          ),
+        };
+      };
+
       /**
        * Convert DataSourceConnection list to efficient map structure
        */
@@ -102,25 +158,12 @@ export class DatasourcesService extends Effect.Service<DatasourcesService>()(
           const databasesMap = new Map();
 
           for (const db of conn.databases) {
-            const schemasMap = new Map();
-
-            for (const schema of db.schemas) {
-              const tablesMap = new Map();
-              for (const table of schema.tables) {
-                tablesMap.set(table.name, table);
-              }
-
-              schemasMap.set(schema.name, {
-                name: schema.name,
-                tables: tablesMap,
-              });
-            }
-
             databasesMap.set(db.name, {
               name: db.name,
               dialect: db.dialect,
               engine: db.engine ?? null,
-              schemas: schemasMap,
+              schemas: convertSchemasToMap(db.schemas),
+              schemasResolved: db.schemas_resolved ?? true,
             });
           }
 
@@ -177,6 +220,100 @@ export class DatasourcesService extends Effect.Service<DatasourcesService>()(
                 count: operation.connections.length,
               }),
             );
+          });
+        },
+
+        updateSchemaList(
+          notebookUri: NotebookId,
+          operation: SqlSchemaListPreviewNotification,
+        ) {
+          return Effect.gen(function* () {
+            if (operation.error != null) {
+              yield* Effect.logWarning(
+                "Failed to list datasource schemas",
+              ).pipe(
+                Effect.annotateLogs({
+                  notebookUri,
+                  requestId: operation.request_id,
+                  error: operation.error,
+                }),
+              );
+              return;
+            }
+
+            yield* SubscriptionRef.update(connectionsRef, (notebooks) => {
+              const current = HashMap.get(notebooks, notebookUri);
+              if (current._tag === "None") return notebooks;
+              const { connection, database } = operation.metadata;
+              const schemaPath = operation.metadata.schema_path ?? [];
+              const schemas = convertSchemasToMap(operation.schemas ?? []);
+              const next = updateDatabase(
+                current.value,
+                connection,
+                database,
+                (db) =>
+                  schemaPath.length === 0
+                    ? { ...db, schemas, schemasResolved: true }
+                    : {
+                        ...db,
+                        schemas: updateSchemaAtPath(
+                          db.schemas,
+                          schemaPath,
+                          (schema) => ({
+                            ...schema,
+                            childSchemas: schemas,
+                            childSchemasResolved: true,
+                          }),
+                        ),
+                      },
+              );
+              return next === current.value
+                ? notebooks
+                : HashMap.set(notebooks, notebookUri, next);
+            });
+          });
+        },
+
+        updateTableList(
+          notebookUri: NotebookId,
+          operation: SqlTableListPreviewNotification,
+        ) {
+          return Effect.gen(function* () {
+            if (operation.error != null) {
+              yield* Effect.logWarning("Failed to list datasource tables").pipe(
+                Effect.annotateLogs({
+                  notebookUri,
+                  requestId: operation.request_id,
+                  error: operation.error,
+                }),
+              );
+              return;
+            }
+
+            yield* SubscriptionRef.update(connectionsRef, (notebooks) => {
+              const current = HashMap.get(notebooks, notebookUri);
+              if (current._tag === "None") return notebooks;
+              const { connection, database, schema } = operation.metadata;
+              const schemaPath = operation.metadata.schema_path ?? [];
+              const path = schemaPath.length > 0 ? schemaPath : [schema];
+              const tables = convertTablesToMap(operation.tables ?? []);
+              const next = updateDatabase(
+                current.value,
+                connection,
+                database,
+                (db) => ({
+                  ...db,
+                  schemas: updateSchemaAtPath(db.schemas, path, (current) => ({
+                    ...current,
+                    tables,
+                    tablesResolved: true,
+                  })),
+                }),
+              );
+              return next === current.value
+                ? notebooks
+                : HashMap.set(notebooks, notebookUri, next);
+            });
           });
         },
 

--- a/extension/src/panel/datasources/DatasourcesService.ts
+++ b/extension/src/panel/datasources/DatasourcesService.ts
@@ -1,5 +1,6 @@
-import { Effect, HashMap, SubscriptionRef } from "effect";
+import { Data, Deferred, Effect, HashMap, SubscriptionRef } from "effect";
 
+import { MarimoClient } from "../../lsp/MarimoClient.ts";
 import type { NotebookId } from "../../schemas/MarimoNotebookDocument.ts";
 import type {
   DataSourceConnection,
@@ -50,6 +51,16 @@ interface DatasetsMap {
   clear_channel: ("catalog" | "connection" | "duckdb" | "local") | null;
 }
 
+export class DatasourceExpansionError extends Data.TaggedError(
+  "DatasourceExpansionError",
+)<{ readonly message: string }> {}
+
+interface PendingExpansion {
+  readonly notebookUri: NotebookId;
+  readonly requestId: string;
+  readonly deferred: Deferred.Deferred<void, DatasourceExpansionError>;
+}
+
 /**
  * Manages datasource state across all notebooks.
  *
@@ -64,6 +75,8 @@ export class DatasourcesService extends Effect.Service<DatasourcesService>()(
   "DatasourcesService",
   {
     scoped: Effect.gen(function* () {
+      const marimo = yield* MarimoClient;
+
       // Track data source connections: NotebookUri -> DataSourceConnectionMap
       const connectionsRef = yield* SubscriptionRef.make(
         HashMap.empty<NotebookId, DataSourceConnectionMap>(),
@@ -73,6 +86,63 @@ export class DatasourcesService extends Effect.Service<DatasourcesService>()(
       const datasetsRef = yield* SubscriptionRef.make(
         HashMap.empty<NotebookId, DatasetsMap>(),
       );
+      const pendingByLocation = new Map<string, PendingExpansion>();
+      const pendingByRequest = new Map<string, PendingExpansion>();
+
+      const expansionKey = (
+        notebookUri: NotebookId,
+        connection: string,
+        database: string,
+        kind: "schemas" | "tables",
+        schemaPath: readonly string[],
+      ) =>
+        JSON.stringify([notebookUri, connection, database, kind, schemaPath]);
+
+      const requestExpansion = Effect.fn(function* (
+        notebookUri: NotebookId,
+        location: string,
+        send: (requestId: string) => Effect.Effect<void, unknown>,
+      ) {
+        const current = pendingByLocation.get(location);
+        if (current !== undefined) {
+          return yield* Deferred.await(current.deferred);
+        }
+
+        const requestId = crypto.randomUUID();
+        const deferred = yield* Deferred.make<void, DatasourceExpansionError>();
+        const pending = { notebookUri, requestId, deferred };
+        pendingByLocation.set(location, pending);
+        pendingByRequest.set(requestId, pending);
+
+        yield* send(requestId).pipe(
+          Effect.catchAll((cause) =>
+            Deferred.fail(
+              deferred,
+              new DatasourceExpansionError({ message: String(cause) }),
+            ),
+          ),
+        );
+
+        return yield* Deferred.await(deferred).pipe(
+          Effect.ensuring(
+            Effect.sync(() => {
+              pendingByLocation.delete(location);
+              pendingByRequest.delete(requestId);
+            }),
+          ),
+        );
+      });
+
+      const completeExpansion = (requestId: string, error?: string | null) => {
+        const pending = pendingByRequest.get(requestId);
+        if (pending === undefined) return Effect.void;
+        return error == null
+          ? Deferred.succeed(pending.deferred, undefined)
+          : Deferred.fail(
+              pending.deferred,
+              new DatasourceExpansionError({ message: error }),
+            );
+      };
 
       const convertTablesToMap = (tables: readonly DataTable[]) =>
         new Map(tables.map((table) => [table.name, table]));
@@ -229,6 +299,7 @@ export class DatasourcesService extends Effect.Service<DatasourcesService>()(
         ) {
           return Effect.gen(function* () {
             if (operation.error != null) {
+              yield* completeExpansion(operation.request_id, operation.error);
               yield* Effect.logWarning(
                 "Failed to list datasource schemas",
               ).pipe(
@@ -271,6 +342,7 @@ export class DatasourcesService extends Effect.Service<DatasourcesService>()(
                 ? notebooks
                 : HashMap.set(notebooks, notebookUri, next);
             });
+            yield* completeExpansion(operation.request_id);
           });
         },
 
@@ -280,6 +352,7 @@ export class DatasourcesService extends Effect.Service<DatasourcesService>()(
         ) {
           return Effect.gen(function* () {
             if (operation.error != null) {
+              yield* completeExpansion(operation.request_id, operation.error);
               yield* Effect.logWarning("Failed to list datasource tables").pipe(
                 Effect.annotateLogs({
                   notebookUri,
@@ -314,7 +387,62 @@ export class DatasourcesService extends Effect.Service<DatasourcesService>()(
                 ? notebooks
                 : HashMap.set(notebooks, notebookUri, next);
             });
+            yield* completeExpansion(operation.request_id);
           });
+        },
+
+        loadSchemas(
+          notebookUri: NotebookId,
+          connection: string,
+          database: string,
+          schemaPath: readonly string[],
+        ) {
+          const location = expansionKey(
+            notebookUri,
+            connection,
+            database,
+            "schemas",
+            schemaPath,
+          );
+          return requestExpansion(notebookUri, location, (requestId) =>
+            marimo.listSqlSchemas({
+              notebookUri,
+              inner: {
+                requestId,
+                engine: connection,
+                database,
+                schemaPath: [...schemaPath],
+              },
+            }),
+          );
+        },
+
+        loadTables(
+          notebookUri: NotebookId,
+          connection: string,
+          database: string,
+          schema: string,
+          schemaPath: readonly string[],
+        ) {
+          const location = expansionKey(
+            notebookUri,
+            connection,
+            database,
+            "tables",
+            schemaPath,
+          );
+          return requestExpansion(notebookUri, location, (requestId) =>
+            marimo.listSqlTables({
+              notebookUri,
+              inner: {
+                requestId,
+                engine: connection,
+                database,
+                schema,
+                schemaPath: [...schemaPath],
+              },
+            }),
+          );
         },
 
         /**
@@ -366,6 +494,16 @@ export class DatasourcesService extends Effect.Service<DatasourcesService>()(
          */
         clearNotebook(notebookUri: NotebookId) {
           return Effect.gen(function* () {
+            for (const pending of pendingByRequest.values()) {
+              if (pending.notebookUri === notebookUri) {
+                yield* Deferred.fail(
+                  pending.deferred,
+                  new DatasourceExpansionError({
+                    message: "Notebook closed",
+                  }),
+                );
+              }
+            }
             yield* SubscriptionRef.update(connectionsRef, (map) =>
               HashMap.remove(map, notebookUri),
             );

--- a/extension/src/panel/datasources/DatasourcesView.ts
+++ b/extension/src/panel/datasources/DatasourcesView.ts
@@ -1,9 +1,19 @@
-import { Effect, Layer, Option, Ref, Stream } from "effect";
+import { Effect, Layer, Option, Stream } from "effect";
 
+import { unreachable } from "../../assert.ts";
 import { NotebookEditorRegistry } from "../../notebook/NotebookEditorRegistry.ts";
 import type { NotebookId } from "../../schemas/MarimoNotebookDocument.ts";
+import type { DataTable } from "../../types.ts";
 import { TreeView } from "../TreeView.ts";
-import { DatasourcesService } from "./DatasourcesService.ts";
+import {
+  type DatasourceDatabase,
+  type DatasourceSchema,
+  DatasourcesService,
+} from "./DatasourcesService.ts";
+
+const IN_MEMORY_CONNECTION = "__in_memory";
+const IN_MEMORY_DATABASE = "default";
+const IN_MEMORY_SCHEMA = "default";
 
 type DatasourceTreeItem =
   | ConnectionItem
@@ -12,184 +22,345 @@ type DatasourceTreeItem =
   | TableItem;
 
 interface ConnectionItem {
-  type: "connection";
-  notebookUri: NotebookId;
-  connectionName: string;
-  displayName: string;
-  dialect: string;
+  readonly type: "connection";
+  readonly notebookUri: NotebookId;
+  readonly connectionName: string;
+  readonly displayName: string;
+  readonly dialect: string;
 }
 
 interface DatabaseItem {
-  type: "database";
-  notebookUri: NotebookId;
-  connectionName: string;
-  databaseName: string;
-  dialect: string;
+  readonly type: "database";
+  readonly notebookUri: NotebookId;
+  readonly connectionName: string;
+  readonly databaseName: string;
+  readonly dialect: string;
 }
 
 interface SchemaItem {
-  type: "schema";
-  notebookUri: NotebookId;
-  connectionName: string;
-  databaseName: string;
-  schemaName: string;
+  readonly type: "schema";
+  readonly notebookUri: NotebookId;
+  readonly connectionName: string;
+  readonly databaseName: string;
+  readonly schemaPath: readonly string[];
+  readonly schemaName: string;
 }
 
 interface TableItem {
-  type: "table";
-  notebookUri: NotebookId;
-  connectionName: string;
-  databaseName: string;
-  schemaName: string;
-  tableName: string;
-  tableType: "table" | "view";
-  numRows: number | null;
-  numColumns: number | null;
+  readonly type: "table";
+  readonly notebookUri: NotebookId;
+  readonly connectionName: string;
+  readonly databaseName: string;
+  readonly schemaPath: readonly string[];
+  readonly tableName: string;
+  readonly tableType: "table" | "view";
+  readonly numRows: number | null;
+  readonly numColumns: number | null;
 }
+
+const findSchema = (
+  database: DatasourceDatabase,
+  path: readonly string[],
+): DatasourceSchema | undefined => {
+  let schemas = database.schemas;
+  let current: DatasourceSchema | undefined;
+  for (const name of path) {
+    current = schemas.get(name);
+    if (current === undefined) return undefined;
+    schemas = current.childSchemas;
+  }
+  return current;
+};
+
+const schemaItem = (
+  parent: DatabaseItem | SchemaItem,
+  schema: DatasourceSchema,
+  path: readonly string[],
+): SchemaItem => ({
+  type: "schema",
+  notebookUri: parent.notebookUri,
+  connectionName: parent.connectionName,
+  databaseName: parent.databaseName,
+  schemaPath: path,
+  schemaName: schema.name,
+});
+
+const tableItem = (
+  parent: DatabaseItem | SchemaItem,
+  table: DataTable,
+  schemaPath: readonly string[],
+): TableItem => ({
+  type: "table",
+  notebookUri: parent.notebookUri,
+  connectionName: parent.connectionName,
+  databaseName: parent.databaseName,
+  schemaPath,
+  tableName: table.name,
+  tableType: table.type ?? "table",
+  numRows: table.num_rows,
+  numColumns: table.num_columns,
+});
+
+const itemId = (item: DatasourceTreeItem): string => {
+  switch (item.type) {
+    case "connection":
+      return JSON.stringify([item.notebookUri, item.type, item.connectionName]);
+    case "database":
+      return JSON.stringify([
+        item.notebookUri,
+        item.type,
+        item.connectionName,
+        item.databaseName,
+      ]);
+    case "schema":
+      return JSON.stringify([
+        item.notebookUri,
+        item.type,
+        item.connectionName,
+        item.databaseName,
+        item.schemaPath,
+      ]);
+    case "table":
+      return JSON.stringify([
+        item.notebookUri,
+        item.type,
+        item.connectionName,
+        item.databaseName,
+        item.schemaPath,
+        item.tableName,
+      ]);
+  }
+
+  return unreachable(item);
+};
 
 /**
  * Manages the datasources tree view for the active notebook.
  *
- * Displays a hierarchical view of data sources:
- * Connection → Database → Schema → Table
- *
- * Subscribes to datasource changes and updates the tree view in real-time.
+ * Displays recursive SQL schemas and loads deferred schemas/tables when their
+ * parent is expanded. In-memory datasets remain an eager synthetic branch.
  */
 export const DatasourcesViewLive = Layer.scopedDiscard(
   Effect.gen(function* () {
     const treeView = yield* TreeView;
-    const datasourcesService = yield* DatasourcesService;
-    const editorRegistry = yield* NotebookEditorRegistry;
+    const datasources = yield* DatasourcesService;
+    const editors = yield* NotebookEditorRegistry;
 
-    // Track the current datasource items for the active notebook
-    const datasourceItems = yield* Ref.make<readonly DatasourceTreeItem[]>([]);
+    const getDatabase = Effect.fn(function* (item: DatabaseItem | SchemaItem) {
+      const connections = yield* datasources.getConnections(item.notebookUri);
+      if (Option.isNone(connections)) return undefined;
+      return connections.value.connections
+        .get(item.connectionName)
+        ?.databases.get(item.databaseName);
+    });
 
-    // Create the tree data provider
+    const ignoreExpansionError = <A, E>(effect: Effect.Effect<A, E>) =>
+      effect.pipe(
+        Effect.catchAllCause((cause) =>
+          Effect.logWarning("Failed to expand datasource tree").pipe(
+            Effect.annotateLogs({ cause }),
+          ),
+        ),
+      );
+
+    const loadDatabaseSchemas = Effect.fn(function* (
+      item: DatabaseItem,
+      database: DatasourceDatabase,
+    ) {
+      if (!database.schemasResolved) {
+        yield* ignoreExpansionError(
+          datasources.loadSchemas(
+            item.notebookUri,
+            item.connectionName,
+            item.databaseName,
+            [],
+          ),
+        );
+      }
+
+      let current = yield* getDatabase(item);
+      if (current === undefined) return [];
+
+      const children: DatasourceTreeItem[] = [];
+      for (const schema of current.schemas.values()) {
+        if (schema.name !== "") {
+          children.push(schemaItem(item, schema, [schema.name]));
+          continue;
+        }
+
+        // Schemaless databases expose their tables directly below the database.
+        if (!schema.tablesResolved) {
+          yield* ignoreExpansionError(
+            datasources.loadTables(
+              item.notebookUri,
+              item.connectionName,
+              item.databaseName,
+              schema.name,
+              [],
+            ),
+          );
+          current = yield* getDatabase(item);
+        }
+        const schemaless = current?.schemas.get("");
+        if (schemaless !== undefined) {
+          children.push(
+            ...[...schemaless.tables.values()].map((table) =>
+              tableItem(item, table, []),
+            ),
+          );
+        }
+      }
+      return children;
+    });
+
+    const loadSchemaChildren = Effect.fn(function* (item: SchemaItem) {
+      const database = yield* getDatabase(item);
+      const schema = database && findSchema(database, item.schemaPath);
+      if (schema === undefined) return [];
+
+      const loads: Array<Effect.Effect<unknown>> = [];
+      if (!schema.childSchemasResolved) {
+        loads.push(
+          ignoreExpansionError(
+            datasources.loadSchemas(
+              item.notebookUri,
+              item.connectionName,
+              item.databaseName,
+              item.schemaPath,
+            ),
+          ),
+        );
+      }
+      if (!schema.tablesResolved) {
+        loads.push(
+          ignoreExpansionError(
+            datasources.loadTables(
+              item.notebookUri,
+              item.connectionName,
+              item.databaseName,
+              item.schemaName,
+              item.schemaPath,
+            ),
+          ),
+        );
+      }
+      yield* Effect.all(loads, { concurrency: "unbounded", discard: true });
+
+      const currentDatabase = yield* getDatabase(item);
+      const current =
+        currentDatabase && findSchema(currentDatabase, item.schemaPath);
+      if (current === undefined) return [];
+      return [
+        ...[...current.childSchemas.values()].map((child) =>
+          schemaItem(item, child, [...item.schemaPath, child.name]),
+        ),
+        ...[...current.tables.values()].map((table) =>
+          tableItem(item, table, item.schemaPath),
+        ),
+      ];
+    });
+
     const provider = yield* treeView.createTreeDataProvider({
       viewId: "marimo-explorer-datasources",
       getChildren: (element?: DatasourceTreeItem) =>
         Effect.gen(function* () {
-          if (!element) {
-            // Root level: return connections
-            const items = yield* Ref.get(datasourceItems);
-            return items.filter((item) => item.type === "connection");
-          }
+          if (element === undefined) {
+            const active = yield* editors.getActiveNotebookUri();
+            if (Option.isNone(active)) return [];
+            const notebookUri = active.value;
+            const connections = yield* datasources.getConnections(notebookUri);
+            const datasets = yield* datasources.getDatasets(notebookUri);
+            const items: ConnectionItem[] = [];
 
-          const activeNotebookUri =
-            yield* editorRegistry.getActiveNotebookUri();
-          if (Option.isNone(activeNotebookUri)) {
-            return [];
+            if (Option.isSome(connections)) {
+              for (const connection of connections.value.connections.values()) {
+                items.push({
+                  type: "connection",
+                  notebookUri,
+                  connectionName: connection.name,
+                  displayName: connection.display_name,
+                  dialect: connection.dialect,
+                });
+              }
+            }
+            if (Option.isSome(datasets) && datasets.value.tables.size > 0) {
+              items.push({
+                type: "connection",
+                notebookUri,
+                connectionName: IN_MEMORY_CONNECTION,
+                displayName: "In-memory",
+                dialect: "python",
+              });
+            }
+            return items;
           }
-
-          const notebookUri = activeNotebookUri.value;
-          const items = yield* Ref.get(datasourceItems);
 
           if (element.type === "connection") {
-            // Get databases for this connection
-            // For in-memory connection, just filter from items (no need to query datasourcesService)
-            if (element.connectionName === "__in_memory") {
-              return items.filter(
-                (item) =>
-                  item.type === "database" &&
-                  item.connectionName === element.connectionName,
-              );
+            if (element.connectionName === IN_MEMORY_CONNECTION) {
+              return [
+                {
+                  type: "database" as const,
+                  notebookUri: element.notebookUri,
+                  connectionName: element.connectionName,
+                  databaseName: IN_MEMORY_DATABASE,
+                  dialect: "python",
+                },
+              ];
             }
-
-            // For regular connections, filter from items
-            const connections =
-              yield* datasourcesService.getConnections(notebookUri);
-            if (Option.isNone(connections)) {
-              return [];
-            }
-
-            const connectionsMap = connections.value;
-            const conn = connectionsMap.connections.get(element.connectionName);
-            if (!conn) return [];
-
-            return items.filter(
-              (item) =>
-                item.type === "database" &&
-                item.connectionName === element.connectionName,
+            const connections = yield* datasources.getConnections(
+              element.notebookUri,
             );
+            const connection = Option.isSome(connections)
+              ? connections.value.connections.get(element.connectionName)
+              : undefined;
+            if (connection === undefined) return [];
+            return [...connection.databases.values()].map((database) => ({
+              type: "database" as const,
+              notebookUri: element.notebookUri,
+              connectionName: element.connectionName,
+              databaseName: database.name,
+              dialect: database.dialect,
+            }));
           }
 
           if (element.type === "database") {
-            // Get schemas for this database
-            // For in-memory connection, just filter from items
-            if (element.connectionName === "__in_memory") {
-              return items.filter(
-                (item) =>
-                  item.type === "schema" &&
-                  item.connectionName === element.connectionName &&
-                  item.databaseName === element.databaseName,
-              );
+            if (element.connectionName === IN_MEMORY_CONNECTION) {
+              return [
+                {
+                  type: "schema" as const,
+                  notebookUri: element.notebookUri,
+                  connectionName: element.connectionName,
+                  databaseName: element.databaseName,
+                  schemaPath: [IN_MEMORY_SCHEMA],
+                  schemaName: IN_MEMORY_SCHEMA,
+                },
+              ];
             }
-
-            // For regular connections, check if database exists
-            const connections =
-              yield* datasourcesService.getConnections(notebookUri);
-            if (Option.isNone(connections)) {
-              return [];
-            }
-
-            const connectionsMap = connections.value;
-            const conn = connectionsMap.connections.get(element.connectionName);
-            if (!conn) return [];
-
-            const db = conn.databases.get(element.databaseName);
-            if (!db) return [];
-
-            return items.filter(
-              (item) =>
-                item.type === "schema" &&
-                item.connectionName === element.connectionName &&
-                item.databaseName === element.databaseName,
-            );
+            const database = yield* getDatabase(element);
+            return database === undefined
+              ? []
+              : yield* loadDatabaseSchemas(element, database);
           }
 
           if (element.type === "schema") {
-            // Get tables for this schema
-            // For in-memory connection, just filter from items
-            if (element.connectionName === "__in_memory") {
-              return items.filter(
-                (item) =>
-                  item.type === "table" &&
-                  item.connectionName === element.connectionName &&
-                  item.databaseName === element.databaseName &&
-                  item.schemaName === element.schemaName,
+            if (element.connectionName === IN_MEMORY_CONNECTION) {
+              const datasets = yield* datasources.getDatasets(
+                element.notebookUri,
               );
+              return Option.isSome(datasets)
+                ? [...datasets.value.tables.values()].map((table) =>
+                    tableItem(element, table, element.schemaPath),
+                  )
+                : [];
             }
-
-            // For regular connections, check if schema exists
-            const connections =
-              yield* datasourcesService.getConnections(notebookUri);
-            if (Option.isNone(connections)) {
-              return [];
-            }
-
-            const connectionsMap = connections.value;
-            const conn = connectionsMap.connections.get(element.connectionName);
-            if (!conn) return [];
-
-            const db = conn.databases.get(element.databaseName);
-            if (!db) return [];
-
-            const schema = db.schemas.get(element.schemaName);
-            if (!schema) return [];
-
-            return items.filter(
-              (item) =>
-                item.type === "table" &&
-                item.connectionName === element.connectionName &&
-                item.databaseName === element.databaseName &&
-                item.schemaName === element.schemaName,
-            );
+            return yield* loadSchemaChildren(element);
           }
 
           return [];
         }),
       getTreeItem: (element: DatasourceTreeItem) =>
         Effect.succeed({
+          id: itemId(element),
           label:
             element.type === "connection"
               ? element.displayName
@@ -199,26 +370,19 @@ export const DatasourcesViewLive = Layer.scopedDiscard(
                   ? element.schemaName
                   : element.tableName,
           description:
-            element.type === "connection"
+            element.type === "connection" || element.type === "database"
               ? element.dialect
-              : element.type === "database"
-                ? element.dialect
-                : element.type === "table"
-                  ? element.numRows !== null
-                    ? `${element.numRows} rows`
-                    : undefined
-                  : undefined,
+              : element.type === "table" && element.numRows !== null
+                ? `${element.numRows} rows`
+                : undefined,
           tooltip:
             element.type === "connection"
               ? `${element.displayName} (${element.dialect})`
               : element.type === "database"
                 ? `${element.databaseName} (${element.dialect})`
                 : element.type === "schema"
-                  ? element.schemaName
-                  : element.type === "table"
-                    ? `${element.tableName} (${element.tableType})${element.numRows !== null ? `\n${element.numRows} rows` : ""}${element.numColumns !== null ? `, ${element.numColumns} columns` : ""}`
-                    : undefined,
-          iconPath: undefined,
+                  ? element.schemaPath.join(".")
+                  : `${element.tableName} (${element.tableType})${element.numRows !== null ? `\n${element.numRows} rows` : ""}${element.numColumns !== null ? `, ${element.numColumns} columns` : ""}`,
           contextValue:
             element.type === "connection"
               ? "marimoConnection"
@@ -234,166 +398,20 @@ export const DatasourcesViewLive = Layer.scopedDiscard(
         }),
     });
 
-    // Helper to rebuild the datasources list from current state
-    const refreshDatasources = Effect.fn(function* () {
-      const activeNotebookUri = yield* editorRegistry.getActiveNotebookUri();
-
-      yield* Effect.logTrace("Refreshing datasources").pipe(
-        Effect.annotateLogs({
-          activeNotebookUri: Option.getOrElse(activeNotebookUri, () => null),
-        }),
-      );
-
-      if (Option.isNone(activeNotebookUri)) {
-        yield* Ref.set(datasourceItems, []);
-        yield* provider.refresh();
-        return;
-      }
-
-      const notebookUri = activeNotebookUri.value;
-      const connections = yield* datasourcesService.getConnections(notebookUri);
-      const datasets = yield* datasourcesService.getDatasets(notebookUri); // in-memory datasources
-
-      const connectionsMap = Option.getOrElse(connections, () => ({
-        connections: new Map(),
-      }));
-      const datasetsMap = Option.getOrElse(datasets, () => ({
-        tables: new Map(),
-        clear_channel: null,
-      }));
-
-      const items: DatasourceTreeItem[] = [];
-
-      // Build hierarchical tree items for connections
-      for (const [connName, conn] of connectionsMap.connections) {
-        items.push({
-          type: "connection",
-          notebookUri,
-          connectionName: connName,
-          displayName: conn.display_name,
-          dialect: conn.dialect,
-        });
-
-        for (const [dbName, db] of conn.databases) {
-          items.push({
-            type: "database",
-            notebookUri,
-            connectionName: connName,
-            databaseName: dbName,
-            dialect: db.dialect,
-          });
-
-          for (const [schemaName, schema] of db.schemas) {
-            items.push({
-              type: "schema",
-              notebookUri,
-              connectionName: connName,
-              databaseName: dbName,
-              schemaName: schemaName,
-            });
-
-            for (const [tableName, table] of schema.tables) {
-              items.push({
-                type: "table",
-                notebookUri,
-                connectionName: connName,
-                databaseName: dbName,
-                schemaName: schemaName,
-                tableName: tableName,
-                tableType: table.type,
-                numRows: table.num_rows,
-                numColumns: table.num_columns,
-              });
-            }
-          }
-        }
-      }
-
-      // Add in-memory datasets as a special connection
-      if (datasetsMap.tables.size > 0) {
-        const inMemoryConnName = "__in_memory";
-        const inMemoryDbName = "default";
-        const inMemorySchemaName = "default";
-
-        items.push({
-          type: "connection",
-          notebookUri,
-          connectionName: inMemoryConnName,
-          displayName: "In-memory",
-          dialect: "python",
-        });
-
-        items.push({
-          type: "database",
-          notebookUri,
-          connectionName: inMemoryConnName,
-          databaseName: inMemoryDbName,
-          dialect: "python",
-        });
-
-        items.push({
-          type: "schema",
-          notebookUri,
-          connectionName: inMemoryConnName,
-          databaseName: inMemoryDbName,
-          schemaName: inMemorySchemaName,
-        });
-
-        for (const [tableName, table] of datasetsMap.tables) {
-          items.push({
-            type: "table",
-            notebookUri,
-            connectionName: inMemoryConnName,
-            databaseName: inMemoryDbName,
-            schemaName: inMemorySchemaName,
-            tableName: tableName,
-            tableType: table.type,
-            numRows: table.num_rows,
-            numColumns: table.num_columns,
-          });
-        }
-      }
-
-      yield* Effect.logTrace("Refreshed datasources").pipe(
-        Effect.annotateLogs({
-          connections: connectionsMap.connections.size,
-          inMemoryTables: datasetsMap.tables.size,
-          totalItems: items.length,
-        }),
-      );
-      yield* Ref.set(datasourceItems, items);
-      yield* provider.refresh();
-    });
-
-    // Subscribe to active notebook changes
     yield* Effect.forkScoped(
-      editorRegistry.streamActiveNotebookChanges().pipe(
-        Stream.runForEach(() => {
-          return refreshDatasources();
-        }),
-      ),
+      editors
+        .streamActiveNotebookChanges()
+        .pipe(Stream.runForEach(() => provider.refresh())),
     );
-
-    // Subscribe to datasource connection changes
     yield* Effect.forkScoped(
-      datasourcesService.streamConnectionsChanges().pipe(
-        Stream.runForEach(
-          Effect.fn(function* (_connectionsMap) {
-            yield* refreshDatasources();
-          }),
-        ),
-      ),
+      datasources
+        .streamConnectionsChanges()
+        .pipe(Stream.runForEach(() => provider.refresh())),
     );
-
-    // Subscribe to dataset changes
     yield* Effect.forkScoped(
-      datasourcesService.streamDatasetsChanges().pipe(
-        Stream.runForEach(
-          Effect.fn(function* (_datasetsMap) {
-            yield* refreshDatasources();
-          }),
-        ),
-      ),
+      datasources
+        .streamDatasetsChanges()
+        .pipe(Stream.runForEach(() => provider.refresh())),
     );
 
     yield* Effect.logDebug("Datasources view initialized");

--- a/extension/src/panel/datasources/__tests__/DatasourcesService.test.ts
+++ b/extension/src/panel/datasources/__tests__/DatasourcesService.test.ts
@@ -1,0 +1,187 @@
+import { assert, expect, it } from "@effect/vitest";
+import { Effect, Option } from "effect";
+
+import { notebookId, requestId } from "../../../lib/__tests__/branded.ts";
+import type {
+  DataSourceConnectionsNotification,
+  DatabaseSchema,
+  DataTable,
+  SqlSchemaListPreviewNotification,
+  SqlTableListPreviewNotification,
+} from "../../../types.ts";
+import { DatasourcesService } from "../DatasourcesService.ts";
+
+const NOTEBOOK_URI = notebookId("file:///test/notebook.py");
+
+const table = (name: string): DataTable => ({
+  name,
+  source: "warehouse",
+  source_type: "connection",
+  num_rows: null,
+  num_columns: null,
+  variable_name: null,
+  columns: [],
+});
+
+const schema = (
+  name: string,
+  options: Partial<DatabaseSchema> = {},
+): DatabaseSchema => ({
+  name,
+  tables: [],
+  ...options,
+});
+
+const connections = (
+  schemas: DatabaseSchema[],
+  schemasResolved = true,
+): DataSourceConnectionsNotification => ({
+  op: "data-source-connections",
+  connections: [
+    {
+      name: "warehouse",
+      source: "postgres",
+      dialect: "postgres",
+      display_name: "Warehouse",
+      databases: [
+        {
+          name: "analytics",
+          dialect: "postgres",
+          schemas,
+          schemas_resolved: schemasResolved,
+        },
+      ],
+    },
+  ],
+});
+
+const getDatabase = Effect.fn(function* () {
+  const service = yield* DatasourcesService;
+  const state = yield* service.getConnections(NOTEBOOK_URI);
+  assert(Option.isSome(state));
+  const database = state.value.connections
+    .get("warehouse")
+    ?.databases.get("analytics");
+  assert(database !== undefined);
+  return database;
+});
+
+it.effect("preserves recursive schemas and deferred discovery", () =>
+  Effect.gen(function* () {
+    const service = yield* DatasourcesService;
+    yield* service.updateConnections(
+      NOTEBOOK_URI,
+      connections(
+        [
+          schema("catalog", {
+            tables_resolved: false,
+            child_schemas_resolved: false,
+            child_schemas: [schema("loaded", { tables: [table("events")] })],
+          }),
+        ],
+        false,
+      ),
+    );
+
+    const database = yield* getDatabase();
+    const catalog = database.schemas.get("catalog");
+    assert(catalog !== undefined);
+    expect(database.schemasResolved).toBe(false);
+    expect(catalog.tablesResolved).toBe(false);
+    expect(catalog.childSchemasResolved).toBe(false);
+    expect(catalog.childSchemas.get("loaded")?.tables.has("events")).toBe(true);
+  }).pipe(Effect.provide(DatasourcesService.Default)),
+);
+
+it.effect("merges child schemas at their parent path", () =>
+  Effect.gen(function* () {
+    const service = yield* DatasourcesService;
+    yield* service.updateConnections(
+      NOTEBOOK_URI,
+      connections([
+        schema("catalog", {
+          tables: [table("existing")],
+          child_schemas_resolved: false,
+        }),
+      ]),
+    );
+
+    const operation: SqlSchemaListPreviewNotification = {
+      op: "sql-schema-list-preview",
+      request_id: requestId("schemas"),
+      metadata: {
+        connection: "warehouse",
+        database: "analytics",
+        schema_path: ["catalog"],
+      },
+      schemas: [schema("events", { tables_resolved: false })],
+    };
+    yield* service.updateSchemaList(NOTEBOOK_URI, operation);
+
+    const catalog = (yield* getDatabase()).schemas.get("catalog");
+    assert(catalog !== undefined);
+    expect(catalog.childSchemasResolved).toBe(true);
+    expect(catalog.childSchemas.get("events")?.tablesResolved).toBe(false);
+    expect(catalog.tables.has("existing")).toBe(true);
+  }).pipe(Effect.provide(DatasourcesService.Default)),
+);
+
+it.effect("merges tables at a nested schema path", () =>
+  Effect.gen(function* () {
+    const service = yield* DatasourcesService;
+    yield* service.updateConnections(
+      NOTEBOOK_URI,
+      connections([
+        schema("catalog", {
+          child_schemas: [schema("events", { tables_resolved: false })],
+        }),
+      ]),
+    );
+
+    const operation: SqlTableListPreviewNotification = {
+      op: "sql-table-list-preview",
+      request_id: requestId("tables"),
+      metadata: {
+        type: "sql-metadata",
+        connection: "warehouse",
+        database: "analytics",
+        schema: "events",
+        schema_path: ["catalog", "events"],
+      },
+      tables: [table("clicks")],
+    };
+    yield* service.updateTableList(NOTEBOOK_URI, operation);
+
+    const events = (yield* getDatabase()).schemas
+      .get("catalog")
+      ?.childSchemas.get("events");
+    expect(events?.tablesResolved).toBe(true);
+    expect(events?.tables.has("clicks")).toBe(true);
+  }).pipe(Effect.provide(DatasourcesService.Default)),
+);
+
+it.effect("does not resolve deferred state after an error", () =>
+  Effect.gen(function* () {
+    const service = yield* DatasourcesService;
+    yield* service.updateConnections(
+      NOTEBOOK_URI,
+      connections([schema("public", { tables_resolved: false })]),
+    );
+    yield* service.updateTableList(NOTEBOOK_URI, {
+      op: "sql-table-list-preview",
+      request_id: requestId("tables"),
+      metadata: {
+        type: "sql-metadata",
+        connection: "warehouse",
+        database: "analytics",
+        schema: "public",
+      },
+      tables: [],
+      error: "connection lost",
+    });
+
+    expect((yield* getDatabase()).schemas.get("public")?.tablesResolved).toBe(
+      false,
+    );
+  }).pipe(Effect.provide(DatasourcesService.Default)),
+);

--- a/extension/src/panel/datasources/__tests__/DatasourcesService.test.ts
+++ b/extension/src/panel/datasources/__tests__/DatasourcesService.test.ts
@@ -380,7 +380,7 @@ it.scoped("retries nested table expansion after an error", () => {
   }).pipe(Effect.provide(layer));
 });
 
-it.scoped("retries expansion after a response times out", () => {
+it.scoped("shares one timeout deadline and retries after it expires", () => {
   const calls: MarimoApiCall[] = [];
   const layer = makeLayer((request) => {
     calls.push(request);
@@ -399,8 +399,18 @@ it.scoped("retries expansion after a response times out", () => {
     yield* Effect.yieldNow();
     expect(calls).toHaveLength(1);
 
-    yield* TestClock.adjust("30 seconds");
+    yield* TestClock.adjust("20 seconds");
+    const joined = yield* Effect.fork(
+      Effect.either(
+        service.loadSchemas(NOTEBOOK_URI, "warehouse", "analytics", []),
+      ),
+    );
+    yield* Effect.yieldNow();
+    expect(calls).toHaveLength(1);
+
+    yield* TestClock.adjust("10 seconds");
     expect((yield* Fiber.join(first))._tag).toBe("Left");
+    expect((yield* Fiber.join(joined))._tag).toBe("Left");
 
     const retry = yield* Effect.fork(
       service.loadSchemas(NOTEBOOK_URI, "warehouse", "analytics", []),

--- a/extension/src/panel/datasources/__tests__/DatasourcesService.test.ts
+++ b/extension/src/panel/datasources/__tests__/DatasourcesService.test.ts
@@ -1,6 +1,7 @@
 import { assert, expect, it } from "@effect/vitest";
-import { Effect, Option } from "effect";
+import { Effect, Fiber, Layer, Option } from "effect";
 
+import { makeTestMarimoClient } from "../../../__tests__/__utils__/TestMarimoClient.ts";
 import { notebookId, requestId } from "../../../lib/__tests__/branded.ts";
 import type {
   DataSourceConnectionsNotification,
@@ -9,9 +10,19 @@ import type {
   SqlSchemaListPreviewNotification,
   SqlTableListPreviewNotification,
 } from "../../../types.ts";
+import type { MarimoApiCall } from "../../../types.ts";
 import { DatasourcesService } from "../DatasourcesService.ts";
 
 const NOTEBOOK_URI = notebookId("file:///test/notebook.py");
+
+const makeLayer = (
+  execute: (request: MarimoApiCall) => Effect.Effect<unknown> = () =>
+    Effect.succeed(null),
+) =>
+  Layer.empty.pipe(
+    Layer.provideMerge(DatasourcesService.Default),
+    Layer.provide(makeTestMarimoClient({ execute })),
+  );
 
 const table = (name: string): DataTable => ({
   name,
@@ -90,7 +101,7 @@ it.effect("preserves recursive schemas and deferred discovery", () =>
     expect(catalog.tablesResolved).toBe(false);
     expect(catalog.childSchemasResolved).toBe(false);
     expect(catalog.childSchemas.get("loaded")?.tables.has("events")).toBe(true);
-  }).pipe(Effect.provide(DatasourcesService.Default)),
+  }).pipe(Effect.provide(makeLayer())),
 );
 
 it.effect("merges child schemas at their parent path", () =>
@@ -123,7 +134,7 @@ it.effect("merges child schemas at their parent path", () =>
     expect(catalog.childSchemasResolved).toBe(true);
     expect(catalog.childSchemas.get("events")?.tablesResolved).toBe(false);
     expect(catalog.tables.has("existing")).toBe(true);
-  }).pipe(Effect.provide(DatasourcesService.Default)),
+  }).pipe(Effect.provide(makeLayer())),
 );
 
 it.effect("merges tables at a nested schema path", () =>
@@ -157,7 +168,7 @@ it.effect("merges tables at a nested schema path", () =>
       ?.childSchemas.get("events");
     expect(events?.tablesResolved).toBe(true);
     expect(events?.tables.has("clicks")).toBe(true);
-  }).pipe(Effect.provide(DatasourcesService.Default)),
+  }).pipe(Effect.provide(makeLayer())),
 );
 
 it.effect("does not resolve deferred state after an error", () =>
@@ -183,5 +194,108 @@ it.effect("does not resolve deferred state after an error", () =>
     expect((yield* getDatabase()).schemas.get("public")?.tablesResolved).toBe(
       false,
     );
-  }).pipe(Effect.provide(DatasourcesService.Default)),
+  }).pipe(Effect.provide(makeLayer())),
 );
+
+it.scoped("deduplicates concurrent schema expansion requests", () => {
+  const calls: MarimoApiCall[] = [];
+  const layer = makeLayer((request) => {
+    calls.push(request);
+    return Effect.succeed(null);
+  });
+
+  return Effect.gen(function* () {
+    const service = yield* DatasourcesService;
+    yield* service.updateConnections(NOTEBOOK_URI, connections([], false));
+
+    const first = yield* Effect.fork(
+      service.loadSchemas(NOTEBOOK_URI, "warehouse", "analytics", []),
+    );
+    const second = yield* Effect.fork(
+      service.loadSchemas(NOTEBOOK_URI, "warehouse", "analytics", []),
+    );
+    yield* Effect.yieldNow();
+
+    expect(calls).toHaveLength(1);
+    const call = calls[0];
+    assert(call?.method === "list-sql-schemas");
+    yield* service.updateSchemaList(NOTEBOOK_URI, {
+      op: "sql-schema-list-preview",
+      request_id: requestId(call.params.inner.requestId),
+      metadata: {
+        connection: "warehouse",
+        database: "analytics",
+      },
+      schemas: [schema("public")],
+    });
+
+    yield* Fiber.join(first);
+    yield* Fiber.join(second);
+    const database = yield* getDatabase();
+    expect(database.schemasResolved).toBe(true);
+    expect(database.schemas.has("public")).toBe(true);
+  }).pipe(Effect.provide(layer));
+});
+
+it.scoped("retries nested table expansion after an error", () => {
+  const calls: MarimoApiCall[] = [];
+  const layer = makeLayer((request) => {
+    calls.push(request);
+    return Effect.succeed(null);
+  });
+
+  return Effect.gen(function* () {
+    const service = yield* DatasourcesService;
+    yield* service.updateConnections(
+      NOTEBOOK_URI,
+      connections([
+        schema("catalog", {
+          child_schemas: [schema("events", { tables_resolved: false })],
+        }),
+      ]),
+    );
+
+    const first = yield* Effect.fork(
+      Effect.either(
+        service.loadTables(NOTEBOOK_URI, "warehouse", "analytics", "events", [
+          "catalog",
+          "events",
+        ]),
+      ),
+    );
+    yield* Effect.yieldNow();
+
+    const call = calls[0];
+    assert(call?.method === "list-sql-tables");
+    expect(call.params.inner).toMatchObject({
+      engine: "warehouse",
+      database: "analytics",
+      schema: "events",
+      schemaPath: ["catalog", "events"],
+    });
+    yield* service.updateTableList(NOTEBOOK_URI, {
+      op: "sql-table-list-preview",
+      request_id: requestId(call.params.inner.requestId),
+      metadata: {
+        type: "sql-metadata",
+        connection: "warehouse",
+        database: "analytics",
+        schema: "events",
+        schema_path: ["catalog", "events"],
+      },
+      tables: [],
+      error: "connection lost",
+    });
+    expect((yield* Fiber.join(first))._tag).toBe("Left");
+
+    const retry = yield* Effect.fork(
+      service.loadTables(NOTEBOOK_URI, "warehouse", "analytics", "events", [
+        "catalog",
+        "events",
+      ]),
+    );
+    yield* Effect.yieldNow();
+    expect(calls).toHaveLength(2);
+    yield* Fiber.interrupt(retry);
+  }).pipe(Effect.provide(layer));
+});

--- a/extension/src/panel/datasources/__tests__/DatasourcesService.test.ts
+++ b/extension/src/panel/datasources/__tests__/DatasourcesService.test.ts
@@ -24,6 +24,17 @@ const makeLayer = (
     Layer.provide(makeTestMarimoClient({ execute })),
   );
 
+const makeRecordingLayer = () => {
+  const calls: MarimoApiCall[] = [];
+  return {
+    calls,
+    layer: makeLayer((request) => {
+      calls.push(request);
+      return Effect.succeed(null);
+    }),
+  };
+};
+
 const table = (name: string): DataTable => ({
   name,
   source: "warehouse",
@@ -104,8 +115,9 @@ it.effect("preserves recursive schemas and deferred discovery", () =>
   }).pipe(Effect.provide(makeLayer())),
 );
 
-it.effect("merges child schemas at their parent path", () =>
-  Effect.gen(function* () {
+it.scoped("merges child schemas at their parent path", () => {
+  const { calls, layer } = makeRecordingLayer();
+  return Effect.gen(function* () {
     const service = yield* DatasourcesService;
     yield* service.updateConnections(
       NOTEBOOK_URI,
@@ -117,9 +129,16 @@ it.effect("merges child schemas at their parent path", () =>
       ]),
     );
 
+    const load = yield* Effect.fork(
+      service.loadSchemas(NOTEBOOK_URI, "warehouse", "analytics", ["catalog"]),
+    );
+    yield* Effect.yieldNow();
+    const call = calls[0];
+    assert(call?.method === "list-sql-schemas");
+
     const operation: SqlSchemaListPreviewNotification = {
       op: "sql-schema-list-preview",
-      request_id: requestId("schemas"),
+      request_id: requestId(call.params.inner.requestId),
       metadata: {
         connection: "warehouse",
         database: "analytics",
@@ -128,17 +147,19 @@ it.effect("merges child schemas at their parent path", () =>
       schemas: [schema("events", { tables_resolved: false })],
     };
     yield* service.updateSchemaList(NOTEBOOK_URI, operation);
+    yield* Fiber.join(load);
 
     const catalog = (yield* getDatabase()).schemas.get("catalog");
     assert(catalog !== undefined);
     expect(catalog.childSchemasResolved).toBe(true);
     expect(catalog.childSchemas.get("events")?.tablesResolved).toBe(false);
     expect(catalog.tables.has("existing")).toBe(true);
-  }).pipe(Effect.provide(makeLayer())),
-);
+  }).pipe(Effect.provide(layer));
+});
 
-it.effect("merges tables at a nested schema path", () =>
-  Effect.gen(function* () {
+it.scoped("merges tables at a nested schema path", () => {
+  const { calls, layer } = makeRecordingLayer();
+  return Effect.gen(function* () {
     const service = yield* DatasourcesService;
     yield* service.updateConnections(
       NOTEBOOK_URI,
@@ -149,9 +170,19 @@ it.effect("merges tables at a nested schema path", () =>
       ]),
     );
 
+    const load = yield* Effect.fork(
+      service.loadTables(NOTEBOOK_URI, "warehouse", "analytics", "events", [
+        "catalog",
+        "events",
+      ]),
+    );
+    yield* Effect.yieldNow();
+    const call = calls[0];
+    assert(call?.method === "list-sql-tables");
+
     const operation: SqlTableListPreviewNotification = {
       op: "sql-table-list-preview",
-      request_id: requestId("tables"),
+      request_id: requestId(call.params.inner.requestId),
       metadata: {
         type: "sql-metadata",
         connection: "warehouse",
@@ -162,25 +193,39 @@ it.effect("merges tables at a nested schema path", () =>
       tables: [table("clicks")],
     };
     yield* service.updateTableList(NOTEBOOK_URI, operation);
+    yield* Fiber.join(load);
 
     const events = (yield* getDatabase()).schemas
       .get("catalog")
       ?.childSchemas.get("events");
     expect(events?.tablesResolved).toBe(true);
     expect(events?.tables.has("clicks")).toBe(true);
-  }).pipe(Effect.provide(makeLayer())),
-);
+  }).pipe(Effect.provide(layer));
+});
 
-it.effect("does not resolve deferred state after an error", () =>
-  Effect.gen(function* () {
+it.scoped("does not resolve deferred state after an error", () => {
+  const { calls, layer } = makeRecordingLayer();
+  return Effect.gen(function* () {
     const service = yield* DatasourcesService;
     yield* service.updateConnections(
       NOTEBOOK_URI,
       connections([schema("public", { tables_resolved: false })]),
     );
+
+    const load = yield* Effect.fork(
+      Effect.either(
+        service.loadTables(NOTEBOOK_URI, "warehouse", "analytics", "public", [
+          "public",
+        ]),
+      ),
+    );
+    yield* Effect.yieldNow();
+    const call = calls[0];
+    assert(call?.method === "list-sql-tables");
+
     yield* service.updateTableList(NOTEBOOK_URI, {
       op: "sql-table-list-preview",
-      request_id: requestId("tables"),
+      request_id: requestId(call.params.inner.requestId),
       metadata: {
         type: "sql-metadata",
         connection: "warehouse",
@@ -190,10 +235,45 @@ it.effect("does not resolve deferred state after an error", () =>
       tables: [],
       error: "connection lost",
     });
+    expect((yield* Fiber.join(load))._tag).toBe("Left");
 
     expect((yield* getDatabase()).schemas.get("public")?.tablesResolved).toBe(
       false,
     );
+  }).pipe(Effect.provide(layer));
+});
+
+it.effect("ignores uncorrelated expansion responses", () =>
+  Effect.gen(function* () {
+    const service = yield* DatasourcesService;
+    yield* service.updateConnections(
+      NOTEBOOK_URI,
+      connections([schema("public", { tables_resolved: false })], false),
+    );
+
+    yield* service.updateSchemaList(NOTEBOOK_URI, {
+      op: "sql-schema-list-preview",
+      request_id: requestId("stale-schemas"),
+      metadata: { connection: "warehouse", database: "analytics" },
+      schemas: [schema("stale")],
+    });
+    yield* service.updateTableList(NOTEBOOK_URI, {
+      op: "sql-table-list-preview",
+      request_id: requestId("stale-tables"),
+      metadata: {
+        type: "sql-metadata",
+        connection: "warehouse",
+        database: "analytics",
+        schema: "public",
+      },
+      tables: [table("stale")],
+    });
+
+    const database = yield* getDatabase();
+    expect(database.schemasResolved).toBe(false);
+    expect(database.schemas.has("stale")).toBe(false);
+    expect(database.schemas.get("public")?.tablesResolved).toBe(false);
+    expect(database.schemas.get("public")?.tables.has("stale")).toBe(false);
   }).pipe(Effect.provide(makeLayer())),
 );
 

--- a/extension/src/panel/datasources/__tests__/DatasourcesService.test.ts
+++ b/extension/src/panel/datasources/__tests__/DatasourcesService.test.ts
@@ -1,5 +1,5 @@
 import { assert, expect, it } from "@effect/vitest";
-import { Effect, Fiber, Layer, Option } from "effect";
+import { Effect, Fiber, Layer, Option, TestClock } from "effect";
 
 import { makeTestMarimoClient } from "../../../__tests__/__utils__/TestMarimoClient.ts";
 import { notebookId, requestId } from "../../../lib/__tests__/branded.ts";
@@ -293,6 +293,37 @@ it.scoped("retries nested table expansion after an error", () => {
         "catalog",
         "events",
       ]),
+    );
+    yield* Effect.yieldNow();
+    expect(calls).toHaveLength(2);
+    yield* Fiber.interrupt(retry);
+  }).pipe(Effect.provide(layer));
+});
+
+it.scoped("retries expansion after a response times out", () => {
+  const calls: MarimoApiCall[] = [];
+  const layer = makeLayer((request) => {
+    calls.push(request);
+    return Effect.succeed(null);
+  });
+
+  return Effect.gen(function* () {
+    const service = yield* DatasourcesService;
+    yield* service.updateConnections(NOTEBOOK_URI, connections([], false));
+
+    const first = yield* Effect.fork(
+      Effect.either(
+        service.loadSchemas(NOTEBOOK_URI, "warehouse", "analytics", []),
+      ),
+    );
+    yield* Effect.yieldNow();
+    expect(calls).toHaveLength(1);
+
+    yield* TestClock.adjust("30 seconds");
+    expect((yield* Fiber.join(first))._tag).toBe("Left");
+
+    const retry = yield* Effect.fork(
+      service.loadSchemas(NOTEBOOK_URI, "warehouse", "analytics", []),
     );
     yield* Effect.yieldNow();
     expect(calls).toHaveLength(2);

--- a/extension/src/schemas/Models.gen.ts
+++ b/extension/src/schemas/Models.gen.ts
@@ -534,6 +534,37 @@ export const DeleteCellPayload = Schema.Struct({
   inner: DeleteCellRequest,
 });
 
+export const ListSQLSchemasRequest = Schema.Struct({
+  requestId: Schema.String,
+  engine: Schema.String,
+  database: Schema.String,
+  schemaPath: Schema.optionalWith(Schema.Array(Schema.String), {
+    default: () => [],
+  }),
+}).annotations({ identifier: "ListSQLSchemasRequest" });
+export type ListSQLSchemasRequest = typeof ListSQLSchemasRequest.Type;
+
+export const ListSqlSchemasPayload = Schema.Struct({
+  notebookUri: Schema.String,
+  inner: ListSQLSchemasRequest,
+});
+
+export const ListSQLTablesRequest = Schema.Struct({
+  requestId: Schema.String,
+  engine: Schema.String,
+  database: Schema.String,
+  schema: Schema.String,
+  schemaPath: Schema.optionalWith(Schema.Array(Schema.String), {
+    default: () => [],
+  }),
+}).annotations({ identifier: "ListSQLTablesRequest" });
+export type ListSQLTablesRequest = typeof ListSQLTablesRequest.Type;
+
+export const ListSqlTablesPayload = Schema.Struct({
+  notebookUri: Schema.String,
+  inner: ListSQLTablesRequest,
+});
+
 export const StdinRequest = Schema.Struct({
   text: Schema.String,
 }).annotations({ identifier: "StdinRequest" });
@@ -1374,6 +1405,14 @@ export type MarimoApiCall =
       readonly params: typeof DeleteCellPayload.Encoded;
     }
   | {
+      readonly method: "list-sql-schemas";
+      readonly params: typeof ListSqlSchemasPayload.Encoded;
+    }
+  | {
+      readonly method: "list-sql-tables";
+      readonly params: typeof ListSqlTablesPayload.Encoded;
+    }
+  | {
       readonly method: "send-stdin";
       readonly params: typeof SendStdinPayload.Encoded;
     }
@@ -1504,6 +1543,20 @@ export const makeApiClient = <E, R>(execute: Execute<E, R>) => ({
       execute,
       { method: "delete-cell", params },
       DeleteCellPayload,
+      Schema.Null,
+    ),
+  listSqlSchemas: (params: typeof ListSqlSchemasPayload.Encoded) =>
+    dispatch(
+      execute,
+      { method: "list-sql-schemas", params },
+      ListSqlSchemasPayload,
+      Schema.Null,
+    ),
+  listSqlTables: (params: typeof ListSqlTablesPayload.Encoded) =>
+    dispatch(
+      execute,
+      { method: "list-sql-tables", params },
+      ListSqlTablesPayload,
       Schema.Null,
     ),
   sendStdin: (params: typeof SendStdinPayload.Encoded) =>

--- a/extension/src/types.ts
+++ b/extension/src/types.ts
@@ -27,9 +27,14 @@ export type DataColumnPreviewNotification =
 export type DataSourceConnectionsNotification =
   NotificationOf<"data-source-connections">;
 export type DatasetsNotification = NotificationOf<"datasets">;
+export type SqlSchemaListPreviewNotification =
+  NotificationOf<"sql-schema-list-preview">;
 export type SqlTablePreviewNotification = NotificationOf<"sql-table-preview">;
 export type SqlTableListPreviewNotification =
   NotificationOf<"sql-table-list-preview">;
+export type DataSourceConnection = Schemas["DataSourceConnection"];
+export type DataTable = Schemas["DataTable"];
+export type DatabaseSchema = Schemas["Schema"];
 export type DocumentTransactionNotification =
   NotificationOf<"notebook-document-transaction">;
 /** A single change within a document transaction (create/edit/move/... a cell). */

--- a/src/marimo_lsp/api.py
+++ b/src/marimo_lsp/api.py
@@ -303,7 +303,8 @@ async def list_sql_schemas(
 ) -> None:
     """Request the immediate child schemas at a database path."""
     session = ctx.sessions.get(args.notebook_uri)
-    assert session, f"No session in workspace for {args.notebook_uri}"
+    if session is None:
+        raise SessionNotFoundError(args.notebook_uri)
     session.put_control_request(args.inner.as_command(), from_consumer_id=None)
 
 
@@ -314,7 +315,8 @@ async def list_sql_tables(
 ) -> None:
     """Request the tables belonging to a schema path."""
     session = ctx.sessions.get(args.notebook_uri)
-    assert session, f"No session in workspace for {args.notebook_uri}"
+    if session is None:
+        raise SessionNotFoundError(args.notebook_uri)
     session.put_control_request(args.inner.as_command(), from_consumer_id=None)
 
 

--- a/src/marimo_lsp/api.py
+++ b/src/marimo_lsp/api.py
@@ -53,6 +53,8 @@ from marimo_lsp.models import (
     ListPackagesResponse,
     ListSessionsRequest,
     ListSessionsResponse,
+    ListSQLSchemasRequest,
+    ListSQLTablesRequest,
     ModelRequest,
     MoveSessionRequest,
     NotebookCommand,
@@ -292,6 +294,28 @@ async def delete_cell(
         logger.info(f"Delete cell request sent for {args.notebook_uri}")
     else:
         logger.warning(f"No session found for {args.notebook_uri}")
+
+
+@marimo_api("list-sql-schemas")
+async def list_sql_schemas(
+    ctx: ApiContext,
+    args: NotebookCommand[ListSQLSchemasRequest],
+) -> None:
+    """Request the immediate child schemas at a database path."""
+    session = ctx.sessions.get(args.notebook_uri)
+    assert session, f"No session in workspace for {args.notebook_uri}"
+    session.put_control_request(args.inner.as_command(), from_consumer_id=None)
+
+
+@marimo_api("list-sql-tables")
+async def list_sql_tables(
+    ctx: ApiContext,
+    args: NotebookCommand[ListSQLTablesRequest],
+) -> None:
+    """Request the tables belonging to a schema path."""
+    session = ctx.sessions.get(args.notebook_uri)
+    assert session, f"No session in workspace for {args.notebook_uri}"
+    session.put_control_request(args.inner.as_command(), from_consumer_id=None)
 
 
 @marimo_api("send-stdin")

--- a/src/marimo_lsp/models.py
+++ b/src/marimo_lsp/models.py
@@ -376,4 +376,6 @@ ExecuteCellsRequest = core.ExecuteCellsRequest
 UpdateUIElementRequest = core.UpdateUIElementRequest
 ModelRequest = core.ModelRequest
 DeleteCellRequest = core.DeleteCellRequest
+ListSQLSchemasRequest = core.ListSQLSchemasRequest
+ListSQLTablesRequest = core.ListSQLTablesRequest
 StdinRequest = core.StdinRequest

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -7,15 +7,20 @@ from unittest.mock import MagicMock, patch
 import msgspec
 import pytest
 from marimo._config.config import DEFAULT_CONFIG
+from marimo._types.ids import RequestId
 
 from marimo_lsp.api import (
     ApiBuilder,
     ApiContext,
     get_configuration,
+    list_sql_schemas,
+    list_sql_tables,
     update_configuration,
 )
 from marimo_lsp.models import (
     GetConfigurationRequest,
+    ListSQLSchemasRequest,
+    ListSQLTablesRequest,
     NotebookCommand,
     SetDisplayThemeRequest,
     UpdateConfigurationRequest,
@@ -146,3 +151,54 @@ async def test_update_configuration_propagates_save_errors() -> None:
 def test_display_theme_rejects_unresolved_theme() -> None:
     with pytest.raises(msgspec.ValidationError):
         msgspec.convert({"theme": "system"}, type=SetDisplayThemeRequest)
+
+
+@pytest.mark.asyncio
+async def test_list_sql_schemas_is_forwarded_to_the_kernel() -> None:
+    request = ListSQLSchemasRequest(
+        request_id=RequestId("schemas"),
+        engine="warehouse",
+        database="analytics",
+        schema_path=["catalog"],
+    )
+    session = MagicMock()
+    sessions = MagicMock()
+    sessions.get.return_value = session
+
+    await list_sql_schemas(
+        _context(sessions),
+        NotebookCommand(
+            notebook_uri="file:///notebook.py",
+            inner=request,
+        ),
+    )
+
+    session.put_control_request.assert_called_once_with(
+        request.as_command(), from_consumer_id=None
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_sql_tables_is_forwarded_to_the_kernel() -> None:
+    request = ListSQLTablesRequest(
+        request_id=RequestId("tables"),
+        engine="warehouse",
+        database="analytics",
+        schema="events",
+        schema_path=["catalog", "events"],
+    )
+    session = MagicMock()
+    sessions = MagicMock()
+    sessions.get.return_value = session
+
+    await list_sql_tables(
+        _context(sessions),
+        NotebookCommand(
+            notebook_uri="file:///notebook.py",
+            inner=request,
+        ),
+    )
+
+    session.put_control_request.assert_called_once_with(
+        request.as_command(), from_consumer_id=None
+    )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
 import msgspec
@@ -25,6 +26,11 @@ from marimo_lsp.models import (
     SetDisplayThemeRequest,
     UpdateConfigurationRequest,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+NOTEBOOK_URI = "file:///notebook.py"
 
 
 def _context(sessions: MagicMock) -> ApiContext:
@@ -202,3 +208,40 @@ async def test_list_sql_tables_is_forwarded_to_the_kernel() -> None:
     session.put_control_request.assert_called_once_with(
         request.as_command(), from_consumer_id=None
     )
+
+
+@pytest.mark.parametrize(
+    ("handler", "sql_request"),
+    [
+        (
+            list_sql_schemas,
+            ListSQLSchemasRequest(
+                request_id=RequestId("schemas"),
+                engine="warehouse",
+                database="analytics",
+            ),
+        ),
+        (
+            list_sql_tables,
+            ListSQLTablesRequest(
+                request_id=RequestId("tables"),
+                engine="warehouse",
+                database="analytics",
+                schema="events",
+            ),
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_list_sql_metadata_rejects_a_missing_session(
+    handler: Callable[..., Awaitable[None]],
+    sql_request: ListSQLSchemasRequest | ListSQLTablesRequest,
+) -> None:
+    sessions = MagicMock()
+    sessions.get.return_value = None
+
+    with pytest.raises(ValueError, match=f"No session found for {NOTEBOOK_URI}"):
+        await handler(
+            _context(sessions),
+            NotebookCommand(notebook_uri=NOTEBOOK_URI, inner=sql_request),
+        )


### PR DESCRIPTION
Closes #599

marimo shifted datasource discovery to recursive schemas with explicit resolution state, while the extension was still built around the old eager schema and table shape.

This PR exposes schema and table expansion through `marimo.api`, preserves recursive schemas in `DatasourcesService`, and lets the explorer load unresolved children at their schema path.

A small request coordinator correlates preview notifications with expansion requests and deduplicates concurrent loads of the same node.