### PR TITLE
Classify notebook open failures

### DIFF
--- a/extension/src/__mocks__/TestMarimoClient.ts
+++ b/extension/src/__mocks__/TestMarimoClient.ts
@@ -1,6 +1,6 @@
 import * as NodeChildProcess from "node:child_process";
 
-import { Effect, Layer, Stream } from "effect";
+import { Effect, Layer, Redacted, Stream } from "effect";
 import * as rpc from "vscode-jsonrpc/node";
 
 import { acquireDisposable } from "../lib/acquireDisposable.ts";
@@ -58,7 +58,11 @@ export const TestMarimoClientLive = Layer.scoped(
                 command: command.command,
                 arguments: [command.params],
               }),
-            catch: (cause) => new MarimoCommandError({ command, cause }),
+            catch: (cause) =>
+              new MarimoCommandError({
+                command: Redacted.make(command),
+                cause,
+              }),
           });
         },
         operations() {

--- a/extension/src/__mocks__/TestVsCode.ts
+++ b/extension/src/__mocks__/TestVsCode.ts
@@ -1711,15 +1711,15 @@ export class TestVsCode extends Data.TaggedClass("TestVsCode")<{
           showInputBox:
             options.window?.showInputBox ??
             (() => Effect.succeed(Option.none())),
-          showInformationMessage() {
-            return Effect.succeed(Option.none());
-          },
-          showWarningMessage() {
-            return Effect.succeed(Option.none());
-          },
-          showErrorMessage() {
-            return Effect.succeed(Option.none());
-          },
+          showInformationMessage:
+            options.window?.showInformationMessage ??
+            (() => Effect.succeed(Option.none())),
+          showWarningMessage:
+            options.window?.showWarningMessage ??
+            (() => Effect.succeed(Option.none())),
+          showErrorMessage:
+            options.window?.showErrorMessage ??
+            (() => Effect.succeed(Option.none())),
           showQuickPick() {
             return Effect.succeed(Option.none());
           },

--- a/extension/src/commands.ts
+++ b/extension/src/commands.ts
@@ -120,6 +120,8 @@ export function decodeCommandResult<Result>(
 
 // Pulled from https://code.visualstudio.com/api/references/commands
 export type VscodeBuiltinCommand =
+  // Command registered by marimo-lsp to convert a source file into a copy.
+  | "marimo.convert"
   // Focus the built-in Outline view.
   | "outline.focus"
   // Invoke notebook serializer

--- a/extension/src/commands/__tests__/openAsMarimoNotebook.test.ts
+++ b/extension/src/commands/__tests__/openAsMarimoNotebook.test.ts
@@ -1,5 +1,5 @@
 import { expect, it } from "@effect/vitest";
-import { Effect, Layer, Option } from "effect";
+import { Effect, Option } from "effect";
 import { vi } from "vitest";
 
 import {
@@ -7,24 +7,11 @@ import {
   createTestTextEditor,
   TestVsCode,
 } from "../../__mocks__/TestVsCode.ts";
-import { makeTestMarimoClient } from "../../__tests__/__utils__/TestMarimoClient.ts";
 import { NOTEBOOK_TYPE } from "../../constants.ts";
 import { openAsMarimoNotebook } from "../openAsMarimoNotebook.ts";
 
-const nativeNotebook = {
-  kind: "success",
-  notebook: {
-    notebook: { version: "1", cells: [], metadata: {} },
-  },
-} as const;
-
-function provideCommand(vscode: TestVsCode, result: unknown = nativeNotebook) {
-  return Effect.provide(
-    Layer.merge(
-      vscode.layer,
-      makeTestMarimoClient({ execute: () => Effect.succeed(result) }),
-    ),
-  );
+function provideCommand(vscode: TestVsCode) {
+  return Effect.provide(vscode.layer);
 }
 
 it.effect(
@@ -167,82 +154,5 @@ it.effect(
 
     expect(save).toHaveBeenCalledOnce();
     expect(yield* vscode.executions).toEqual([]);
-  }),
-);
-
-it.effect(
-  "keeps unrecoverable syntax open as text with a line-aware message",
-  Effect.fn(function* () {
-    const messages: string[] = [];
-    const vscode = yield* TestVsCode.make({
-      window: {
-        showErrorMessage(message) {
-          messages.push(message);
-          return Effect.succeed(Option.none());
-        },
-      },
-    });
-    const document = createTestTextDocument(
-      "/test/notebook.py",
-      "python",
-      "invalid source",
-    );
-    yield* vscode.setActiveTextEditor(
-      Option.some(createTestTextEditor(document)),
-    );
-
-    yield* openAsMarimoNotebook().pipe(
-      provideCommand(vscode, {
-        kind: "invalid-syntax",
-        message: "The file contains invalid Python syntax.",
-        line: 7,
-        column: 3,
-      }),
-    );
-
-    expect(messages).toEqual([
-      "This file can't be opened as a marimo notebook because it has a Python syntax error at line 7.",
-    ]);
-    expect(yield* vscode.executions).toEqual([]);
-  }),
-);
-
-it.effect(
-  "offers to convert non-marimo Python into a copy",
-  Effect.fn(function* () {
-    const messages: string[] = [];
-    const vscode = yield* TestVsCode.make({
-      window: {
-        showInformationMessage(message, options) {
-          messages.push(message);
-          return Effect.succeed(Option.fromNullable(options?.items?.[0]));
-        },
-      },
-    });
-    const document = createTestTextDocument(
-      "/test/script.py",
-      "python",
-      "print('hello')",
-    );
-    yield* vscode.setActiveTextEditor(
-      Option.some(createTestTextEditor(document)),
-    );
-
-    yield* openAsMarimoNotebook().pipe(
-      provideCommand(vscode, {
-        kind: "not-marimo",
-        message: "The file is not a native marimo notebook.",
-      }),
-    );
-
-    expect(messages).toEqual([
-      "This is a Python script, not a native marimo notebook.",
-    ]);
-    expect(yield* vscode.executions).toEqual([
-      {
-        command: "marimo.convert",
-        args: [{ uri: "file:///test/script.py" }],
-      },
-    ]);
   }),
 );

--- a/extension/src/commands/__tests__/openAsMarimoNotebook.test.ts
+++ b/extension/src/commands/__tests__/openAsMarimoNotebook.test.ts
@@ -1,5 +1,5 @@
 import { expect, it } from "@effect/vitest";
-import { Effect, Option } from "effect";
+import { Effect, Layer, Option } from "effect";
 import { vi } from "vitest";
 
 import {
@@ -7,16 +7,40 @@ import {
   createTestTextEditor,
   TestVsCode,
 } from "../../__mocks__/TestVsCode.ts";
+import { makeTestMarimoClient } from "../../__tests__/__utils__/TestMarimoClient.ts";
 import { NOTEBOOK_TYPE } from "../../constants.ts";
 import { openAsMarimoNotebook } from "../openAsMarimoNotebook.ts";
+
+const nativeNotebook = {
+  kind: "success",
+  notebook: {
+    notebook: { version: "1", cells: [], metadata: {} },
+  },
+} as const;
+
+function provideCommand(vscode: TestVsCode, result: unknown = nativeNotebook) {
+  return Effect.provide(
+    Layer.merge(
+      vscode.layer,
+      makeTestMarimoClient({ execute: () => Effect.succeed(result) }),
+    ),
+  );
+}
 
 it.effect(
   "opens a native VS Code URI passed by an editor action",
   Effect.fn(function* () {
-    const vscode = yield* TestVsCode.make();
+    const vscode = yield* TestVsCode.make({
+      fileSystem: new Map([
+        [
+          "file:///test/notebook.py",
+          new TextEncoder().encode("import marimo\napp = marimo.App()\n"),
+        ],
+      ]),
+    });
     const uri = vscode.createMockUri("/test/notebook.py");
 
-    yield* openAsMarimoNotebook(uri).pipe(Effect.provide(vscode.layer));
+    yield* openAsMarimoNotebook(uri).pipe(provideCommand(vscode));
 
     expect(yield* vscode.executions).toEqual([
       {
@@ -30,10 +54,17 @@ it.effect(
 it.effect(
   "parses and opens a URI string passed by a programmatic caller",
   Effect.fn(function* () {
-    const vscode = yield* TestVsCode.make();
+    const vscode = yield* TestVsCode.make({
+      fileSystem: new Map([
+        [
+          "file:///test/notebook.py",
+          new TextEncoder().encode("import marimo\napp = marimo.App()\n"),
+        ],
+      ]),
+    });
 
     yield* openAsMarimoNotebook("file:///test/notebook.py").pipe(
-      Effect.provide(vscode.layer),
+      provideCommand(vscode),
     );
 
     const executions = yield* vscode.executions;
@@ -57,7 +88,7 @@ it.effect(
       Option.some(createTestTextEditor(document)),
     );
 
-    yield* openAsMarimoNotebook().pipe(Effect.provide(vscode.layer));
+    yield* openAsMarimoNotebook().pipe(provideCommand(vscode));
 
     expect(yield* vscode.executions).toEqual([
       {
@@ -84,7 +115,7 @@ it.effect(
     );
 
     yield* openAsMarimoNotebook(document.uri.toString()).pipe(
-      Effect.provide(vscode.layer),
+      provideCommand(vscode),
     );
 
     expect(save).toHaveBeenCalledOnce();
@@ -111,7 +142,7 @@ it.effect(
       Option.some(createTestTextEditor(document)),
     );
 
-    yield* openAsMarimoNotebook().pipe(Effect.provide(vscode.layer));
+    yield* openAsMarimoNotebook().pipe(provideCommand(vscode));
 
     expect(save).not.toHaveBeenCalled();
   }),
@@ -132,9 +163,86 @@ it.effect(
       Option.some(createTestTextEditor(document)),
     );
 
-    yield* openAsMarimoNotebook().pipe(Effect.provide(vscode.layer));
+    yield* openAsMarimoNotebook().pipe(provideCommand(vscode));
 
     expect(save).toHaveBeenCalledOnce();
     expect(yield* vscode.executions).toEqual([]);
+  }),
+);
+
+it.effect(
+  "keeps unrecoverable syntax open as text with a line-aware message",
+  Effect.fn(function* () {
+    const messages: string[] = [];
+    const vscode = yield* TestVsCode.make({
+      window: {
+        showErrorMessage(message) {
+          messages.push(message);
+          return Effect.succeed(Option.none());
+        },
+      },
+    });
+    const document = createTestTextDocument(
+      "/test/notebook.py",
+      "python",
+      "invalid source",
+    );
+    yield* vscode.setActiveTextEditor(
+      Option.some(createTestTextEditor(document)),
+    );
+
+    yield* openAsMarimoNotebook().pipe(
+      provideCommand(vscode, {
+        kind: "invalid-syntax",
+        message: "The file contains invalid Python syntax.",
+        line: 7,
+        column: 3,
+      }),
+    );
+
+    expect(messages).toEqual([
+      "This file can't be opened as a marimo notebook because it has a Python syntax error at line 7.",
+    ]);
+    expect(yield* vscode.executions).toEqual([]);
+  }),
+);
+
+it.effect(
+  "offers to convert non-marimo Python into a copy",
+  Effect.fn(function* () {
+    const messages: string[] = [];
+    const vscode = yield* TestVsCode.make({
+      window: {
+        showInformationMessage(message, options) {
+          messages.push(message);
+          return Effect.succeed(Option.fromNullable(options?.items?.[0]));
+        },
+      },
+    });
+    const document = createTestTextDocument(
+      "/test/script.py",
+      "python",
+      "print('hello')",
+    );
+    yield* vscode.setActiveTextEditor(
+      Option.some(createTestTextEditor(document)),
+    );
+
+    yield* openAsMarimoNotebook().pipe(
+      provideCommand(vscode, {
+        kind: "not-marimo",
+        message: "The file is not a native marimo notebook.",
+      }),
+    );
+
+    expect(messages).toEqual([
+      "This is a Python script, not a native marimo notebook.",
+    ]);
+    expect(yield* vscode.executions).toEqual([
+      {
+        command: "marimo.convert",
+        args: [{ uri: "file:///test/script.py" }],
+      },
+    ]);
   }),
 );

--- a/extension/src/commands/openAsMarimoNotebook.ts
+++ b/extension/src/commands/openAsMarimoNotebook.ts
@@ -1,11 +1,17 @@
-import { Effect, Either, Option } from "effect";
+import { Cause, Effect, Either, Option } from "effect";
 import type * as vscode from "vscode";
 
 import { NOTEBOOK_TYPE } from "../constants.ts";
+import { MarimoClient, MarimoClientStartError } from "../lsp/MarimoClient.ts";
 import { VsCode } from "../platform/VsCode.ts";
+
+const CONVERT_COPY = "Convert a copy";
+const KEEP_TEXT = "Keep open as text";
+
 export const openAsMarimoNotebook = Effect.fn("command.openAsMarimoNotebook")(
   function* (resource?: string | vscode.Uri) {
     const code = yield* VsCode;
+    const marimo = yield* MarimoClient;
 
     let uri: vscode.Uri;
     if (typeof resource === "string") {
@@ -34,6 +40,58 @@ export const openAsMarimoNotebook = Effect.fn("command.openAsMarimoNotebook")(
     const document = documents.find(
       (document) => document.uri.toString() === uri.toString(),
     );
+
+    const source =
+      document?.getText() ??
+      new TextDecoder().decode(yield* code.workspace.fs.readFile(uri));
+    const inspection = yield* Effect.either(marimo.deserialize({ source }));
+
+    if (Either.isLeft(inspection)) {
+      const error = inspection.left;
+      yield* Effect.logError(
+        "Failed to inspect file before notebook open",
+      ).pipe(
+        Effect.annotateLogs({
+          cause: Cause.fail(error),
+          "rpc.method": "deserialize",
+        }),
+      );
+      const message =
+        error instanceof MarimoClientStartError
+          ? "The marimo language server couldn't start, so this file couldn't be checked. The file remains open as text."
+          : "marimo couldn't inspect this file before opening it as a notebook. The file remains open as text.";
+      const selection = yield* code.window.showErrorMessage(
+        `${message}\n\nSee ${marimo.channel.name} logs for details.`,
+        { items: ["Open Logs"] },
+      );
+      if (Option.isSome(selection)) marimo.channel.show();
+      return;
+    }
+
+    const result = inspection.right;
+    if (result.kind === "invalid-syntax") {
+      const location = result.line === null ? "" : ` at line ${result.line}`;
+      yield* code.window.showErrorMessage(
+        `This file can't be opened as a marimo notebook because it has a Python syntax error${location}.`,
+      );
+      return;
+    }
+
+    if (result.kind !== "success") {
+      const message =
+        result.kind === "unsupported-format"
+          ? "This file uses Jupytext percent format, not the native marimo notebook format."
+          : "This is a Python script, not a native marimo notebook.";
+      const selection = yield* code.window.showInformationMessage(message, {
+        items: [CONVERT_COPY, KEEP_TEXT],
+      });
+      if (Option.contains(selection, CONVERT_COPY)) {
+        yield* code.commands.executeVSCode("marimo.convert", {
+          uri: uri.toString(),
+        });
+      }
+      return;
+    }
 
     // `vscode.openWith` deserializes the notebook from disk, so persist any
     // in-memory edits before switching editors.

--- a/extension/src/commands/openAsMarimoNotebook.ts
+++ b/extension/src/commands/openAsMarimoNotebook.ts
@@ -4,6 +4,7 @@ import type * as vscode from "vscode";
 import { NOTEBOOK_TYPE } from "../constants.ts";
 import { MarimoClient, MarimoClientStartError } from "../lsp/MarimoClient.ts";
 import { VsCode } from "../platform/VsCode.ts";
+import { classifyNotebookDeserializeError } from "../telemetry/classifyNotebookDeserializeError.ts";
 
 const CONVERT_COPY = "Convert a copy";
 const KEEP_TEXT = "Keep open as text";
@@ -48,12 +49,15 @@ export const openAsMarimoNotebook = Effect.fn("command.openAsMarimoNotebook")(
 
     if (Either.isLeft(inspection)) {
       const error = inspection.left;
+      const classification = classifyNotebookDeserializeError(error);
       yield* Effect.logError(
         "Failed to inspect file before notebook open",
       ).pipe(
         Effect.annotateLogs({
           cause: Cause.fail(error),
-          "rpc.method": "deserialize",
+          "error.domain": classification.domain,
+          "error.kind": classification.kind,
+          ...classification.safeContext,
         }),
       );
       const message =

--- a/extension/src/commands/openAsMarimoNotebook.ts
+++ b/extension/src/commands/openAsMarimoNotebook.ts
@@ -1,18 +1,12 @@
-import { Cause, Effect, Either, Option } from "effect";
+import { Effect, Either, Option } from "effect";
 import type * as vscode from "vscode";
 
 import { NOTEBOOK_TYPE } from "../constants.ts";
-import { MarimoClient, MarimoClientStartError } from "../lsp/MarimoClient.ts";
 import { VsCode } from "../platform/VsCode.ts";
-import { classifyNotebookDeserializeError } from "../telemetry/classifyNotebookDeserializeError.ts";
-
-const CONVERT_COPY = "Convert a copy";
-const KEEP_TEXT = "Keep open as text";
 
 export const openAsMarimoNotebook = Effect.fn("command.openAsMarimoNotebook")(
   function* (resource?: string | vscode.Uri) {
     const code = yield* VsCode;
-    const marimo = yield* MarimoClient;
 
     let uri: vscode.Uri;
     if (typeof resource === "string") {
@@ -41,61 +35,6 @@ export const openAsMarimoNotebook = Effect.fn("command.openAsMarimoNotebook")(
     const document = documents.find(
       (document) => document.uri.toString() === uri.toString(),
     );
-
-    const source =
-      document?.getText() ??
-      new TextDecoder().decode(yield* code.workspace.fs.readFile(uri));
-    const inspection = yield* Effect.either(marimo.deserialize({ source }));
-
-    if (Either.isLeft(inspection)) {
-      const error = inspection.left;
-      const classification = classifyNotebookDeserializeError(error);
-      yield* Effect.logError(
-        "Failed to inspect file before notebook open",
-      ).pipe(
-        Effect.annotateLogs({
-          cause: Cause.fail(error),
-          "error.domain": classification.domain,
-          "error.kind": classification.kind,
-          ...classification.safeContext,
-        }),
-      );
-      const message =
-        error instanceof MarimoClientStartError
-          ? "The marimo language server couldn't start, so this file couldn't be checked. The file remains open as text."
-          : "marimo couldn't inspect this file before opening it as a notebook. The file remains open as text.";
-      const selection = yield* code.window.showErrorMessage(
-        `${message}\n\nSee ${marimo.channel.name} logs for details.`,
-        { items: ["Open Logs"] },
-      );
-      if (Option.isSome(selection)) marimo.channel.show();
-      return;
-    }
-
-    const result = inspection.right;
-    if (result.kind === "invalid-syntax") {
-      const location = result.line === null ? "" : ` at line ${result.line}`;
-      yield* code.window.showErrorMessage(
-        `This file can't be opened as a marimo notebook because it has a Python syntax error${location}.`,
-      );
-      return;
-    }
-
-    if (result.kind !== "success") {
-      const message =
-        result.kind === "unsupported-format"
-          ? "This file uses Jupytext percent format, not the native marimo notebook format."
-          : "This is a Python script, not a native marimo notebook.";
-      const selection = yield* code.window.showInformationMessage(message, {
-        items: [CONVERT_COPY, KEEP_TEXT],
-      });
-      if (Option.contains(selection, CONVERT_COPY)) {
-        yield* code.commands.executeVSCode("marimo.convert", {
-          uri: uri.toString(),
-        });
-      }
-      return;
-    }
 
     // `vscode.openWith` deserializes the notebook from disk, so persist any
     // in-memory edits before switching editors.

--- a/extension/src/kernel/PythonController.ts
+++ b/extension/src/kernel/PythonController.ts
@@ -1,6 +1,14 @@
 import * as semver from "@std/semver";
 import type * as py from "@vscode/python-extension";
-import { Brand, Cause, Effect, Option, Runtime, Stream } from "effect";
+import {
+  Brand,
+  Cause,
+  Effect,
+  Option,
+  Redacted,
+  Runtime,
+  Stream,
+} from "effect";
 import type * as vscode from "vscode";
 
 import { unreachable } from "../assert.ts";
@@ -105,7 +113,7 @@ export const createPythonController = Effect.fn("createPythonController")(
               yield* Effect.logError("Failed to execute command").pipe(
                 Effect.annotateLogs({
                   cause: Cause.fail(error),
-                  command: error.command.command,
+                  command: Redacted.value(error.command).command,
                 }),
               );
               const detail = extractPythonError(error.cause);

--- a/extension/src/lsp/MarimoClient.ts
+++ b/extension/src/lsp/MarimoClient.ts
@@ -2,7 +2,7 @@ import * as NodeChildProcess from "node:child_process";
 import * as NodeFs from "node:fs";
 import * as NodePath from "node:path";
 
-import { Cause, Data, Effect, Option, PubSub, Stream } from "effect";
+import { Cause, Data, Effect, Option, PubSub, Redacted, Stream } from "effect";
 import * as lsp from "vscode-languageclient/node";
 
 import { Config } from "../config/Config.ts";
@@ -38,10 +38,10 @@ export class MarimoClientStartError extends Data.TaggedError(
 }> {}
 
 export class MarimoCommandError extends Data.TaggedError("MarimoCommandError")<{
-  readonly command: {
+  readonly command: Redacted.Redacted<{
     readonly command: "marimo.api";
     readonly params: MarimoApiCall;
-  };
+  }>;
   readonly cause: unknown;
 }> {}
 
@@ -271,7 +271,11 @@ export class MarimoClient extends Effect.Service<MarimoClient>()(
                 { command: command.command, arguments: [command.params] },
                 tokenFromSignal(signal),
               ),
-            catch: (cause) => new MarimoCommandError({ command, cause }),
+            catch: (cause) =>
+              new MarimoCommandError({
+                command: Redacted.make(command),
+                cause,
+              }),
           }).pipe(
             Effect.withSpan("lsp.executeCommand", {
               attributes: {

--- a/extension/src/notebook/NotebookSerializer.ts
+++ b/extension/src/notebook/NotebookSerializer.ts
@@ -1,7 +1,6 @@
 import { MarkdownParser, SQLParser } from "@marimo-team/smart-cells";
 import {
   Cause,
-  Data,
   Effect,
   Fiber,
   Option,
@@ -21,7 +20,12 @@ import {
   MarimoNotebookDocument,
 } from "../schemas/MarimoNotebookDocument.ts";
 import * as Api from "../schemas/Models.gen.ts";
+import { classifyNotebookDeserializeError } from "../telemetry/classifyNotebookDeserializeError.ts";
 import { classifyCellCode } from "./classifyCellCode.ts";
+import {
+  NotebookSourceError,
+  notebookSourceFailureMessage,
+} from "./NotebookSourceError.ts";
 import { pickLiveNotebook } from "./pickLiveNotebook.ts";
 
 type BooleanMap<T> = {
@@ -31,16 +35,7 @@ type BooleanMap<T> = {
 type EncodedCellMetadata = typeof Api.CellMetadata.Encoded;
 type EncodedNotebookDocumentMetadata =
   typeof Api.NotebookDocumentMetadata.Encoded;
-type NotebookSourceFailure = Exclude<
-  Api.DeserializeResult,
-  { readonly kind: "success" }
->;
-
-export class NotebookSourceError extends Data.TaggedError(
-  "NotebookSourceError",
-)<{
-  readonly failure: NotebookSourceFailure;
-}> {}
+export { NotebookSourceError } from "./NotebookSourceError.ts";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -191,7 +186,7 @@ export class NotebookSerializer extends Effect.Service<NotebookSerializer>()(
                   Effect.tapErrorCause(logDeserializeFailure),
                   Effect.mapError((error) =>
                     error instanceof NotebookSourceError
-                      ? new Error(sourceFailureMessage(error.failure))
+                      ? new Error(notebookSourceFailureMessage(error.failure))
                       : new Error(
                           `Failed to deserialize notebook. See marimo logs for details.`,
                         ),
@@ -230,37 +225,23 @@ export class NotebookSerializer extends Effect.Service<NotebookSerializer>()(
   },
 ) {}
 
-function sourceFailureMessage(failure: NotebookSourceFailure): string {
-  switch (failure.kind) {
-    case "invalid-syntax": {
-      const location = failure.line === null ? "" : ` at line ${failure.line}`;
-      return `This file can't be opened as a marimo notebook because it has a Python syntax error${location}.`;
-    }
-    case "not-marimo":
-      return "This is a Python script, not a native marimo notebook.";
-    case "unsupported-format":
-      return "This file uses an unsupported notebook format and must be converted first.";
-    default: {
-      const exhaustive: never = failure;
-      return exhaustive;
-    }
-  }
-}
-
 function logDeserializeFailure(cause: Cause.Cause<unknown>) {
   const failure = Option.getOrUndefined(Cause.failureOption(cause));
-  if (failure instanceof NotebookSourceError) {
+  const classification = classifyNotebookDeserializeError(failure);
+  const annotations = {
+    "error.domain": classification.domain,
+    "error.kind": classification.kind,
+    ...classification.safeContext,
+  };
+  if (!classification.report) {
     return Effect.logWarning("Notebook source could not be deserialized").pipe(
-      Effect.annotateLogs({
-        "error.tag": failure._tag,
-        "source.kind": failure.failure.kind,
-      }),
+      Effect.annotateLogs(annotations),
     );
   }
   return Effect.logError(`Notebook deserialize failed`).pipe(
     Effect.annotateLogs({
       cause,
-      "error.tag": causeTag(cause),
+      ...annotations,
     }),
   );
 }

--- a/extension/src/notebook/NotebookSerializer.ts
+++ b/extension/src/notebook/NotebookSerializer.ts
@@ -1,6 +1,7 @@
 import { MarkdownParser, SQLParser } from "@marimo-team/smart-cells";
 import {
   Cause,
+  Duration,
   Effect,
   Fiber,
   Option,
@@ -35,6 +36,7 @@ type BooleanMap<T> = {
 type EncodedCellMetadata = typeof Api.CellMetadata.Encoded;
 type EncodedNotebookDocumentMetadata =
   typeof Api.NotebookDocumentMetadata.Encoded;
+const DESERIALIZE_TIMEOUT = Duration.seconds(30);
 export { NotebookSourceError } from "./NotebookSourceError.ts";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -84,9 +86,11 @@ export class NotebookSerializer extends Effect.Service<NotebookSerializer>()(
       const deserializeEffect = Effect.fn("NotebookSerializer.deserialize")(
         function* (bytes: Uint8Array) {
           yield* Effect.annotateCurrentSpan("bytes", bytes.length);
-          const result = yield* marimo.deserialize({
-            source: new TextDecoder().decode(bytes),
-          });
+          const result = yield* marimo
+            .deserialize({
+              source: new TextDecoder().decode(bytes),
+            })
+            .pipe(Effect.timeout(DESERIALIZE_TIMEOUT));
           if (result.kind !== "success") {
             return yield* new NotebookSourceError({ failure: result });
           }
@@ -226,8 +230,11 @@ export class NotebookSerializer extends Effect.Service<NotebookSerializer>()(
 ) {}
 
 function logDeserializeFailure(cause: Cause.Cause<unknown>) {
+  if (Cause.isInterruptedOnly(cause)) return Effect.void;
+
   const failure = Option.getOrUndefined(Cause.failureOption(cause));
-  const classification = classifyNotebookDeserializeError(failure);
+  const defect = [...Cause.defects(cause)][0];
+  const classification = classifyNotebookDeserializeError(failure ?? defect);
   const annotations = {
     "error.domain": classification.domain,
     "error.kind": classification.kind,

--- a/extension/src/notebook/NotebookSerializer.ts
+++ b/extension/src/notebook/NotebookSerializer.ts
@@ -1,6 +1,7 @@
 import { MarkdownParser, SQLParser } from "@marimo-team/smart-cells";
 import {
   Cause,
+  Data,
   Effect,
   Fiber,
   Option,
@@ -30,6 +31,16 @@ type BooleanMap<T> = {
 type EncodedCellMetadata = typeof Api.CellMetadata.Encoded;
 type EncodedNotebookDocumentMetadata =
   typeof Api.NotebookDocumentMetadata.Encoded;
+type NotebookSourceFailure = Exclude<
+  Api.DeserializeResult,
+  { readonly kind: "success" }
+>;
+
+export class NotebookSourceError extends Data.TaggedError(
+  "NotebookSourceError",
+)<{
+  readonly failure: NotebookSourceFailure;
+}> {}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -78,13 +89,15 @@ export class NotebookSerializer extends Effect.Service<NotebookSerializer>()(
       const deserializeEffect = Effect.fn("NotebookSerializer.deserialize")(
         function* (bytes: Uint8Array) {
           yield* Effect.annotateCurrentSpan("bytes", bytes.length);
-          const {
-            notebook: document,
-            appConfig,
-            header,
-          } = yield* marimo.deserialize({
+          const result = yield* marimo.deserialize({
             source: new TextDecoder().decode(bytes),
           });
+          if (result.kind !== "success") {
+            return yield* new NotebookSourceError({ failure: result });
+          }
+          const {
+            notebook: { notebook: document, appConfig, header },
+          } = result;
 
           const notebook = {
             metadata: MarimoNotebookDocument.createMetadata({

--- a/extension/src/notebook/NotebookSerializer.ts
+++ b/extension/src/notebook/NotebookSerializer.ts
@@ -188,19 +188,13 @@ export class NotebookSerializer extends Effect.Service<NotebookSerializer>()(
                   );
                   return yield* Fiber.join(fiber);
                 }).pipe(
-                  Effect.tapErrorCause((cause) =>
-                    Effect.logError(`Notebook deserialize failed`).pipe(
-                      Effect.annotateLogs({
-                        cause,
-                        "error.tag": causeTag(cause),
-                      }),
-                    ),
-                  ),
-                  Effect.mapError(
-                    () =>
-                      new Error(
-                        `Failed to deserialize notebook. See marimo logs for details.`,
-                      ),
+                  Effect.tapErrorCause(logDeserializeFailure),
+                  Effect.mapError((error) =>
+                    error instanceof NotebookSourceError
+                      ? new Error(sourceFailureMessage(error.failure))
+                      : new Error(
+                          `Failed to deserialize notebook. See marimo logs for details.`,
+                        ),
                   ),
                 ),
               );
@@ -235,6 +229,41 @@ export class NotebookSerializer extends Effect.Service<NotebookSerializer>()(
     }),
   },
 ) {}
+
+function sourceFailureMessage(failure: NotebookSourceFailure): string {
+  switch (failure.kind) {
+    case "invalid-syntax": {
+      const location = failure.line === null ? "" : ` at line ${failure.line}`;
+      return `This file can't be opened as a marimo notebook because it has a Python syntax error${location}.`;
+    }
+    case "not-marimo":
+      return "This is a Python script, not a native marimo notebook.";
+    case "unsupported-format":
+      return "This file uses an unsupported notebook format and must be converted first.";
+    default: {
+      const exhaustive: never = failure;
+      return exhaustive;
+    }
+  }
+}
+
+function logDeserializeFailure(cause: Cause.Cause<unknown>) {
+  const failure = Option.getOrUndefined(Cause.failureOption(cause));
+  if (failure instanceof NotebookSourceError) {
+    return Effect.logWarning("Notebook source could not be deserialized").pipe(
+      Effect.annotateLogs({
+        "error.tag": failure._tag,
+        "source.kind": failure.failure.kind,
+      }),
+    );
+  }
+  return Effect.logError(`Notebook deserialize failed`).pipe(
+    Effect.annotateLogs({
+      cause,
+      "error.tag": causeTag(cause),
+    }),
+  );
+}
 
 function hasStringTag(value: unknown): value is { _tag: string } {
   return (

--- a/extension/src/notebook/NotebookSerializer.ts
+++ b/extension/src/notebook/NotebookSerializer.ts
@@ -191,9 +191,13 @@ export class NotebookSerializer extends Effect.Service<NotebookSerializer>()(
                   Effect.mapError((error) =>
                     error instanceof NotebookSourceError
                       ? new Error(notebookSourceFailureMessage(error.failure))
-                      : new Error(
-                          `Failed to deserialize notebook. See marimo logs for details.`,
-                        ),
+                      : Cause.isTimeoutException(error)
+                        ? new Error(
+                            `Timed out after ${Duration.toSeconds(DESERIALIZE_TIMEOUT)} seconds while opening the notebook. See marimo logs for details.`,
+                          )
+                        : new Error(
+                            `Failed to deserialize notebook. See marimo logs for details.`,
+                          ),
                   ),
                 ),
               );

--- a/extension/src/notebook/NotebookSourceError.ts
+++ b/extension/src/notebook/NotebookSourceError.ts
@@ -21,10 +21,8 @@ export function notebookSourceFailureMessage(
       const location = failure.line === null ? "" : ` at line ${failure.line}`;
       return `This file can't be opened as a marimo notebook because it has a Python syntax error${location}.`;
     }
-    case "not-marimo":
-      return "This is a Python script, not a native marimo notebook.";
-    case "unsupported-format":
-      return "This file uses an unsupported notebook format and must be converted first.";
+    case "convertible":
+      return "This is not a native marimo notebook and must be converted first.";
     default: {
       const exhaustive: never = failure;
       return exhaustive;

--- a/extension/src/notebook/NotebookSourceError.ts
+++ b/extension/src/notebook/NotebookSourceError.ts
@@ -1,0 +1,33 @@
+import { Data } from "effect";
+
+import type * as Api from "../schemas/Models.gen.ts";
+
+export type NotebookSourceFailure = Exclude<
+  Api.DeserializeResult,
+  { readonly kind: "success" }
+>;
+
+export class NotebookSourceError extends Data.TaggedError(
+  "NotebookSourceError",
+)<{
+  readonly failure: NotebookSourceFailure;
+}> {}
+
+export function notebookSourceFailureMessage(
+  failure: NotebookSourceFailure,
+): string {
+  switch (failure.kind) {
+    case "invalid-syntax": {
+      const location = failure.line === null ? "" : ` at line ${failure.line}`;
+      return `This file can't be opened as a marimo notebook because it has a Python syntax error${location}.`;
+    }
+    case "not-marimo":
+      return "This is a Python script, not a native marimo notebook.";
+    case "unsupported-format":
+      return "This file uses an unsupported notebook format and must be converted first.";
+    default: {
+      const exhaustive: never = failure;
+      return exhaustive;
+    }
+  }
+}

--- a/extension/src/notebook/__tests__/NotebookSerializer.test.ts
+++ b/extension/src/notebook/__tests__/NotebookSerializer.test.ts
@@ -1,7 +1,17 @@
 import * as NodeFs from "node:fs";
 
 import { assert, expect, it } from "@effect/vitest";
-import { Effect, Either, HashSet, Layer, Ref } from "effect";
+import {
+  Duration,
+  Effect,
+  Either,
+  Exit,
+  Fiber,
+  HashSet,
+  Layer,
+  Ref,
+  TestClock,
+} from "effect";
 
 import packageJson from "../../../package.json";
 import { TestMarimoClientLive } from "../../__mocks__/TestMarimoClient.ts";
@@ -21,6 +31,31 @@ const NotebookSerializerLive = Layer.empty.pipe(
 );
 
 it.scoped(
+  "bounds a deserialize request that never completes",
+  Effect.fn(function* () {
+    const layer = Layer.empty.pipe(
+      Layer.provideMerge(NotebookSerializer.Default),
+      Layer.provideMerge(makeTestMarimoClient({ execute: () => Effect.never })),
+      Layer.provideMerge(Constants.Default),
+    );
+
+    const exit = yield* Effect.gen(function* () {
+      const serializer = yield* NotebookSerializer;
+      const deserialize = yield* Effect.fork(
+        serializer
+          .deserializeEffect(new TextEncoder().encode("app = marimo.App()"))
+          .pipe(Effect.exit),
+      );
+      yield* TestClock.adjust(Duration.seconds(30));
+      return yield* Fiber.join(deserialize);
+    }).pipe(Effect.provide(layer));
+
+    assert(Exit.isFailure(exit));
+    expect(String(exit)).toContain("TimeoutException");
+  }),
+);
+
+it.scoped(
   "registered serializer explains non-marimo source failures",
   Effect.fn(function* () {
     const vscode = yield* TestVsCode.make();
@@ -30,8 +65,7 @@ it.scoped(
         makeTestMarimoClient({
           execute: () =>
             Effect.succeed({
-              kind: "not-marimo",
-              message: "The file is not a native marimo notebook.",
+              kind: "convertible",
             }),
         }),
       ),
@@ -64,7 +98,7 @@ it.scoped(
 
       assert(error instanceof Error);
       expect(error.message).toBe(
-        "This is a Python script, not a native marimo notebook.",
+        "This is not a native marimo notebook and must be converted first.",
       );
     }).pipe(Effect.provide(layer));
   }),
@@ -271,8 +305,7 @@ it.layer(NotebookSerializerLive, { timeout: 30_000 })(
         assert(Either.isLeft(result));
         assert(result.left instanceof NotebookSourceError);
         expect(result.left.failure).toEqual({
-          kind: "not-marimo",
-          message: "The file is not a native marimo notebook.",
+          kind: "convertible",
         });
       }),
     );

--- a/extension/src/notebook/__tests__/NotebookSerializer.test.ts
+++ b/extension/src/notebook/__tests__/NotebookSerializer.test.ts
@@ -2,6 +2,7 @@ import * as NodeFs from "node:fs";
 
 import { assert, expect, it } from "@effect/vitest";
 import {
+  Cause,
   Duration,
   Effect,
   Either,
@@ -51,7 +52,51 @@ it.scoped(
     }).pipe(Effect.provide(layer));
 
     assert(Exit.isFailure(exit));
-    expect(String(exit)).toContain("TimeoutException");
+    const failure = Cause.failureOption(exit.cause);
+    assert(failure._tag === "Some");
+    assert(Cause.isTimeoutException(failure.value));
+  }),
+);
+
+it.scoped(
+  "registered serializer explains deserialize timeouts",
+  Effect.fn(function* () {
+    const vscode = yield* TestVsCode.make();
+    const layer = Layer.empty.pipe(
+      Layer.provideMerge(NotebookSerializer.Default),
+      Layer.provideMerge(makeTestMarimoClient({ execute: () => Effect.never })),
+      Layer.provideMerge(Constants.Default),
+      Layer.provideMerge(vscode.layer),
+    );
+
+    yield* Effect.gen(function* () {
+      yield* NotebookSerializer;
+      const registrations = HashSet.toValues(
+        yield* Ref.get(vscode.serializers),
+      );
+      const registration = registrations[0];
+      assert.isDefined(registration);
+
+      const pending = registration.serializer.deserializeNotebook(
+        new TextEncoder().encode("app = marimo.App()"),
+        {
+          isCancellationRequested: false,
+          onCancellationRequested: () => ({ dispose() {} }),
+        },
+      );
+      const settled = Promise.resolve(pending).then(
+        () => undefined,
+        (error: unknown) => error,
+      );
+      yield* Effect.yieldNow();
+      yield* TestClock.adjust(Duration.seconds(30));
+      const error = yield* Effect.promise(() => settled);
+
+      assert(error instanceof Error);
+      expect(error.message).toBe(
+        "Timed out after 30 seconds while opening the notebook. See marimo logs for details.",
+      );
+    }).pipe(Effect.provide(layer));
   }),
 );
 

--- a/extension/src/notebook/__tests__/NotebookSerializer.test.ts
+++ b/extension/src/notebook/__tests__/NotebookSerializer.test.ts
@@ -1,10 +1,12 @@
 import * as NodeFs from "node:fs";
 
 import { assert, expect, it } from "@effect/vitest";
-import { Effect, Either, Layer } from "effect";
+import { Effect, Either, HashSet, Layer, Ref } from "effect";
 
 import packageJson from "../../../package.json";
 import { TestMarimoClientLive } from "../../__mocks__/TestMarimoClient.ts";
+import { TestVsCode } from "../../__mocks__/TestVsCode.ts";
+import { makeTestMarimoClient } from "../../__tests__/__utils__/TestMarimoClient.ts";
 import { NOTEBOOK_TYPE } from "../../constants.ts";
 import {
   NotebookSerializer,
@@ -16,6 +18,56 @@ const NotebookSerializerLive = Layer.empty.pipe(
   Layer.provideMerge(NotebookSerializer.Default),
   Layer.provideMerge(TestMarimoClientLive),
   Layer.provideMerge(Constants.Default),
+);
+
+it.scoped(
+  "registered serializer explains non-marimo source failures",
+  Effect.fn(function* () {
+    const vscode = yield* TestVsCode.make();
+    const layer = Layer.empty.pipe(
+      Layer.provideMerge(NotebookSerializer.Default),
+      Layer.provideMerge(
+        makeTestMarimoClient({
+          execute: () =>
+            Effect.succeed({
+              kind: "not-marimo",
+              message: "The file is not a native marimo notebook.",
+            }),
+        }),
+      ),
+      Layer.provideMerge(Constants.Default),
+      Layer.provideMerge(vscode.layer),
+    );
+
+    yield* Effect.gen(function* () {
+      yield* NotebookSerializer;
+      const registrations = HashSet.toValues(
+        yield* Ref.get(vscode.serializers),
+      );
+      const registration = registrations[0];
+      assert.isDefined(registration);
+
+      const error = yield* Effect.promise(async () => {
+        try {
+          await registration.serializer.deserializeNotebook(
+            new TextEncoder().encode("print('hello')\n"),
+            {
+              isCancellationRequested: false,
+              onCancellationRequested: () => ({ dispose() {} }),
+            },
+          );
+          return undefined;
+        } catch (error: unknown) {
+          return error;
+        }
+      });
+
+      assert(error instanceof Error);
+      expect(error.message).toBe(
+        "This is a Python script, not a native marimo notebook.",
+      );
+    }).pipe(Effect.provide(layer));
+  }),
 );
 
 it.layer(NotebookSerializerLive, { timeout: 30_000 })(

--- a/extension/src/notebook/__tests__/NotebookSerializer.test.ts
+++ b/extension/src/notebook/__tests__/NotebookSerializer.test.ts
@@ -6,7 +6,10 @@ import { Effect, Either, Layer } from "effect";
 import packageJson from "../../../package.json";
 import { TestMarimoClientLive } from "../../__mocks__/TestMarimoClient.ts";
 import { NOTEBOOK_TYPE } from "../../constants.ts";
-import { NotebookSerializer } from "../../notebook/NotebookSerializer.ts";
+import {
+  NotebookSerializer,
+  NotebookSourceError,
+} from "../../notebook/NotebookSerializer.ts";
 import { Constants } from "../../platform/Constants.ts";
 
 const NotebookSerializerLive = Layer.empty.pipe(
@@ -200,6 +203,25 @@ it.layer(NotebookSerializerLive, { timeout: 30_000 })(
         );
 
         expect(Either.isLeft(result)).toBe(true);
+      }),
+    );
+
+    it.effect(
+      "returns a typed source error for non-marimo Python",
+      Effect.fn(function* () {
+        const serializer = yield* NotebookSerializer;
+        const result = yield* Effect.either(
+          serializer.deserializeEffect(
+            new TextEncoder().encode("print('hello')\n"),
+          ),
+        );
+
+        assert(Either.isLeft(result));
+        assert(result.left instanceof NotebookSourceError);
+        expect(result.left.failure).toEqual({
+          kind: "not-marimo",
+          message: "The file is not a native marimo notebook.",
+        });
       }),
     );
 

--- a/extension/src/schemas/Models.gen.ts
+++ b/extension/src/schemas/Models.gen.ts
@@ -261,6 +261,56 @@ export const DeserializeRequest = Schema.Struct({
 export type DeserializeRequest = typeof DeserializeRequest.Type;
 
 /**
+ * A successfully parsed native marimo notebook.
+ */
+export const DeserializeSuccess = Schema.Struct({
+  kind: Schema.Literal("success"),
+  notebook: NotebookDocument,
+}).annotations({ identifier: "DeserializeSuccess" });
+export type DeserializeSuccess = typeof DeserializeSuccess.Type;
+
+/**
+ * Python syntax prevented the source from being inspected.
+ */
+export const DeserializeInvalidSyntax = Schema.Struct({
+  kind: Schema.Literal("invalid-syntax"),
+  message: Schema.String,
+  line: Schema.optionalWith(Schema.NullOr(Schema.Int), { default: () => null }),
+  column: Schema.optionalWith(Schema.NullOr(Schema.Int), {
+    default: () => null,
+  }),
+}).annotations({ identifier: "DeserializeInvalidSyntax" });
+export type DeserializeInvalidSyntax = typeof DeserializeInvalidSyntax.Type;
+
+/**
+ * Valid Python source that is not a native marimo notebook.
+ */
+export const DeserializeNotMarimo = Schema.Struct({
+  kind: Schema.Literal("not-marimo"),
+  message: Schema.String,
+}).annotations({ identifier: "DeserializeNotMarimo" });
+export type DeserializeNotMarimo = typeof DeserializeNotMarimo.Type;
+
+/**
+ * A recognized non-native notebook format requiring explicit conversion.
+ */
+export const DeserializeUnsupportedFormat = Schema.Struct({
+  kind: Schema.Literal("unsupported-format"),
+  format: Schema.Literal("jupytext-percent", "plain-python", "unknown"),
+  message: Schema.String,
+}).annotations({ identifier: "DeserializeUnsupportedFormat" });
+export type DeserializeUnsupportedFormat =
+  typeof DeserializeUnsupportedFormat.Type;
+
+export const DeserializeResult = Schema.Union(
+  DeserializeSuccess,
+  DeserializeInvalidSyntax,
+  DeserializeNotMarimo,
+  DeserializeUnsupportedFormat,
+).annotations({ identifier: "DeserializeResult" });
+export type DeserializeResult = typeof DeserializeResult.Type;
+
+/**
  * A request to convert a file source a marimo notebook.
  */
 export const ConvertRequest = Schema.Struct({
@@ -1634,7 +1684,7 @@ export const makeApiClient = <E, R>(execute: Execute<E, R>) => ({
       execute,
       { method: "deserialize", params },
       DeserializePayload,
-      NotebookDocument,
+      DeserializeResult,
     ),
   getConfiguration: (params: typeof GetConfigurationPayload.Encoded) =>
     dispatch(

--- a/extension/src/schemas/Models.gen.ts
+++ b/extension/src/schemas/Models.gen.ts
@@ -274,7 +274,6 @@ export type DeserializeSuccess = typeof DeserializeSuccess.Type;
  */
 export const DeserializeInvalidSyntax = Schema.Struct({
   kind: Schema.Literal("invalid-syntax"),
-  message: Schema.String,
   line: Schema.optionalWith(Schema.NullOr(Schema.Int), { default: () => null }),
   column: Schema.optionalWith(Schema.NullOr(Schema.Int), {
     default: () => null,
@@ -283,30 +282,17 @@ export const DeserializeInvalidSyntax = Schema.Struct({
 export type DeserializeInvalidSyntax = typeof DeserializeInvalidSyntax.Type;
 
 /**
- * Valid Python source that is not a native marimo notebook.
+ * Valid Python source that can be converted to a marimo notebook.
  */
-export const DeserializeNotMarimo = Schema.Struct({
-  kind: Schema.Literal("not-marimo"),
-  message: Schema.String,
-}).annotations({ identifier: "DeserializeNotMarimo" });
-export type DeserializeNotMarimo = typeof DeserializeNotMarimo.Type;
-
-/**
- * A recognized non-native notebook format requiring explicit conversion.
- */
-export const DeserializeUnsupportedFormat = Schema.Struct({
-  kind: Schema.Literal("unsupported-format"),
-  format: Schema.Literal("jupytext-percent", "plain-python", "unknown"),
-  message: Schema.String,
-}).annotations({ identifier: "DeserializeUnsupportedFormat" });
-export type DeserializeUnsupportedFormat =
-  typeof DeserializeUnsupportedFormat.Type;
+export const DeserializeConvertible = Schema.Struct({
+  kind: Schema.Literal("convertible"),
+}).annotations({ identifier: "DeserializeConvertible" });
+export type DeserializeConvertible = typeof DeserializeConvertible.Type;
 
 export const DeserializeResult = Schema.Union(
   DeserializeSuccess,
   DeserializeInvalidSyntax,
-  DeserializeNotMarimo,
-  DeserializeUnsupportedFormat,
+  DeserializeConvertible,
 ).annotations({ identifier: "DeserializeResult" });
 export type DeserializeResult = typeof DeserializeResult.Type;
 

--- a/extension/src/telemetry/__tests__/Telemetry.test.ts
+++ b/extension/src/telemetry/__tests__/Telemetry.test.ts
@@ -1,5 +1,14 @@
 import { expect, it } from "@effect/vitest";
-import { Cause, Effect, Layer, Logger, Queue, Redacted, Stream } from "effect";
+import {
+  Cause,
+  Effect,
+  Layer,
+  Logger,
+  Option,
+  Queue,
+  Redacted,
+  Stream,
+} from "effect";
 import { vi } from "vite-plus/test";
 import type * as vscode from "vscode";
 
@@ -8,8 +17,12 @@ import { TestVsCode } from "../../__mocks__/TestVsCode.ts";
 import { MarimoCommandError } from "../../lsp/MarimoClient.ts";
 import { Telemetry } from "../Telemetry.ts";
 
+interface TestSentryOptions {
+  readonly beforeSend: (event: Record<string, unknown>) => unknown;
+}
+
 const sentrySdk = vi.hoisted(() => ({
-  init: vi.fn(),
+  init: vi.fn<(options: TestSentryOptions) => void>(),
   setTag: vi.fn(),
   setUser: vi.fn(),
   close: vi.fn(async () => true),
@@ -247,43 +260,11 @@ it.scoped("redacts user data from classified and unexpected errors", () =>
                 "defects": [
                   {
                     "exceptionClass": "UnexpectedConverterError",
-                    "traceback": [
-                      {
-                        "column": 1,
-                        "file": "customer-notebook.py",
-                        "function": "convert",
-                        "line": 1,
-                      },
-                    ],
                   },
                 ],
                 "failures": [
                   {
-                    "byteCount": 71,
-                    "cause": {
-                      "exceptionClass": "ResponseError",
-                      "rpcCode": -32603,
-                      "traceback": [
-                        {
-                          "column": 1,
-                          "file": "customer-notebook.py",
-                          "function": "rpcDispatch",
-                          "line": 1,
-                        },
-                      ],
-                    },
-                    "cellCount": 2,
                     "exceptionClass": "MarimoCommandError",
-                    "fileType": "py",
-                    "method": "execute-cells",
-                    "traceback": [
-                      {
-                        "column": 1,
-                        "file": "customer-notebook.py",
-                        "function": "deserialize",
-                        "line": 1,
-                      },
-                    ],
                   },
                 ],
               },
@@ -302,6 +283,92 @@ it.scoped("redacts user data from classified and unexpected errors", () =>
         ],
       ]
     `);
+  }),
+);
+
+it.scoped("retains safe diagnostics from Cause log messages", () =>
+  Effect.gen(function* () {
+    const ctx = yield* withTestCtx();
+    const secret = "DO_NOT_UPLOAD_CAUSE_MESSAGE";
+
+    yield* Effect.logError(
+      Cause.fail({ name: "ResponseError", code: -32603, message: secret }),
+    ).pipe(
+      Effect.provide(
+        Logger.replace(Logger.defaultLogger, ctx.telemetry.errorLogger),
+      ),
+    );
+
+    const payload = sentrySdk.captureMessage.mock.calls[0]?.[1];
+    expect(payload?.extra).toEqual({
+      "logger.cause": {
+        failures: [{ exceptionClass: "ResponseError", rpcCode: -32603 }],
+        defects: [],
+      },
+    });
+    expect(JSON.stringify(payload)).not.toContain(secret);
+  }),
+);
+
+it.scoped("sanitizes SDK events at the final Sentry boundary", () =>
+  Effect.gen(function* () {
+    yield* withTestCtx();
+    const secret = "DO_NOT_UPLOAD_BEFORE_SEND";
+    const localPath = "/Users/alice/private/customer-notebook.py";
+    const initOptions = Option.getOrThrow(
+      Option.fromNullable(sentrySdk.init.mock.calls[0]?.[0]),
+    );
+
+    const result = initOptions.beforeSend({
+      message: secret,
+      request: { data: secret },
+      contexts: { private: { secret } },
+      server_name: secret,
+      extra: {
+        "error.domain": "notebook.deserialize",
+        private: secret,
+      },
+      logentry: { message: secret },
+      exception: {
+        values: [
+          {
+            type: "ResponseError",
+            value: secret,
+            stacktrace: {
+              frames: [
+                {
+                  filename: `/marimo${localPath}`,
+                  abs_path: localPath,
+                  function: "customerFunction",
+                  module: "customerModule",
+                  context_line: secret,
+                  vars: { secret },
+                  lineno: 7,
+                },
+              ],
+            },
+          },
+        ],
+      },
+    });
+
+    const payload = JSON.stringify(result);
+    expect(payload).not.toContain(secret);
+    expect(payload).not.toContain("customer-notebook.py");
+    expect(payload).not.toContain("customerFunction");
+    expect(result).toMatchObject({
+      message: "marimo extension error",
+      extra: { "error.domain": "notebook.deserialize" },
+      exception: {
+        values: [
+          {
+            type: "ResponseError",
+            value: "marimo extension error",
+            stacktrace: { frames: [{ lineno: 7 }] },
+          },
+        ],
+      },
+    });
   }),
 );
 

--- a/extension/src/telemetry/__tests__/Telemetry.test.ts
+++ b/extension/src/telemetry/__tests__/Telemetry.test.ts
@@ -305,6 +305,43 @@ it.scoped("redacts user data from classified and unexpected errors", () =>
   }),
 );
 
+it.scoped("groups notebook deserialize failures by safe classification", () =>
+  Effect.gen(function* () {
+    const ctx = yield* withTestCtx();
+
+    yield* Effect.logError("Notebook deserialize failed").pipe(
+      Effect.annotateLogs({
+        "error.domain": "notebook.deserialize",
+        "error.kind": "rpc.internal",
+        "error.exception_class": "ResponseError",
+        "rpc.method": "deserialize",
+        "rpc.code": -32603,
+      }),
+      Effect.provide(
+        Logger.replace(Logger.defaultLogger, ctx.telemetry.errorLogger),
+      ),
+    );
+
+    expect(sentrySdk.captureMessage).toHaveBeenCalledWith(
+      "marimo extension error",
+      expect.objectContaining({
+        fingerprint: [
+          "notebook.deserialize",
+          "rpc.internal",
+          "-32603",
+          "ResponseError",
+        ],
+        tags: expect.objectContaining({
+          "error.domain": "notebook.deserialize",
+          "error.kind": "rpc.internal",
+          "rpc.method": "deserialize",
+          "rpc.code": "-32603",
+        }),
+      }),
+    );
+  }),
+);
+
 it.scoped("does not retain error annotations created without consent", () =>
   Effect.gen(function* () {
     const ctx = yield* withTestCtx({ telemetry: false });

--- a/extension/src/telemetry/__tests__/Telemetry.test.ts
+++ b/extension/src/telemetry/__tests__/Telemetry.test.ts
@@ -1,10 +1,11 @@
 import { expect, it } from "@effect/vitest";
-import { Effect, Layer, Queue, Stream } from "effect";
+import { Cause, Effect, Layer, Logger, Queue, Redacted, Stream } from "effect";
 import { vi } from "vite-plus/test";
 import type * as vscode from "vscode";
 
 import { TestExtensionContextLive } from "../../__mocks__/TestExtensionContext.ts";
 import { TestVsCode } from "../../__mocks__/TestVsCode.ts";
+import { MarimoCommandError } from "../../lsp/MarimoClient.ts";
 import { Telemetry } from "../Telemetry.ts";
 
 const sentrySdk = vi.hoisted(() => ({
@@ -12,6 +13,8 @@ const sentrySdk = vi.hoisted(() => ({
   setTag: vi.fn(),
   setUser: vi.fn(),
   close: vi.fn(async () => true),
+  captureMessage: vi.fn(),
+  addBreadcrumb: vi.fn(),
 }));
 
 const posthog = vi.hoisted(() => ({
@@ -37,6 +40,8 @@ const withTestCtx = Effect.fn(function* (options?: { telemetry?: boolean }) {
   sentrySdk.init.mockClear();
   sentrySdk.close.mockClear();
   sentrySdk.setTag.mockClear();
+  sentrySdk.captureMessage.mockClear();
+  sentrySdk.addBreadcrumb.mockClear();
   posthog.capture.mockClear();
   posthog.shutdown.mockClear();
 
@@ -163,6 +168,140 @@ it.scoped("contains synchronous capture failures", () =>
     // A failed capture does not disable later telemetry.
     yield* ctx.telemetry.capture("new_notebook_created");
     expect(posthog.capture).toHaveBeenCalledTimes(2);
+  }),
+);
+
+it.scoped("redacts user data from classified and unexpected errors", () =>
+  Effect.gen(function* () {
+    const ctx = yield* withTestCtx();
+    const source = "DO_NOT_UPLOAD_123 = 'notebook source'";
+    const secondCell = "print('DO_NOT_UPLOAD_SECOND_CELL')";
+    const localPath = "/Users/alice/private/customer-notebook.py";
+    const environmentSecret = "DO_NOT_UPLOAD_API_TOKEN";
+    const commandError = new MarimoCommandError({
+      command: Redacted.make({
+        command: "marimo.api",
+        params: {
+          method: "execute-cells",
+          params: {
+            notebookUri: `file://${localPath}`,
+            executable: "/private/venv/bin/python",
+            workingDirectory: "/Users/alice/private",
+            inner: { cellIds: ["one", "two"], codes: [source, secondCell] },
+          },
+        },
+      }),
+      cause: {
+        name: "ResponseError",
+        code: -32603,
+        message: source,
+        stack: `ResponseError: ${source}\n    at rpcDispatch (${localPath}:1:1)`,
+      },
+    });
+    commandError.stack = `MarimoCommandError: ${source}\n    at deserialize (${localPath}:1:1)`;
+    const unexpected = {
+      name: "UnexpectedConverterError",
+      message: source,
+      data: { source, environment: { API_TOKEN: environmentSecret } },
+      stack: `UnexpectedConverterError: ${source}\n    at convert (${localPath}:1:1)`,
+    };
+    const cause = Cause.parallel(
+      Cause.fail(commandError),
+      Cause.die(unexpected),
+    );
+
+    yield* Effect.logError(source).pipe(
+      Effect.annotateLogs({
+        cause,
+        "error.tag": "MarimoCommandError",
+        rawCells: [source, secondCell],
+        environment: { API_TOKEN: environmentSecret },
+        notebookUri: localPath,
+      }),
+      Effect.provide(
+        Logger.replace(Logger.defaultLogger, ctx.telemetry.errorLogger),
+      ),
+    );
+    yield* Effect.logWarning(source).pipe(
+      Effect.annotateLogs({ rawCells: [source], notebookUri: localPath }),
+      Effect.provide(
+        Logger.replace(Logger.defaultLogger, ctx.telemetry.errorLogger),
+      ),
+    );
+
+    const payload = JSON.stringify({
+      events: sentrySdk.captureMessage.mock.calls,
+      breadcrumbs: sentrySdk.addBreadcrumb.mock.calls,
+    });
+    expect(payload).not.toContain(source);
+    expect(payload).not.toContain(secondCell);
+    expect(payload).not.toContain(localPath);
+    expect(payload).not.toContain(environmentSecret);
+    expect(sentrySdk.captureMessage.mock.calls).toMatchInlineSnapshot(`
+      [
+        [
+          "marimo extension error",
+          {
+            "extra": {
+              "cause": {
+                "defects": [
+                  {
+                    "exceptionClass": "UnexpectedConverterError",
+                    "traceback": [
+                      {
+                        "column": 1,
+                        "file": "customer-notebook.py",
+                        "function": "convert",
+                        "line": 1,
+                      },
+                    ],
+                  },
+                ],
+                "failures": [
+                  {
+                    "byteCount": 71,
+                    "cause": {
+                      "exceptionClass": "ResponseError",
+                      "rpcCode": -32603,
+                      "traceback": [
+                        {
+                          "column": 1,
+                          "file": "customer-notebook.py",
+                          "function": "rpcDispatch",
+                          "line": 1,
+                        },
+                      ],
+                    },
+                    "cellCount": 2,
+                    "exceptionClass": "MarimoCommandError",
+                    "fileType": "py",
+                    "method": "execute-cells",
+                    "traceback": [
+                      {
+                        "column": 1,
+                        "file": "customer-notebook.py",
+                        "function": "deserialize",
+                        "line": 1,
+                      },
+                    ],
+                  },
+                ],
+              },
+              "error.tag": "MarimoCommandError",
+            },
+            "fingerprint": [
+              "marimo extension error",
+              "MarimoCommandError",
+            ],
+            "level": "error",
+            "tags": {
+              "error.tag": "MarimoCommandError",
+              "marimo": "true",
+            },
+          },
+        ],
+      ]
+    `);
   }),
 );
 

--- a/extension/src/telemetry/__tests__/classifyNotebookDeserializeError.test.ts
+++ b/extension/src/telemetry/__tests__/classifyNotebookDeserializeError.test.ts
@@ -13,18 +13,15 @@ it("does not report known notebook source failures", () => {
     new NotebookSourceError({
       failure: {
         kind: "invalid-syntax",
-        message: "safe message",
         line: 7,
         column: 3,
       },
     }),
   );
-  const jupytext = classifyNotebookDeserializeError(
+  const convertible = classifyNotebookDeserializeError(
     new NotebookSourceError({
       failure: {
-        kind: "unsupported-format",
-        format: "jupytext-percent",
-        message: "safe message",
+        kind: "convertible",
       },
     }),
   );
@@ -35,10 +32,10 @@ it("does not report known notebook source failures", () => {
     kind: "source.invalid-syntax",
     safeContext: {},
   });
-  expect(jupytext).toMatchObject({
+  expect(convertible).toMatchObject({
     report: false,
-    kind: "source.unsupported-format",
-    safeContext: { "source.format": "jupytext-percent" },
+    kind: "source.convertible",
+    safeContext: {},
   });
 });
 
@@ -54,11 +51,6 @@ it("separates LSP startup failures", () => {
     report: true,
     domain: "notebook.deserialize",
     kind: "transport.lsp-start",
-    fingerprint: [
-      "notebook.deserialize",
-      "transport.lsp-start",
-      "MarimoClientStartError",
-    ],
     safeContext: { "error.exception_class": "MarimoClientStartError" },
   });
 });
@@ -77,12 +69,6 @@ it("groups internal RPC failures by method, code, and exception class", () => {
     report: true,
     domain: "notebook.deserialize",
     kind: "rpc.internal",
-    fingerprint: [
-      "notebook.deserialize",
-      "rpc.internal",
-      "-32603",
-      "ResponseError",
-    ],
     safeContext: {
       "rpc.method": "deserialize",
       "rpc.code": -32603,
@@ -101,11 +87,10 @@ it("separates client lifecycle failures from internal RPC errors", () => {
   );
 
   expect(result.kind).toBe("transport.client-not-running");
-  expect(result.fingerprint).toEqual([
-    "notebook.deserialize",
-    "transport.client-not-running",
-    "Error",
-  ]);
+  expect(result.safeContext).toEqual({
+    "rpc.method": "deserialize",
+    "error.exception_class": "Error",
+  });
 });
 
 function commandError(cause: unknown) {

--- a/extension/src/telemetry/__tests__/classifyNotebookDeserializeError.test.ts
+++ b/extension/src/telemetry/__tests__/classifyNotebookDeserializeError.test.ts
@@ -1,5 +1,5 @@
 import { expect, it } from "@effect/vitest";
-import { Redacted } from "effect";
+import { Cause, Redacted } from "effect";
 
 import {
   MarimoClientStartError,
@@ -52,6 +52,17 @@ it("separates LSP startup failures", () => {
     domain: "notebook.deserialize",
     kind: "transport.lsp-start",
     safeContext: { "error.exception_class": "MarimoClientStartError" },
+  });
+});
+
+it("separates deserialize timeouts from internal RPC failures", () => {
+  const result = classifyNotebookDeserializeError(new Cause.TimeoutException());
+
+  expect(result).toEqual({
+    report: true,
+    domain: "notebook.deserialize",
+    kind: "transport.timeout",
+    safeContext: { "error.exception_class": "TimeoutException" },
   });
 });
 

--- a/extension/src/telemetry/__tests__/classifyNotebookDeserializeError.test.ts
+++ b/extension/src/telemetry/__tests__/classifyNotebookDeserializeError.test.ts
@@ -1,0 +1,122 @@
+import { expect, it } from "@effect/vitest";
+import { Redacted } from "effect";
+
+import {
+  MarimoClientStartError,
+  MarimoCommandError,
+} from "../../lsp/MarimoClient.ts";
+import { NotebookSourceError } from "../../notebook/NotebookSourceError.ts";
+import { classifyNotebookDeserializeError } from "../classifyNotebookDeserializeError.ts";
+
+it("does not report known notebook source failures", () => {
+  const syntax = classifyNotebookDeserializeError(
+    new NotebookSourceError({
+      failure: {
+        kind: "invalid-syntax",
+        message: "safe message",
+        line: 7,
+        column: 3,
+      },
+    }),
+  );
+  const jupytext = classifyNotebookDeserializeError(
+    new NotebookSourceError({
+      failure: {
+        kind: "unsupported-format",
+        format: "jupytext-percent",
+        message: "safe message",
+      },
+    }),
+  );
+
+  expect(syntax).toMatchObject({
+    report: false,
+    domain: "notebook.deserialize",
+    kind: "source.invalid-syntax",
+    safeContext: {},
+  });
+  expect(jupytext).toMatchObject({
+    report: false,
+    kind: "source.unsupported-format",
+    safeContext: { "source.format": "jupytext-percent" },
+  });
+});
+
+it("separates LSP startup failures", () => {
+  const result = classifyNotebookDeserializeError(
+    new MarimoClientStartError({
+      exec: { command: "uv", args: ["run", "marimo-lsp"] },
+      cause: new Error("spawn failed"),
+    }),
+  );
+
+  expect(result).toEqual({
+    report: true,
+    domain: "notebook.deserialize",
+    kind: "transport.lsp-start",
+    fingerprint: [
+      "notebook.deserialize",
+      "transport.lsp-start",
+      "MarimoClientStartError",
+    ],
+    safeContext: { "error.exception_class": "MarimoClientStartError" },
+  });
+});
+
+it("groups internal RPC failures by method, code, and exception class", () => {
+  const secret = "DO_NOT_UPLOAD_CLASSIFIER_SOURCE";
+  const result = classifyNotebookDeserializeError(
+    commandError({
+      name: "ResponseError",
+      code: -32603,
+      message: secret,
+    }),
+  );
+
+  expect(result).toEqual({
+    report: true,
+    domain: "notebook.deserialize",
+    kind: "rpc.internal",
+    fingerprint: [
+      "notebook.deserialize",
+      "rpc.internal",
+      "-32603",
+      "ResponseError",
+    ],
+    safeContext: {
+      "rpc.method": "deserialize",
+      "rpc.code": -32603,
+      "error.exception_class": "ResponseError",
+    },
+  });
+  expect(JSON.stringify(result)).not.toContain(secret);
+});
+
+it("separates client lifecycle failures from internal RPC errors", () => {
+  const result = classifyNotebookDeserializeError(
+    commandError({
+      name: "Error",
+      message: "Client is not running",
+    }),
+  );
+
+  expect(result.kind).toBe("transport.client-not-running");
+  expect(result.fingerprint).toEqual([
+    "notebook.deserialize",
+    "transport.client-not-running",
+    "Error",
+  ]);
+});
+
+function commandError(cause: unknown) {
+  return new MarimoCommandError({
+    command: Redacted.make({
+      command: "marimo.api" as const,
+      params: {
+        method: "deserialize" as const,
+        params: { source: "DO_NOT_UPLOAD_COMMAND_SOURCE" },
+      },
+    }),
+    cause,
+  });
+}

--- a/extension/src/telemetry/classifyNotebookDeserializeError.ts
+++ b/extension/src/telemetry/classifyNotebookDeserializeError.ts
@@ -1,0 +1,122 @@
+import { Redacted } from "effect";
+
+import {
+  MarimoClientStartError,
+  MarimoCommandError,
+} from "../lsp/MarimoClient.ts";
+import { NotebookSourceError } from "../notebook/NotebookSourceError.ts";
+
+export type NotebookDeserializeErrorKind =
+  | "source.invalid-syntax"
+  | "source.not-marimo"
+  | "source.unsupported-format"
+  | "transport.lsp-start"
+  | "transport.client-not-running"
+  | "rpc.internal";
+
+export interface ErrorClassification {
+  readonly report: boolean;
+  readonly domain: "notebook.deserialize";
+  readonly kind: NotebookDeserializeErrorKind;
+  readonly fingerprint: readonly string[];
+  readonly safeContext: Readonly<Record<string, string | number>>;
+}
+
+export function classifyNotebookDeserializeError(
+  error: unknown,
+): ErrorClassification {
+  if (error instanceof NotebookSourceError) {
+    const kind = `source.${error.failure.kind}` as const;
+    return {
+      report: false,
+      domain: "notebook.deserialize",
+      kind,
+      fingerprint: ["notebook.deserialize", kind],
+      safeContext: {
+        ...(error.failure.kind === "unsupported-format"
+          ? { "source.format": error.failure.format }
+          : {}),
+      },
+    };
+  }
+
+  if (error instanceof MarimoClientStartError) {
+    return {
+      report: true,
+      domain: "notebook.deserialize",
+      kind: "transport.lsp-start",
+      fingerprint: ["notebook.deserialize", "transport.lsp-start", error._tag],
+      safeContext: { "error.exception_class": error._tag },
+    };
+  }
+
+  if (error instanceof MarimoCommandError) {
+    const method = commandMethod(error);
+    const code = rpcCode(error.cause);
+    const exceptionClass = safeClassName(error.cause);
+    const kind = isClientNotRunning(error.cause)
+      ? "transport.client-not-running"
+      : "rpc.internal";
+    return {
+      report: true,
+      domain: "notebook.deserialize",
+      kind,
+      fingerprint: [
+        "notebook.deserialize",
+        kind,
+        ...(code === undefined ? [] : [String(code)]),
+        exceptionClass,
+      ],
+      safeContext: {
+        ...(method ? { "rpc.method": method } : {}),
+        ...(code === undefined ? {} : { "rpc.code": code }),
+        "error.exception_class": exceptionClass,
+      },
+    };
+  }
+
+  const exceptionClass = safeClassName(error);
+  return {
+    report: true,
+    domain: "notebook.deserialize",
+    kind: "rpc.internal",
+    fingerprint: ["notebook.deserialize", "rpc.internal", exceptionClass],
+    safeContext: { "error.exception_class": exceptionClass },
+  };
+}
+
+function commandMethod(error: MarimoCommandError): string | undefined {
+  const command = Redacted.value(error.command);
+  return command.params.method;
+}
+
+function rpcCode(error: unknown): number | undefined {
+  return isRecord(error) && typeof error.code === "number"
+    ? error.code
+    : undefined;
+}
+
+function isClientNotRunning(error: unknown): boolean {
+  return (
+    isRecord(error) &&
+    typeof error.message === "string" &&
+    error.message.toLowerCase().includes("client is not running")
+  );
+}
+
+function safeClassName(value: unknown): string {
+  if (!isRecord(value)) return typeof value;
+  for (const candidate of [value._tag, value.name, value.constructor?.name]) {
+    if (
+      typeof candidate === "string" &&
+      /^[A-Za-z_$][\w$.-]{0,79}$/.test(candidate)
+    ) {
+      return candidate;
+    }
+  }
+  return "Error";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/extension/src/telemetry/classifyNotebookDeserializeError.ts
+++ b/extension/src/telemetry/classifyNotebookDeserializeError.ts
@@ -8,8 +8,7 @@ import { NotebookSourceError } from "../notebook/NotebookSourceError.ts";
 
 export type NotebookDeserializeErrorKind =
   | "source.invalid-syntax"
-  | "source.not-marimo"
-  | "source.unsupported-format"
+  | "source.convertible"
   | "transport.lsp-start"
   | "transport.client-not-running"
   | "rpc.internal";
@@ -18,7 +17,6 @@ export interface ErrorClassification {
   readonly report: boolean;
   readonly domain: "notebook.deserialize";
   readonly kind: NotebookDeserializeErrorKind;
-  readonly fingerprint: readonly string[];
   readonly safeContext: Readonly<Record<string, string | number>>;
 }
 
@@ -31,12 +29,7 @@ export function classifyNotebookDeserializeError(
       report: false,
       domain: "notebook.deserialize",
       kind,
-      fingerprint: ["notebook.deserialize", kind],
-      safeContext: {
-        ...(error.failure.kind === "unsupported-format"
-          ? { "source.format": error.failure.format }
-          : {}),
-      },
+      safeContext: {},
     };
   }
 
@@ -45,7 +38,6 @@ export function classifyNotebookDeserializeError(
       report: true,
       domain: "notebook.deserialize",
       kind: "transport.lsp-start",
-      fingerprint: ["notebook.deserialize", "transport.lsp-start", error._tag],
       safeContext: { "error.exception_class": error._tag },
     };
   }
@@ -61,12 +53,6 @@ export function classifyNotebookDeserializeError(
       report: true,
       domain: "notebook.deserialize",
       kind,
-      fingerprint: [
-        "notebook.deserialize",
-        kind,
-        ...(code === undefined ? [] : [String(code)]),
-        exceptionClass,
-      ],
       safeContext: {
         ...(method ? { "rpc.method": method } : {}),
         ...(code === undefined ? {} : { "rpc.code": code }),
@@ -80,7 +66,6 @@ export function classifyNotebookDeserializeError(
     report: true,
     domain: "notebook.deserialize",
     kind: "rpc.internal",
-    fingerprint: ["notebook.deserialize", "rpc.internal", exceptionClass],
     safeContext: { "error.exception_class": exceptionClass },
   };
 }

--- a/extension/src/telemetry/classifyNotebookDeserializeError.ts
+++ b/extension/src/telemetry/classifyNotebookDeserializeError.ts
@@ -1,4 +1,4 @@
-import { Redacted } from "effect";
+import { Cause, Redacted } from "effect";
 
 import {
   MarimoClientStartError,
@@ -11,6 +11,7 @@ export type NotebookDeserializeErrorKind =
   | "source.convertible"
   | "transport.lsp-start"
   | "transport.client-not-running"
+  | "transport.timeout"
   | "rpc.internal";
 
 export interface ErrorClassification {
@@ -39,6 +40,15 @@ export function classifyNotebookDeserializeError(
       domain: "notebook.deserialize",
       kind: "transport.lsp-start",
       safeContext: { "error.exception_class": error._tag },
+    };
+  }
+
+  if (Cause.isTimeoutException(error)) {
+    return {
+      report: true,
+      domain: "notebook.deserialize",
+      kind: "transport.timeout",
+      safeContext: { "error.exception_class": "TimeoutException" },
     };
   }
 

--- a/extension/src/telemetry/sentrySink.ts
+++ b/extension/src/telemetry/sentrySink.ts
@@ -139,12 +139,24 @@ export function makeSentrySink() {
       // Build extra context with annotations
       const extra: Record<string, unknown> = {};
       let errorTag: string | undefined;
+      let errorDomain: string | undefined;
+      let errorKind: string | undefined;
+      let rpcCode: number | undefined;
+      let exceptionClass: string | undefined;
       for (const [key, value] of HashMap.toEntries(opts.annotations)) {
         const safeValue = safeAnnotation(key, value);
         if (safeValue !== undefined) extra[key] = safeValue;
         if (key === "error.tag" && typeof value === "string") {
           errorTag = safeToken(value);
         }
+        if (key === "error.domain" && typeof safeValue === "string")
+          errorDomain = safeValue;
+        if (key === "error.kind" && typeof safeValue === "string")
+          errorKind = safeValue;
+        if (key === "rpc.code" && typeof safeValue === "number")
+          rpcCode = safeValue;
+        if (key === "error.exception_class" && typeof safeValue === "string")
+          exceptionClass = safeValue;
       }
 
       // Include cause if present
@@ -158,8 +170,27 @@ export function makeSentrySink() {
       const tags = {
         marimo: "true",
         ...(errorTag ? { "error.tag": errorTag } : {}),
+        ...(errorDomain ? { "error.domain": errorDomain } : {}),
+        ...(errorKind ? { "error.kind": errorKind } : {}),
+        ...(typeof extra["rpc.method"] === "string"
+          ? { "rpc.method": extra["rpc.method"] }
+          : {}),
+        ...(rpcCode === undefined ? {} : { "rpc.code": String(rpcCode) }),
+        ...(typeof extra["source.format"] === "string"
+          ? { "source.format": extra["source.format"] }
+          : {}),
       };
-      const fingerprint = errorTag ? [SENTRY_MESSAGE, errorTag] : undefined;
+      const fingerprint =
+        errorDomain && errorKind
+          ? [
+              errorDomain,
+              errorKind,
+              ...(rpcCode === undefined ? [] : [String(rpcCode)]),
+              ...(exceptionClass ? [exceptionClass] : []),
+            ]
+          : errorTag
+            ? [SENTRY_MESSAGE, errorTag]
+            : undefined;
 
       if (opts.logLevel === LogLevel.Error) {
         SentrySDK.captureMessage(SENTRY_MESSAGE, {
@@ -226,13 +257,19 @@ const SAFE_ANNOTATIONS = new Set([
   "cellCount",
   "code",
   "count",
+  "error.domain",
+  "error.exception_class",
+  "error.kind",
   "error.tag",
   "fileType",
   "kind",
   "method",
   "mode",
+  "rpc.code",
+  "rpc.method",
   "server",
   "service",
+  "source.format",
   "status",
   "version",
 ]);
@@ -242,7 +279,8 @@ function safeAnnotation(key: string, value: unknown): unknown {
     return Cause.isEmpty(value) ? undefined : summarizeCause(value);
   }
   if (!SAFE_ANNOTATIONS.has(key)) return undefined;
-  if (key === "code") return typeof value === "number" ? value : undefined;
+  if (key === "code" || key === "rpc.code")
+    return typeof value === "number" ? value : undefined;
   if (typeof value === "number" || typeof value === "boolean") return value;
   return typeof value === "string" ? safeToken(value) : undefined;
 }

--- a/extension/src/telemetry/sentrySink.ts
+++ b/extension/src/telemetry/sentrySink.ts
@@ -3,16 +3,17 @@ import {
   Cause,
   Effect,
   HashMap,
-  Inspectable,
   Logger,
   LogLevel,
   MutableRef,
+  Redacted,
   Array as ReadonlyArray,
 } from "effect";
 
 // This is a public DSN
 const SENTRY_DSN =
   "https://717e07e6f9831ef39f872ab4a7a63dc2@o4505919839862784.ingest.us.sentry.io/4510382050770944";
+const SENTRY_MESSAGE = "marimo extension error";
 
 export interface SentrySinkOptions {
   readonly appHost: string;
@@ -69,7 +70,15 @@ export function makeSentrySink() {
               return null;
             }
 
-            return event;
+            return sanitizeSentryEvent(event);
+          },
+          beforeBreadcrumb(breadcrumb) {
+            if (breadcrumb.category === "marimo") return breadcrumb;
+            return {
+              category: breadcrumb.category,
+              level: breadcrumb.level,
+              message: "external breadcrumb",
+            };
           },
         }),
       ),
@@ -101,7 +110,9 @@ export function makeSentrySink() {
       if (!MutableRef.get(active)) return;
       try {
         for (const [key, value] of Object.entries(annotations)) {
-          SentrySDK.setTag(key, value);
+          if (["ruff.version", "ty.version", "uv.version"].includes(key)) {
+            SentrySDK.setTag(key, safeToken(value));
+          }
         }
       } catch {
         // Telemetry must never affect product behavior.
@@ -117,7 +128,9 @@ export function makeSentrySink() {
 
     try {
       const messages = ReadonlyArray.ensure(opts.message);
-      const messageStr = messages.map(formatValue).join("\n");
+      const messageStr = messages
+        .filter((message): message is string => typeof message === "string")
+        .join("\n");
 
       if (shouldFilterMessage(messageStr)) {
         return;
@@ -127,22 +140,16 @@ export function makeSentrySink() {
       const extra: Record<string, unknown> = {};
       let errorTag: string | undefined;
       for (const [key, value] of HashMap.toEntries(opts.annotations)) {
-        extra[key] = structuredMessage(value);
+        const safeValue = safeAnnotation(key, value);
+        if (safeValue !== undefined) extra[key] = safeValue;
         if (key === "error.tag" && typeof value === "string") {
-          errorTag = value;
-        }
-        if (Cause.isCause(value) && !Cause.isEmpty(value)) {
-          extra[`${key}.pretty`] = Cause.pretty(value, {
-            renderErrorCause: true,
-          });
+          errorTag = safeToken(value);
         }
       }
 
       // Include cause if present
       if (!Cause.isEmpty(opts.cause)) {
-        extra["logger.cause"] = Cause.pretty(opts.cause, {
-          renderErrorCause: true,
-        });
+        extra["logger.cause"] = summarizeCause(opts.cause);
       }
 
       // Splitting the Sentry group by inner failure tag turns coarse
@@ -152,17 +159,17 @@ export function makeSentrySink() {
         marimo: "true",
         ...(errorTag ? { "error.tag": errorTag } : {}),
       };
-      const fingerprint = errorTag ? [messageStr, errorTag] : undefined;
+      const fingerprint = errorTag ? [SENTRY_MESSAGE, errorTag] : undefined;
 
       if (opts.logLevel === LogLevel.Error) {
-        SentrySDK.captureMessage(messageStr, {
+        SentrySDK.captureMessage(SENTRY_MESSAGE, {
           extra,
           level: "error",
           tags,
           fingerprint,
         });
       } else if (opts.logLevel === LogLevel.Fatal) {
-        SentrySDK.captureMessage(messageStr, {
+        SentrySDK.captureMessage(SENTRY_MESSAGE, {
           extra,
           level: "fatal",
           tags,
@@ -170,13 +177,15 @@ export function makeSentrySink() {
         });
       } else if (opts.logLevel === LogLevel.Warning) {
         SentrySDK.addBreadcrumb({
-          message: messageStr,
+          category: "marimo",
+          message: "marimo extension warning",
           level: "warning",
           data: extra,
         });
       } else if (opts.logLevel === LogLevel.Info) {
         SentrySDK.addBreadcrumb({
-          message: messageStr,
+          category: "marimo",
+          message: "marimo extension info",
           level: "info",
           data: extra,
         });
@@ -211,49 +220,209 @@ function isMarimoStackTrace(frames: SentrySDK.StackFrame[]) {
   return frames.some((frame) => frame.filename?.includes("marimo"));
 }
 
-/**
- * Convert a value to a JSON-serializable form suitable for Sentry's extra data.
- *
- * Sentry truncates nested objects at ~3 levels deep, so complex Effect types
- * (Cause, TaggedErrors with nested fields) get rendered as `[Array]`/`[Object]`.
- * We flatten these to strings to ensure full visibility in Sentry.
- */
-function structuredMessage(u: unknown): unknown {
-  switch (typeof u) {
-    case "bigint":
-    case "function":
-    case "symbol":
-      return String(u);
-    default: {
-      const json = Inspectable.toJSON(u);
-      // If toJSON produced an object, stringify it to avoid Sentry depth truncation
-      if (json !== null && typeof json === "object") {
-        try {
-          return Inspectable.format(json);
-        } catch {
-          // oxlint-disable-next-line typescript/no-base-to-string
-          return String(u);
-        }
-      }
-      return json;
-    }
+const SAFE_ANNOTATIONS = new Set([
+  "byteCount",
+  "cached",
+  "cellCount",
+  "code",
+  "count",
+  "error.tag",
+  "fileType",
+  "kind",
+  "method",
+  "mode",
+  "server",
+  "service",
+  "status",
+  "version",
+]);
+
+function safeAnnotation(key: string, value: unknown): unknown {
+  if (Cause.isCause(value)) {
+    return Cause.isEmpty(value) ? undefined : summarizeCause(value);
   }
+  if (!SAFE_ANNOTATIONS.has(key)) return undefined;
+  if (key === "code") return typeof value === "number" ? value : undefined;
+  if (typeof value === "number" || typeof value === "boolean") return value;
+  return typeof value === "string" ? safeToken(value) : undefined;
 }
 
-/**
- * Format a value as a string for Sentry
- */
-function formatValue(value: unknown) {
+function summarizeCause(cause: Cause.Cause<unknown>): unknown {
+  return {
+    failures: [...Cause.failures(cause)]
+      .slice(0, 3)
+      .map((failure) => summarizeError(failure)),
+    defects: [...Cause.defects(cause)]
+      .slice(0, 3)
+      .map((defect) => summarizeError(defect)),
+  };
+}
+
+function summarizeError(
+  value: unknown,
+  seen = new Set<object>(),
+  depth = 0,
+): Record<string, unknown> {
+  if (!isRecord(value)) return { exceptionClass: typeof value };
+  if (seen.has(value) || depth >= 4) return { exceptionClass: "NestedError" };
+  seen.add(value);
+
+  const summary: Record<string, unknown> = {
+    exceptionClass:
+      safeClassName(value._tag) ??
+      safeClassName(value.name) ??
+      safeClassName(value.constructor?.name) ??
+      "Error",
+  };
+  if (typeof value.code === "number") summary.rpcCode = value.code;
+  if (typeof value.line === "number") summary.line = value.line;
+  if (typeof value.column === "number") summary.column = value.column;
+
+  if (value._tag === "MarimoCommandError") {
+    const command = Redacted.isRedacted(value.command)
+      ? Redacted.value(value.command)
+      : value.command;
+    if (isRecord(command) && isRecord(command.params)) {
+      const rpc = command.params;
+      if (typeof rpc.method === "string")
+        summary.method = safeToken(rpc.method);
+      Object.assign(summary, rpcMetadata(rpc.params));
+    }
+  }
+
+  const traceback = [
+    ...sanitizeTraceback(value.stack),
+    ...(isRecord(value.data) ? sanitizeTraceback(value.data.traceback) : []),
+  ].slice(0, 12);
+  if (traceback.length > 0) summary.traceback = traceback;
+  if (isRecord(value.cause)) {
+    summary.cause = summarizeError(value.cause, seen, depth + 1);
+  }
+  return summary;
+}
+
+function rpcMetadata(value: unknown): Record<string, unknown> {
+  let byteCount = 0;
+  let cellCount: number | undefined;
+  let fileType: string | undefined;
+  const seen = new Set<object>();
+
+  const visit = (current: unknown, key = ""): void => {
+    if (typeof current === "string") {
+      if (/^(?:code|contents?|source)$/i.test(key)) {
+        byteCount += Buffer.byteLength(current);
+      } else if (/^(?:filename|notebookUri|path|uri)$/i.test(key)) {
+        fileType = /\.([A-Za-z0-9]{1,10})(?:[?#].*)?$/.exec(current)?.[1];
+      }
+      return;
+    }
+    if (!current || typeof current !== "object" || seen.has(current)) return;
+    seen.add(current);
+    if (Array.isArray(current)) {
+      if (/^(?:cells|codes)$/i.test(key)) cellCount = current.length;
+      for (const item of current) visit(item, key === "codes" ? "code" : key);
+      return;
+    }
+    for (const [childKey, child] of Object.entries(current))
+      visit(child, childKey);
+  };
+  visit(value);
+  return {
+    ...(byteCount > 0 ? { byteCount } : {}),
+    ...(cellCount === undefined ? {} : { cellCount }),
+    ...(fileType ? { fileType: fileType.toLowerCase() } : {}),
+  };
+}
+
+function sanitizeSentryEvent<Event extends SentrySDK.Event>(
+  event: Event,
+): Event {
+  delete event.request;
+  delete event.contexts;
+  delete event.server_name;
+  for (const exception of event.exception?.values ?? []) {
+    exception.value = safeClassName(exception.type) ?? "marimo extension error";
+    for (const frame of exception.stacktrace?.frames ?? []) {
+      delete frame.pre_context;
+      delete frame.context_line;
+      delete frame.post_context;
+      delete frame.vars;
+      frame.filename = frame.filename?.split(/[\\/]/).at(-1);
+      if (frame.abs_path) frame.abs_path = "redacted";
+    }
+  }
+  return event;
+}
+
+interface SafeTracebackFrame {
+  readonly function?: string;
+  readonly file?: string;
+  readonly line?: number;
+  readonly column?: number;
+}
+
+function sanitizeTraceback(value: unknown): SafeTracebackFrame[] {
   if (typeof value === "string") {
-    return value;
+    const frames: SafeTracebackFrame[] = [];
+    for (const line of value.split("\n")) {
+      const js = /^\s*at\s+(?:(.+?)\s+\()?(.+?):(\d+):(\d+)\)?$/.exec(line);
+      if (js) {
+        frames.push({
+          ...(js[1] ? { function: safeToken(js[1]) } : {}),
+          file: basename(js[2]),
+          line: Number(js[3]),
+          column: Number(js[4]),
+        });
+        continue;
+      }
+      const python = /^\s*File "(.+)", line (\d+), in (.+)$/.exec(line);
+      if (python) {
+        frames.push({
+          function: safeToken(python[3]),
+          file: basename(python[1]),
+          line: Number(python[2]),
+        });
+      }
+    }
+    return frames;
   }
-  if (value === null || value === undefined) {
-    return String(value);
-  }
-  try {
-    return JSON.stringify(structuredMessage(value));
-  } catch {
-    // oxlint-disable-next-line typescript/no-base-to-string
-    return String(value);
-  }
+  if (Array.isArray(value)) return value.flatMap(sanitizeTraceback);
+  if (!isRecord(value)) return [];
+
+  const path = [value.filename, value.file, value.path].find(
+    (item): item is string => typeof item === "string",
+  );
+  const fn = [value.function, value.functionName, value.name].find(
+    (item): item is string => typeof item === "string",
+  );
+  const line = typeof value.line === "number" ? value.line : undefined;
+  const column = typeof value.column === "number" ? value.column : undefined;
+  if (!path && !fn && line === undefined && column === undefined) return [];
+  return [
+    {
+      ...(fn ? { function: safeToken(fn) } : {}),
+      ...(path ? { file: basename(path) } : {}),
+      ...(line === undefined ? {} : { line }),
+      ...(column === undefined ? {} : { column }),
+    },
+  ];
+}
+
+function basename(path: string): string {
+  return path.split(/[\\/]/).at(-1) ?? "unknown";
+}
+
+function safeToken(value: string): string {
+  return /^[A-Za-z0-9_.$<>: -]{1,100}$/.test(value) ? value : "redacted";
+}
+
+function safeClassName(value: unknown): string | undefined {
+  return typeof value === "string" &&
+    /^[A-Za-z][A-Za-z0-9_.-]{0,79}$/.test(value)
+    ? value
+    : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object";
 }

--- a/extension/src/telemetry/sentrySink.ts
+++ b/extension/src/telemetry/sentrySink.ts
@@ -6,7 +6,6 @@ import {
   Logger,
   LogLevel,
   MutableRef,
-  Redacted,
   Array as ReadonlyArray,
 } from "effect";
 
@@ -73,7 +72,14 @@ export function makeSentrySink() {
             return sanitizeSentryEvent(event);
           },
           beforeBreadcrumb(breadcrumb) {
-            if (breadcrumb.category === "marimo") return breadcrumb;
+            if (breadcrumb.category === "marimo") {
+              return {
+                category: breadcrumb.category,
+                level: breadcrumb.level,
+                message: breadcrumb.message,
+                data: sanitizeTelemetryExtra(breadcrumb.data),
+              };
+            }
             return {
               category: breadcrumb.category,
               level: breadcrumb.level,
@@ -176,9 +182,6 @@ export function makeSentrySink() {
           ? { "rpc.method": extra["rpc.method"] }
           : {}),
         ...(rpcCode === undefined ? {} : { "rpc.code": String(rpcCode) }),
-        ...(typeof extra["source.format"] === "string"
-          ? { "source.format": extra["source.format"] }
-          : {}),
       };
       const fingerprint =
         errorDomain && errorKind
@@ -269,13 +272,12 @@ const SAFE_ANNOTATIONS = new Set([
   "rpc.method",
   "server",
   "service",
-  "source.format",
   "status",
   "version",
 ]);
 
 function safeAnnotation(key: string, value: unknown): unknown {
-  if (Cause.isCause(value)) {
+  if (key === "cause" && Cause.isCause(value)) {
     return Cause.isEmpty(value) ? undefined : summarizeCause(value);
   }
   if (!SAFE_ANNOTATIONS.has(key)) return undefined;
@@ -296,14 +298,8 @@ function summarizeCause(cause: Cause.Cause<unknown>): unknown {
   };
 }
 
-function summarizeError(
-  value: unknown,
-  seen = new Set<object>(),
-  depth = 0,
-): Record<string, unknown> {
+function summarizeError(value: unknown): Record<string, unknown> {
   if (!isRecord(value)) return { exceptionClass: typeof value };
-  if (seen.has(value) || depth >= 4) return { exceptionClass: "NestedError" };
-  seen.add(value);
 
   const summary: Record<string, unknown> = {
     exceptionClass:
@@ -315,61 +311,7 @@ function summarizeError(
   if (typeof value.code === "number") summary.rpcCode = value.code;
   if (typeof value.line === "number") summary.line = value.line;
   if (typeof value.column === "number") summary.column = value.column;
-
-  if (value._tag === "MarimoCommandError") {
-    const command = Redacted.isRedacted(value.command)
-      ? Redacted.value(value.command)
-      : value.command;
-    if (isRecord(command) && isRecord(command.params)) {
-      const rpc = command.params;
-      if (typeof rpc.method === "string")
-        summary.method = safeToken(rpc.method);
-      Object.assign(summary, rpcMetadata(rpc.params));
-    }
-  }
-
-  const traceback = [
-    ...sanitizeTraceback(value.stack),
-    ...(isRecord(value.data) ? sanitizeTraceback(value.data.traceback) : []),
-  ].slice(0, 12);
-  if (traceback.length > 0) summary.traceback = traceback;
-  if (isRecord(value.cause)) {
-    summary.cause = summarizeError(value.cause, seen, depth + 1);
-  }
   return summary;
-}
-
-function rpcMetadata(value: unknown): Record<string, unknown> {
-  let byteCount = 0;
-  let cellCount: number | undefined;
-  let fileType: string | undefined;
-  const seen = new Set<object>();
-
-  const visit = (current: unknown, key = ""): void => {
-    if (typeof current === "string") {
-      if (/^(?:code|contents?|source)$/i.test(key)) {
-        byteCount += Buffer.byteLength(current);
-      } else if (/^(?:filename|notebookUri|path|uri)$/i.test(key)) {
-        fileType = /\.([A-Za-z0-9]{1,10})(?:[?#].*)?$/.exec(current)?.[1];
-      }
-      return;
-    }
-    if (!current || typeof current !== "object" || seen.has(current)) return;
-    seen.add(current);
-    if (Array.isArray(current)) {
-      if (/^(?:cells|codes)$/i.test(key)) cellCount = current.length;
-      for (const item of current) visit(item, key === "codes" ? "code" : key);
-      return;
-    }
-    for (const [childKey, child] of Object.entries(current))
-      visit(child, childKey);
-  };
-  visit(value);
-  return {
-    ...(byteCount > 0 ? { byteCount } : {}),
-    ...(cellCount === undefined ? {} : { cellCount }),
-    ...(fileType ? { fileType: fileType.toLowerCase() } : {}),
-  };
 }
 
 function sanitizeSentryEvent<Event extends SentrySDK.Event>(
@@ -378,76 +320,71 @@ function sanitizeSentryEvent<Event extends SentrySDK.Event>(
   delete event.request;
   delete event.contexts;
   delete event.server_name;
+  event.extra = sanitizeTelemetryExtra(event.extra);
+  if (event.message !== undefined) event.message = SENTRY_MESSAGE;
+  if (event.logentry?.message !== undefined) {
+    event.logentry.message = SENTRY_MESSAGE;
+  }
   for (const exception of event.exception?.values ?? []) {
-    exception.value = safeClassName(exception.type) ?? "marimo extension error";
+    exception.value = SENTRY_MESSAGE;
+    exception.type = safeClassName(exception.type) ?? "Error";
     for (const frame of exception.stacktrace?.frames ?? []) {
       delete frame.pre_context;
       delete frame.context_line;
       delete frame.post_context;
       delete frame.vars;
-      frame.filename = frame.filename?.split(/[\\/]/).at(-1);
-      if (frame.abs_path) frame.abs_path = "redacted";
+      delete frame.filename;
+      delete frame.abs_path;
+      delete frame.function;
+      delete frame.module;
     }
   }
   return event;
 }
 
-interface SafeTracebackFrame {
-  readonly function?: string;
-  readonly file?: string;
-  readonly line?: number;
-  readonly column?: number;
-}
-
-function sanitizeTraceback(value: unknown): SafeTracebackFrame[] {
-  if (typeof value === "string") {
-    const frames: SafeTracebackFrame[] = [];
-    for (const line of value.split("\n")) {
-      const js = /^\s*at\s+(?:(.+?)\s+\()?(.+?):(\d+):(\d+)\)?$/.exec(line);
-      if (js) {
-        frames.push({
-          ...(js[1] ? { function: safeToken(js[1]) } : {}),
-          file: basename(js[2]),
-          line: Number(js[3]),
-          column: Number(js[4]),
-        });
-        continue;
-      }
-      const python = /^\s*File "(.+)", line (\d+), in (.+)$/.exec(line);
-      if (python) {
-        frames.push({
-          function: safeToken(python[3]),
-          file: basename(python[1]),
-          line: Number(python[2]),
-        });
-      }
+function sanitizeTelemetryExtra(
+  extra: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  if (!extra) return undefined;
+  const sanitized: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(extra)) {
+    if (key === "cause" || key === "logger.cause") {
+      const cause = sanitizeCauseSummary(value);
+      if (cause) sanitized[key] = cause;
+      continue;
     }
-    return frames;
+    const safeValue = safeAnnotation(key, value);
+    if (safeValue !== undefined) sanitized[key] = safeValue;
   }
-  if (Array.isArray(value)) return value.flatMap(sanitizeTraceback);
-  if (!isRecord(value)) return [];
-
-  const path = [value.filename, value.file, value.path].find(
-    (item): item is string => typeof item === "string",
-  );
-  const fn = [value.function, value.functionName, value.name].find(
-    (item): item is string => typeof item === "string",
-  );
-  const line = typeof value.line === "number" ? value.line : undefined;
-  const column = typeof value.column === "number" ? value.column : undefined;
-  if (!path && !fn && line === undefined && column === undefined) return [];
-  return [
-    {
-      ...(fn ? { function: safeToken(fn) } : {}),
-      ...(path ? { file: basename(path) } : {}),
-      ...(line === undefined ? {} : { line }),
-      ...(column === undefined ? {} : { column }),
-    },
-  ];
+  return Object.keys(sanitized).length === 0 ? undefined : sanitized;
 }
 
-function basename(path: string): string {
-  return path.split(/[\\/]/).at(-1) ?? "unknown";
+function sanitizeCauseSummary(value: unknown): unknown {
+  if (!isRecord(value)) return undefined;
+  const sanitizeItems = (items: unknown) =>
+    Array.isArray(items)
+      ? items.slice(0, 3).flatMap((item) => {
+          if (!isRecord(item)) return [];
+          const exceptionClass = safeClassName(item.exceptionClass);
+          if (!exceptionClass) return [];
+          return [
+            {
+              exceptionClass,
+              ...(typeof item.rpcCode === "number"
+                ? { rpcCode: item.rpcCode }
+                : {}),
+              ...(typeof item.line === "number" ? { line: item.line } : {}),
+              ...(typeof item.column === "number"
+                ? { column: item.column }
+                : {}),
+            },
+          ];
+        })
+      : [];
+  return {
+    failures: sanitizeItems(value.failures),
+    defects: sanitizeItems(value.defects),
+  };
 }
 
 function safeToken(value: string): string {

--- a/scripts/codegen/effect_schemas.py
+++ b/scripts/codegen/effect_schemas.py
@@ -55,6 +55,7 @@ CONCRETE: list[tuple[str, type | object]] = [
     ("NotebookDocumentMetadata", models.NotebookDocumentMetadata),
     ("NotebookDocument", models.NotebookDocument),
     ("DeserializeRequest", models.DeserializeRequest),
+    ("DeserializeResult", models.DeserializeResult),
     ("ConvertRequest", models.ConvertRequest),
     ("InterruptRequest", models.InterruptRequest),
     ("ListPackagesRequest", models.ListPackagesRequest),

--- a/src/marimo_lsp/api.py
+++ b/src/marimo_lsp/api.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, cast
 
 import msgspec
 from marimo._ast.app_config import _AppConfig
+from marimo._ast.compiler import module_compile
 from marimo._ast.parse import MarimoFileError
 from marimo._config.config import MarimoConfig  # noqa: TC002 - API introspection
 from marimo._config.manager import get_default_config_manager
@@ -565,11 +566,7 @@ async def deserialize(
         converter = MarimoConvert.from_py(args.source)
         ir = converter.to_ir()
     except SyntaxError as error:
-        line, column = _syntax_error_position(args.source, error)
-        return DeserializeInvalidSyntax(
-            line=line,
-            column=column,
-        )
+        return _classify_convertible(args.source, syntax_error=error)
     except MarimoFileError as error:
         if str(error) != "`marimo.App` definition expected.":
             raise
@@ -610,11 +607,29 @@ def _syntax_error_position(
 
 def _classify_convertible(
     source: str,
+    syntax_error: SyntaxError | None = None,
 ) -> DeserializeConvertible | DeserializeInvalidSyntax:
     try:
-        compile(source, "notebook.py", "exec")
+        # Use the same compiler as marimo cells so valid notebook constructs,
+        # notably top-level await, are not rejected as ordinary scripts.
+        module_compile(source)
     except SyntaxError as error:
-        return DeserializeInvalidSyntax(line=error.lineno, column=error.offset)
+        if "# %%" in source:
+            try:
+                # Jupytext magics are not Python syntax until the percent
+                # converter rewrites them. Validate the conversion we actually
+                # offer instead of guessing from the original source.
+                converted = MarimoConvert.from_non_marimo_python_script(source).to_ir()
+                for cell in converted.cells:
+                    module_compile(cell.code)
+            except SyntaxError:
+                pass
+            else:
+                return DeserializeConvertible()
+
+        failure = syntax_error or error
+        line, column = _syntax_error_position(source, failure)
+        return DeserializeInvalidSyntax(line=line, column=column)
     return DeserializeConvertible()
 
 

--- a/src/marimo_lsp/api.py
+++ b/src/marimo_lsp/api.py
@@ -43,12 +43,11 @@ from marimo_lsp.models import (
     DeleteCellRequest,
     DependencyTreeRequest,
     DependencyTreeResponse,
+    DeserializeConvertible,
     DeserializeInvalidSyntax,
-    DeserializeNotMarimo,
     DeserializeRequest,
     DeserializeResult,
     DeserializeSuccess,
-    DeserializeUnsupportedFormat,
     ExecuteCellsRequest,
     ExecuteScratchRequest,
     ExportAsIpynbRequest,
@@ -568,17 +567,16 @@ async def deserialize(
     except SyntaxError as error:
         line, column = _syntax_error_position(args.source, error)
         return DeserializeInvalidSyntax(
-            message="The file contains invalid Python syntax.",
             line=line,
             column=column,
         )
     except MarimoFileError as error:
         if str(error) != "`marimo.App` definition expected.":
             raise
-        return _non_marimo_result(args.source)
+        return _classify_convertible(args.source)
 
     if not ir.valid:
-        return _non_marimo_result(args.source)
+        return _classify_convertible(args.source)
 
     return DeserializeSuccess(
         notebook=NotebookDocument(
@@ -610,15 +608,14 @@ def _syntax_error_position(
     return matches[0], error.offset
 
 
-def _non_marimo_result(
+def _classify_convertible(
     source: str,
-) -> DeserializeNotMarimo | DeserializeUnsupportedFormat:
-    if "# %%" in source:
-        return DeserializeUnsupportedFormat(
-            format="jupytext-percent",
-            message="Jupytext percent files require explicit conversion.",
-        )
-    return DeserializeNotMarimo(message="The file is not a native marimo notebook.")
+) -> DeserializeConvertible | DeserializeInvalidSyntax:
+    try:
+        compile(source, "notebook.py", "exec")
+    except SyntaxError as error:
+        return DeserializeInvalidSyntax(line=error.lineno, column=error.offset)
+    return DeserializeConvertible()
 
 
 @marimo_api("get-configuration")

--- a/src/marimo_lsp/api.py
+++ b/src/marimo_lsp/api.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, cast
 
 import msgspec
 from marimo._ast.app_config import _AppConfig
+from marimo._ast.parse import MarimoFileError
 from marimo._config.config import MarimoConfig  # noqa: TC002 - API introspection
 from marimo._config.manager import get_default_config_manager
 from marimo._convert.converters import MarimoConvert
@@ -42,7 +43,12 @@ from marimo_lsp.models import (
     DeleteCellRequest,
     DependencyTreeRequest,
     DependencyTreeResponse,
+    DeserializeInvalidSyntax,
+    DeserializeNotMarimo,
     DeserializeRequest,
+    DeserializeResult,
+    DeserializeSuccess,
+    DeserializeUnsupportedFormat,
     ExecuteCellsRequest,
     ExecuteScratchRequest,
     ExportAsIpynbRequest,
@@ -555,14 +561,64 @@ async def serialize(_ctx: ApiContext, args: NotebookDocument) -> SerializeRespon
 async def deserialize(
     _ctx: ApiContext,
     args: DeserializeRequest,
-) -> NotebookDocument:
-    converter = MarimoConvert.from_py(args.source)
-    ir = converter.to_ir()
-    return NotebookDocument(
-        notebook=converter.to_notebook_v1(),
-        app_config=_AppConfig.from_untrusted_dict(ir.app.options),
-        header=ir.header.value if ir.header is not None else None,
+) -> DeserializeResult:
+    try:
+        converter = MarimoConvert.from_py(args.source)
+        ir = converter.to_ir()
+    except SyntaxError as error:
+        line, column = _syntax_error_position(args.source, error)
+        return DeserializeInvalidSyntax(
+            message="The file contains invalid Python syntax.",
+            line=line,
+            column=column,
+        )
+    except MarimoFileError as error:
+        if str(error) != "`marimo.App` definition expected.":
+            raise
+        return _non_marimo_result(args.source)
+
+    if not ir.valid:
+        return _non_marimo_result(args.source)
+
+    return DeserializeSuccess(
+        notebook=NotebookDocument(
+            notebook=converter.to_notebook_v1(),
+            app_config=_AppConfig.from_untrusted_dict(ir.app.options),
+            header=ir.header.value if ir.header is not None else None,
+        )
     )
+
+
+def _syntax_error_position(
+    source: str, error: SyntaxError
+) -> tuple[int | None, int | None]:
+    if error.filename == "notebook.py":
+        return error.lineno, error.offset
+
+    # Some failures in marimo's cell fallback are relative to the extracted
+    # cell body. Only translate them when the offending line is unambiguous.
+    if error.text is None:
+        return None, None
+    error_line = error.text.rstrip("\r\n")
+    matches = [
+        line_number
+        for line_number, source_line in enumerate(source.splitlines(), start=1)
+        if source_line == error_line
+    ]
+    if len(matches) != 1:
+        return None, None
+    return matches[0], error.offset
+
+
+def _non_marimo_result(
+    source: str,
+) -> DeserializeNotMarimo | DeserializeUnsupportedFormat:
+    if "# %%" in source:
+        return DeserializeUnsupportedFormat(
+            format="jupytext-percent",
+            message="Jupytext percent files require explicit conversion.",
+        )
+    return DeserializeNotMarimo(message="The file is not a native marimo notebook.")
 
 
 @marimo_api("get-configuration")

--- a/src/marimo_lsp/models.py
+++ b/src/marimo_lsp/models.py
@@ -234,33 +234,18 @@ class DeserializeInvalidSyntax(
 ):
     """Python syntax prevented the source from being inspected."""
 
-    message: str
     line: int | None = None
     column: int | None = None
 
 
-class DeserializeNotMarimo(
-    msgspec.Struct, tag="not-marimo", tag_field="kind", rename="camel"
+class DeserializeConvertible(
+    msgspec.Struct, tag="convertible", tag_field="kind", rename="camel"
 ):
-    """Valid Python source that is not a native marimo notebook."""
-
-    message: str
-
-
-class DeserializeUnsupportedFormat(
-    msgspec.Struct, tag="unsupported-format", tag_field="kind", rename="camel"
-):
-    """A recognized non-native notebook format requiring explicit conversion."""
-
-    format: typing.Literal["jupytext-percent", "plain-python", "unknown"]
-    message: str
+    """Valid Python source that can be converted to a marimo notebook."""
 
 
 type DeserializeResult = (
-    DeserializeSuccess
-    | DeserializeInvalidSyntax
-    | DeserializeNotMarimo
-    | DeserializeUnsupportedFormat
+    DeserializeSuccess | DeserializeInvalidSyntax | DeserializeConvertible
 )
 
 

--- a/src/marimo_lsp/models.py
+++ b/src/marimo_lsp/models.py
@@ -221,6 +221,49 @@ class DeserializeRequest(msgspec.Struct, rename="camel"):
     """The Python source code to deserialize."""
 
 
+class DeserializeSuccess(
+    msgspec.Struct, tag="success", tag_field="kind", rename="camel"
+):
+    """A successfully parsed native marimo notebook."""
+
+    notebook: NotebookDocument
+
+
+class DeserializeInvalidSyntax(
+    msgspec.Struct, tag="invalid-syntax", tag_field="kind", rename="camel"
+):
+    """Python syntax prevented the source from being inspected."""
+
+    message: str
+    line: int | None = None
+    column: int | None = None
+
+
+class DeserializeNotMarimo(
+    msgspec.Struct, tag="not-marimo", tag_field="kind", rename="camel"
+):
+    """Valid Python source that is not a native marimo notebook."""
+
+    message: str
+
+
+class DeserializeUnsupportedFormat(
+    msgspec.Struct, tag="unsupported-format", tag_field="kind", rename="camel"
+):
+    """A recognized non-native notebook format requiring explicit conversion."""
+
+    format: typing.Literal["jupytext-percent", "plain-python", "unknown"]
+    message: str
+
+
+type DeserializeResult = (
+    DeserializeSuccess
+    | DeserializeInvalidSyntax
+    | DeserializeNotMarimo
+    | DeserializeUnsupportedFormat
+)
+
+
 class ConvertRequest(msgspec.Struct, rename="camel"):
     """A request to convert a file source a marimo notebook."""
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -13,12 +13,18 @@ from marimo._types.ids import RequestId
 from marimo_lsp.api import (
     ApiBuilder,
     ApiContext,
+    deserialize,
     get_configuration,
     list_sql_schemas,
     list_sql_tables,
     update_configuration,
 )
 from marimo_lsp.models import (
+    DeserializeInvalidSyntax,
+    DeserializeNotMarimo,
+    DeserializeRequest,
+    DeserializeSuccess,
+    DeserializeUnsupportedFormat,
     GetConfigurationRequest,
     ListSQLSchemasRequest,
     ListSQLTablesRequest,
@@ -31,6 +37,97 @@ if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
 NOTEBOOK_URI = "file:///notebook.py"
+
+
+@pytest.mark.asyncio
+async def test_deserialize_native_marimo_notebook() -> None:
+    source = """\
+import marimo
+
+app = marimo.App()
+
+if __name__ == "__main__":
+    app.run()
+"""
+
+    result = await deserialize(_context(MagicMock()), DeserializeRequest(source=source))
+
+    assert isinstance(result, DeserializeSuccess)
+
+
+@pytest.mark.asyncio
+async def test_deserialize_recovers_syntax_error_inside_cell() -> None:
+    source = """\
+import marimo
+
+app = marimo.App()
+
+@app.cell
+def _():
+    value = (
+    return
+"""
+
+    result = await deserialize(_context(MagicMock()), DeserializeRequest(source=source))
+
+    assert isinstance(result, DeserializeSuccess)
+
+
+@pytest.mark.asyncio
+async def test_deserialize_reports_unrecoverable_indentation_location() -> None:
+    source = """\
+import marimo
+app = marimo.App()
+@app.cell
+def _():
+    if True:
+        x = 1
+      y = 2
+    return
+"""
+    result = await deserialize(
+        _context(MagicMock()),
+        DeserializeRequest(source=source),
+    )
+
+    assert isinstance(result, DeserializeInvalidSyntax)
+    assert result.line == 7
+    assert result.column is not None
+    assert "y = 2" not in result.message
+
+
+@pytest.mark.asyncio
+async def test_deserialize_classifies_plain_python() -> None:
+    result = await deserialize(
+        _context(MagicMock()), DeserializeRequest(source="print('hello')\n")
+    )
+
+    assert isinstance(result, DeserializeNotMarimo)
+
+
+@pytest.mark.asyncio
+async def test_deserialize_classifies_jupytext_percent() -> None:
+    result = await deserialize(
+        _context(MagicMock()),
+        DeserializeRequest(source="# %%\nprint('hello')\n"),
+    )
+
+    assert isinstance(result, DeserializeUnsupportedFormat)
+    assert result.format == "jupytext-percent"
+
+
+@pytest.mark.asyncio
+async def test_deserialize_propagates_unexpected_converter_error() -> None:
+    with (
+        patch(
+            "marimo_lsp.api.MarimoConvert.from_py",
+            side_effect=RuntimeError("converter broke"),
+        ),
+        pytest.raises(RuntimeError, match="converter broke"),
+    ):
+        await deserialize(
+            _context(MagicMock()), DeserializeRequest(source="print('hello')")
+        )
 
 
 def _context(sessions: MagicMock) -> ApiContext:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -118,6 +118,32 @@ async def test_deserialize_classifies_jupytext_percent_as_convertible() -> None:
 @pytest.mark.parametrize(
     "source",
     [
+        "await fetch_data()\n",
+        "# %%\nawait fetch_data()\n",
+        "# %%\n%matplotlib inline\n",
+        "# %%\n%%bash\necho hello\n",
+    ],
+)
+async def test_deserialize_accepts_convertible_notebook_syntax(source: str) -> None:
+    result = await deserialize(_context(MagicMock()), DeserializeRequest(source=source))
+
+    assert isinstance(result, DeserializeConvertible)
+
+
+@pytest.mark.asyncio
+async def test_deserialize_rejects_malformed_jupytext_cell() -> None:
+    result = await deserialize(
+        _context(MagicMock()), DeserializeRequest(source="# %%\nprint(\n")
+    )
+
+    assert isinstance(result, DeserializeInvalidSyntax)
+    assert result.line == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "source",
+    [
         "print(\n",
         "def f(:\n",
         "import marimo\napp = marimo.App(\n",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -20,11 +20,10 @@ from marimo_lsp.api import (
     update_configuration,
 )
 from marimo_lsp.models import (
+    DeserializeConvertible,
     DeserializeInvalidSyntax,
-    DeserializeNotMarimo,
     DeserializeRequest,
     DeserializeSuccess,
-    DeserializeUnsupportedFormat,
     GetConfigurationRequest,
     ListSQLSchemasRequest,
     ListSQLTablesRequest,
@@ -71,6 +70,7 @@ def _():
     result = await deserialize(_context(MagicMock()), DeserializeRequest(source=source))
 
     assert isinstance(result, DeserializeSuccess)
+    assert [cell["code"] for cell in result.notebook.notebook["cells"]] == ["value = ("]
 
 
 @pytest.mark.asyncio
@@ -93,7 +93,6 @@ def _():
     assert isinstance(result, DeserializeInvalidSyntax)
     assert result.line == 7
     assert result.column is not None
-    assert "y = 2" not in result.message
 
 
 @pytest.mark.asyncio
@@ -102,18 +101,44 @@ async def test_deserialize_classifies_plain_python() -> None:
         _context(MagicMock()), DeserializeRequest(source="print('hello')\n")
     )
 
-    assert isinstance(result, DeserializeNotMarimo)
+    assert isinstance(result, DeserializeConvertible)
 
 
 @pytest.mark.asyncio
-async def test_deserialize_classifies_jupytext_percent() -> None:
+async def test_deserialize_classifies_jupytext_percent_as_convertible() -> None:
     result = await deserialize(
         _context(MagicMock()),
         DeserializeRequest(source="# %%\nprint('hello')\n"),
     )
 
-    assert isinstance(result, DeserializeUnsupportedFormat)
-    assert result.format == "jupytext-percent"
+    assert isinstance(result, DeserializeConvertible)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "source",
+    [
+        "print(\n",
+        "def f(:\n",
+        "import marimo\napp = marimo.App(\n",
+    ],
+)
+async def test_deserialize_reports_syntax_errors_in_non_marimo_python(
+    source: str,
+) -> None:
+    result = await deserialize(_context(MagicMock()), DeserializeRequest(source=source))
+
+    assert isinstance(result, DeserializeInvalidSyntax)
+    assert result.line is not None
+
+
+@pytest.mark.asyncio
+async def test_percent_marker_inside_string_is_just_convertible_python() -> None:
+    result = await deserialize(
+        _context(MagicMock()), DeserializeRequest(source='x = "# %%"\n')
+    )
+
+    assert isinstance(result, DeserializeConvertible)
 
 
 @pytest.mark.asyncio

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -344,33 +344,36 @@ if __name__ == "__main__":
 
     assert result == snapshot(
         {
+            "kind": "success",
             "notebook": {
-                "version": "1",
-                "cells": [
-                    {
-                        "id": "Hbol",
-                        "code": "import marimo as mo",
-                        "code_hash": "1d0db38904205bec4d6f6f6a1f6cec3e",
-                        "name": "__",
-                        "config": {
-                            "column": None,
-                            "disabled": False,
-                            "hide_code": False,
-                        },
-                    }
-                ],
-                "metadata": {"marimo_version": "0.23.16"},
+                "notebook": {
+                    "version": "1",
+                    "cells": [
+                        {
+                            "id": "Hbol",
+                            "code": "import marimo as mo",
+                            "code_hash": "1d0db38904205bec4d6f6f6a1f6cec3e",
+                            "name": "__",
+                            "config": {
+                                "column": None,
+                                "disabled": False,
+                                "hide_code": False,
+                            },
+                        }
+                    ],
+                    "metadata": {"marimo_version": "0.23.16"},
+                },
+                "appConfig": {
+                    "width": "compact",
+                    "app_title": None,
+                    "layout_file": None,
+                    "css_file": None,
+                    "html_head_file": None,
+                    "auto_download": [],
+                    "sql_output": "auto",
+                },
+                "header": "",
             },
-            "appConfig": {
-                "width": "compact",
-                "app_title": None,
-                "layout_file": None,
-                "css_file": None,
-                "html_head_file": None,
-                "auto_download": [],
-                "sql_output": "auto",
-            },
-            "header": "",
         }
     )
 


### PR DESCRIPTION
Notebook opening previously collapsed invalid source, unsupported formats, LSP startup, and unexpected converter errors into the same JSON-RPC failure. Expected source outcomes are now generated as Effect schemas from a msgspec tagged union:

```ts
export const DeserializeResult = Schema.Union(
  DeserializeSuccess,
  DeserializeInvalidSyntax,
  DeserializeConvertible,
);
```

Our **Open as marimo notebook** action intentionally deserializes twice: first to check the current source before switching editors, then when `vscode.openWith` invokes the serializer after save. Direct `openWith` calls deserialize once.

The preflight exposed a `LanguageClient` race where concurrent requests could start the client more than once or restart could stop it before `sendRequest`. Startup is now single-flight, and active requests prevent restart or disposal from stopping the client.
