### PR TITLE
Route telemetry through VS Code

### DIFF
--- a/extension/src/__mocks__/TestTelemetry.ts
+++ b/extension/src/__mocks__/TestTelemetry.ts
@@ -8,9 +8,13 @@ import { Telemetry } from "../telemetry/Telemetry.ts";
 export const TestTelemetryLive = Layer.succeed(
   Telemetry,
   Telemetry.make({
-    capture: () => Effect.void,
-    reportBinaryResolved: () => Effect.void,
-    annotateErrors: () => Effect.void,
+    commandExecuted: () => Effect.void,
+    notebookCreated: () => Effect.void,
+    notebookOpened: () => Effect.void,
+    tutorialOpened: () => Effect.void,
+    uvMissing: () => Effect.void,
+    uvInstallClicked: () => Effect.void,
+    binaryResolved: () => Effect.void,
     errorLogger: Logger.none,
   }),
 );

--- a/extension/src/__mocks__/TestVsCode.ts
+++ b/extension/src/__mocks__/TestVsCode.ts
@@ -2046,19 +2046,23 @@ export class TestVsCode extends Data.TaggedClass("TestVsCode")<{
           appRoot: "/mocks",
           appHost: "desktop",
           machineId: "mock-machine-id",
-          createTelemetryLogger(sender) {
+          createTelemetryLogger(sender, loggerOptions) {
+            const withCommon = (data: Record<string, unknown> = {}) => ({
+              ...data,
+              ...loggerOptions?.additionalCommonProperties,
+            });
             return acquireDisposable(() => ({
               isUsageEnabled: true,
               isErrorsEnabled: true,
               onDidChangeEnableStates: () => ({ dispose() {} }),
               logUsage(eventName, data) {
-                sender.sendEventData(eventName, data);
+                sender.sendEventData(eventName, withCommon(data));
               },
               logError(eventNameOrError, data) {
                 if (typeof eventNameOrError === "string") {
-                  sender.sendEventData(eventNameOrError, data);
+                  sender.sendEventData(eventNameOrError, withCommon(data));
                 } else {
-                  sender.sendErrorData(eventNameOrError, data);
+                  sender.sendErrorData(eventNameOrError, withCommon(data));
                 }
               },
               dispose() {},

--- a/extension/src/__mocks__/TestVsCode.ts
+++ b/extension/src/__mocks__/TestVsCode.ts
@@ -1630,6 +1630,7 @@ export class TestVsCode extends Data.TaggedClass("TestVsCode")<{
       window?: Partial<Window>;
       commands?: Partial<Commands>;
       workspace?: Partial<Workspace>;
+      env?: Partial<Env>;
     } = {},
   ) {
     const activeTextEditor = yield* SubscriptionRef.make(
@@ -2045,9 +2046,28 @@ export class TestVsCode extends Data.TaggedClass("TestVsCode")<{
           appRoot: "/mocks",
           appHost: "desktop",
           machineId: "mock-machine-id",
+          createTelemetryLogger(sender) {
+            return acquireDisposable(() => ({
+              isUsageEnabled: true,
+              isErrorsEnabled: true,
+              onDidChangeEnableStates: () => ({ dispose() {} }),
+              logUsage(eventName, data) {
+                sender.sendEventData(eventName, data);
+              },
+              logError(eventNameOrError, data) {
+                if (typeof eventNameOrError === "string") {
+                  sender.sendEventData(eventNameOrError, data);
+                } else {
+                  sender.sendErrorData(eventNameOrError, data);
+                }
+              },
+              dispose() {},
+            }));
+          },
           openExternal() {
             return Effect.succeed(true);
           },
+          ...options.env,
         }),
         debug: Debug.make({
           registerDebugConfigurationProvider() {

--- a/extension/src/commands/newMarimoNotebook.ts
+++ b/extension/src/commands/newMarimoNotebook.ts
@@ -45,7 +45,7 @@ def _():
       Effect.annotateLogs({ uri: notebook.uri.toString() }),
     );
 
-    yield* telemetry.capture("new_notebook_created");
+    yield* telemetry.notebookCreated();
   },
   flow(
     Effect.catchTag(

--- a/extension/src/features/RegisterCommands.ts
+++ b/extension/src/features/RegisterCommands.ts
@@ -93,15 +93,9 @@ export const RegisterCommandsLive = Layer.scopedDiscard(
         Stream.runForEach(
           Effect.fn(function* (result) {
             if (Either.isLeft(result)) {
-              yield* telemetry.capture("executed_command", {
-                command: result.left,
-                success: false,
-              });
+              yield* telemetry.commandExecuted(result.left, false);
             } else {
-              yield* telemetry.capture("executed_command", {
-                command: result.right,
-                success: true,
-              });
+              yield* telemetry.commandExecuted(result.right, true);
             }
           }),
         ),

--- a/extension/src/features/ReloadOnConfigChange.ts
+++ b/extension/src/features/ReloadOnConfigChange.ts
@@ -46,11 +46,29 @@ export const watchForConfigurationChanges = Effect.fn(function* () {
 
   yield* Effect.forkScoped(
     code.workspace.configurationChanges().pipe(
+      Stream.filter((event) => event.affectsConfiguration("marimo.telemetry")),
+      Stream.runForEach(
+        Effect.fn(function* () {
+          const reload = yield* code.window.showInformationMessage(
+            "Changing telemetry requires reloading the window to take effect.",
+            { items: ["Reload Window"] },
+          );
+
+          if (Option.isSome(reload) && reload.value === "Reload Window") {
+            yield* code.commands.executeVSCode("workbench.action.reloadWindow");
+          }
+        }),
+      ),
+    ),
+  );
+
+  yield* Effect.forkScoped(
+    code.workspace.configurationChanges().pipe(
       Stream.filter((event) =>
         event.affectsConfiguration("marimo.disableManagedLanguageFeatures"),
       ),
-      Stream.runForEach(() =>
-        Effect.gen(function* () {
+      Stream.runForEach(
+        Effect.fn(function* () {
           const reload = yield* code.window.showInformationMessage(
             "Changing managed language features requires reloading the window to take effect.",
             { items: ["Reload Window"] },
@@ -69,8 +87,8 @@ export const watchForConfigurationChanges = Effect.fn(function* () {
       Stream.filter((event) =>
         event.affectsConfiguration("marimo.notebookFileRoot"),
       ),
-      Stream.runForEach((event) =>
-        Effect.gen(function* () {
+      Stream.runForEach(
+        Effect.fn(function* (event) {
           for (const { notebookId } of yield* notebooks.getRuntimeSessions()) {
             const uri = code.utils.parseUri(notebookId);
             if (

--- a/extension/src/features/ReloadOnConfigChange.ts
+++ b/extension/src/features/ReloadOnConfigChange.ts
@@ -23,6 +23,29 @@ export const watchForConfigurationChanges = Effect.fn(function* () {
   const notebooks = yield* NotebookRuntime;
   const pendingFileRootChanges = new Set<string>();
 
+  const watchForWindowReload = Effect.fn(function* (
+    section: string,
+    message: string,
+  ) {
+    yield* Effect.forkScoped(
+      code.workspace.configurationChanges().pipe(
+        Stream.filter((event) => event.affectsConfiguration(section)),
+        Stream.runForEach(
+          Effect.fn(function* () {
+            const reload = yield* code.window.showInformationMessage(message, {
+              items: ["Reload Window"],
+            });
+            if (Option.isSome(reload) && reload.value === "Reload Window") {
+              yield* code.commands.executeVSCode(
+                "workbench.action.reloadWindow",
+              );
+            }
+          }),
+        ),
+      ),
+    );
+  });
+
   const promptForActiveAffectedSession = Effect.fn(function* () {
     const activeNotebook = Option.filterMap(
       yield* code.window.getActiveNotebookEditor(),
@@ -44,42 +67,13 @@ export const watchForConfigurationChanges = Effect.fn(function* () {
     yield* promptToRestartKernelForFileRootChange();
   });
 
-  yield* Effect.forkScoped(
-    code.workspace.configurationChanges().pipe(
-      Stream.filter((event) => event.affectsConfiguration("marimo.telemetry")),
-      Stream.runForEach(
-        Effect.fn(function* () {
-          const reload = yield* code.window.showInformationMessage(
-            "Changing telemetry requires reloading the window to take effect.",
-            { items: ["Reload Window"] },
-          );
-
-          if (Option.isSome(reload) && reload.value === "Reload Window") {
-            yield* code.commands.executeVSCode("workbench.action.reloadWindow");
-          }
-        }),
-      ),
-    ),
+  yield* watchForWindowReload(
+    "marimo.telemetry",
+    "Changing telemetry requires reloading the window to take effect.",
   );
-
-  yield* Effect.forkScoped(
-    code.workspace.configurationChanges().pipe(
-      Stream.filter((event) =>
-        event.affectsConfiguration("marimo.disableManagedLanguageFeatures"),
-      ),
-      Stream.runForEach(
-        Effect.fn(function* () {
-          const reload = yield* code.window.showInformationMessage(
-            "Changing managed language features requires reloading the window to take effect.",
-            { items: ["Reload Window"] },
-          );
-
-          if (Option.isSome(reload) && reload.value === "Reload Window") {
-            yield* code.commands.executeVSCode("workbench.action.reloadWindow");
-          }
-        }),
-      ),
-    ),
+  yield* watchForWindowReload(
+    "marimo.disableManagedLanguageFeatures",
+    "Changing managed language features requires reloading the window to take effect.",
   );
 
   yield* Effect.forkScoped(

--- a/extension/src/features/__tests__/ReloadOnConfigChange.test.ts
+++ b/extension/src/features/__tests__/ReloadOnConfigChange.test.ts
@@ -1,5 +1,5 @@
 import { expect, it } from "@effect/vitest";
-import { Deferred, Effect, Layer, Option, Ref, Stream } from "effect";
+import { Deferred, Effect, Layer, Option, Queue, Ref, Stream } from "effect";
 import type * as vscode from "vscode";
 
 import { TestVsCode } from "../../__mocks__/TestVsCode.ts";
@@ -45,40 +45,48 @@ it.scoped(
 );
 
 it.scoped(
-  "offers to reload after telemetry changes",
+  "reloads after telemetry changes only when selected",
   Effect.fn(function* () {
-    const prompted = yield* Deferred.make<void>();
+    const prompted = yield* Queue.unbounded<void>();
+    let acceptReload = true;
     const configurationChange: vscode.ConfigurationChangeEvent = {
       affectsConfiguration: (section) => section === "marimo.telemetry",
     };
     const vscode = yield* TestVsCode.make({
       window: {
-        showInformationMessage: (message, options = {}) => {
+        showInformationMessage: <T extends string>(
+          message: string,
+          options: vscode.MessageOptions & { items?: readonly T[] } = {},
+        ) => {
           expect(message).toBe(
             "Changing telemetry requires reloading the window to take effect.",
           );
-          return Deferred.succeed(prompted, undefined).pipe(
-            Effect.as(
-              Option.fromNullable(
+          const selection = acceptReload
+            ? Option.fromNullable(
                 options.items?.find((item) => item === "Reload Window"),
-              ),
-            ),
-          );
+              )
+            : Option.none<T>();
+          acceptReload = false;
+          return Queue.offer(prompted, undefined).pipe(Effect.as(selection));
         },
       },
       workspace: {
-        configurationChanges: () => Stream.make(configurationChange),
+        configurationChanges: () =>
+          Stream.make(configurationChange, configurationChange),
       },
     });
     const services = Layer.merge(vscode.layer, makeTestNotebookRuntime());
 
     yield* watchForConfigurationChanges().pipe(Effect.provide(services));
-    yield* Deferred.await(prompted);
+    yield* Queue.take(prompted);
+    yield* Queue.take(prompted);
 
-    expect(yield* Ref.get(vscode.executions)).toContainEqual({
-      command: "workbench.action.reloadWindow",
-      args: [],
-    });
+    expect(yield* Ref.get(vscode.executions)).toEqual([
+      {
+        command: "workbench.action.reloadWindow",
+        args: [],
+      },
+    ]);
   }),
 );
 

--- a/extension/src/features/__tests__/ReloadOnConfigChange.test.ts
+++ b/extension/src/features/__tests__/ReloadOnConfigChange.test.ts
@@ -12,8 +12,9 @@ import {
   watchForConfigurationChanges,
 } from "../ReloadOnConfigChange.ts";
 
-it.scoped("runs the restart command only when selected", () =>
-  Effect.gen(function* () {
+it.scoped(
+  "runs the restart command only when selected",
+  Effect.fn(function* () {
     let acceptRestart = true;
     const vscode = yield* TestVsCode.make({
       window: {
@@ -44,68 +45,105 @@ it.scoped("runs the restart command only when selected", () =>
 );
 
 it.scoped(
-  "prompts when an affected inactive RuntimeSession becomes active",
-  () =>
-    Effect.gen(function* () {
-      const editor = TestVsCode.makeNotebookEditor("/project/notebook.py");
-      const id = notebookId(editor.notebook.uri.toString());
-      const prompts = yield* Ref.make(0);
-      const prompted = yield* Deferred.make<void>();
-      const activeEditor = yield* Ref.make<
-        Option.Option<vscode.NotebookEditor>
-      >(Option.none());
-      let resolveResourceChecked: (() => void) | undefined;
-      const resourceChecked = new Promise<void>((resolve) => {
-        resolveResourceChecked = resolve;
-      });
-      const configurationChange: vscode.ConfigurationChangeEvent = {
-        affectsConfiguration: (section, resource) => {
-          const affected =
-            section === "marimo.notebookFileRoot" &&
-            (resource === undefined ||
-              ("scheme" in resource &&
-                resource.scheme === editor.notebook.uri.scheme &&
-                resource.path === editor.notebook.uri.path));
-          if (affected && resource !== undefined) {
-            resolveResourceChecked?.();
-          }
-          return affected;
-        },
-      };
-      const vscode = yield* TestVsCode.make({
-        window: {
-          getActiveNotebookEditor: () => Ref.get(activeEditor),
-          activeNotebookEditorChanges: () =>
-            Stream.fromEffect(
-              Effect.promise(() => resourceChecked).pipe(
-                Effect.andThen(Ref.set(activeEditor, Option.some(editor))),
-                Effect.as(Option.some(editor)),
+  "offers to reload after telemetry changes",
+  Effect.fn(function* () {
+    const prompted = yield* Deferred.make<void>();
+    const configurationChange: vscode.ConfigurationChangeEvent = {
+      affectsConfiguration: (section) => section === "marimo.telemetry",
+    };
+    const vscode = yield* TestVsCode.make({
+      window: {
+        showInformationMessage: (message, options = {}) => {
+          expect(message).toBe(
+            "Changing telemetry requires reloading the window to take effect.",
+          );
+          return Deferred.succeed(prompted, undefined).pipe(
+            Effect.as(
+              Option.fromNullable(
+                options.items?.find((item) => item === "Reload Window"),
               ),
             ),
-          showInformationMessage: <T extends string>() =>
-            Ref.update(prompts, (count) => count + 1).pipe(
-              Effect.andThen(Deferred.succeed(prompted, undefined)),
-              Effect.as(Option.none<T>()),
-            ),
+          );
         },
-        workspace: {
-          configurationChanges: () => Stream.make(configurationChange),
-        },
-      });
-      const session = {
-        executable: "/python",
-        workingDirectory: "/project",
-      };
-      const services = Layer.merge(
-        vscode.layer,
-        makeTestNotebookRuntime({
-          runtimeSession: session,
-          runtimeSessions: [{ notebookId: id, session }],
-        }),
-      );
-      yield* watchForConfigurationChanges().pipe(Effect.provide(services));
+      },
+      workspace: {
+        configurationChanges: () => Stream.make(configurationChange),
+      },
+    });
+    const services = Layer.merge(vscode.layer, makeTestNotebookRuntime());
 
-      yield* Deferred.await(prompted);
-      expect(yield* Ref.get(prompts)).toBe(1);
-    }),
+    yield* watchForConfigurationChanges().pipe(Effect.provide(services));
+    yield* Deferred.await(prompted);
+
+    expect(yield* Ref.get(vscode.executions)).toContainEqual({
+      command: "workbench.action.reloadWindow",
+      args: [],
+    });
+  }),
+);
+
+it.scoped(
+  "prompts when an affected inactive RuntimeSession becomes active",
+  Effect.fn(function* () {
+    const editor = TestVsCode.makeNotebookEditor("/project/notebook.py");
+    const id = notebookId(editor.notebook.uri.toString());
+    const prompts = yield* Ref.make(0);
+    const prompted = yield* Deferred.make<void>();
+    const activeEditor = yield* Ref.make<Option.Option<vscode.NotebookEditor>>(
+      Option.none(),
+    );
+    let resolveResourceChecked: (() => void) | undefined;
+    const resourceChecked = new Promise<void>((resolve) => {
+      resolveResourceChecked = resolve;
+    });
+    const configurationChange: vscode.ConfigurationChangeEvent = {
+      affectsConfiguration: (section, resource) => {
+        const affected =
+          section === "marimo.notebookFileRoot" &&
+          (resource === undefined ||
+            ("scheme" in resource &&
+              resource.scheme === editor.notebook.uri.scheme &&
+              resource.path === editor.notebook.uri.path));
+        if (affected && resource !== undefined) {
+          resolveResourceChecked?.();
+        }
+        return affected;
+      },
+    };
+    const vscode = yield* TestVsCode.make({
+      window: {
+        getActiveNotebookEditor: () => Ref.get(activeEditor),
+        activeNotebookEditorChanges: () =>
+          Stream.fromEffect(
+            Effect.promise(() => resourceChecked).pipe(
+              Effect.andThen(Ref.set(activeEditor, Option.some(editor))),
+              Effect.as(Option.some(editor)),
+            ),
+          ),
+        showInformationMessage: <T extends string>() =>
+          Ref.update(prompts, (count) => count + 1).pipe(
+            Effect.andThen(Deferred.succeed(prompted, undefined)),
+            Effect.as(Option.none<T>()),
+          ),
+      },
+      workspace: {
+        configurationChanges: () => Stream.make(configurationChange),
+      },
+    });
+    const session = {
+      executable: "/python",
+      workingDirectory: "/project",
+    };
+    const services = Layer.merge(
+      vscode.layer,
+      makeTestNotebookRuntime({
+        runtimeSession: session,
+        runtimeSessions: [{ notebookId: id, session }],
+      }),
+    );
+    yield* watchForConfigurationChanges().pipe(Effect.provide(services));
+
+    yield* Deferred.await(prompted);
+    expect(yield* Ref.get(prompts)).toBe(1);
+  }),
 );

--- a/extension/src/lsp/RuffLanguageServer.ts
+++ b/extension/src/lsp/RuffLanguageServer.ts
@@ -140,14 +140,11 @@ export class RuffLanguageServer extends Effect.Service<RuffLanguageServer>()(
           );
 
           if (Option.isSome(telemetry)) {
-            yield* telemetry.value.annotateErrors({
-              "ruff.version": serverVersion,
-            });
-            yield* telemetry.value.reportBinaryResolved(
-              "ruff",
+            yield* telemetry.value.binaryResolved({
+              server: "ruff",
               resolved,
-              serverVersion,
-            );
+              version: serverVersion,
+            });
           }
 
           yield* Ref.set(

--- a/extension/src/lsp/TyLanguageServer.ts
+++ b/extension/src/lsp/TyLanguageServer.ts
@@ -1,6 +1,6 @@
 import * as NodePath from "node:path";
 
-import { type Cause, Data, Effect, Option, Ref, Stream } from "effect";
+import { Cause, Data, Effect, Option, Ref, Stream } from "effect";
 
 import { Config } from "../config/Config.ts";
 import {
@@ -167,14 +167,11 @@ export class TyLanguageServer extends Effect.Service<TyLanguageServer>()(
             );
 
             if (Option.isSome(telemetry)) {
-              yield* telemetry.value.annotateErrors({
-                "ty.version": serverVersion,
-              });
-              yield* telemetry.value.reportBinaryResolved(
-                "ty",
+              yield* telemetry.value.binaryResolved({
+                server: "ty",
                 resolved,
-                serverVersion,
-              );
+                version: serverVersion,
+              });
             }
 
             // Update running status with current Python environment
@@ -209,6 +206,7 @@ export class TyLanguageServer extends Effect.Service<TyLanguageServer>()(
           yield* Effect.forever(serverCycle).pipe(
             Effect.catchAllCause((cause) =>
               Effect.gen(function* () {
+                if (Cause.isInterruptedOnly(cause)) return;
                 const message = "Failed to start language server";
                 yield* Ref.set(
                   statusRef,

--- a/extension/src/notebook/NotebookEditorRegistry.ts
+++ b/extension/src/notebook/NotebookEditorRegistry.ts
@@ -54,9 +54,9 @@ export class NotebookEditorRegistry extends Effect.Service<NotebookEditorRegistr
 
               // Track notebook opened event (only for new notebooks)
               if (!isNewNotebook) {
-                yield* telemetry.capture("notebook_opened", {
-                  cellCount: editor.value.notebook.cellCount,
-                });
+                yield* telemetry.notebookOpened(
+                  editor.value.notebook.cellCount,
+                );
               }
 
               yield* SubscriptionRef.set(

--- a/extension/src/platform/VsCode.ts
+++ b/extension/src/platform/VsCode.ts
@@ -545,6 +545,14 @@ export class Env extends Effect.Service<Env>()("Env", {
       appRoot: api.appRoot,
       appHost: api.appHost,
       machineId: api.machineId,
+      createTelemetryLogger(
+        sender: vscode.TelemetrySender,
+        options?: vscode.TelemetryLoggerOptions,
+      ) {
+        return acquireDisposable(() =>
+          api.createTelemetryLogger(sender, options),
+        );
+      },
       openExternal(target: vscode.Uri): Effect.Effect<boolean> {
         return Effect.promise(() => api.openExternal(target));
       },

--- a/extension/src/python/Uv.ts
+++ b/extension/src/python/Uv.ts
@@ -196,12 +196,15 @@ export class Uv extends Effect.Service<Uv>()("Uv", {
 
     {
       const version = Option.match(uvBinary.version, {
-        onSome: (v) => v.format(),
+        onSome: (v) => v.version,
         onNone: () => "unknown",
       });
 
-      yield* telemetry.annotateErrors({ "uv.version": version });
-      yield* telemetry.capture("uv_init", { binType: uvBinary._tag, version });
+      yield* telemetry.binaryResolved({
+        server: "uv",
+        source: uvBinary._tag,
+        version,
+      });
     }
 
     const uv = createUv(uvBinary, executor, channel);
@@ -628,7 +631,7 @@ const handleUvNotInstalled = Effect.fn("handleUvNotInstalled")(function* (
   code: VsCode,
   telemetry: Telemetry,
 ) {
-  yield* telemetry.capture("uv_missing", { binType: error.bin._tag });
+  yield* telemetry.uvMissing(error.bin._tag);
 
   const errorMessage = UvBin.$match(error.bin, {
     Bundled: (bin) =>
@@ -650,7 +653,7 @@ const handleUvNotInstalled = Effect.fn("handleUvNotInstalled")(function* (
   });
 
   if (Option.isSome(choice) && choice.value === "Install uv") {
-    yield* telemetry.capture("uv_install_clicked");
+    yield* telemetry.uvInstallClicked();
 
     // Create hidden terminal so Python extension doesn't auto-activate environments
     const terminal = yield* code.window.createTerminal({

--- a/extension/src/statusbar/MarimoStatusBar.ts
+++ b/extension/src/statusbar/MarimoStatusBar.ts
@@ -263,7 +263,5 @@ const tutorialCommands = Effect.fn(function* () {
   }
 
   // Track walkthrough step completion
-  yield* telemetry.capture("tutorial_opened", {
-    tutorial: tutorialName,
-  });
+  yield* telemetry.tutorialOpened(tutorialName);
 });

--- a/extension/src/telemetry/Telemetry.ts
+++ b/extension/src/telemetry/Telemetry.ts
@@ -1,216 +1,415 @@
-import { Effect, Exit, Option, Ref, Schema, Scope, Stream } from "effect";
-import type { PostHog } from "posthog-node";
+import {
+  Cause,
+  Effect,
+  HashMap,
+  Inspectable,
+  Logger,
+  LogLevel,
+  Option,
+  Schema,
+  Array as ReadonlyArray,
+} from "effect";
+import type * as vscode from "vscode";
 
 import { type BinarySource } from "../lib/binaryResolution.ts";
 import { getExtensionVersion } from "../lib/getExtensionVersion.ts";
 import { createStorageKey, Storage } from "../platform/Storage.ts";
 import { VsCode } from "../platform/VsCode.ts";
-import { acquirePostHogSink } from "./posthogSink.ts";
-import { makeSentrySink } from "./sentrySink.ts";
+import { acquirePostHogAdapter, type PostHogAdapter } from "./posthogSink.ts";
+import { acquireSentryAdapter, type SentryAdapter } from "./sentrySink.ts";
 
-// Create a storage key for the anonymous ID
 const ANONYMOUS_ID_KEY = createStorageKey(
   "telemetry.anonymousId",
   Schema.String,
 );
 
-/**
- * Get or create an anonymous ID for telemetry tracking.
- * The ID is persisted in global storage and generated once per installation.
- */
-function anonymousId(storage: Storage): Effect.Effect<string> {
-  return Effect.gen(function* () {
-    // Try to get existing ID
-    const maybeId = yield* storage.global.get(ANONYMOUS_ID_KEY);
-    if (Option.isSome(maybeId)) {
-      return maybeId.value;
+type ResolvedBinary =
+  | {
+      readonly server: "uv";
+      readonly source: "Default" | "Configured" | "Discovered" | "Bundled";
+      readonly version: string;
     }
+  | {
+      readonly server: "ruff" | "ty";
+      readonly resolved: BinarySource;
+      readonly version: string;
+    };
 
-    // Generate and store new ID
-    const newId = crypto.randomUUID();
-    yield* storage.global.set(ANONYMOUS_ID_KEY, newId).pipe(
-      Effect.ignore, // Ignore errors when storing
-    );
+const NOOP_SENTRY: SentryAdapter = {
+  captureError() {},
+  addBreadcrumb() {},
+  setBinaryVersion() {},
+};
 
-    return newId;
-  }).pipe(
-    Effect.orElseSucceed(() => "unknown"), // Fallback if anything fails
-  );
-}
-
-type EventMap = {
-  executed_command: { command: string; success: boolean };
-  new_notebook_created: undefined;
-  notebook_opened: { cellCount: number };
-  tutorial_opened: { tutorial: string };
-  uv_missing: { binType: "Default" | "Configured" | "Discovered" | "Bundled" };
-  uv_init: {
-    binType: "Default" | "Configured" | "Discovered" | "Bundled";
-    version: string;
-  };
-  uv_install_clicked: undefined;
-  lsp_binary_resolved: {
-    server: "ruff" | "ty";
-    source: BinarySource["_tag"];
-    kind?: "configured" | "bundled";
-    version: string;
-  };
+const NOOP_POSTHOG: PostHogAdapter = {
+  capture() {},
 };
 
 /**
- * The single module through which the extension reports product events and
- * errors. Callers invoke its methods unconditionally; whether anything is
- * actually sent is this module's own concern.
+ * The extension's single telemetry runtime.
  *
- * Consent (the `marimo.telemetry` setting) is read here and nowhere else.
- * The two sinks — PostHog for product events, Sentry for errors — are scoped
- * resources: acquired when consent turns on, flushed and released when it
- * turns off.
+ * Marimo consent is read once at activation. VS Code's TelemetryLogger remains
+ * responsible for its global usage/error gates and for cleaning all caller
+ * data before the private PostHog and Sentry adapters receive it.
  */
 export class Telemetry extends Effect.Service<Telemetry>()("Telemetry", {
   dependencies: [Storage.Default],
   scoped: Effect.gen(function* () {
     const code = yield* VsCode;
-    const storage = yield* Storage;
+    const config = yield* code.workspace.getConfiguration("marimo");
+    const enabled = config.get<boolean>("telemetry") ?? true;
+    if (!enabled) return disabledTelemetry();
 
+    const storage = yield* Storage;
     const extensionVersion = Option.getOrElse(
       yield* getExtensionVersion(),
       () => "unknown",
     );
     const distinctId = yield* anonymousId(storage);
-    const sentry = makeSentrySink();
 
-    // Consent: the only reader of the marimo.telemetry setting.
-    const readConsent = Effect.map(
-      code.workspace.getConfiguration("marimo"),
-      (config) => config.get<boolean>("telemetry") ?? true,
+    const sentry = yield* acquireSentryAdapter({
+      appHost: code.env.appHost,
+      appName: code.env.appName,
+      machineId: code.env.machineId,
+      extensionVersion,
+    }).pipe(
+      Effect.catchAllCause((cause) =>
+        Effect.logWarning("Failed to initialize Sentry telemetry").pipe(
+          Effect.annotateLogs({ cause }),
+          Effect.as(NOOP_SENTRY),
+        ),
+      ),
+    );
+    const posthog = yield* acquirePostHogAdapter.pipe(
+      Effect.catchAllCause((cause) =>
+        Effect.logWarning("Failed to initialize PostHog telemetry").pipe(
+          Effect.annotateLogs({ cause }),
+          Effect.as(NOOP_POSTHOG),
+        ),
+      ),
     );
 
-    const sinksRef = yield* Ref.make(
-      Option.none<{
-        readonly scope: Scope.CloseableScope;
-        readonly posthog: PostHog;
-      }>(),
-    );
+    const sender = makeTelemetrySender(sentry, posthog, distinctId);
+    const maybeLogger = yield* code.env
+      .createTelemetryLogger(sender, {
+        additionalCommonProperties: {
+          extension_version: extensionVersion,
+          app_name: code.env.appName,
+          app_host: code.env.appHost,
+        },
+      })
+      .pipe(
+        Effect.map(Option.some),
+        Effect.catchAllCause((cause) =>
+          Effect.logWarning("Failed to initialize VS Code telemetry").pipe(
+            Effect.annotateLogs({ cause }),
+            Effect.as(Option.none<vscode.TelemetryLogger>()),
+          ),
+        ),
+      );
+    if (Option.isNone(maybeLogger)) return disabledTelemetry();
+    const logger = maybeLogger.value;
+    const errorLogger = makeEffectErrorLogger(logger);
 
-    const acquireSinks = Effect.gen(function* () {
-      yield* sentry.acquire({
-        appHost: code.env.appHost,
-        appName: code.env.appName,
-        machineId: code.env.machineId,
-        extensionVersion,
-      });
-      return yield* acquirePostHogSink({
-        distinctId,
-        extensionVersion,
-        appName: code.env.appName,
-        appHost: code.env.appHost,
-      });
-    });
+    const usage = (event: string, data?: Record<string, unknown>) =>
+      Effect.sync(() =>
+        ignoreTelemetryError(() => logger.logUsage(event, data)),
+      );
 
-    // Sinks follow consent: acquired into their own scope when consent turns
-    // on, and released (flush + close) when it turns off. Only ever invoked
-    // sequentially — from construction below, the single watcher fiber, or
-    // the teardown finalizer.
-    //
-    // Telemetry must never be observable outside its dashboards: a sink that
-    // fails to acquire or release is logged and dropped, so a broken SDK can
-    // neither fail activation nor kill the consent watcher.
-    const applyConsent = Effect.fn("Telemetry.applyConsent")(function* (
-      enabled: boolean,
-    ) {
-      const current = yield* Ref.get(sinksRef);
-      if (enabled && Option.isNone(current)) {
-        const scope = yield* Scope.make();
-        const acquired = yield* Effect.exit(Scope.extend(acquireSinks, scope));
-        if (Exit.isSuccess(acquired)) {
-          yield* Ref.set(
-            sinksRef,
-            Option.some({ scope, posthog: acquired.value }),
-          );
-        } else {
-          yield* Effect.logWarning("Failed to acquire telemetry sinks").pipe(
-            Effect.annotateLogs({ cause: acquired.cause }),
-          );
-          yield* Effect.ignoreLogged(Scope.close(scope, acquired));
-        }
-      } else if (!enabled && Option.isSome(current)) {
-        yield* Ref.set(sinksRef, Option.none());
-        yield* Effect.ignoreLogged(Scope.close(current.value.scope, Exit.void));
-      }
-    });
-
-    yield* Effect.addFinalizer(() => applyConsent(false));
-
-    yield* applyConsent(yield* readConsent);
-
-    yield* code.workspace.configurationChanges().pipe(
-      Stream.filter((event) => event.affectsConfiguration("marimo.telemetry")),
-      Stream.mapEffect(() => readConsent),
-      Stream.changes,
-      Stream.runForEach(applyConsent),
-      Effect.forkScoped,
-    );
-
-    const capture = <K extends keyof EventMap>(
-      event: K,
-      ...args: EventMap[K] extends undefined ? [] : [properties: EventMap[K]]
-    ): Effect.Effect<void> =>
-      Ref.modify(sinksRef, (sinks) => {
-        if (Option.isNone(sinks)) return [undefined, sinks] as const;
-        const properties = args[0];
-
-        try {
-          // Invoke capture inside the atomic Ref modification so consent loss
-          // and capture have a single ordering: an event is either accepted
-          // before opt-out, or sees the empty sink afterward.
-          sinks.value.posthog.capture({
-            distinctId,
-            event,
-            properties: {
-              ...properties,
-              extension_version: extensionVersion,
-            },
-          });
-        } catch {
-          // Telemetry must never affect product behavior.
-        }
-        return [undefined, sinks] as const;
+    const binaryResolved = (binary: ResolvedBinary): Effect.Effect<void> =>
+      Effect.sync(() => {
+        sentry.setBinaryVersion(binary.server, binary.version);
+        ignoreTelemetryError(() => {
+          if (binary.server === "uv") {
+            logger.logUsage("uv_init", {
+              binType: binary.source,
+              version: binary.version,
+            });
+          } else {
+            logger.logUsage("lsp_binary_resolved", {
+              server: binary.server,
+              source: binary.resolved._tag,
+              ...("kind" in binary.resolved
+                ? { kind: binary.resolved.kind }
+                : {}),
+              version: binary.version,
+            });
+          }
+        });
       });
 
+    yield* usage("extension_activated");
     return {
-      /**
-       * Track an event with optional properties
-       */
-      capture,
-
-      /**
-       * Report which binary source was resolved for a language server.
-       */
-      reportBinaryResolved: (
-        server: "ruff" | "ty",
-        source: BinarySource,
-        version: string,
-      ): Effect.Effect<void> =>
-        capture("lsp_binary_resolved", {
-          server,
-          source: source._tag,
-          ...("kind" in source ? { kind: source.kind } : {}),
-          version,
-        }),
-
-      /**
-       * Attach ambient context to future error reports, mirroring
-       * `Effect.annotateLogs`.
-       */
-      annotateErrors: (
-        annotations: Record<string, string>,
-      ): Effect.Effect<void> => sentry.annotateErrors(annotations),
-
-      /**
-       * Error logger forwarding Effect log output to the error sink.
-       */
-      errorLogger: sentry.errorLogger,
+      commandExecuted: (command: string, success: boolean) =>
+        usage("executed_command", { command, success }),
+      notebookCreated: () => usage("new_notebook_created"),
+      notebookOpened: (cellCount: number) =>
+        usage("notebook_opened", { cellCount }),
+      tutorialOpened: (tutorial: string) =>
+        usage("tutorial_opened", { tutorial }),
+      uvMissing: (
+        binType: "Default" | "Configured" | "Discovered" | "Bundled",
+      ) => usage("uv_missing", { binType }),
+      uvInstallClicked: () => usage("uv_install_clicked"),
+      binaryResolved,
+      errorLogger,
     };
   }),
 }) {}
+
+function disabledTelemetry() {
+  return {
+    commandExecuted: (_command: string, _success: boolean) => Effect.void,
+    notebookCreated: () => Effect.void,
+    notebookOpened: (_cellCount: number) => Effect.void,
+    tutorialOpened: (_tutorial: string) => Effect.void,
+    uvMissing: (
+      _binType: "Default" | "Configured" | "Discovered" | "Bundled",
+    ) => Effect.void,
+    uvInstallClicked: () => Effect.void,
+    binaryResolved: (_binary: ResolvedBinary) => Effect.void,
+    errorLogger: Logger.none,
+  };
+}
+
+function makeTelemetrySender(
+  sentry: SentryAdapter,
+  posthog: PostHogAdapter,
+  distinctId: string,
+): vscode.TelemetrySender {
+  return {
+    sendEventData(eventName, data) {
+      const event = unprefixEventName(eventName);
+      if (event === "marimo.log.info") {
+        sentry.addBreadcrumb(String(data?.message ?? ""), "info", data);
+        return;
+      }
+      if (event === "marimo.log.warning") {
+        sentry.addBreadcrumb(String(data?.message ?? ""), "warning", data);
+        return;
+      }
+      ignoreTelemetryError(() => {
+        posthog.capture({ distinctId, event, properties: data });
+      });
+    },
+    sendErrorData(error, data) {
+      sentry.captureError(restoreErrorCause(error, data), data);
+    },
+  };
+}
+
+function restoreErrorCause(
+  error: Error,
+  data: Record<string, unknown> | undefined,
+): Error {
+  const cause = asRecord(data?.cause);
+  const summaries = [
+    ...(Array.isArray(cause?.failures) ? cause.failures : []),
+    ...(Array.isArray(cause?.defects) ? cause.defects : []),
+  ];
+  const primary = summaries.find(
+    (summary) =>
+      asRecord(summary)?.name === error.name ||
+      asRecord(summary)?.message === error.message,
+  );
+  const restoredCause = errorFromSummary(asRecord(primary)?.cause);
+  if (!restoredCause) return error;
+
+  const restored = new Error(error.message, { cause: restoredCause });
+  copyErrorFields(restored, asRecord(primary) ?? {});
+  copyErrorFields(restored, error);
+  restored.name = error.name;
+  restored.stack = error.stack;
+  return restored;
+}
+
+function errorFromSummary(value: unknown): Error | undefined {
+  const summary = asRecord(value);
+  if (!summary || typeof summary.message !== "string") return undefined;
+
+  const cause = errorFromSummary(summary.cause);
+  const error = new Error(summary.message, cause ? { cause } : undefined);
+  copyErrorFields(error, summary);
+  if (typeof summary.name === "string") error.name = summary.name;
+  if (typeof summary.stack === "string") error.stack = summary.stack;
+  return error;
+}
+
+function copyErrorFields(target: Error, source: object): void {
+  for (const [key, value] of Object.entries(source)) {
+    if (key !== "cause") Object.assign(target, { [key]: value });
+  }
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return isRecord(value) ? value : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object";
+}
+
+function makeEffectErrorLogger(logger: vscode.TelemetryLogger) {
+  return Logger.make((options) => {
+    try {
+      const messages = ReadonlyArray.ensure(options.message);
+      const message = messages
+        .filter((item): item is string => typeof item === "string")
+        .join("\n");
+      const cause = findCause(options.cause, options.annotations, messages);
+      if (!Cause.isEmpty(cause) && Cause.isInterruptedOnly(cause)) return;
+      const data = logData(options.annotations, cause);
+
+      if (
+        options.logLevel === LogLevel.Error ||
+        options.logLevel === LogLevel.Fatal
+      ) {
+        logger.logError(errorFromCause(cause, message), {
+          ...data,
+          "error.level":
+            options.logLevel === LogLevel.Fatal ? "fatal" : "error",
+        });
+      } else if (options.logLevel === LogLevel.Warning) {
+        logger.logError("marimo.log.warning", { message, ...data });
+      } else if (options.logLevel === LogLevel.Info) {
+        logger.logError("marimo.log.info", { message, ...data });
+      }
+    } catch {
+      // Logging must not be able to fail an application fiber.
+    }
+  }).pipe(
+    Logger.filterLogLevel(
+      (level) =>
+        level === LogLevel.Info ||
+        level === LogLevel.Warning ||
+        level === LogLevel.Error ||
+        level === LogLevel.Fatal,
+    ),
+    Logger.map((): void => undefined),
+  );
+}
+
+function findCause(
+  loggerCause: Cause.Cause<unknown>,
+  annotations: HashMap.HashMap<string, unknown>,
+  messages: ReadonlyArray<unknown>,
+): Cause.Cause<unknown> {
+  if (!Cause.isEmpty(loggerCause)) return loggerCause;
+  for (const [key, value] of HashMap.toEntries(annotations)) {
+    if (key === "cause" && Cause.isCause(value)) return value;
+  }
+  return messages.find(Cause.isCause) ?? Cause.empty;
+}
+
+function logData(
+  annotations: HashMap.HashMap<string, unknown>,
+  cause: Cause.Cause<unknown>,
+): Record<string, unknown> {
+  const data: Record<string, unknown> = {};
+  for (const [key, value] of HashMap.toEntries(annotations)) {
+    if (key === "cause" && Cause.isCause(value)) continue;
+    data[key] = diagnosticValue(value);
+  }
+  if (!Cause.isEmpty(cause)) data.cause = summarizeCause(cause);
+  return data;
+}
+
+function errorFromCause(cause: Cause.Cause<unknown>, message: string): Error {
+  const values = [...Cause.failures(cause), ...Cause.defects(cause)];
+  const error = values.find((value): value is Error => value instanceof Error);
+  if (error) {
+    const needsMessage =
+      error.message.trim().length === 0 ||
+      error.message === "An error has occurred";
+    if (!message || !needsMessage) return error;
+    const enriched = new Error(message, { cause: error.cause });
+    enriched.name = error.name;
+    enriched.stack = error.stack?.replace(
+      /^.*?(?=\n|$)/,
+      `${error.name}: ${message}`,
+    );
+    return enriched;
+  }
+
+  const fallback = new Error(message || describeUnknown(values[0]));
+  fallback.name = values.length > 0 ? "UnknownFailure" : "EffectLogError";
+  return fallback;
+}
+
+function summarizeCause(cause: Cause.Cause<unknown>) {
+  return {
+    pretty: Cause.pretty(cause, { renderErrorCause: true }),
+    interrupted: Cause.isInterrupted(cause),
+    failures: [...Cause.failures(cause)].slice(0, 5).map(summarizeFailure),
+    defects: [...Cause.defects(cause)].slice(0, 5).map(summarizeFailure),
+  };
+}
+
+function summarizeFailure(value: unknown, depth = 0): unknown {
+  if (!(value instanceof Error)) return diagnosticValue(value, depth + 1);
+
+  const summary: Record<string, unknown> = {
+    name: value.name,
+    message: value.message,
+    stack: value.stack,
+  };
+  if (depth < 4 && value.cause !== undefined) {
+    summary.cause = summarizeFailure(value.cause, depth + 1);
+  }
+  if (depth < 4) {
+    for (const [key, field] of Object.entries(value)) {
+      if (key === "cause" || key in summary) continue;
+      summary[key] = diagnosticValue(field, depth + 1);
+    }
+  }
+  return summary;
+}
+
+function diagnosticValue(value: unknown, depth = 0): unknown {
+  if (value instanceof Error) return summarizeFailure(value, depth);
+  if (Cause.isCause(value)) return summarizeCause(value);
+  if (depth >= 4) return describeUnknown(value);
+  try {
+    return Inspectable.toJSON(value);
+  } catch {
+    return describeUnknown(value);
+  }
+}
+
+function describeUnknown(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (
+    value === undefined ||
+    value === null ||
+    typeof value === "number" ||
+    typeof value === "boolean" ||
+    typeof value === "bigint"
+  ) {
+    return String(value);
+  }
+  return Object.prototype.toString.call(value);
+}
+
+function unprefixEventName(eventName: string): string {
+  const separator = eventName.indexOf("/");
+  return separator === -1 ? eventName : eventName.slice(separator + 1);
+}
+
+function ignoreTelemetryError(action: () => void): void {
+  try {
+    action();
+  } catch {
+    // Telemetry is best-effort.
+  }
+}
+
+function anonymousId(storage: Storage): Effect.Effect<string> {
+  return Effect.gen(function* () {
+    const maybeId = yield* storage.global.get(ANONYMOUS_ID_KEY);
+    if (Option.isSome(maybeId)) return maybeId.value;
+
+    const newId = crypto.randomUUID();
+    yield* storage.global.set(ANONYMOUS_ID_KEY, newId).pipe(Effect.ignore);
+    return newId;
+  }).pipe(Effect.orElseSucceed(() => "unknown"));
+}

--- a/extension/src/telemetry/Telemetry.ts
+++ b/extension/src/telemetry/Telemetry.ts
@@ -67,29 +67,11 @@ export class Telemetry extends Effect.Service<Telemetry>()("Telemetry", {
     );
     const distinctId = yield* anonymousId(storage);
 
-    const sentry = yield* acquireSentryAdapter({
-      appHost: code.env.appHost,
-      appName: code.env.appName,
-      machineId: code.env.machineId,
-      extensionVersion,
-    }).pipe(
-      Effect.catchAllCause((cause) =>
-        Effect.logWarning("Failed to initialize Sentry telemetry").pipe(
-          Effect.annotateLogs({ cause }),
-          Effect.as(NOOP_SENTRY),
-        ),
-      ),
-    );
-    const posthog = yield* acquirePostHogAdapter.pipe(
-      Effect.catchAllCause((cause) =>
-        Effect.logWarning("Failed to initialize PostHog telemetry").pipe(
-          Effect.annotateLogs({ cause }),
-          Effect.as(NOOP_POSTHOG),
-        ),
-      ),
-    );
-
-    const sender = makeTelemetrySender(sentry, posthog, distinctId);
+    const adapters = {
+      sentry: NOOP_SENTRY,
+      posthog: NOOP_POSTHOG,
+    };
+    const sender = makeTelemetrySender(adapters, distinctId);
     const maybeLogger = yield* code.env
       .createTelemetryLogger(sender, {
         additionalCommonProperties: {
@@ -109,6 +91,29 @@ export class Telemetry extends Effect.Service<Telemetry>()("Telemetry", {
       );
     if (Option.isNone(maybeLogger)) return disabledTelemetry();
     const logger = maybeLogger.value;
+
+    adapters.sentry = yield* acquireSentryAdapter({
+      appHost: code.env.appHost,
+      appName: code.env.appName,
+      machineId: code.env.machineId,
+      extensionVersion,
+    }).pipe(
+      Effect.catchAllCause((cause) =>
+        Effect.logWarning("Failed to initialize Sentry telemetry").pipe(
+          Effect.annotateLogs({ cause }),
+          Effect.as(NOOP_SENTRY),
+        ),
+      ),
+    );
+    adapters.posthog = yield* acquirePostHogAdapter.pipe(
+      Effect.catchAllCause((cause) =>
+        Effect.logWarning("Failed to initialize PostHog telemetry").pipe(
+          Effect.annotateLogs({ cause }),
+          Effect.as(NOOP_POSTHOG),
+        ),
+      ),
+    );
+
     const errorLogger = makeEffectErrorLogger(logger);
 
     const usage = (event: string, data?: Record<string, unknown>) =>
@@ -118,7 +123,12 @@ export class Telemetry extends Effect.Service<Telemetry>()("Telemetry", {
 
     const binaryResolved = (binary: ResolvedBinary): Effect.Effect<void> =>
       Effect.sync(() => {
-        sentry.setBinaryVersion(binary.server, binary.version);
+        ignoreTelemetryError(() => {
+          logger.logError("marimo.binary.resolved", {
+            server: binary.server,
+            version: binary.version,
+          });
+        });
         ignoreTelemetryError(() => {
           if (binary.server === "uv") {
             logger.logUsage("uv_init", {
@@ -173,27 +183,40 @@ function disabledTelemetry() {
 }
 
 function makeTelemetrySender(
-  sentry: SentryAdapter,
-  posthog: PostHogAdapter,
+  adapters: {
+    readonly sentry: SentryAdapter;
+    readonly posthog: PostHogAdapter;
+  },
   distinctId: string,
 ): vscode.TelemetrySender {
   return {
     sendEventData(eventName, data) {
       const event = unprefixEventName(eventName);
       if (event === "marimo.log.info") {
-        sentry.addBreadcrumb(String(data?.message ?? ""), "info", data);
+        adapters.sentry.addBreadcrumb(String(data?.message ?? ""), "info");
         return;
       }
       if (event === "marimo.log.warning") {
-        sentry.addBreadcrumb(String(data?.message ?? ""), "warning", data);
+        adapters.sentry.addBreadcrumb(String(data?.message ?? ""), "warning");
+        return;
+      }
+      if (event === "marimo.binary.resolved") {
+        const server = data?.server;
+        const version = data?.version;
+        if (
+          (server === "uv" || server === "ruff" || server === "ty") &&
+          typeof version === "string"
+        ) {
+          adapters.sentry.setBinaryVersion(server, version);
+        }
         return;
       }
       ignoreTelemetryError(() => {
-        posthog.capture({ distinctId, event, properties: data });
+        adapters.posthog.capture({ distinctId, event, properties: data });
       });
     },
     sendErrorData(error, data) {
-      sentry.captureError(restoreErrorCause(error, data), data);
+      adapters.sentry.captureError(restoreErrorCause(error, data), data);
     },
   };
 }
@@ -258,21 +281,21 @@ function makeEffectErrorLogger(logger: vscode.TelemetryLogger) {
         .join("\n");
       const cause = findCause(options.cause, options.annotations, messages);
       if (!Cause.isEmpty(cause) && Cause.isInterruptedOnly(cause)) return;
-      const data = logData(options.annotations, cause);
 
       if (
         options.logLevel === LogLevel.Error ||
         options.logLevel === LogLevel.Fatal
       ) {
+        const data = logData(options.annotations, cause);
         logger.logError(errorFromCause(cause, message), {
           ...data,
           "error.level":
             options.logLevel === LogLevel.Fatal ? "fatal" : "error",
         });
       } else if (options.logLevel === LogLevel.Warning) {
-        logger.logError("marimo.log.warning", { message, ...data });
+        logger.logError("marimo.log.warning", { message });
       } else if (options.logLevel === LogLevel.Info) {
-        logger.logError("marimo.log.info", { message, ...data });
+        logger.logError("marimo.log.info", { message });
       }
     } catch {
       // Logging must not be able to fail an application fiber.

--- a/extension/src/telemetry/__tests__/Telemetry.test.ts
+++ b/extension/src/telemetry/__tests__/Telemetry.test.ts
@@ -212,6 +212,8 @@ it.scoped(
     yield* ctx.telemetry.notebookCreated();
     expect(posthog.capture).not.toHaveBeenCalled();
     expect(sentrySdk.captureException).not.toHaveBeenCalled();
+    expect(sentrySdk.init).not.toHaveBeenCalled();
+    expect(posthog.constructed).not.toHaveBeenCalled();
   }),
 );
 
@@ -397,7 +399,7 @@ it.scoped(
 );
 
 it.scoped(
-  "keeps diagnostic breadcrumbs in VS Code error-only mode",
+  "keeps message-only breadcrumbs in VS Code error-only mode",
   Effect.fn(function* () {
     const ctx = yield* withTestCtx({
       usageEnabled: false,
@@ -417,7 +419,7 @@ it.scoped(
         category: "marimo",
         message: "language server retrying",
         level: "warning",
-        data: expect.objectContaining({ server: "ty", attempt: 2 }),
+        data: undefined,
       }),
       100,
     );
@@ -490,6 +492,37 @@ it.scoped(
           version: "0.15.0",
         }),
       }),
+    );
+  }),
+);
+
+it.scoped(
+  "gates binary Sentry context independently from usage events",
+  Effect.fn(function* () {
+    const errorsOnly = yield* withTestCtx({
+      usageEnabled: false,
+      errorsEnabled: true,
+    });
+    yield* errorsOnly.telemetry.binaryResolved({
+      server: "ty",
+      resolved: BinarySource.UserConfigured({ path: "/ty" }),
+      version: "0.0.63",
+    });
+    expect(sentrySdk.setTag).toHaveBeenCalledWith("ty.version", "0.0.63");
+    expect(posthog.capture).not.toHaveBeenCalled();
+
+    const usageOnly = yield* withTestCtx({
+      usageEnabled: true,
+      errorsEnabled: false,
+    });
+    yield* usageOnly.telemetry.binaryResolved({
+      server: "ty",
+      resolved: BinarySource.UserConfigured({ path: "/ty" }),
+      version: "0.0.63",
+    });
+    expect(sentrySdk.setTag).not.toHaveBeenCalled();
+    expect(posthog.capture).toHaveBeenCalledWith(
+      expect.objectContaining({ event: "lsp_binary_resolved" }),
     );
   }),
 );

--- a/extension/src/telemetry/__tests__/Telemetry.test.ts
+++ b/extension/src/telemetry/__tests__/Telemetry.test.ts
@@ -1,37 +1,61 @@
 import { expect, it } from "@effect/vitest";
-import {
-  Cause,
-  Effect,
-  Layer,
-  Logger,
-  Option,
-  Queue,
-  Redacted,
-  Stream,
-} from "effect";
+import { Cause, Effect, Layer, Logger } from "effect";
 import { vi } from "vite-plus/test";
 import type * as vscode from "vscode";
 
 import { TestExtensionContextLive } from "../../__mocks__/TestExtensionContext.ts";
 import { TestVsCode } from "../../__mocks__/TestVsCode.ts";
-import { MarimoCommandError } from "../../lsp/MarimoClient.ts";
+import { BinarySource } from "../../lib/binaryResolution.ts";
 import { Telemetry } from "../Telemetry.ts";
 
-interface TestSentryOptions {
-  readonly beforeSend: (event: Record<string, unknown>) => unknown;
-}
+const sentrySdk = vi.hoisted(() => {
+  const init = vi.fn();
+  const close = vi.fn(async () => true);
+  const setClient = vi.fn();
+  const setTags = vi.fn();
+  const setTag = vi.fn();
+  const setUser = vi.fn();
+  const addBreadcrumb = vi.fn();
+  const captureException = vi.fn();
+  const linkedErrorsIntegration = vi.fn(() => ({ name: "LinkedErrors" }));
+  const extraErrorDataIntegration = vi.fn(() => ({ name: "ExtraErrorData" }));
+  const globalClient = { name: "existing Sentry client" };
+  const globalSetClient = vi.fn();
+  const globalScope = {
+    getClient: vi.fn(() => globalClient),
+    setClient: globalSetClient,
+  };
 
-const sentrySdk = vi.hoisted(() => ({
-  init: vi.fn<(options: TestSentryOptions) => void>(),
-  setTag: vi.fn(),
-  setUser: vi.fn(),
-  close: vi.fn(async () => true),
-  captureMessage: vi.fn(),
-  addBreadcrumb: vi.fn(),
-}));
+  class Scope {
+    setClient = setClient;
+    setTags = setTags;
+    setTag = setTag;
+    setUser = setUser;
+    addBreadcrumb = addBreadcrumb;
+    captureException = captureException;
+  }
+
+  return {
+    Scope,
+    initWithoutDefaultIntegrations: init,
+    init,
+    close,
+    setClient,
+    setTags,
+    setTag,
+    setUser,
+    addBreadcrumb,
+    captureException,
+    linkedErrorsIntegration,
+    extraErrorDataIntegration,
+    getCurrentScope: vi.fn(() => globalScope),
+    globalClient,
+    globalSetClient,
+  };
+});
 
 const posthog = vi.hoisted(() => ({
-  instances: [] as Array<{ capture: ReturnType<typeof vi.fn> }>,
+  constructed: vi.fn(),
   capture: vi.fn(),
   shutdown: vi.fn(async () => undefined),
 }));
@@ -40,31 +64,102 @@ vi.mock("@sentry/node", () => sentrySdk);
 
 vi.mock("posthog-node", () => ({
   PostHog: class {
+    constructor() {
+      posthog.constructed();
+    }
     capture = posthog.capture;
     shutdown = posthog.shutdown;
   },
 }));
 
-const telemetryChange: vscode.ConfigurationChangeEvent = {
-  affectsConfiguration: (section) => section === "marimo.telemetry",
-};
+const withTestCtx = Effect.fn(function* (options?: {
+  telemetry?: boolean;
+  usageEnabled?: boolean;
+  errorsEnabled?: boolean;
+  sentryFailure?: boolean;
+  loggerFailure?: boolean;
+}) {
+  for (const mock of [
+    sentrySdk.close,
+    sentrySdk.setClient,
+    sentrySdk.setTags,
+    sentrySdk.setTag,
+    sentrySdk.setUser,
+    sentrySdk.addBreadcrumb,
+    sentrySdk.captureException,
+    sentrySdk.linkedErrorsIntegration,
+    sentrySdk.extraErrorDataIntegration,
+    sentrySdk.globalSetClient,
+    posthog.constructed,
+    posthog.capture,
+    posthog.shutdown,
+  ]) {
+    mock.mockReset();
+  }
+  sentrySdk.init.mockReset();
+  if (options?.sentryFailure) {
+    sentrySdk.init.mockImplementationOnce(() => {
+      throw new Error("sentry exploded");
+    });
+  } else {
+    sentrySdk.init.mockReturnValue({ close: sentrySdk.close });
+  }
+  sentrySdk.close.mockResolvedValue(true);
+  posthog.shutdown.mockResolvedValue(undefined);
 
-const withTestCtx = Effect.fn(function* (options?: { telemetry?: boolean }) {
-  sentrySdk.init.mockClear();
-  sentrySdk.close.mockClear();
-  sentrySdk.setTag.mockClear();
-  sentrySdk.captureMessage.mockClear();
-  sentrySdk.addBreadcrumb.mockClear();
-  posthog.capture.mockClear();
-  posthog.shutdown.mockClear();
-
-  let telemetry = options?.telemetry ?? true;
-  // A Queue (not a PubSub) so events published before the service's forked
-  // fiber subscribes are buffered instead of dropped.
-  const changes = yield* Queue.unbounded<vscode.ConfigurationChangeEvent>();
+  const loggerCreated = vi.fn();
   const vscodeMock = yield* TestVsCode.make({
+    env: {
+      createTelemetryLogger(sender, loggerOptions) {
+        if (options?.loggerFailure) {
+          return Effect.die(new Error("VS Code telemetry exploded"));
+        }
+        return Effect.acquireRelease(
+          Effect.sync(() => {
+            loggerCreated();
+            const common = {
+              "common.vscodeversion": "1.100.0",
+              ...loggerOptions?.additionalCommonProperties,
+            };
+            const withCommon = (data: Record<string, unknown> = {}) => ({
+              ...data,
+              ...common,
+            });
+            const prefix = (event: string) =>
+              `marimo-team.vscode-marimo/${event}`;
+
+            return {
+              isUsageEnabled: options?.usageEnabled ?? true,
+              isErrorsEnabled: options?.errorsEnabled ?? true,
+              onDidChangeEnableStates: () => ({ dispose() {} }),
+              logUsage(event, data) {
+                if (options?.usageEnabled === false) return;
+                sender.sendEventData(prefix(event), withCommon(data));
+              },
+              logError(eventOrError, data) {
+                if (options?.errorsEnabled === false) return;
+                if (typeof eventOrError === "string") {
+                  sender.sendEventData(prefix(eventOrError), withCommon(data));
+                  return;
+                }
+                const cleanedError = new Error(eventOrError.message, {
+                  cause:
+                    eventOrError.cause instanceof Error
+                      ? {}
+                      : eventOrError.cause,
+                });
+                cleanedError.name = eventOrError.name;
+                cleanedError.stack = eventOrError.stack;
+                sender.sendErrorData(cleanedError, withCommon(data));
+              },
+              dispose() {},
+            } satisfies vscode.TelemetryLogger;
+          }),
+          (logger) => Effect.sync(() => logger.dispose()),
+        );
+      },
+    },
     workspace: {
-      configurationChanges: () => Stream.fromQueue(changes),
       getConfiguration: (section) =>
         Effect.succeed({
           // oxlint-disable-next-line typescript/no-unnecessary-type-parameters
@@ -72,7 +167,7 @@ const withTestCtx = Effect.fn(function* (options?: { telemetry?: boolean }) {
             // oxlint-disable-next-line typescript/no-unsafe-type-assertion
             return (
               section === "marimo" && key === "telemetry"
-                ? telemetry
+                ? (options?.telemetry ?? true)
                 : defaultValue
             ) as T;
           },
@@ -92,296 +187,83 @@ const withTestCtx = Effect.fn(function* (options?: { telemetry?: boolean }) {
 
   return {
     telemetry: yield* Telemetry.pipe(Effect.provide(context)),
-    setTelemetry: (value: boolean) =>
-      Effect.suspend(() => {
-        telemetry = value;
-        return Queue.offer(changes, telemetryChange);
-      }),
+    loggerCreated,
   };
 });
 
-const waitFor = (assertion: () => void) =>
-  Effect.promise(() => vi.waitFor(assertion));
+it.scoped(
+  "does not acquire telemetry resources when disabled",
+  Effect.fn(function* () {
+    const ctx = yield* withTestCtx({ telemetry: false });
 
-it.scoped("releases both sinks on consent loss and re-acquires them", () =>
-  Effect.gen(function* () {
-    const ctx = yield* withTestCtx();
-    expect(sentrySdk.init).toHaveBeenCalledTimes(1);
-    // Activation event goes to PostHog on acquire
-    expect(posthog.capture).toHaveBeenCalledWith(
-      expect.objectContaining({ event: "extension_activated" }),
-    );
-
-    yield* ctx.setTelemetry(false);
-    yield* waitFor(() => expect(sentrySdk.close).toHaveBeenCalledTimes(1));
-    expect(posthog.shutdown).toHaveBeenCalledTimes(1);
-
-    yield* ctx.setTelemetry(true);
-    yield* waitFor(() => expect(sentrySdk.init).toHaveBeenCalledTimes(2));
+    expect(ctx.loggerCreated).not.toHaveBeenCalled();
+    expect(sentrySdk.init).not.toHaveBeenCalled();
+    expect(posthog.constructed).not.toHaveBeenCalled();
+    yield* ctx.telemetry.notebookCreated();
+    expect(posthog.capture).not.toHaveBeenCalled();
   }),
 );
 
 it.scoped(
-  "a sink that throws neither fails construction nor kills consent tracking",
-  () =>
-    Effect.gen(function* () {
-      sentrySdk.init.mockImplementationOnce(() => {
-        throw new Error("sentry exploded");
-      });
+  "does not fail activation when VS Code telemetry fails",
+  Effect.fn(function* () {
+    const ctx = yield* withTestCtx({ loggerFailure: true });
 
-      // Consent is on but acquisition fails: construction must survive
-      // and capture must degrade to a no-op.
-      const ctx = yield* withTestCtx();
-      yield* ctx.telemetry.capture("new_notebook_created");
-      expect(posthog.capture).not.toHaveBeenCalled();
-
-      // The consent watcher must still be alive: toggling off and on
-      // re-acquires the sinks now that the SDK behaves again.
-      yield* ctx.setTelemetry(false);
-      yield* ctx.setTelemetry(true);
-      yield* waitFor(() => expect(sentrySdk.init).toHaveBeenCalledTimes(2));
-
-      yield* ctx.telemetry.capture("new_notebook_created");
-      expect(posthog.capture).toHaveBeenCalledWith(
-        expect.objectContaining({ event: "new_notebook_created" }),
-      );
-    }),
+    yield* ctx.telemetry.notebookCreated();
+    expect(posthog.capture).not.toHaveBeenCalled();
+    expect(sentrySdk.captureException).not.toHaveBeenCalled();
+  }),
 );
 
-it.scoped("capture is a no-op without consent, live with it", () =>
-  Effect.gen(function* () {
-    const ctx = yield* withTestCtx({ telemetry: false });
-    expect(sentrySdk.init).not.toHaveBeenCalled();
+it.scoped(
+  "routes stable product events through VS Code",
+  Effect.fn(function* () {
+    const ctx = yield* withTestCtx();
 
-    yield* ctx.telemetry.capture("new_notebook_created");
-    expect(posthog.capture).not.toHaveBeenCalled();
+    expect(posthog.capture).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: "extension_activated",
+        properties: expect.objectContaining({
+          extension_version: expect.any(String),
+          "common.vscodeversion": "1.100.0",
+        }),
+      }),
+    );
 
-    yield* ctx.setTelemetry(true);
-    yield* waitFor(() => expect(sentrySdk.init).toHaveBeenCalledTimes(1));
-
-    yield* ctx.telemetry.capture("new_notebook_created");
+    yield* ctx.telemetry.notebookCreated();
     expect(posthog.capture).toHaveBeenCalledWith(
       expect.objectContaining({ event: "new_notebook_created" }),
     );
-  }),
-);
-
-it.scoped("contains synchronous capture failures", () =>
-  Effect.gen(function* () {
-    const ctx = yield* withTestCtx();
-    posthog.capture.mockClear();
-    posthog.capture.mockImplementationOnce(() => {
-      throw new Error("posthog exploded");
-    });
-
-    // Reporting failures must not escape into the product effect.
-    yield* ctx.telemetry.capture("new_notebook_created");
-    expect(posthog.capture).toHaveBeenCalledTimes(1);
-
-    // A failed capture does not disable later telemetry.
-    yield* ctx.telemetry.capture("new_notebook_created");
-    expect(posthog.capture).toHaveBeenCalledTimes(2);
-  }),
-);
-
-it.scoped("redacts user data from classified and unexpected errors", () =>
-  Effect.gen(function* () {
-    const ctx = yield* withTestCtx();
-    const source = "DO_NOT_UPLOAD_123 = 'notebook source'";
-    const secondCell = "print('DO_NOT_UPLOAD_SECOND_CELL')";
-    const localPath = "/Users/alice/private/customer-notebook.py";
-    const environmentSecret = "DO_NOT_UPLOAD_API_TOKEN";
-    const commandError = new MarimoCommandError({
-      command: Redacted.make({
-        command: "marimo.api",
-        params: {
-          method: "execute-cells",
-          params: {
-            notebookUri: `file://${localPath}`,
-            executable: "/private/venv/bin/python",
-            workingDirectory: "/Users/alice/private",
-            inner: { cellIds: ["one", "two"], codes: [source, secondCell] },
-          },
-        },
+    expect(sentrySdk.init).toHaveBeenCalledWith(
+      expect.objectContaining({
+        skipOpenTelemetrySetup: true,
+        normalizeDepth: 8,
       }),
-      cause: {
-        name: "ResponseError",
-        code: -32603,
-        message: source,
-        stack: `ResponseError: ${source}\n    at rpcDispatch (${localPath}:1:1)`,
-      },
-    });
-    commandError.stack = `MarimoCommandError: ${source}\n    at deserialize (${localPath}:1:1)`;
-    const unexpected = {
-      name: "UnexpectedConverterError",
-      message: source,
-      data: { source, environment: { API_TOKEN: environmentSecret } },
-      stack: `UnexpectedConverterError: ${source}\n    at convert (${localPath}:1:1)`,
-    };
-    const cause = Cause.parallel(
-      Cause.fail(commandError),
-      Cause.die(unexpected),
     );
-
-    yield* Effect.logError(source).pipe(
-      Effect.annotateLogs({
-        cause,
-        "error.tag": "MarimoCommandError",
-        rawCells: [source, secondCell],
-        environment: { API_TOKEN: environmentSecret },
-        notebookUri: localPath,
-      }),
-      Effect.provide(
-        Logger.replace(Logger.defaultLogger, ctx.telemetry.errorLogger),
-      ),
+    expect(sentrySdk.globalSetClient).toHaveBeenCalledWith(
+      sentrySdk.globalClient,
     );
-    yield* Effect.logWarning(source).pipe(
-      Effect.annotateLogs({ rawCells: [source], notebookUri: localPath }),
-      Effect.provide(
-        Logger.replace(Logger.defaultLogger, ctx.telemetry.errorLogger),
-      ),
-    );
-
-    const payload = JSON.stringify({
-      events: sentrySdk.captureMessage.mock.calls,
-      breadcrumbs: sentrySdk.addBreadcrumb.mock.calls,
-    });
-    expect(payload).not.toContain(source);
-    expect(payload).not.toContain(secondCell);
-    expect(payload).not.toContain(localPath);
-    expect(payload).not.toContain(environmentSecret);
-    expect(sentrySdk.captureMessage.mock.calls).toMatchInlineSnapshot(`
-      [
-        [
-          "marimo extension error",
-          {
-            "extra": {
-              "cause": {
-                "defects": [
-                  {
-                    "exceptionClass": "UnexpectedConverterError",
-                  },
-                ],
-                "failures": [
-                  {
-                    "exceptionClass": "MarimoCommandError",
-                  },
-                ],
-              },
-              "error.tag": "MarimoCommandError",
-            },
-            "fingerprint": [
-              "marimo extension error",
-              "MarimoCommandError",
-            ],
-            "level": "error",
-            "tags": {
-              "error.tag": "MarimoCommandError",
-              "marimo": "true",
-            },
-          },
-        ],
-      ]
-    `);
   }),
 );
 
-it.scoped("retains safe diagnostics from Cause log messages", () =>
-  Effect.gen(function* () {
+it.scoped(
+  "preserves Error type, trace, cause, and structured diagnostics",
+  Effect.fn(function* () {
     const ctx = yield* withTestCtx();
-    const secret = "DO_NOT_UPLOAD_CAUSE_MESSAGE";
-
-    yield* Effect.logError(
-      Cause.fail({ name: "ResponseError", code: -32603, message: secret }),
-    ).pipe(
-      Effect.provide(
-        Logger.replace(Logger.defaultLogger, ctx.telemetry.errorLogger),
-      ),
+    const inner = new Error("invalid wire type");
+    const error = Object.assign(
+      new Error("Failed to decode notebook response", { cause: inner }),
+      { stderr: "converter exited with code 2" },
     );
-
-    const payload = sentrySdk.captureMessage.mock.calls[0]?.[1];
-    expect(payload?.extra).toEqual({
-      "logger.cause": {
-        failures: [{ exceptionClass: "ResponseError", rpcCode: -32603 }],
-        defects: [],
-      },
-    });
-    expect(JSON.stringify(payload)).not.toContain(secret);
-  }),
-);
-
-it.scoped("sanitizes SDK events at the final Sentry boundary", () =>
-  Effect.gen(function* () {
-    yield* withTestCtx();
-    const secret = "DO_NOT_UPLOAD_BEFORE_SEND";
-    const localPath = "/Users/alice/private/customer-notebook.py";
-    const initOptions = Option.getOrThrow(
-      Option.fromNullable(sentrySdk.init.mock.calls[0]?.[0]),
-    );
-
-    const result = initOptions.beforeSend({
-      message: secret,
-      request: { data: secret },
-      contexts: { private: { secret } },
-      server_name: secret,
-      extra: {
-        "error.domain": "notebook.deserialize",
-        private: secret,
-      },
-      logentry: { message: secret },
-      exception: {
-        values: [
-          {
-            type: "ResponseError",
-            value: secret,
-            stacktrace: {
-              frames: [
-                {
-                  filename: `/marimo${localPath}`,
-                  abs_path: localPath,
-                  function: "customerFunction",
-                  module: "customerModule",
-                  context_line: secret,
-                  vars: { secret },
-                  lineno: 7,
-                },
-              ],
-            },
-          },
-        ],
-      },
-    });
-
-    const payload = JSON.stringify(result);
-    expect(payload).not.toContain(secret);
-    expect(payload).not.toContain("customer-notebook.py");
-    expect(payload).not.toContain("customerFunction");
-    expect(result).toMatchObject({
-      message: "marimo extension error",
-      extra: { "error.domain": "notebook.deserialize" },
-      exception: {
-        values: [
-          {
-            type: "ResponseError",
-            value: "marimo extension error",
-            stacktrace: { frames: [{ lineno: 7 }] },
-          },
-        ],
-      },
-    });
-  }),
-);
-
-it.scoped("groups notebook deserialize failures by safe classification", () =>
-  Effect.gen(function* () {
-    const ctx = yield* withTestCtx();
+    error.name = "UnexpectedConverterError";
+    error.stack = `${error.name}: ${error.message}\n    at convert (extension.js:7:3)`;
 
     yield* Effect.logError("Notebook deserialize failed").pipe(
       Effect.annotateLogs({
+        cause: Cause.fail(error),
         "error.domain": "notebook.deserialize",
         "error.kind": "rpc.internal",
-        "error.exception_class": "ResponseError",
-        "rpc.method": "deserialize",
+        "error.exception_class": "UnexpectedConverterError",
         "rpc.code": -32603,
       }),
       Effect.provide(
@@ -389,43 +271,253 @@ it.scoped("groups notebook deserialize failures by safe classification", () =>
       ),
     );
 
-    expect(sentrySdk.captureMessage).toHaveBeenCalledWith(
-      "marimo extension error",
+    const [captured, hint] = sentrySdk.captureException.mock.calls[0];
+    expect(captured).not.toBe(error);
+    expect(captured.cause).not.toBe(inner);
+    expect(captured).toMatchObject({
+      name: "UnexpectedConverterError",
+      message: "Failed to decode notebook response",
+      stderr: "converter exited with code 2",
+      cause: {
+        name: "Error",
+        message: "invalid wire type",
+      },
+    });
+    expect(captured.stack).toContain("at convert");
+    expect(hint.captureContext).toMatchObject({
+      fingerprint: [
+        "notebook.deserialize",
+        "rpc.internal",
+        "-32603",
+        "UnexpectedConverterError",
+      ],
+      tags: {
+        "error.domain": "notebook.deserialize",
+        "error.kind": "rpc.internal",
+        "error.exception_class": "UnexpectedConverterError",
+        "rpc.code": "-32603",
+      },
+      extra: {
+        cause: {
+          failures: [
+            {
+              name: "UnexpectedConverterError",
+              message: "Failed to decode notebook response",
+              stack: expect.stringContaining("at convert"),
+              stderr: "converter exited with code 2",
+              cause: {
+                name: "Error",
+                message: "invalid wire type",
+              },
+            },
+          ],
+        },
+      },
+    });
+  }),
+);
+
+it.scoped(
+  "retains non-Error Effect failures",
+  Effect.fn(function* () {
+    const ctx = yield* withTestCtx();
+
+    yield* Effect.logError(Cause.fail("uv exited with code 2")).pipe(
+      Effect.provide(
+        Logger.replace(Logger.defaultLogger, ctx.telemetry.errorLogger),
+      ),
+    );
+
+    const [error, hint] = sentrySdk.captureException.mock.calls[0];
+    expect(error).toMatchObject({
+      name: "UnknownFailure",
+      message: "uv exited with code 2",
+    });
+    expect(hint.captureContext.extra.cause.failures).toEqual([
+      "uv exited with code 2",
+    ]);
+  }),
+);
+
+it.scoped(
+  "uses log context when the native Error message is not diagnostic",
+  Effect.fn(function* () {
+    const ctx = yield* withTestCtx();
+    const timeout = new Cause.TimeoutException();
+
+    yield* Effect.logError("Notebook deserialize failed").pipe(
+      Effect.annotateLogs({ cause: Cause.fail(timeout) }),
+      Effect.provide(
+        Logger.replace(Logger.defaultLogger, ctx.telemetry.errorLogger),
+      ),
+    );
+
+    const [captured] = sentrySdk.captureException.mock.calls[0];
+    expect(captured).toMatchObject({
+      name: "TimeoutException",
+      message: "Notebook deserialize failed",
+    });
+    expect(captured.stack).toContain(
+      "TimeoutException: Notebook deserialize failed",
+    );
+
+    sentrySdk.captureException.mockClear();
+    const generic = new Error("An error has occurred");
+    generic.name = "UvExecutionError";
+    yield* Effect.logError("uv command failed").pipe(
+      Effect.annotateLogs({ cause: Cause.fail(generic) }),
+      Effect.provide(
+        Logger.replace(Logger.defaultLogger, ctx.telemetry.errorLogger),
+      ),
+    );
+
+    expect(sentrySdk.captureException.mock.calls[0]?.[0]).toMatchObject({
+      name: "UvExecutionError",
+      message: "uv command failed",
+    });
+  }),
+);
+
+it.scoped(
+  "keeps error-tag fingerprint grouping",
+  Effect.fn(function* () {
+    const ctx = yield* withTestCtx();
+
+    yield* Effect.logError("Notebook serialization failed").pipe(
+      Effect.annotateLogs({ "error.tag": "NotebookSerializeError" }),
+      Effect.provide(
+        Logger.replace(Logger.defaultLogger, ctx.telemetry.errorLogger),
+      ),
+    );
+
+    expect(
+      sentrySdk.captureException.mock.calls[0]?.[1].captureContext.fingerprint,
+    ).toEqual(["marimo extension error", "NotebookSerializeError"]);
+  }),
+);
+
+it.scoped(
+  "keeps diagnostic breadcrumbs in VS Code error-only mode",
+  Effect.fn(function* () {
+    const ctx = yield* withTestCtx({
+      usageEnabled: false,
+      errorsEnabled: true,
+    });
+    expect(posthog.capture).not.toHaveBeenCalled();
+
+    yield* Effect.logWarning("language server retrying").pipe(
+      Effect.annotateLogs({ server: "ty", attempt: 2 }),
+      Effect.provide(
+        Logger.replace(Logger.defaultLogger, ctx.telemetry.errorLogger),
+      ),
+    );
+
+    expect(sentrySdk.addBreadcrumb).toHaveBeenCalledWith(
       expect.objectContaining({
-        fingerprint: [
-          "notebook.deserialize",
-          "rpc.internal",
-          "-32603",
-          "ResponseError",
-        ],
-        tags: expect.objectContaining({
-          "error.domain": "notebook.deserialize",
-          "error.kind": "rpc.internal",
-          "rpc.method": "deserialize",
-          "rpc.code": "-32603",
+        category: "marimo",
+        message: "language server retrying",
+        level: "warning",
+        data: expect.objectContaining({ server: "ty", attempt: 2 }),
+      }),
+      100,
+    );
+  }),
+);
+
+it.scoped(
+  "respects VS Code error gating independently",
+  Effect.fn(function* () {
+    const ctx = yield* withTestCtx({
+      usageEnabled: true,
+      errorsEnabled: false,
+    });
+
+    yield* Effect.logError("language server failed").pipe(
+      Effect.provide(
+        Logger.replace(Logger.defaultLogger, ctx.telemetry.errorLogger),
+      ),
+    );
+
+    expect(posthog.capture).toHaveBeenCalledWith(
+      expect.objectContaining({ event: "extension_activated" }),
+    );
+    expect(sentrySdk.captureException).not.toHaveBeenCalled();
+  }),
+);
+
+it.scoped(
+  "reports each resolved binary once with exact version context",
+  Effect.fn(function* () {
+    const ctx = yield* withTestCtx();
+    posthog.capture.mockClear();
+
+    yield* ctx.telemetry.binaryResolved({
+      server: "uv",
+      source: "Bundled",
+      version: "0.8.3 (abc123 2026-08-03)",
+    });
+    expect(sentrySdk.setTag).toHaveBeenCalledWith(
+      "uv.version",
+      "0.8.3 (abc123 2026-08-03)",
+    );
+    expect(posthog.capture).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: "uv_init",
+        properties: expect.objectContaining({
+          binType: "Bundled",
+          version: "0.8.3 (abc123 2026-08-03)",
+        }),
+      }),
+    );
+
+    yield* ctx.telemetry.binaryResolved({
+      server: "ruff",
+      resolved: BinarySource.CompanionExtension({
+        extensionId: "charliermarsh.ruff",
+        path: "/ruff",
+        kind: "bundled",
+      }),
+      version: "0.15.0",
+    });
+    expect(sentrySdk.setTag).toHaveBeenCalledWith("ruff.version", "0.15.0");
+    expect(posthog.capture).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: "lsp_binary_resolved",
+        properties: expect.objectContaining({
+          server: "ruff",
+          source: "CompanionExtension",
+          kind: "bundled",
+          version: "0.15.0",
         }),
       }),
     );
   }),
 );
 
-it.scoped("does not retain error annotations created without consent", () =>
-  Effect.gen(function* () {
-    const ctx = yield* withTestCtx({ telemetry: false });
+it.scoped(
+  "contains independent vendor failures",
+  Effect.fn(function* () {
+    const ctx = yield* withTestCtx({ sentryFailure: true });
 
-    yield* ctx.telemetry.annotateErrors({ "uv.version": "off" });
-    expect(sentrySdk.setTag).not.toHaveBeenCalled();
+    yield* ctx.telemetry.notebookCreated();
+    expect(posthog.capture).toHaveBeenCalledWith(
+      expect.objectContaining({ event: "new_notebook_created" }),
+    );
 
-    yield* ctx.setTelemetry(true);
-    yield* waitFor(() => expect(sentrySdk.init).toHaveBeenCalledTimes(1));
-    sentrySdk.setTag.mockClear();
-    yield* ctx.telemetry.annotateErrors({ "uv.version": "on" });
-    expect(sentrySdk.setTag).toHaveBeenCalledWith("uv.version", "on");
+    posthog.capture.mockImplementationOnce(() => {
+      throw new Error("posthog exploded");
+    });
+    yield* ctx.telemetry.notebookCreated();
+    yield* ctx.telemetry.notebookCreated();
+    expect(posthog.capture).toHaveBeenCalledTimes(4);
+  }),
+);
 
-    yield* ctx.setTelemetry(false);
-    yield* waitFor(() => expect(sentrySdk.close).toHaveBeenCalledTimes(1));
-    sentrySdk.setTag.mockClear();
-    yield* ctx.telemetry.annotateErrors({ "uv.version": "off-again" });
-    expect(sentrySdk.setTag).not.toHaveBeenCalled();
+it.effect(
+  "closes both private adapters with the extension scope",
+  Effect.fn(function* () {
+    yield* Effect.scoped(withTestCtx());
+    expect(sentrySdk.close).toHaveBeenCalledTimes(1);
+    expect(posthog.shutdown).toHaveBeenCalledTimes(1);
   }),
 );

--- a/extension/src/telemetry/posthogSink.ts
+++ b/extension/src/telemetry/posthogSink.ts
@@ -4,44 +4,26 @@ import { PostHog } from "posthog-node";
 // Public API key (not a secret)
 const API_KEY = "phc_wT21gBodGcVJINBFaEQEtRjZjvn1rChAg8hDvCopAFe";
 
-export interface PostHogSinkOptions {
-  readonly distinctId: string;
-  readonly extensionVersion: string;
-  readonly appName: string;
-  readonly appHost: string;
+export interface PostHogAdapter {
+  readonly capture: PostHog["capture"];
 }
 
-/**
- * PostHog sink: product events for the Telemetry facade.
- *
- * Acquiring creates the client and records activation; releasing flushes and
- * shuts it down. The returned client is only valid while the sink's scope is
- * open — the facade drops its reference on release.
- */
-export const acquirePostHogSink = Effect.fn("telemetry.acquirePostHogSink")(
-  function* (options: PostHogSinkOptions) {
-    const client = yield* Effect.acquireRelease(
-      Effect.sync(
-        () =>
-          new PostHog(API_KEY, {
-            host: "https://us.i.posthog.com",
-          }),
-      ),
-      (client) => Effect.promise(async () => client.shutdown()),
-    );
-
-    // Track extension activation
-    client.capture({
-      distinctId: options.distinctId,
-      event: "extension_activated",
-      properties: {
-        extension_version: options.extensionVersion,
-        app_name: options.appName,
-        app_host: options.appHost,
-      },
-    });
-    yield* Effect.logDebug("Anonymous telemetry enabled");
-
-    return client;
-  },
+/** Private PostHog delivery adapter owned by the Telemetry scope. */
+export const acquirePostHogAdapter = Effect.acquireRelease(
+  Effect.sync(
+    () =>
+      new PostHog(API_KEY, {
+        host: "https://us.i.posthog.com",
+      }),
+  ),
+  (client) =>
+    Effect.promise(() => client.shutdown()).pipe(
+      Effect.catchAllCause(() => Effect.void),
+    ),
+).pipe(
+  Effect.map(
+    (client): PostHogAdapter => ({
+      capture: client.capture.bind(client),
+    }),
+  ),
 );

--- a/extension/src/telemetry/sentrySink.ts
+++ b/extension/src/telemetry/sentrySink.ts
@@ -1,403 +1,153 @@
 import * as SentrySDK from "@sentry/node";
-import {
-  Cause,
-  Effect,
-  HashMap,
-  Logger,
-  LogLevel,
-  MutableRef,
-  Array as ReadonlyArray,
-} from "effect";
+import { Effect } from "effect";
 
-// This is a public DSN
+// Public DSN (not a secret)
 const SENTRY_DSN =
   "https://717e07e6f9831ef39f872ab4a7a63dc2@o4505919839862784.ingest.us.sentry.io/4510382050770944";
-const SENTRY_MESSAGE = "marimo extension error";
 
-export interface SentrySinkOptions {
+export interface SentryAdapter {
+  readonly captureError: (error: Error, data?: Record<string, unknown>) => void;
+  readonly addBreadcrumb: (
+    message: string,
+    level: "info" | "warning",
+    data?: Record<string, unknown>,
+  ) => void;
+  readonly setBinaryVersion: (
+    server: "ruff" | "ty" | "uv",
+    version: string,
+  ) => void;
+}
+
+export interface SentryAdapterOptions {
   readonly appHost: string;
   readonly appName: string;
   readonly machineId: string;
   readonly extensionVersion: string;
 }
 
-/**
- * Sentry sink: error reporting for the Telemetry facade.
- *
- * Acquiring initializes the SDK; releasing first disables this sink, then
- * flushes and closes it. Annotation and logger calls check the sink's active
- * state, so callers never need to check consent.
- */
-export function makeSentrySink() {
-  const active = MutableRef.make(false);
+/** Private Sentry delivery adapter owned by the Telemetry scope. */
+export const acquireSentryAdapter = Effect.fn("telemetry.acquireSentryAdapter")(
+  function* (options: SentryAdapterOptions) {
+    const scope = new SentrySDK.Scope();
+    scope.setTags({
+      marimo: "true",
+      "editor.appHost": options.appHost,
+      "editor.appName": options.appName,
+      "extension.version": options.extensionVersion,
+    });
+    scope.setUser({ id: options.machineId });
 
-  const acquire = Effect.fn("telemetry.acquireSentrySink")(function* (
-    options: SentrySinkOptions,
-  ) {
     yield* Effect.acquireRelease(
-      Effect.sync(() =>
-        SentrySDK.init({
-          dsn: SENTRY_DSN,
-          release: `vscode-marimo@${options.extensionVersion}`,
-          environment: process.env.NODE_ENV ?? "production",
-          // Disable automatic capture of unhandled errors
-          integrations: (integrations) => {
-            return integrations.filter((integration) => {
-              // Filter out integrations that automatically capture unhandled errors
-              return (
-                integration.name !== "OnUncaughtException" &&
-                integration.name !== "OnUnhandledRejection"
-              );
-            });
-          },
-          // Only capture errors that originate from this extension
-          beforeSend(event) {
-            // Filter out errors from other extensions by checking stack traces
-            const frames = event.exception?.values?.[0]?.stacktrace?.frames;
-            if (frames && frames.length > 0) {
-              if (!isMarimoStackTrace(frames)) {
-                return null;
-              }
-            }
-
-            // Filter out errors that contain stack traces from other extensions in the message
-            const message =
-              event.message ||
-              event.exception?.values?.[0]?.value ||
-              event.logentry?.message;
-            if (message && shouldFilterMessage(message)) {
-              return null;
-            }
-
-            return sanitizeSentryEvent(event);
-          },
-          beforeBreadcrumb(breadcrumb) {
-            if (breadcrumb.category === "marimo") {
-              return {
-                category: breadcrumb.category,
-                level: breadcrumb.level,
-                message: breadcrumb.message,
-                data: sanitizeTelemetryExtra(breadcrumb.data),
-              };
-            }
-            return {
-              category: breadcrumb.category,
-              level: breadcrumb.level,
-              message: "external breadcrumb",
-            };
-          },
-        }),
-      ),
-      () =>
-        Effect.gen(function* () {
-          MutableRef.set(active, false);
-          yield* Effect.promise(async () => {
-            await SentrySDK.close(2000);
+      Effect.sync(() => {
+        const globalScope = SentrySDK.getCurrentScope();
+        const previousClient = globalScope.getClient();
+        let client;
+        try {
+          client = SentrySDK.initWithoutDefaultIntegrations({
+            dsn: SENTRY_DSN,
+            release: `vscode-marimo@${options.extensionVersion}`,
+            environment: process.env.NODE_ENV ?? "production",
+            skipOpenTelemetrySetup: true,
+            normalizeDepth: 8,
+            integrations: [
+              SentrySDK.linkedErrorsIntegration(),
+              SentrySDK.extraErrorDataIntegration(),
+            ],
           });
-        }),
+        } finally {
+          globalScope.setClient(previousClient);
+        }
+        if (!client) throw new Error("Sentry failed to initialize");
+        try {
+          scope.setClient(client);
+        } catch (error) {
+          void client.close(2000);
+          throw error;
+        }
+        return client;
+      }),
+      (client) =>
+        Effect.promise(() => client.close(2000)).pipe(
+          Effect.catchAllCause(() => Effect.void),
+        ),
     );
 
-    // Set global context only after the close finalizer has been installed.
-    // If any SDK call throws, acquiring the surrounding scope still releases
-    // the partially initialized client.
-    SentrySDK.setTag("editor.appHost", options.appHost);
-    SentrySDK.setTag("editor.appName", options.appName);
-    SentrySDK.setTag("extension.version", options.extensionVersion);
-    SentrySDK.setUser({ id: options.machineId });
-    MutableRef.set(active, true);
-  });
-
-  /**
-   * Attach ambient context (Sentry tags) to future error reports. A no-op
-   * while the sink is released.
-   */
-  const annotateErrors = (annotations: Record<string, string>) =>
-    Effect.sync(() => {
-      if (!MutableRef.get(active)) return;
+    const captureError: SentryAdapter["captureError"] = (error, data) => {
       try {
-        for (const [key, value] of Object.entries(annotations)) {
-          if (["ruff.version", "ty.version", "uv.version"].includes(key)) {
-            SentrySDK.setTag(key, safeToken(value));
-          }
-        }
+        const classification = classify(data);
+        scope.captureException(error, {
+          captureContext: {
+            ...(data ? { extra: data } : {}),
+            level: data?.["error.level"] === "fatal" ? "fatal" : "error",
+            tags: classification.tags,
+            ...(classification.fingerprint
+              ? { fingerprint: classification.fingerprint }
+              : {}),
+          },
+        });
       } catch {
         // Telemetry must never affect product behavior.
       }
-    });
+    };
 
-  /**
-   * Error logger forwarding Effect log output to Sentry. A no-op while the
-   * sink is released.
-   */
-  const errorLogger = Logger.make((opts) => {
-    if (!MutableRef.get(active)) return;
-
-    try {
-      const messages = ReadonlyArray.ensure(opts.message);
-      const messageStr = messages
-        .filter((message): message is string => typeof message === "string")
-        .join("\n");
-
-      if (shouldFilterMessage(messageStr)) {
-        return;
+    const addBreadcrumb: SentryAdapter["addBreadcrumb"] = (
+      message,
+      level,
+      data,
+    ) => {
+      try {
+        scope.addBreadcrumb({ category: "marimo", message, level, data }, 100);
+      } catch {
+        // Telemetry must never affect product behavior.
       }
+    };
 
-      // Build extra context with annotations
-      const extra: Record<string, unknown> = {};
-      let errorTag: string | undefined;
-      let errorDomain: string | undefined;
-      let errorKind: string | undefined;
-      let rpcCode: number | undefined;
-      let exceptionClass: string | undefined;
-      for (const [key, value] of HashMap.toEntries(opts.annotations)) {
-        const safeValue = safeAnnotation(key, value);
-        if (safeValue !== undefined) extra[key] = safeValue;
-        if (key === "error.tag" && typeof value === "string") {
-          errorTag = safeToken(value);
-        }
-        if (key === "error.domain" && typeof safeValue === "string")
-          errorDomain = safeValue;
-        if (key === "error.kind" && typeof safeValue === "string")
-          errorKind = safeValue;
-        if (key === "rpc.code" && typeof safeValue === "number")
-          rpcCode = safeValue;
-        if (key === "error.exception_class" && typeof safeValue === "string")
-          exceptionClass = safeValue;
+    const setBinaryVersion: SentryAdapter["setBinaryVersion"] = (
+      server,
+      version,
+    ) => {
+      try {
+        scope.setTag(`${server}.version`, version.slice(0, 100));
+      } catch {
+        // Telemetry must never affect product behavior.
       }
+    };
 
-      // Include cause if present
-      if (!Cause.isEmpty(opts.cause)) {
-        extra["logger.cause"] = summarizeCause(opts.cause);
-      }
+    return { captureError, addBreadcrumb, setBinaryVersion };
+  },
+);
 
-      // Splitting the Sentry group by inner failure tag turns coarse
-      // "Notebook deserialize failed" buckets into one group per root
-      // cause (MarimoClientStartError vs MarimoCommandError vs ...).
-      const tags = {
-        marimo: "true",
-        ...(errorTag ? { "error.tag": errorTag } : {}),
-        ...(errorDomain ? { "error.domain": errorDomain } : {}),
-        ...(errorKind ? { "error.kind": errorKind } : {}),
-        ...(typeof extra["rpc.method"] === "string"
-          ? { "rpc.method": extra["rpc.method"] }
-          : {}),
-        ...(rpcCode === undefined ? {} : { "rpc.code": String(rpcCode) }),
-      };
-      const fingerprint =
-        errorDomain && errorKind
-          ? [
-              errorDomain,
-              errorKind,
-              ...(rpcCode === undefined ? [] : [String(rpcCode)]),
-              ...(exceptionClass ? [exceptionClass] : []),
-            ]
-          : errorTag
-            ? [SENTRY_MESSAGE, errorTag]
-            : undefined;
-
-      if (opts.logLevel === LogLevel.Error) {
-        SentrySDK.captureMessage(SENTRY_MESSAGE, {
-          extra,
-          level: "error",
-          tags,
-          fingerprint,
-        });
-      } else if (opts.logLevel === LogLevel.Fatal) {
-        SentrySDK.captureMessage(SENTRY_MESSAGE, {
-          extra,
-          level: "fatal",
-          tags,
-          fingerprint,
-        });
-      } else if (opts.logLevel === LogLevel.Warning) {
-        SentrySDK.addBreadcrumb({
-          category: "marimo",
-          message: "marimo extension warning",
-          level: "warning",
-          data: extra,
-        });
-      } else if (opts.logLevel === LogLevel.Info) {
-        SentrySDK.addBreadcrumb({
-          category: "marimo",
-          message: "marimo extension info",
-          level: "info",
-          data: extra,
-        });
-      }
-    } catch {
-      // A reporting SDK failure must not break logging or application fibers.
-    }
-  });
-
-  return { acquire, annotateErrors, errorLogger } as const;
-}
-
-function shouldFilterMessage(message: string) {
-  const lowerMessage = message.toLowerCase();
-  if (lowerMessage.includes("marimo")) {
-    return false;
-  }
-
-  // Filter noise from other extensions:
-  // - '.vscode/extensions' or '.vscode\extensions' paths
-  // - the Augment AI extension (AugmentExtensionSidecar / augmentcode.com),
-  //   which dominates this project's Sentry volume
-  return (
-    lowerMessage.includes(".vscode/extensions") ||
-    lowerMessage.includes(".vscode\\extensions") ||
-    lowerMessage.includes("augmentextensionsidecar") ||
-    lowerMessage.includes("augmentcode")
-  );
-}
-
-function isMarimoStackTrace(frames: SentrySDK.StackFrame[]) {
-  return frames.some((frame) => frame.filename?.includes("marimo"));
-}
-
-const SAFE_ANNOTATIONS = new Set([
-  "byteCount",
-  "cached",
-  "cellCount",
-  "code",
-  "count",
-  "error.domain",
-  "error.exception_class",
-  "error.kind",
-  "error.tag",
-  "fileType",
-  "kind",
-  "method",
-  "mode",
-  "rpc.code",
-  "rpc.method",
-  "server",
-  "service",
-  "status",
-  "version",
-]);
-
-function safeAnnotation(key: string, value: unknown): unknown {
-  if (key === "cause" && Cause.isCause(value)) {
-    return Cause.isEmpty(value) ? undefined : summarizeCause(value);
-  }
-  if (!SAFE_ANNOTATIONS.has(key)) return undefined;
-  if (key === "code" || key === "rpc.code")
-    return typeof value === "number" ? value : undefined;
-  if (typeof value === "number" || typeof value === "boolean") return value;
-  return typeof value === "string" ? safeToken(value) : undefined;
-}
-
-function summarizeCause(cause: Cause.Cause<unknown>): unknown {
-  return {
-    failures: [...Cause.failures(cause)]
-      .slice(0, 3)
-      .map((failure) => summarizeError(failure)),
-    defects: [...Cause.defects(cause)]
-      .slice(0, 3)
-      .map((defect) => summarizeError(defect)),
-  };
-}
-
-function summarizeError(value: unknown): Record<string, unknown> {
-  if (!isRecord(value)) return { exceptionClass: typeof value };
-
-  const summary: Record<string, unknown> = {
-    exceptionClass:
-      safeClassName(value._tag) ??
-      safeClassName(value.name) ??
-      safeClassName(value.constructor?.name) ??
-      "Error",
-  };
-  if (typeof value.code === "number") summary.rpcCode = value.code;
-  if (typeof value.line === "number") summary.line = value.line;
-  if (typeof value.column === "number") summary.column = value.column;
-  return summary;
-}
-
-function sanitizeSentryEvent<Event extends SentrySDK.Event>(
-  event: Event,
-): Event {
-  delete event.request;
-  delete event.contexts;
-  delete event.server_name;
-  event.extra = sanitizeTelemetryExtra(event.extra);
-  if (event.message !== undefined) event.message = SENTRY_MESSAGE;
-  if (event.logentry?.message !== undefined) {
-    event.logentry.message = SENTRY_MESSAGE;
-  }
-  for (const exception of event.exception?.values ?? []) {
-    exception.value = SENTRY_MESSAGE;
-    exception.type = safeClassName(exception.type) ?? "Error";
-    for (const frame of exception.stacktrace?.frames ?? []) {
-      delete frame.pre_context;
-      delete frame.context_line;
-      delete frame.post_context;
-      delete frame.vars;
-      delete frame.filename;
-      delete frame.abs_path;
-      delete frame.function;
-      delete frame.module;
+function classify(data: Record<string, unknown> | undefined) {
+  const tags: Record<string, string> = {};
+  for (const key of [
+    "error.domain",
+    "error.exception_class",
+    "error.kind",
+    "error.tag",
+    "rpc.method",
+    "rpc.code",
+  ]) {
+    const value = data?.[key];
+    if (typeof value === "string" || typeof value === "number") {
+      tags[key] = String(value).slice(0, 200);
     }
   }
-  return event;
-}
 
-function sanitizeTelemetryExtra(
-  extra: Record<string, unknown> | undefined,
-): Record<string, unknown> | undefined {
-  if (!extra) return undefined;
-  const sanitized: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(extra)) {
-    if (key === "cause" || key === "logger.cause") {
-      const cause = sanitizeCauseSummary(value);
-      if (cause) sanitized[key] = cause;
-      continue;
-    }
-    const safeValue = safeAnnotation(key, value);
-    if (safeValue !== undefined) sanitized[key] = safeValue;
-  }
-  return Object.keys(sanitized).length === 0 ? undefined : sanitized;
-}
-
-function sanitizeCauseSummary(value: unknown): unknown {
-  if (!isRecord(value)) return undefined;
-  const sanitizeItems = (items: unknown) =>
-    Array.isArray(items)
-      ? items.slice(0, 3).flatMap((item) => {
-          if (!isRecord(item)) return [];
-          const exceptionClass = safeClassName(item.exceptionClass);
-          if (!exceptionClass) return [];
-          return [
-            {
-              exceptionClass,
-              ...(typeof item.rpcCode === "number"
-                ? { rpcCode: item.rpcCode }
-                : {}),
-              ...(typeof item.line === "number" ? { line: item.line } : {}),
-              ...(typeof item.column === "number"
-                ? { column: item.column }
-                : {}),
-            },
-          ];
-        })
-      : [];
-  return {
-    failures: sanitizeItems(value.failures),
-    defects: sanitizeItems(value.defects),
-  };
-}
-
-function safeToken(value: string): string {
-  return /^[A-Za-z0-9_.$<>: -]{1,100}$/.test(value) ? value : "redacted";
-}
-
-function safeClassName(value: unknown): string | undefined {
-  return typeof value === "string" &&
-    /^[A-Za-z][A-Za-z0-9_.-]{0,79}$/.test(value)
-    ? value
-    : undefined;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === "object";
+  const domain = tags["error.domain"];
+  const kind = tags["error.kind"];
+  const code = tags["rpc.code"];
+  const exceptionClass = tags["error.exception_class"];
+  const errorTag = tags["error.tag"];
+  const fingerprint =
+    domain && kind
+      ? [
+          domain,
+          kind,
+          ...(code ? [code] : []),
+          ...(exceptionClass ? [exceptionClass] : []),
+        ]
+      : errorTag
+        ? ["marimo extension error", errorTag]
+        : undefined;
+  return { tags, fingerprint };
 }


### PR DESCRIPTION
Telemetry was implemented alongside VS Code telemetry, with separate gating and sanitization. This duplicated host behavior and over-redacted useful error context. Route usage and errors through TelemetryLogger instead, leaving PostHog and Sentry as private scoped delivery adapters.