### PR TITLE
Simplify marimo notebook commands

### DIFF
--- a/extension/README.md
+++ b/extension/README.md
@@ -30,12 +30,11 @@ icon in the editor title bar to open it as a notebook (see image above).
 | --------------------------------------------------------- | ------------------------------------------------------------------------- |
 | `marimo: New marimo notebook`                             | Create a new marimo notebook                                              |
 | `marimo: Open as marimo notebook`                         | Open a Python file as a marimo notebook                                   |
-| `marimo: Toggle on-cell-change mode`                      | Switch between auto-run and lazy execution modes                          |
+| `marimo: Show notebook menu`                              | Configure reactivity and exports, create a setup cell, or publish         |
 | `marimo: Run stale cells`                                 | Execute all cells that need to be re-run                                  |
 | `marimo: Restart notebook kernel`                         | Restart the notebook's Python kernel                                      |
 | `marimo: Create setup cell`                               | Create or navigate to an existing setup cell                              |
-| `marimo: Publish notebook as Gist`                        | Share your notebook as a GitHub Gist                                      |
-| `marimo: Publish notebook as...`                          | Export your notebook in various formats                                   |
+| `marimo: Publish notebook...`                             | Share your notebook as a GitHub Gist                                      |
 | `marimo: Export static HTML`                              | Export notebook with current outputs as HTML (without re-executing cells) |
 | `marimo: Set Python interpreter to match notebook kernel` | Set the active Python interpreter to match the notebook's kernel          |
 | `marimo: Restart marimo language server (marimo-lsp)`     | Restart the LSP server if it becomes unresponsive                         |

--- a/extension/package.json
+++ b/extension/package.json
@@ -278,8 +278,8 @@
         "category": "marimo"
       },
       {
-        "command": "marimo.showNotebookActions",
-        "title": "Show notebook actions",
+        "command": "marimo.showNotebookMenu",
+        "title": "Show notebook menu",
         "shortTitle": "marimo",
         "category": "marimo",
         "icon": "images/small-icon.png",
@@ -311,23 +311,8 @@
         "enablement": "notebookType == 'marimo-notebook'"
       },
       {
-        "command": "marimo.configureAutoExport",
-        "title": "Configure export formats",
-        "shortTitle": "Export formats…",
-        "category": "marimo",
-        "icon": "$(save-all)",
-        "enablement": "notebookType == 'marimo-notebook'"
-      },
-      {
-        "command": "marimo.publishMarimoNotebookGist",
-        "title": "Publish notebook as Gist",
-        "shortTitle": "Publish Gist",
-        "category": "marimo",
-        "enablement": "notebookType == 'marimo-notebook'"
-      },
-      {
         "command": "marimo.publishMarimoNotebook",
-        "title": "Publish notebook as ...",
+        "title": "Publish notebook…",
         "shortTitle": "Publish notebook",
         "category": "marimo",
         "enablement": "notebookType == 'marimo-notebook'"
@@ -379,46 +364,6 @@
         "enablement": "notebookType == 'marimo-notebook'"
       },
       {
-        "command": "marimo.config.toggleOnCellChangeAutoRun",
-        "title": "Configure behavior after cell changes",
-        "shortTitle": "Cell changes: Auto-run",
-        "category": "marimo",
-        "icon": "$(zap)",
-        "enablement": "notebookType == 'marimo-notebook'"
-      },
-      {
-        "command": "marimo.config.toggleOnCellChangeLazy",
-        "title": "Configure behavior after cell changes",
-        "shortTitle": "Cell changes: Lazy",
-        "category": "marimo",
-        "icon": "$(history)",
-        "enablement": "notebookType == 'marimo-notebook'"
-      },
-      {
-        "command": "marimo.config.toggleAutoReloadOff",
-        "title": "Configure behavior after module changes",
-        "shortTitle": "Module changes: Off",
-        "category": "marimo",
-        "icon": "$(circle-slash)",
-        "enablement": "notebookType == 'marimo-notebook'"
-      },
-      {
-        "command": "marimo.config.toggleAutoReloadLazy",
-        "title": "Configure behavior after module changes",
-        "shortTitle": "Module changes: Lazy",
-        "category": "marimo",
-        "icon": "$(history)",
-        "enablement": "notebookType == 'marimo-notebook'"
-      },
-      {
-        "command": "marimo.config.toggleAutoReloadAutorun",
-        "title": "Configure behavior after module changes",
-        "shortTitle": "Module changes: Auto-run",
-        "category": "marimo",
-        "icon": "$(zap)",
-        "enablement": "notebookType == 'marimo-notebook'"
-      },
-      {
         "command": "marimo.restartKernel",
         "title": "Restart notebook kernel",
         "shortTitle": "Restart Kernel",
@@ -452,6 +397,11 @@
         "shortTitle": "Export static HTML",
         "category": "marimo",
         "enablement": "notebookType == 'marimo-notebook'"
+      },
+      {
+        "command": "marimo.updateCellMetadata",
+        "title": "Update cell metadata",
+        "category": "marimo"
       },
       {
         "command": "marimo.updateActivePythonEnvironment",
@@ -492,6 +442,10 @@
     "menus": {
       "commandPalette": [
         {
+          "command": "marimo.showMarimoMenu",
+          "when": "never"
+        },
+        {
           "command": "marimo.openSession",
           "when": "never"
         },
@@ -504,23 +458,15 @@
           "when": "never"
         },
         {
-          "command": "marimo.config.toggleOnCellChangeAutoRun",
+          "command": "marimo.shutdownAllSessions",
           "when": "never"
         },
         {
-          "command": "marimo.config.toggleOnCellChangeLazy",
+          "command": "marimo.refreshPackages",
           "when": "never"
         },
         {
-          "command": "marimo.config.toggleAutoReloadOff",
-          "when": "never"
-        },
-        {
-          "command": "marimo.config.toggleAutoReloadLazy",
-          "when": "never"
-        },
-        {
-          "command": "marimo.config.toggleAutoReloadAutorun",
+          "command": "marimo.updateCellMetadata",
           "when": "never"
         }
       ],
@@ -581,7 +527,7 @@
           "group": "navigation@3"
         },
         {
-          "command": "marimo.showNotebookActions",
+          "command": "marimo.showNotebookMenu",
           "when": "notebookType == 'marimo-notebook'",
           "group": "navigation@4"
         }

--- a/extension/src/__mocks__/TestVsCode.ts
+++ b/extension/src/__mocks__/TestVsCode.ts
@@ -1912,14 +1912,6 @@ export class TestVsCode extends Data.TaggedClass("TestVsCode")<{
               );
             });
           },
-          registerEphemeral(name) {
-            return Effect.gen(function* () {
-              yield* Ref.update(commands, HashSet.add<string>(name));
-              yield* Effect.addFinalizer(() =>
-                Ref.update(commands, HashSet.remove<string>(name)),
-              );
-            });
-          },
         }),
         workspace: Workspace.make({
           fs: {

--- a/extension/src/__tests__/extension.test.ts
+++ b/extension/src/__tests__/extension.test.ts
@@ -71,13 +71,8 @@ describe("extension.activate", () => {
       // We don't need to snapshot all commands and views, since we
       // check them against package.json below.
 
-      // Should exactly match package.json (excluding dynamic commands)
-      // Dynamic commands are created at runtime and shouldn't be in package.json
-      const staticCommands = snapshot.commands.filter(
-        (cmd: string) => !cmd.startsWith("marimo.dynamic."),
-      );
       expect(new Set(pkg.contributes.commands.map((c) => c.command))).toEqual(
-        new Set(staticCommands),
+        new Set(snapshot.commands),
       );
       expect(
         new Set(

--- a/extension/src/commands.ts
+++ b/extension/src/commands.ts
@@ -103,12 +103,6 @@ export function decodeCommandResult<Result>(
   return command[MarimoCommandTypeId].decodeResult(result);
 }
 
-export type EphemeralCommand = `marimo.dynamic.${string}`;
-
-export function ephemeralCommand(command: string): EphemeralCommand {
-  return `marimo.dynamic.${command}`;
-}
-
 // Pulled from https://code.visualstudio.com/api/references/commands
 export type VscodeBuiltinCommand =
   // Focus the built-in Outline view.

--- a/extension/src/commands/MarimoCommands.gen.ts
+++ b/extension/src/commands/MarimoCommands.gen.ts
@@ -5,20 +5,6 @@
 import { marimoCommand } from "../commands.ts";
 
 export const GeneratedMarimoCommands = {
-  configToggleAutoReloadAutorun: marimoCommand(
-    "marimo.config.toggleAutoReloadAutorun",
-  ),
-  configToggleAutoReloadLazy: marimoCommand(
-    "marimo.config.toggleAutoReloadLazy",
-  ),
-  configToggleAutoReloadOff: marimoCommand("marimo.config.toggleAutoReloadOff"),
-  configToggleOnCellChangeAutoRun: marimoCommand(
-    "marimo.config.toggleOnCellChangeAutoRun",
-  ),
-  configToggleOnCellChangeLazy: marimoCommand(
-    "marimo.config.toggleOnCellChangeLazy",
-  ),
-  configureAutoExport: marimoCommand("marimo.configureAutoExport"),
   createSetupCell: marimoCommand("marimo.createSetupCell"),
   debugCell: marimoCommand("marimo.debugCell"),
   exportStaticHTML: marimoCommand("marimo.exportStaticHTML"),
@@ -28,7 +14,6 @@ export const GeneratedMarimoCommands = {
   openSession: marimoCommand("marimo.openSession"),
   openTutorial: marimoCommand("marimo.openTutorial"),
   publishMarimoNotebook: marimoCommand("marimo.publishMarimoNotebook"),
-  publishMarimoNotebookGist: marimoCommand("marimo.publishMarimoNotebookGist"),
   refreshPackages: marimoCommand("marimo.refreshPackages"),
   reportIssue: marimoCommand("marimo.reportIssue"),
   restartKernel: marimoCommand("marimo.restartKernel"),
@@ -37,10 +22,11 @@ export const GeneratedMarimoCommands = {
   runStale: marimoCommand("marimo.runStale"),
   showDiagnostics: marimoCommand("marimo.showDiagnostics"),
   showMarimoMenu: marimoCommand("marimo.showMarimoMenu"),
-  showNotebookActions: marimoCommand("marimo.showNotebookActions"),
+  showNotebookMenu: marimoCommand("marimo.showNotebookMenu"),
   shutdownAllSessions: marimoCommand("marimo.shutdownAllSessions"),
   shutdownSession: marimoCommand("marimo.shutdownSession"),
   updateActivePythonEnvironment: marimoCommand(
     "marimo.updateActivePythonEnvironment",
   ),
+  updateCellMetadata: marimoCommand("marimo.updateCellMetadata"),
 } as const;

--- a/extension/src/commands/MarimoCommands.ts
+++ b/extension/src/commands/MarimoCommands.ts
@@ -9,30 +9,21 @@ import { NotebookIdFromString } from "../schemas/MarimoNotebookDocument.ts";
 import { GeneratedMarimoCommands } from "./MarimoCommands.gen.ts";
 
 const notebookCommands = {
-  configToggleAutoReloadAutorun: withOptionalNotebookContext(
-    GeneratedMarimoCommands.configToggleAutoReloadAutorun,
+  createSetupCell: withOptionalNotebookContext(
+    GeneratedMarimoCommands.createSetupCell,
   ),
-  configToggleAutoReloadLazy: withOptionalNotebookContext(
-    GeneratedMarimoCommands.configToggleAutoReloadLazy,
-  ),
-  configToggleAutoReloadOff: withOptionalNotebookContext(
-    GeneratedMarimoCommands.configToggleAutoReloadOff,
-  ),
-  configToggleOnCellChangeAutoRun: withOptionalNotebookContext(
-    GeneratedMarimoCommands.configToggleOnCellChangeAutoRun,
-  ),
-  configToggleOnCellChangeLazy: withOptionalNotebookContext(
-    GeneratedMarimoCommands.configToggleOnCellChangeLazy,
-  ),
-  configureAutoExport: withOptionalNotebookContext(
-    GeneratedMarimoCommands.configureAutoExport,
+  publishMarimoNotebook: withOptionalNotebookContext(
+    GeneratedMarimoCommands.publishMarimoNotebook,
   ),
   restartKernel: withOptionalNotebookContext(
     GeneratedMarimoCommands.restartKernel,
   ),
   runStale: withOptionalNotebookContext(GeneratedMarimoCommands.runStale),
-  showNotebookActions: withOptionalNotebookContext(
-    GeneratedMarimoCommands.showNotebookActions,
+  showNotebookMenu: withOptionalNotebookContext(
+    GeneratedMarimoCommands.showNotebookMenu,
+  ),
+  updateActivePythonEnvironment: withOptionalNotebookContext(
+    GeneratedMarimoCommands.updateActivePythonEnvironment,
   ),
 };
 
@@ -62,5 +53,9 @@ export const MarimoCommands = {
   shutdownSession: withFirstArgument(
     GeneratedMarimoCommands.shutdownSession,
     SessionAction,
+  ),
+  updateCellMetadata: withFirstArgument(
+    GeneratedMarimoCommands.updateCellMetadata,
+    Schema.String,
   ),
 } as const;

--- a/extension/src/commands/__tests__/MarimoCommands.test.ts
+++ b/extension/src/commands/__tests__/MarimoCommands.test.ts
@@ -68,6 +68,26 @@ describe("MarimoCommands", () => {
     }),
   );
 
+  it.effect("preserves notebook context for interpreter synchronization", () =>
+    Effect.gen(function* () {
+      const notebookUri = {
+        scheme: "file",
+        path: "/notebook.py",
+        with() {
+          return this;
+        },
+        toString() {
+          return "file:///notebook.py";
+        },
+      };
+      const args = yield* decodeCommandArguments(
+        MarimoCommands.updateActivePythonEnvironment,
+        [{ notebookEditor: { notebookUri } }],
+      );
+      expect(args).toEqual([{ notebookEditor: { notebookUri } }]);
+    }),
+  );
+
   it.effect("decodes the first external argument for open-as-notebook", () =>
     Effect.gen(function* () {
       const args = yield* decodeCommandArguments(

--- a/extension/src/commands/__tests__/showNotebookMenu.test.ts
+++ b/extension/src/commands/__tests__/showNotebookMenu.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Layer, Option, Ref, Stream } from "effect";
+
+import { TestVsCode } from "../../__mocks__/TestVsCode.ts";
+import { commandId } from "../../commands.ts";
+import { MarimoConfigurationService } from "../../config/MarimoConfigurationService.ts";
+import { marimoConfigFixture } from "../../lib/__tests__/branded.ts";
+import { OutputChannel } from "../../platform/OutputChannel.ts";
+import { MarimoCommands } from "../MarimoCommands.ts";
+import { showNotebookMenu } from "../showNotebookMenu.ts";
+
+const configLayer = Layer.succeed(
+  MarimoConfigurationService,
+  MarimoConfigurationService.make({
+    getConfig: () =>
+      Effect.succeed(
+        marimoConfigFixture({
+          runtime: { on_cell_change: "lazy", auto_reload: "autorun" },
+        }),
+      ),
+    updateConfig: () => Effect.die("not implemented"),
+    clearNotebook: () => Effect.die("not implemented"),
+    streamOf: () => Stream.empty,
+  }),
+);
+
+const testLayer = (vscode: TestVsCode) =>
+  Layer.mergeAll(
+    vscode.layer,
+    configLayer,
+    OutputChannel.Default.pipe(Layer.provide(vscode.layer)),
+  );
+
+describe("showNotebookMenu", () => {
+  it.effect("offers a focused four-item notebook menu", () =>
+    Effect.gen(function* () {
+      const labels = yield* Ref.make<ReadonlyArray<string>>([]);
+      const vscode = yield* TestVsCode.make({
+        window: {
+          showQuickPickItems: (items) =>
+            Ref.set(
+              labels,
+              items.map((item) => item.label),
+            ).pipe(Effect.as(Option.none())),
+        },
+      });
+
+      yield* showNotebookMenu().pipe(Effect.provide(testLayer(vscode)));
+
+      expect(yield* labels).toEqual([
+        "$(zap) Reactivity",
+        "$(save-all) Automatic exports",
+        "$(gear) Create setup cell",
+        "$(cloud-upload) Publish notebook",
+      ]);
+      expect(yield* Ref.get(vscode.executions)).toEqual([]);
+    }),
+  );
+
+  it.effect("routes direct actions through their registered commands", () =>
+    Effect.gen(function* () {
+      const editor = TestVsCode.makeNotebookEditor("/test/notebook.py");
+      const context = {
+        notebookEditor: { notebookUri: editor.notebook.uri },
+      };
+      const vscode = yield* TestVsCode.make({
+        window: {
+          showQuickPickItems: (items) =>
+            Effect.succeed(
+              Option.fromNullable(
+                items.find((item) => item.label.includes("Publish notebook")),
+              ),
+            ),
+        },
+      });
+
+      yield* showNotebookMenu(context).pipe(Effect.provide(testLayer(vscode)));
+
+      expect(yield* Ref.get(vscode.executions)).toContainEqual({
+        command: commandId(MarimoCommands.publishMarimoNotebook),
+        args: [context],
+      });
+    }),
+  );
+
+  it.effect("routes setup-cell creation with the notebook context", () =>
+    Effect.gen(function* () {
+      const editor = TestVsCode.makeNotebookEditor("/test/notebook.py");
+      const context = {
+        notebookEditor: { notebookUri: editor.notebook.uri },
+      };
+      const vscode = yield* TestVsCode.make({
+        window: {
+          showQuickPickItems: (items) =>
+            Effect.succeed(
+              Option.fromNullable(
+                items.find((item) => item.label.includes("Create setup cell")),
+              ),
+            ),
+        },
+      });
+
+      yield* showNotebookMenu(context).pipe(Effect.provide(testLayer(vscode)));
+
+      expect(yield* Ref.get(vscode.executions)).toContainEqual({
+        command: commandId(MarimoCommands.createSetupCell),
+        args: [context],
+      });
+    }),
+  );
+
+  it.effect("shows the current reactivity state", () =>
+    Effect.gen(function* () {
+      const descriptions = yield* Ref.make<ReadonlyArray<string>>([]);
+      const editor = TestVsCode.makeNotebookEditor("/test/notebook.py");
+      const vscode = yield* TestVsCode.make({
+        initialDocuments: [editor.notebook],
+        window: {
+          showQuickPickItems: (items, options) => {
+            if (options?.title === "marimo notebook") {
+              return Effect.succeed(
+                Option.fromNullable(
+                  items.find((item) => item.label.includes("Reactivity")),
+                ),
+              );
+            }
+            return Ref.set(
+              descriptions,
+              items.flatMap((item) => item.description ?? []),
+            ).pipe(Effect.as(Option.none()));
+          },
+        },
+      });
+      yield* vscode.setActiveNotebookEditor(Option.some(editor));
+
+      yield* showNotebookMenu().pipe(Effect.provide(testLayer(vscode)));
+
+      expect(yield* descriptions).toEqual(["Lazy", "Auto-run"]);
+    }),
+  );
+});

--- a/extension/src/commands/createSetupCell.ts
+++ b/extension/src/commands/createSetupCell.ts
@@ -1,6 +1,8 @@
 import { Effect, Option } from "effect";
 
+import type { NotebookCommandContext } from "../commands.ts";
 import { SETUP_CELL_NAME } from "../constants.ts";
+import { getNotebookCommandEditor } from "../lib/getNotebookCommandEditor.ts";
 import { Constants } from "../platform/Constants.ts";
 import { VsCode } from "../platform/VsCode.ts";
 import {
@@ -8,11 +10,13 @@ import {
   MarimoNotebookDocument,
 } from "../schemas/MarimoNotebookDocument.ts";
 
-export const createSetupCell = Effect.fn(function* () {
+export const createSetupCell = Effect.fn("command.createSetupCell")(function* (
+  context?: NotebookCommandContext,
+) {
   const code = yield* VsCode;
   const { LanguageId } = yield* Constants;
   const notebook = Option.filterMap(
-    yield* code.window.getActiveNotebookEditor(),
+    yield* getNotebookCommandEditor(context),
     (editor) => MarimoNotebookDocument.tryFrom(editor.notebook),
   );
 

--- a/extension/src/commands/publishMarimoNotebook.ts
+++ b/extension/src/commands/publishMarimoNotebook.ts
@@ -1,20 +1,10 @@
-import { Effect, Option } from "effect";
+import { Effect } from "effect";
 
-import { VsCode } from "../platform/VsCode.ts";
-import { MarimoCommands } from "./MarimoCommands.ts";
+import type { NotebookCommandContext } from "../commands.ts";
+import { publishMarimoNotebookGist } from "./publishMarimoNotebookGist.ts";
 
-export const publishMarimoNotebook = Effect.fn(function* () {
-  const code = yield* VsCode;
-  const choice = yield* code.window.showQuickPickItems([
-    {
-      label: "GitHub Gist",
-      detail: "Publish marimo notebook as a GitHub Gist",
-    },
-  ]);
-  if (Option.isNone(choice)) {
-    return;
-  }
-  if (choice.value.label === "GitHub Gist") {
-    yield* code.commands.execute(MarimoCommands.publishMarimoNotebookGist);
-  }
-});
+export const publishMarimoNotebook = Effect.fn("command.publishMarimoNotebook")(
+  function* (context?: NotebookCommandContext) {
+    yield* publishMarimoNotebookGist(context);
+  },
+);

--- a/extension/src/commands/publishMarimoNotebookGist.ts
+++ b/extension/src/commands/publishMarimoNotebookGist.ts
@@ -2,6 +2,8 @@ import * as NodePath from "node:path";
 
 import { Cause, Chunk, Effect, Either, flow, Schema, Option } from "effect";
 
+import type { NotebookCommandContext } from "../commands.ts";
+import { getNotebookCommandEditor } from "../lib/getNotebookCommandEditor.ts";
 import { showErrorAndPromptLogs } from "../lib/showErrorAndPromptLogs.ts";
 import { MarimoClient } from "../lsp/MarimoClient.ts";
 import { NotebookSerializer } from "../notebook/NotebookSerializer.ts";
@@ -12,14 +14,14 @@ import { MarimoNotebookDocument } from "../schemas/MarimoNotebookDocument.ts";
 export const publishMarimoNotebookGist = Effect.fn(
   "command.publishMarimoNotebookGist",
 )(
-  function* () {
+  function* (context?: NotebookCommandContext) {
     const code = yield* VsCode;
     const gh = yield* GitHubClient;
     const marimo = yield* MarimoClient;
     const serializer = yield* NotebookSerializer;
 
     const notebook = Option.filterMap(
-      yield* code.window.getActiveNotebookEditor(),
+      yield* getNotebookCommandEditor(context),
       (editor) => MarimoNotebookDocument.tryFrom(editor.notebook),
     );
 

--- a/extension/src/commands/showNotebookMenu.ts
+++ b/extension/src/commands/showNotebookMenu.ts
@@ -6,32 +6,65 @@ import { getNotebookCommandEditor } from "../lib/getNotebookCommandEditor.ts";
 import { VsCode } from "../platform/VsCode.ts";
 import { MarimoNotebookDocument } from "../schemas/MarimoNotebookDocument.ts";
 import { configureAutoExport } from "./configureAutoExport.ts";
+import { MarimoCommands } from "./MarimoCommands.ts";
 import { toggleAutoReload } from "./toggleAutoReload.ts";
 import { toggleOnCellChange } from "./toggleOnCellChange.ts";
 
-export const showNotebookActions = Effect.fn("command.showNotebookActions")(
+const NOTEBOOK_MENU_ITEMS = [
+  {
+    label: "$(zap) Reactivity",
+    detail: "Choose when dependent code runs",
+    value: "reactivity" as const,
+  },
+  {
+    label: "$(save-all) Automatic exports",
+    detail: "Keep HTML or IPYNB copies up to date",
+    value: "automatic-exports" as const,
+  },
+  {
+    label: "$(gear) Create setup cell",
+    detail: "Add an initialization cell at the top of the notebook",
+    value: "create-setup-cell" as const,
+  },
+  {
+    label: "$(cloud-upload) Publish notebook",
+    detail: "Share this notebook as a GitHub Gist",
+    value: "publish-notebook" as const,
+  },
+] as const;
+
+export const showNotebookMenu = Effect.fn("command.showNotebookMenu")(
   function* (context?: NotebookCommandContext) {
     const code = yield* VsCode;
     const selection = yield* code.window.showQuickPickItems(
-      [
-        {
-          label: "$(zap) Reactivity",
-          detail: "Choose when dependent code runs",
-          value: "reactivity" as const,
-        },
-        {
-          label: "$(save-all) Exports",
-          detail: "Keep HTML or IPYNB copies up to date",
-          value: "exports" as const,
-        },
-      ],
-      { title: "marimo notebook" },
+      NOTEBOOK_MENU_ITEMS,
+      {
+        placeHolder: "Choose a notebook action",
+        title: "marimo notebook",
+      },
     );
 
     if (Option.isNone(selection)) return;
-    if (selection.value.value === "exports") {
-      yield* configureAutoExport(context);
-      return;
+
+    switch (selection.value.value) {
+      case "automatic-exports":
+        yield* configureAutoExport(context);
+        return;
+      case "create-setup-cell":
+        yield* context === undefined
+          ? code.commands.execute(MarimoCommands.createSetupCell)
+          : code.commands.execute(MarimoCommands.createSetupCell, context);
+        return;
+      case "publish-notebook":
+        yield* context === undefined
+          ? code.commands.execute(MarimoCommands.publishMarimoNotebook)
+          : code.commands.execute(
+              MarimoCommands.publishMarimoNotebook,
+              context,
+            );
+        return;
+      case "reactivity":
+        break;
     }
 
     const configService = yield* MarimoConfigurationService;

--- a/extension/src/commands/updateActivePythonEnvironment.ts
+++ b/extension/src/commands/updateActivePythonEnvironment.ts
@@ -1,6 +1,8 @@
 import { Effect, Either, Option } from "effect";
 
+import type { NotebookCommandContext } from "../commands.ts";
 import { NotebookRuntime } from "../kernel/NotebookRuntime.ts";
+import { getNotebookCommandEditor } from "../lib/getNotebookCommandEditor.ts";
 import { showErrorAndPromptLogs } from "../lib/showErrorAndPromptLogs.ts";
 import { VsCode } from "../platform/VsCode.ts";
 import { getVenvPythonPath } from "../python/getVenvPythonPath.ts";
@@ -10,17 +12,17 @@ import { MarimoNotebookDocument } from "../schemas/MarimoNotebookDocument.ts";
 
 export const updateActivePythonEnvironment = Effect.fn(
   "command.updateActivePythonEnvironment",
-)(function* () {
+)(function* (context?: NotebookCommandContext) {
   const uv = yield* Uv;
   const code = yield* VsCode;
   const py = yield* PythonExtension;
   const notebooks = yield* NotebookRuntime;
 
-  const editor = yield* code.window.getActiveNotebookEditor();
+  const editor = yield* getNotebookCommandEditor(context);
 
   if (Option.isNone(editor)) {
     yield* code.window.showInformationMessage(
-      "No marimo notebook is currently open",
+      "No marimo notebook is currently open.",
     );
     return;
   }

--- a/extension/src/features/RegisterCommands.ts
+++ b/extension/src/features/RegisterCommands.ts
@@ -1,6 +1,5 @@
 import { Effect, Either, Layer, Stream } from "effect";
 
-import { configureAutoExport } from "../commands/configureAutoExport.ts";
 import { createSetupCell } from "../commands/createSetupCell.ts";
 import { debugCell } from "../commands/debugCell.ts";
 import { exportNotebookAsHtml } from "../commands/exportNotebookAsHtml.ts";
@@ -9,15 +8,12 @@ import { newMarimoNotebook } from "../commands/newMarimoNotebook.ts";
 import { openAsMarimoNotebook } from "../commands/openAsMarimoNotebook.ts";
 import { openOutlineView } from "../commands/openOutlineView.ts";
 import { publishMarimoNotebook } from "../commands/publishMarimoNotebook.ts";
-import { publishMarimoNotebookGist } from "../commands/publishMarimoNotebookGist.ts";
 import { reportIssue } from "../commands/reportIssue.ts";
 import { restartKernel } from "../commands/restartKernel.ts";
 import { restartLsp } from "../commands/restartLsp.ts";
 import { runStale } from "../commands/runStale.ts";
 import { showDiagnostics } from "../commands/showDiagnostics.ts";
-import { showNotebookActions } from "../commands/showNotebookActions.ts";
-import { toggleAutoReload } from "../commands/toggleAutoReload.ts";
-import { toggleOnCellChange } from "../commands/toggleOnCellChange.ts";
+import { showNotebookMenu } from "../commands/showNotebookMenu.ts";
 import { updateActivePythonEnvironment } from "../commands/updateActivePythonEnvironment.ts";
 import { VsCode } from "../platform/VsCode.ts";
 import { Telemetry } from "../telemetry/Telemetry.ts";
@@ -41,11 +37,6 @@ export const RegisterCommandsLive = Layer.scopedDiscard(
     );
 
     yield* code.commands.register(
-      MarimoCommands.configureAutoExport,
-      configureAutoExport,
-    );
-
-    yield* code.commands.register(
       MarimoCommands.openAsMarimoNotebook,
       openAsMarimoNotebook,
     );
@@ -56,36 +47,16 @@ export const RegisterCommandsLive = Layer.scopedDiscard(
     );
 
     yield* code.commands.register(
-      MarimoCommands.publishMarimoNotebookGist,
-      publishMarimoNotebookGist,
-    );
-
-    yield* code.commands.register(
       MarimoCommands.publishMarimoNotebook,
       publishMarimoNotebook,
     );
 
     yield* code.commands.register(MarimoCommands.runStale, runStale);
     yield* code.commands.register(
-      MarimoCommands.showNotebookActions,
-      showNotebookActions,
+      MarimoCommands.showNotebookMenu,
+      showNotebookMenu,
     );
     yield* code.commands.register(MarimoCommands.debugCell, debugCell);
-
-    for (const command of [
-      MarimoCommands.configToggleOnCellChangeAutoRun,
-      MarimoCommands.configToggleOnCellChangeLazy,
-    ]) {
-      yield* code.commands.register(command, toggleOnCellChange);
-    }
-
-    for (const command of [
-      MarimoCommands.configToggleAutoReloadOff,
-      MarimoCommands.configToggleAutoReloadLazy,
-      MarimoCommands.configToggleAutoReloadAutorun,
-    ]) {
-      yield* code.commands.register(command, toggleAutoReload);
-    }
 
     yield* code.commands.register(MarimoCommands.restartKernel, restartKernel);
 

--- a/extension/src/notebook/CellMetadataUIBindingService.ts
+++ b/extension/src/notebook/CellMetadataUIBindingService.ts
@@ -2,7 +2,8 @@ import { Effect, Option, Stream } from "effect";
 import type * as vscode from "vscode";
 
 import { assert } from "../assert.ts";
-import { ephemeralCommand } from "../commands.ts";
+import { commandId } from "../commands.ts";
+import { MarimoCommands } from "../commands/MarimoCommands.ts";
 import { NOTEBOOK_TYPE } from "../constants.ts";
 import { VsCode } from "../platform/VsCode.ts";
 import {
@@ -126,13 +127,6 @@ export class CellMetadataUIBindingService extends Effect.Service<CellMetadataUIB
         Effect.gen(function* () {
           bindings.set(binding.id, binding);
 
-          // Create command for handling clicks
-          const commandId = ephemeralCommand(`cell.metadata.${binding.id}`);
-          yield* code.commands.registerEphemeral(
-            commandId,
-            createBindingCommandFor(binding),
-          );
-
           // Register the provider
           yield* code.notebooks.registerNotebookCellStatusBarItemProvider(
             NOTEBOOK_TYPE,
@@ -153,7 +147,11 @@ export class CellMetadataUIBindingService extends Effect.Service<CellMetadataUIB
                   binding.alignment,
                 );
                 item.tooltip = binding.getTooltip(value);
-                item.command = commandId;
+                item.command = {
+                  command: commandId(MarimoCommands.updateCellMetadata),
+                  title: "Update cell metadata",
+                  arguments: [binding.id],
+                };
 
                 return Effect.succeed([item]);
               },
@@ -302,6 +300,20 @@ export class CellMetadataUIBindingService extends Effect.Service<CellMetadataUIB
           );
         });
       }
+
+      yield* code.commands.register(
+        MarimoCommands.updateCellMetadata,
+        Effect.fn(function* (bindingId) {
+          const binding = bindings.get(bindingId);
+          if (binding === undefined) {
+            yield* Effect.logWarning("Unknown cell metadata binding").pipe(
+              Effect.annotateLogs({ bindingId }),
+            );
+            return;
+          }
+          yield* createBindingCommandFor(binding)();
+        }),
+      );
 
       return { registerBinding } as const;
     }),

--- a/extension/src/notebook/__tests__/CellMetadataUIBindingService.test.ts
+++ b/extension/src/notebook/__tests__/CellMetadataUIBindingService.test.ts
@@ -8,6 +8,8 @@ import {
   createTestNotebookDocument,
   TestVsCode,
 } from "../../__mocks__/TestVsCode.ts";
+import { commandId } from "../../commands.ts";
+import { MarimoCommands } from "../../commands/MarimoCommands.ts";
 import { DEFAULT_SQL_ENGINE } from "../../features/CellMetadataBindings.ts";
 import {
   CellMetadataUIBindingService,
@@ -103,6 +105,11 @@ it.scoped(
       const sqlItems = yield* providers[0].provideCellStatusBarItems(sqlCell);
       expect(sqlItems.length).toBe(1);
       expect(sqlItems[0]?.text).toContain("$(database) df");
+      expect(sqlItems[0]?.command).toEqual({
+        command: commandId(MarimoCommands.updateCellMetadata),
+        title: "Update cell metadata",
+        arguments: ["test.sql"],
+      });
 
       const pythonItems =
         yield* providers[0].provideCellStatusBarItems(pythonCell);

--- a/extension/src/platform/VsCode.ts
+++ b/extension/src/platform/VsCode.ts
@@ -33,7 +33,6 @@ import {
   commandId,
   decodeCommandArguments,
   decodeCommandResult,
-  type EphemeralCommand,
   type MarimoCommand,
   type VscodeBuiltinCommand,
 } from "../commands.ts";
@@ -390,13 +389,6 @@ export class Commands extends Effect.Service<Commands>()("Commands", {
       );
     }
 
-    function registerEphemeral<A, E, R>(
-      command: EphemeralCommand,
-      fn: (...args: unknown[]) => Effect.Effect<A, E, R>,
-    ) {
-      return registerImplementation(command, (args) => fn(...args));
-    }
-
     return {
       subscribeToCommands() {
         return PubSub.subscribe(commandPubSub);
@@ -409,7 +401,6 @@ export class Commands extends Effect.Service<Commands>()("Commands", {
         );
       },
       register,
-      registerEphemeral,
     };
   }),
 }) {}


### PR DESCRIPTION
Keep the marimo notebook menu focused on reactivity, automatic exports, setup-cell creation, and publishing while leaving common runtime actions directly searchable.

Remove state-specific configuration commands and per-binding dynamic command registrations. Cell metadata now routes through one typed hidden command, and notebook menu actions preserve the notebook that opened the menu. Publishing goes directly to Gist visibility selection.