### PR TITLE
Fix uv cache environment path filtering

### DIFF
--- a/extension/src/kernel/NotebookControllers.ts
+++ b/extension/src/kernel/NotebookControllers.ts
@@ -399,8 +399,21 @@ function isInUvCache(
 
   try {
     const envPath = options.code.Uri.file(env.path).fsPath;
-    return envPath.startsWith(options.uvCacheDir.value.fsPath);
+    return isPathInsideDirectory(envPath, options.uvCacheDir.value.fsPath);
   } catch {
     return false;
   }
+}
+
+export function isPathInsideDirectory(
+  candidatePath: string,
+  directoryPath: string,
+): boolean {
+  const relative = NodePath.relative(directoryPath, candidatePath);
+  return (
+    relative === "" ||
+    (relative !== ".." &&
+      !relative.startsWith(`..${NodePath.sep}`) &&
+      !NodePath.isAbsolute(relative))
+  );
 }

--- a/extension/src/kernel/__tests__/NotebookControllers.test.ts
+++ b/extension/src/kernel/__tests__/NotebookControllers.test.ts
@@ -6,7 +6,10 @@ import { TestPythonExtension } from "../../__mocks__/TestPythonExtension.ts";
 import { TestTelemetryLive } from "../../__mocks__/TestTelemetry.ts";
 import { TestVsCode } from "../../__mocks__/TestVsCode.ts";
 import { makeTestNotebookRuntime } from "../../__tests__/__utils__/TestMarimoClient.ts";
-import { NotebookControllersLive } from "../../kernel/NotebookControllers.ts";
+import {
+  isPathInsideDirectory,
+  NotebookControllersLive,
+} from "../../kernel/NotebookControllers.ts";
 import { NotebookRuntime } from "../../kernel/NotebookRuntime.ts";
 import { notebookId } from "../../lib/__tests__/branded.ts";
 import { Constants } from "../../platform/Constants.ts";
@@ -52,6 +55,21 @@ it.effect(
     }).pipe(Effect.provide(ctx.layer));
   }),
 );
+
+it("distinguishes uv cache descendants from shared path prefixes", () => {
+  expect(
+    isPathInsideDirectory(
+      "/home/user/.cache/uv/archive-v0/env/bin/python",
+      "/home/user/.cache/uv",
+    ),
+  ).toBe(true);
+  expect(
+    isPathInsideDirectory(
+      "/home/user/.cache/uv-other/bin/python",
+      "/home/user/.cache/uv",
+    ),
+  ).toBe(false);
+});
 
 it.effect(
   "attaches VS Code controller selections to the notebook runtime",


### PR DESCRIPTION
Use path-aware containment when filtering Python environments from uv's cache, preventing sibling paths with the same prefix from being hidden. Adds regression coverage.

Closes MO-7135