### PR TITLE
Force package refreshes past the cache

### DIFF
--- a/extension/src/panel/packages/PackagesService.ts
+++ b/extension/src/panel/packages/PackagesService.ts
@@ -1,4 +1,4 @@
-import { Effect, HashMap, Option, Ref, SubscriptionRef } from "effect";
+import { Effect, HashMap, Option, SubscriptionRef } from "effect";
 
 import {
   type NotebookController,
@@ -52,50 +52,20 @@ export class PackagesService extends Effect.Service<PackagesService>()(
       const dependencyTreesRef = yield* SubscriptionRef.make(
         HashMap.empty<NotebookId, DependencyTreeState>(),
       );
-      const nextRequestIdRef = yield* Ref.make(0);
-      const latestRequestIdsRef = yield* Ref.make(
-        HashMap.empty<NotebookId, number>(),
-      );
-      const requestStateLock = yield* Effect.makeSemaphore(1);
       const clearCache = (notebookUri: NotebookId) =>
-        requestStateLock.withPermits(1)(
-          Effect.gen(function* () {
-            yield* SubscriptionRef.update(
-              dependencyTreesRef,
-              HashMap.remove(notebookUri),
-            );
-            yield* Ref.update(latestRequestIdsRef, HashMap.remove(notebookUri));
-            yield* Effect.logTrace("Cleared package data").pipe(
-              Effect.annotateLogs({ notebookUri }),
-            );
-          }),
-        );
+        Effect.gen(function* () {
+          yield* SubscriptionRef.update(
+            dependencyTreesRef,
+            HashMap.remove(notebookUri),
+          );
+          yield* Effect.logTrace("Cleared package data").pipe(
+            Effect.annotateLogs({ notebookUri }),
+          );
+        });
 
       const sessions = yield* makeNotebookSessions(code, clearCache);
 
       return {
-        /**
-         * Set dependency tree error state
-         */
-        setDependencyTreeError(notebookUri: NotebookId, error: string) {
-          return Effect.gen(function* () {
-            yield* SubscriptionRef.update(dependencyTreesRef, (map) =>
-              HashMap.set(
-                map,
-                notebookUri,
-                Option.match(HashMap.get(map, notebookUri), {
-                  onSome: (value) => ({ ...value, loading: false, error }),
-                  onNone: () => ({ tree: null, loading: false, error }),
-                }),
-              ),
-            );
-
-            yield* Effect.logError("Dependency tree error").pipe(
-              Effect.annotateLogs({ notebookUri, error }),
-            );
-          });
-        },
-
         /**
          * Get dependency tree state for a notebook
          */
@@ -110,17 +80,10 @@ export class PackagesService extends Effect.Service<PackagesService>()(
          * Fetch dependency tree from the language server
          * Caches the result in dependencyTreesRef and re-uses if already cached
          */
-        fetchDependencyTree(
-          notebookUri: NotebookId,
-          options: { readonly force?: boolean } = {},
-        ) {
+        fetchDependencyTree(notebookUri: NotebookId) {
           return Effect.gen(function* () {
-            const requestId = yield* Ref.updateAndGet(
-              nextRequestIdRef,
-              (current) => current + 1,
-            );
             const session = yield* sessions.sessionFor(notebookUri);
-            const updateIfCurrentSession = (
+            const updateIfCurrent = (
               update: (
                 map: HashMap.HashMap<NotebookId, DependencyTreeState>,
               ) => HashMap.HashMap<NotebookId, DependencyTreeState>,
@@ -135,7 +98,6 @@ export class PackagesService extends Effect.Service<PackagesService>()(
 
             // If we have a tree and it's not in error state, re-use it
             if (
-              !options.force &&
               Option.isSome(existing) &&
               existing.value.tree &&
               !existing.value.error
@@ -161,7 +123,7 @@ export class PackagesService extends Effect.Service<PackagesService>()(
               .forNotebook(activeNotebook.value.id)
               .getController();
             if (Option.isNone(activeController)) {
-              yield* updateIfCurrentSession((map) =>
+              yield* updateIfCurrent((map) =>
                 HashMap.set(map, notebookUri, {
                   tree: null,
                   loading: false,
@@ -175,66 +137,19 @@ export class PackagesService extends Effect.Service<PackagesService>()(
             }
 
             const source = controllerSource(activeController.value);
-            const updateIfCurrentRequest = (
-              update: (
-                map: HashMap.HashMap<NotebookId, DependencyTreeState>,
-              ) => HashMap.HashMap<NotebookId, DependencyTreeState>,
-            ) =>
-              requestStateLock.withPermits(1)(
-                Effect.gen(function* () {
-                  const latestRequestId = HashMap.get(
-                    yield* Ref.get(latestRequestIdsRef),
-                    notebookUri,
-                  );
-                  if (
-                    sessions.current(notebookUri) === session &&
-                    Option.contains(latestRequestId, requestId)
-                  ) {
-                    yield* SubscriptionRef.update(dependencyTreesRef, update);
-                    return true;
-                  }
-                  return false;
+            yield* updateIfCurrent((map) =>
+              HashMap.set(
+                map,
+                notebookUri,
+                Option.match(HashMap.get(map, notebookUri), {
+                  onNone: () => ({
+                    tree: null,
+                    loading: true,
+                    error: null,
+                  }),
+                  onSome: (value) => ({ ...value, loading: true }),
                 }),
-              );
-
-            // Register this request and set loading as one atomic state change.
-            yield* requestStateLock.withPermits(1)(
-              Effect.gen(function* () {
-                yield* Ref.update(latestRequestIdsRef, (requestIds) =>
-                  HashMap.set(
-                    requestIds,
-                    notebookUri,
-                    Option.match(HashMap.get(requestIds, notebookUri), {
-                      onNone: () => requestId,
-                      onSome: (latestRequestId) =>
-                        Math.max(latestRequestId, requestId),
-                    }),
-                  ),
-                );
-                const latestRequestId = HashMap.get(
-                  yield* Ref.get(latestRequestIdsRef),
-                  notebookUri,
-                );
-                if (
-                  sessions.current(notebookUri) === session &&
-                  Option.contains(latestRequestId, requestId)
-                ) {
-                  yield* SubscriptionRef.update(dependencyTreesRef, (map) =>
-                    HashMap.set(
-                      map,
-                      notebookUri,
-                      Option.match(HashMap.get(map, notebookUri), {
-                        onNone: () => ({
-                          tree: null,
-                          loading: true,
-                          error: null,
-                        }),
-                        onSome: (value) => ({ ...value, loading: true }),
-                      }),
-                    ),
-                  );
-                }
-              }),
+              ),
             );
 
             // Fetch from language server
@@ -257,7 +172,7 @@ export class PackagesService extends Effect.Service<PackagesService>()(
                     // Script mode has no useful fallback — `uv tree --script`
                     // is the only path that resolves PEP 723 metadata.
                     if (source.kind === "script") {
-                      yield* updateIfCurrentRequest((map) =>
+                      yield* updateIfCurrent((map) =>
                         HashMap.set(map, notebookUri, {
                           tree: null,
                           loading: false,
@@ -291,7 +206,7 @@ export class PackagesService extends Effect.Service<PackagesService>()(
                         Effect.catchAll((fallbackError) =>
                           Effect.gen(function* () {
                             const fallbackErrorMsg = String(fallbackError);
-                            yield* updateIfCurrentRequest((map) =>
+                            yield* updateIfCurrent((map) =>
                               HashMap.set(map, notebookUri, {
                                 tree: null,
                                 loading: false,
@@ -328,14 +243,14 @@ export class PackagesService extends Effect.Service<PackagesService>()(
                 ),
               );
 
-            const cachedResult = yield* updateIfCurrentRequest((map) =>
-              HashMap.set(map, notebookUri, {
-                tree: rawResult.tree,
-                loading: false,
-                error: null,
-              }),
-            );
-            if (cachedResult) {
+            if (sessions.current(notebookUri) === session) {
+              yield* SubscriptionRef.update(dependencyTreesRef, (map) =>
+                HashMap.set(map, notebookUri, {
+                  tree: rawResult.tree,
+                  loading: false,
+                  error: null,
+                }),
+              );
               yield* Effect.logTrace("Cached dependency tree").pipe(
                 Effect.annotateLogs({
                   notebookUri,

--- a/extension/src/panel/packages/PackagesService.ts
+++ b/extension/src/panel/packages/PackagesService.ts
@@ -118,7 +118,10 @@ export class PackagesService extends Effect.Service<PackagesService>()(
          * Fetch dependency tree from the language server
          * Caches the result in dependencyTreesRef and re-uses if already cached
          */
-        fetchDependencyTree(notebookUri: NotebookId) {
+        fetchDependencyTree(
+          notebookUri: NotebookId,
+          options: { readonly force?: boolean } = {},
+        ) {
           return Effect.gen(function* () {
             const session = yield* sessions.sessionFor(notebookUri);
             const updateIfCurrent = (
@@ -136,6 +139,7 @@ export class PackagesService extends Effect.Service<PackagesService>()(
 
             // If we have a tree and it's not in error state, re-use it
             if (
+              !options.force &&
               Option.isSome(existing) &&
               existing.value.tree &&
               !existing.value.error

--- a/extension/src/panel/packages/PackagesService.ts
+++ b/extension/src/panel/packages/PackagesService.ts
@@ -1,4 +1,4 @@
-import { Effect, HashMap, Option, SubscriptionRef } from "effect";
+import { Effect, HashMap, Option, Ref, SubscriptionRef } from "effect";
 
 import {
   type NotebookController,
@@ -52,36 +52,28 @@ export class PackagesService extends Effect.Service<PackagesService>()(
       const dependencyTreesRef = yield* SubscriptionRef.make(
         HashMap.empty<NotebookId, DependencyTreeState>(),
       );
+      const nextRequestIdRef = yield* Ref.make(0);
+      const latestRequestIdsRef = yield* Ref.make(
+        HashMap.empty<NotebookId, number>(),
+      );
+      const requestStateLock = yield* Effect.makeSemaphore(1);
       const clearCache = (notebookUri: NotebookId) =>
-        Effect.gen(function* () {
-          yield* SubscriptionRef.update(
-            dependencyTreesRef,
-            HashMap.remove(notebookUri),
-          );
-          yield* Effect.logTrace("Cleared package data").pipe(
-            Effect.annotateLogs({ notebookUri }),
-          );
-        });
+        requestStateLock.withPermits(1)(
+          Effect.gen(function* () {
+            yield* SubscriptionRef.update(
+              dependencyTreesRef,
+              HashMap.remove(notebookUri),
+            );
+            yield* Ref.update(latestRequestIdsRef, HashMap.remove(notebookUri));
+            yield* Effect.logTrace("Cleared package data").pipe(
+              Effect.annotateLogs({ notebookUri }),
+            );
+          }),
+        );
 
       const sessions = yield* makeNotebookSessions(code, clearCache);
 
       return {
-        /**
-         * Set dependency tree loading state
-         */
-        setDependencyTreeLoading(notebookUri: NotebookId, loading: boolean) {
-          return SubscriptionRef.update(dependencyTreesRef, (map) =>
-            HashMap.set(
-              map,
-              notebookUri,
-              Option.match(HashMap.get(map, notebookUri), {
-                onNone: () => ({ tree: null, loading, error: null }),
-                onSome: (value) => ({ ...value, loading }),
-              }),
-            ),
-          );
-        },
-
         /**
          * Set dependency tree error state
          */
@@ -123,8 +115,12 @@ export class PackagesService extends Effect.Service<PackagesService>()(
           options: { readonly force?: boolean } = {},
         ) {
           return Effect.gen(function* () {
+            const requestId = yield* Ref.updateAndGet(
+              nextRequestIdRef,
+              (current) => current + 1,
+            );
             const session = yield* sessions.sessionFor(notebookUri);
-            const updateIfCurrent = (
+            const updateIfCurrentSession = (
               update: (
                 map: HashMap.HashMap<NotebookId, DependencyTreeState>,
               ) => HashMap.HashMap<NotebookId, DependencyTreeState>,
@@ -165,7 +161,7 @@ export class PackagesService extends Effect.Service<PackagesService>()(
               .forNotebook(activeNotebook.value.id)
               .getController();
             if (Option.isNone(activeController)) {
-              yield* updateIfCurrent((map) =>
+              yield* updateIfCurrentSession((map) =>
                 HashMap.set(map, notebookUri, {
                   tree: null,
                   loading: false,
@@ -179,17 +175,66 @@ export class PackagesService extends Effect.Service<PackagesService>()(
             }
 
             const source = controllerSource(activeController.value);
-
-            // Set loading state
-            yield* updateIfCurrent((map) =>
-              HashMap.set(
-                map,
-                notebookUri,
-                Option.match(HashMap.get(map, notebookUri), {
-                  onNone: () => ({ tree: null, loading: true, error: null }),
-                  onSome: (value) => ({ ...value, loading: true }),
+            const updateIfCurrentRequest = (
+              update: (
+                map: HashMap.HashMap<NotebookId, DependencyTreeState>,
+              ) => HashMap.HashMap<NotebookId, DependencyTreeState>,
+            ) =>
+              requestStateLock.withPermits(1)(
+                Effect.gen(function* () {
+                  const latestRequestId = HashMap.get(
+                    yield* Ref.get(latestRequestIdsRef),
+                    notebookUri,
+                  );
+                  if (
+                    sessions.current(notebookUri) === session &&
+                    Option.contains(latestRequestId, requestId)
+                  ) {
+                    yield* SubscriptionRef.update(dependencyTreesRef, update);
+                    return true;
+                  }
+                  return false;
                 }),
-              ),
+              );
+
+            // Register this request and set loading as one atomic state change.
+            yield* requestStateLock.withPermits(1)(
+              Effect.gen(function* () {
+                yield* Ref.update(latestRequestIdsRef, (requestIds) =>
+                  HashMap.set(
+                    requestIds,
+                    notebookUri,
+                    Option.match(HashMap.get(requestIds, notebookUri), {
+                      onNone: () => requestId,
+                      onSome: (latestRequestId) =>
+                        Math.max(latestRequestId, requestId),
+                    }),
+                  ),
+                );
+                const latestRequestId = HashMap.get(
+                  yield* Ref.get(latestRequestIdsRef),
+                  notebookUri,
+                );
+                if (
+                  sessions.current(notebookUri) === session &&
+                  Option.contains(latestRequestId, requestId)
+                ) {
+                  yield* SubscriptionRef.update(dependencyTreesRef, (map) =>
+                    HashMap.set(
+                      map,
+                      notebookUri,
+                      Option.match(HashMap.get(map, notebookUri), {
+                        onNone: () => ({
+                          tree: null,
+                          loading: true,
+                          error: null,
+                        }),
+                        onSome: (value) => ({ ...value, loading: true }),
+                      }),
+                    ),
+                  );
+                }
+              }),
             );
 
             // Fetch from language server
@@ -212,7 +257,7 @@ export class PackagesService extends Effect.Service<PackagesService>()(
                     // Script mode has no useful fallback — `uv tree --script`
                     // is the only path that resolves PEP 723 metadata.
                     if (source.kind === "script") {
-                      yield* updateIfCurrent((map) =>
+                      yield* updateIfCurrentRequest((map) =>
                         HashMap.set(map, notebookUri, {
                           tree: null,
                           loading: false,
@@ -246,7 +291,7 @@ export class PackagesService extends Effect.Service<PackagesService>()(
                         Effect.catchAll((fallbackError) =>
                           Effect.gen(function* () {
                             const fallbackErrorMsg = String(fallbackError);
-                            yield* updateIfCurrent((map) =>
+                            yield* updateIfCurrentRequest((map) =>
                               HashMap.set(map, notebookUri, {
                                 tree: null,
                                 loading: false,
@@ -283,14 +328,14 @@ export class PackagesService extends Effect.Service<PackagesService>()(
                 ),
               );
 
-            if (sessions.current(notebookUri) === session) {
-              yield* SubscriptionRef.update(dependencyTreesRef, (map) =>
-                HashMap.set(map, notebookUri, {
-                  tree: rawResult.tree,
-                  loading: false,
-                  error: null,
-                }),
-              );
+            const cachedResult = yield* updateIfCurrentRequest((map) =>
+              HashMap.set(map, notebookUri, {
+                tree: rawResult.tree,
+                loading: false,
+                error: null,
+              }),
+            );
+            if (cachedResult) {
               yield* Effect.logTrace("Cached dependency tree").pipe(
                 Effect.annotateLogs({
                   notebookUri,

--- a/extension/src/panel/packages/PackagesView.ts
+++ b/extension/src/panel/packages/PackagesView.ts
@@ -191,21 +191,7 @@ export const PackagesViewLive = Layer.scopedDiscard(
           Effect.annotateLogs({ notebookUri }),
         );
 
-        yield* packagesService
-          .fetchDependencyTree(notebookUri, { force: true })
-          .pipe(
-            Effect.catchAll((error) =>
-              Effect.gen(function* () {
-                yield* Effect.logError("Failed to refresh packages").pipe(
-                  Effect.annotateLogs({ notebookUri, error: String(error) }),
-                );
-                yield* packagesService.setDependencyTreeError(
-                  notebookUri,
-                  String(error),
-                );
-              }),
-            ),
-          );
+        yield* packagesService.clearNotebook(notebookUri);
       }),
     );
 

--- a/extension/src/panel/packages/PackagesView.ts
+++ b/extension/src/panel/packages/PackagesView.ts
@@ -191,21 +191,21 @@ export const PackagesViewLive = Layer.scopedDiscard(
           Effect.annotateLogs({ notebookUri }),
         );
 
-        // Clear cache and force re-fetch
-        yield* packagesService.setDependencyTreeLoading(notebookUri, true);
-        yield* packagesService.fetchDependencyTree(notebookUri).pipe(
-          Effect.catchAll((error) =>
-            Effect.gen(function* () {
-              yield* Effect.logError("Failed to refresh packages").pipe(
-                Effect.annotateLogs({ notebookUri, error: String(error) }),
-              );
-              yield* packagesService.setDependencyTreeError(
-                notebookUri,
-                String(error),
-              );
-            }),
-          ),
-        );
+        yield* packagesService
+          .fetchDependencyTree(notebookUri, { force: true })
+          .pipe(
+            Effect.catchAll((error) =>
+              Effect.gen(function* () {
+                yield* Effect.logError("Failed to refresh packages").pipe(
+                  Effect.annotateLogs({ notebookUri, error: String(error) }),
+                );
+                yield* packagesService.setDependencyTreeError(
+                  notebookUri,
+                  String(error),
+                );
+              }),
+            ),
+          );
       }),
     );
 

--- a/extension/src/panel/packages/__tests__/PackagesService.test.ts
+++ b/extension/src/panel/packages/__tests__/PackagesService.test.ts
@@ -228,7 +228,7 @@ describe("PackagesService", () => {
   );
 
   it.effect(
-    "forced fetch bypasses the cached dependency tree",
+    "invalidating bypasses the cached dependency tree",
     Effect.fn(function* () {
       let request = 0;
       const firstTree = {
@@ -261,9 +261,10 @@ describe("PackagesService", () => {
         expect(yield* svc.fetchDependencyTree(NOTEBOOK_URI)).toEqual(firstTree);
         expect(recorded).toHaveLength(1);
 
-        expect(
-          yield* svc.fetchDependencyTree(NOTEBOOK_URI, { force: true }),
-        ).toEqual(refreshedTree);
+        yield* svc.clearNotebook(NOTEBOOK_URI);
+        expect(yield* svc.fetchDependencyTree(NOTEBOOK_URI)).toEqual(
+          refreshedTree,
+        );
         expect(recorded).toHaveLength(2);
 
         const state = Option.getOrThrow(
@@ -279,7 +280,7 @@ describe("PackagesService", () => {
   );
 
   it.scoped(
-    "does not let an older request overwrite a newer forced fetch",
+    "does not let an invalidated request overwrite a newer fetch",
     Effect.fn(function* () {
       const firstRequestStarted = yield* Deferred.make<void>();
       const releaseFirstRequest = yield* Deferred.make<void>();
@@ -317,13 +318,12 @@ describe("PackagesService", () => {
       yield* Effect.gen(function* () {
         const svc = yield* PackagesService;
         const olderFetch = yield* Effect.fork(
-          svc.fetchDependencyTree(NOTEBOOK_URI, { force: true }),
+          svc.fetchDependencyTree(NOTEBOOK_URI),
         );
         yield* Deferred.await(firstRequestStarted);
 
-        expect(
-          yield* svc.fetchDependencyTree(NOTEBOOK_URI, { force: true }),
-        ).toEqual(newerTree);
+        yield* svc.clearNotebook(NOTEBOOK_URI);
+        expect(yield* svc.fetchDependencyTree(NOTEBOOK_URI)).toEqual(newerTree);
 
         yield* Deferred.succeed(releaseFirstRequest, undefined);
         expect(yield* Fiber.join(olderFetch)).toEqual(olderTree);

--- a/extension/src/panel/packages/__tests__/PackagesService.test.ts
+++ b/extension/src/panel/packages/__tests__/PackagesService.test.ts
@@ -279,6 +279,67 @@ describe("PackagesService", () => {
   );
 
   it.scoped(
+    "does not let an older request overwrite a newer forced fetch",
+    Effect.fn(function* () {
+      const firstRequestStarted = yield* Deferred.make<void>();
+      const releaseFirstRequest = yield* Deferred.make<void>();
+      let request = 0;
+      const olderTree = {
+        name: "<root>",
+        version: null,
+        tags: [],
+        dependencies: [
+          { name: "older", version: "1.0.0", tags: [], dependencies: [] },
+        ],
+      };
+      const newerTree = {
+        name: "<root>",
+        version: null,
+        tags: [],
+        dependencies: [
+          { name: "newer", version: "2.0.0", tags: [], dependencies: [] },
+        ],
+      };
+      const { layer } = yield* makeContext({
+        controller: Option.some(makeNonPythonController()),
+        treeEffect: Effect.suspend(() => {
+          const currentRequest = request++;
+          if (currentRequest === 0) {
+            return Deferred.succeed(firstRequestStarted, undefined).pipe(
+              Effect.andThen(Deferred.await(releaseFirstRequest)),
+              Effect.as({ tree: olderTree }),
+            );
+          }
+          return Effect.succeed({ tree: newerTree });
+        }),
+      });
+
+      yield* Effect.gen(function* () {
+        const svc = yield* PackagesService;
+        const olderFetch = yield* Effect.fork(
+          svc.fetchDependencyTree(NOTEBOOK_URI, { force: true }),
+        );
+        yield* Deferred.await(firstRequestStarted);
+
+        expect(
+          yield* svc.fetchDependencyTree(NOTEBOOK_URI, { force: true }),
+        ).toEqual(newerTree);
+
+        yield* Deferred.succeed(releaseFirstRequest, undefined);
+        expect(yield* Fiber.join(olderFetch)).toEqual(olderTree);
+
+        expect(
+          Option.getOrThrow(yield* svc.getDependencyTree(NOTEBOOK_URI)),
+        ).toEqual({
+          tree: newerTree,
+          loading: false,
+          error: null,
+        });
+      }).pipe(Effect.provide(layer));
+    }),
+  );
+
+  it.scoped(
     "evicts the dependency tree when its notebook closes",
     Effect.fn(function* () {
       const { layer, recorded, vscode } = yield* makeContext({

--- a/extension/src/panel/packages/__tests__/PackagesService.test.ts
+++ b/extension/src/panel/packages/__tests__/PackagesService.test.ts
@@ -227,6 +227,57 @@ describe("PackagesService", () => {
     }),
   );
 
+  it.effect(
+    "forced fetch bypasses the cached dependency tree",
+    Effect.fn(function* () {
+      let request = 0;
+      const firstTree = {
+        name: "<root>",
+        version: null,
+        tags: [],
+        dependencies: [
+          { name: "first", version: "1.0.0", tags: [], dependencies: [] },
+        ],
+      };
+      const refreshedTree = {
+        name: "<root>",
+        version: null,
+        tags: [],
+        dependencies: [
+          { name: "second", version: "2.0.0", tags: [], dependencies: [] },
+        ],
+      };
+      const { layer, recorded } = yield* makeContext({
+        controller: Option.some(makeNonPythonController()),
+        treeEffect: Effect.sync(() => ({
+          tree: request++ === 0 ? firstTree : refreshedTree,
+        })),
+      });
+
+      yield* Effect.gen(function* () {
+        const svc = yield* PackagesService;
+
+        expect(yield* svc.fetchDependencyTree(NOTEBOOK_URI)).toEqual(firstTree);
+        expect(yield* svc.fetchDependencyTree(NOTEBOOK_URI)).toEqual(firstTree);
+        expect(recorded).toHaveLength(1);
+
+        expect(
+          yield* svc.fetchDependencyTree(NOTEBOOK_URI, { force: true }),
+        ).toEqual(refreshedTree);
+        expect(recorded).toHaveLength(2);
+
+        const state = Option.getOrThrow(
+          yield* svc.getDependencyTree(NOTEBOOK_URI),
+        );
+        expect(state).toEqual({
+          tree: refreshedTree,
+          loading: false,
+          error: null,
+        });
+      }).pipe(Effect.provide(layer));
+    }),
+  );
+
   it.scoped(
     "evicts the dependency tree when its notebook closes",
     Effect.fn(function* () {


### PR DESCRIPTION
Fixes the Packages panel refresh action so it bypasses the cached dependency tree and lets `PackagesService` own the loading transition. Adds a regression test covering cache reuse followed by a forced refresh that issues a second LSP request and replaces the tree.


Follow-up to #683 and MO-7166.