### PR TITLE
Fix notebook status command context

### DIFF
--- a/extension/src/commands.ts
+++ b/extension/src/commands.ts
@@ -45,6 +45,8 @@ export const VscodeUriSchema = Schema.declare<vscode.Uri>(
   { identifier: "vscode.Uri" },
 );
 
+const isVscodeUri = Schema.is(VscodeUriSchema);
+
 export const VscodeNotebookCellSchema = Schema.declare<vscode.NotebookCell>(
   (value): value is vscode.NotebookCell =>
     typeof value === "object" &&
@@ -54,17 +56,32 @@ export const VscodeNotebookCellSchema = Schema.declare<vscode.NotebookCell>(
     "notebook" in value &&
     typeof value.notebook === "object" &&
     value.notebook !== null &&
+    "uri" in value.notebook &&
+    isVscodeUri(value.notebook.uri) &&
     "document" in value &&
     typeof value.document === "object" &&
     value.document !== null,
   { identifier: "vscode.NotebookCell" },
 );
 
-const NotebookCommandContextSchema = Schema.Struct({
+const NotebookToolbarContextShape = Schema.Struct({
   notebookEditor: Schema.Struct({ notebookUri: VscodeUriSchema }),
 });
 
-export type NotebookCommandContext = typeof NotebookCommandContextSchema.Type;
+export type NotebookToolbarContext = typeof NotebookToolbarContextShape.Type;
+
+export const NotebookToolbarContextSchema =
+  Schema.declare<NotebookToolbarContext>(
+    Schema.is(NotebookToolbarContextShape),
+    { identifier: "vscode.NotebookToolbarContext" },
+  );
+
+const NotebookCommandTargetSchema = Schema.Union(
+  NotebookToolbarContextSchema,
+  VscodeNotebookCellSchema,
+);
+
+export type NotebookCommandTarget = typeof NotebookCommandTargetSchema.Type;
 
 export function withFirstArgument<A, I>(
   command: MarimoCommand,
@@ -82,22 +99,45 @@ export function withFirstArgument<A, I>(
   };
 }
 
-export function withOptionalNotebookContext(
+export function withOptionalNotebookTarget(
   command: MarimoCommand,
-): MarimoCommand<[context?: NotebookCommandContext], void> {
+): MarimoCommand<[target?: NotebookCommandTarget], void> {
+  return withOptionalFirstArgument(command, NotebookCommandTargetSchema);
+}
+
+export function withOptionalNotebookToolbarContext(
+  command: MarimoCommand,
+): MarimoCommand<[context?: NotebookToolbarContext], void> {
+  return withOptionalFirstArgument(command, NotebookToolbarContextSchema);
+}
+
+export function withOptionalFirstArgument<A, I>(
+  command: MarimoCommand,
+  schema: Schema.Schema<A, I>,
+): MarimoCommand<[context?: A], void> {
   return {
     [MarimoCommandTypeId]: {
       id: commandId(command),
       decodeArguments: (args) =>
-        Schema.decodeUnknown(Schema.UndefinedOr(NotebookCommandContextSchema))(
-          args[0],
-        ).pipe(
-          Effect.map((context): [context?: NotebookCommandContext] =>
+        Schema.decodeUnknown(Schema.UndefinedOr(schema))(args[0]).pipe(
+          Effect.map((context): [context?: A] =>
             context === undefined ? [] : [context],
           ),
         ),
       decodeResult: Schema.decodeUnknown(Schema.Void),
     },
+  };
+}
+
+export function toVscodeCommand<Args extends ReadonlyArray<unknown>>(
+  command: MarimoCommand<Args>,
+  title: string,
+  ...args: Args
+): vscode.Command {
+  return {
+    command: commandId(command),
+    title,
+    arguments: [...args],
   };
 }
 export function commandId(command: MarimoCommand): string {

--- a/extension/src/commands/MarimoCommands.ts
+++ b/extension/src/commands/MarimoCommands.ts
@@ -2,7 +2,9 @@ import { Schema } from "effect";
 
 import {
   withFirstArgument,
-  withOptionalNotebookContext,
+  withOptionalFirstArgument,
+  withOptionalNotebookTarget,
+  withOptionalNotebookToolbarContext,
   VscodeNotebookCellSchema,
   VscodeUriSchema,
 } from "../commands.ts";
@@ -10,20 +12,20 @@ import { NotebookIdFromString } from "../schemas/MarimoNotebookDocument.ts";
 import { GeneratedMarimoCommands } from "./MarimoCommands.gen.ts";
 
 const notebookCommands = {
-  createSetupCell: withOptionalNotebookContext(
+  createSetupCell: withOptionalNotebookToolbarContext(
     GeneratedMarimoCommands.createSetupCell,
   ),
-  publishMarimoNotebook: withOptionalNotebookContext(
+  publishMarimoNotebook: withOptionalNotebookToolbarContext(
     GeneratedMarimoCommands.publishMarimoNotebook,
   ),
-  restartKernel: withOptionalNotebookContext(
+  restartKernel: withOptionalNotebookToolbarContext(
     GeneratedMarimoCommands.restartKernel,
   ),
-  runStale: withOptionalNotebookContext(GeneratedMarimoCommands.runStale),
-  showNotebookMenu: withOptionalNotebookContext(
+  runStale: withOptionalNotebookTarget(GeneratedMarimoCommands.runStale),
+  showNotebookMenu: withOptionalNotebookToolbarContext(
     GeneratedMarimoCommands.showNotebookMenu,
   ),
-  updateActivePythonEnvironment: withOptionalNotebookContext(
+  updateActivePythonEnvironment: withOptionalNotebookToolbarContext(
     GeneratedMarimoCommands.updateActivePythonEnvironment,
   ),
 };
@@ -51,9 +53,9 @@ export const MarimoCommands = {
   ...GeneratedMarimoCommands,
   ...notebookCommands,
   ...cellCommands,
-  openAsMarimoNotebook: withFirstArgument(
+  openAsMarimoNotebook: withOptionalFirstArgument(
     GeneratedMarimoCommands.openAsMarimoNotebook,
-    Schema.UndefinedOr(Schema.Union(Schema.String, VscodeUriSchema)),
+    Schema.Union(Schema.String, VscodeUriSchema),
   ),
   openSession: withFirstArgument(
     GeneratedMarimoCommands.openSession,

--- a/extension/src/commands/__tests__/MarimoCommands.test.ts
+++ b/extension/src/commands/__tests__/MarimoCommands.test.ts
@@ -51,14 +51,15 @@ describe("MarimoCommands", () => {
           return "file:///notebook.py";
         },
       };
+      const context = {
+        ui: true,
+        notebookEditor: { notebookUri },
+        source: "notebookToolbar",
+      };
       const args = yield* decodeCommandArguments(MarimoCommands.restartKernel, [
-        {
-          ui: true,
-          notebookEditor: { notebookUri },
-          source: "notebookToolbar",
-        },
+        context,
       ]);
-      expect(args).toEqual([{ notebookEditor: { notebookUri } }]);
+      expect(args[0]).toBe(context);
     }),
   );
 
@@ -69,6 +70,39 @@ describe("MarimoCommands", () => {
         [],
       );
       expect(args).toEqual([]);
+    }),
+  );
+
+  it.effect("accepts notebook cell context for a notebook command", () =>
+    Effect.gen(function* () {
+      const notebook = createTestNotebookDocument("/test/notebook_mo.py");
+      const cell = createNotebookCell(
+        notebook,
+        { kind: 2, value: "x = 1", languageId: "python" },
+        5,
+      );
+
+      const args = yield* decodeCommandArguments(MarimoCommands.runStale, [
+        cell,
+      ]);
+
+      expect(args).toEqual([cell]);
+    }),
+  );
+
+  it.effect("rejects notebook cell context for a toolbar-only command", () =>
+    Effect.gen(function* () {
+      const cell = createNotebookCell(
+        createTestNotebookDocument("/test/notebook_mo.py"),
+        { kind: 2, value: "x = 1", languageId: "python" },
+        0,
+      );
+
+      const result = yield* Effect.either(
+        decodeCommandArguments(MarimoCommands.restartKernel, [cell]),
+      );
+
+      expect(result._tag).toBe("Left");
     }),
   );
 

--- a/extension/src/commands/configureAutoExport.ts
+++ b/extension/src/commands/configureAutoExport.ts
@@ -1,6 +1,6 @@
 import { Effect, Option } from "effect";
 
-import type { NotebookCommandContext } from "../commands.ts";
+import type { NotebookToolbarContext } from "../commands.ts";
 import type { AutoExportFormat } from "../features/AutoExport.ts";
 import { getNotebookCommandEditor } from "../lib/getNotebookCommandEditor.ts";
 import { VsCode } from "../platform/VsCode.ts";
@@ -28,7 +28,7 @@ export function mergeAutoDownloadFormats(
 }
 
 export const configureAutoExport = Effect.fn("command.configureAutoExport")(
-  function* (context?: NotebookCommandContext) {
+  function* (context?: NotebookToolbarContext) {
     const code = yield* VsCode;
     const notebook = Option.filterMap(
       yield* getNotebookCommandEditor(context),

--- a/extension/src/commands/createSetupCell.ts
+++ b/extension/src/commands/createSetupCell.ts
@@ -1,6 +1,6 @@
 import { Effect, Option } from "effect";
 
-import type { NotebookCommandContext } from "../commands.ts";
+import type { NotebookToolbarContext } from "../commands.ts";
 import { SETUP_CELL_NAME } from "../constants.ts";
 import { getNotebookCommandEditor } from "../lib/getNotebookCommandEditor.ts";
 import { Constants } from "../platform/Constants.ts";
@@ -11,7 +11,7 @@ import {
 } from "../schemas/MarimoNotebookDocument.ts";
 
 export const createSetupCell = Effect.fn("command.createSetupCell")(function* (
-  context?: NotebookCommandContext,
+  context?: NotebookToolbarContext,
 ) {
   const code = yield* VsCode;
   const { LanguageId } = yield* Constants;

--- a/extension/src/commands/publishMarimoNotebook.ts
+++ b/extension/src/commands/publishMarimoNotebook.ts
@@ -1,10 +1,10 @@
 import { Effect } from "effect";
 
-import type { NotebookCommandContext } from "../commands.ts";
+import type { NotebookToolbarContext } from "../commands.ts";
 import { publishMarimoNotebookGist } from "./publishMarimoNotebookGist.ts";
 
 export const publishMarimoNotebook = Effect.fn("command.publishMarimoNotebook")(
-  function* (context?: NotebookCommandContext) {
+  function* (context?: NotebookToolbarContext) {
     yield* publishMarimoNotebookGist(context);
   },
 );

--- a/extension/src/commands/publishMarimoNotebookGist.ts
+++ b/extension/src/commands/publishMarimoNotebookGist.ts
@@ -2,7 +2,7 @@ import * as NodePath from "node:path";
 
 import { Cause, Chunk, Effect, Either, flow, Schema, Option } from "effect";
 
-import type { NotebookCommandContext } from "../commands.ts";
+import type { NotebookToolbarContext } from "../commands.ts";
 import { getNotebookCommandEditor } from "../lib/getNotebookCommandEditor.ts";
 import { showErrorAndPromptLogs } from "../lib/showErrorAndPromptLogs.ts";
 import { MarimoClient } from "../lsp/MarimoClient.ts";
@@ -14,7 +14,7 @@ import { MarimoNotebookDocument } from "../schemas/MarimoNotebookDocument.ts";
 export const publishMarimoNotebookGist = Effect.fn(
   "command.publishMarimoNotebookGist",
 )(
-  function* (context?: NotebookCommandContext) {
+  function* (context?: NotebookToolbarContext) {
     const code = yield* VsCode;
     const gh = yield* GitHubClient;
     const marimo = yield* MarimoClient;

--- a/extension/src/commands/restartKernel.ts
+++ b/extension/src/commands/restartKernel.ts
@@ -1,6 +1,6 @@
 import { Effect, Option } from "effect";
 
-import type { NotebookCommandContext } from "../commands.ts";
+import type { NotebookToolbarContext } from "../commands.ts";
 import { CellExecutions } from "../kernel/CellExecutions.ts";
 import { getNotebookCommandEditor } from "../lib/getNotebookCommandEditor.ts";
 import { showErrorAndPromptLogs } from "../lib/showErrorAndPromptLogs.ts";
@@ -9,7 +9,7 @@ import { VsCode } from "../platform/VsCode.ts";
 import { MarimoNotebookDocument } from "../schemas/MarimoNotebookDocument.ts";
 
 export const restartKernel = Effect.fn("command.restartKernel")(function* (
-  context?: NotebookCommandContext,
+  context?: NotebookToolbarContext,
 ) {
   const code = yield* VsCode;
   const sessions = yield* SessionsService;

--- a/extension/src/commands/runStale.ts
+++ b/extension/src/commands/runStale.ts
@@ -1,6 +1,6 @@
 import { Effect, flow, Option } from "effect";
 
-import type { NotebookCommandContext } from "../commands.ts";
+import type { NotebookCommandTarget } from "../commands.ts";
 import { CellExecutions } from "../kernel/CellExecutions.ts";
 import { getNotebookCommandEditor } from "../lib/getNotebookCommandEditor.ts";
 import { showErrorAndPromptLogs } from "../lib/showErrorAndPromptLogs.ts";
@@ -8,7 +8,7 @@ import { VsCode } from "../platform/VsCode.ts";
 import { MarimoNotebookDocument } from "../schemas/MarimoNotebookDocument.ts";
 
 export const runStale = Effect.fn("command.runStale")(
-  function* (context?: NotebookCommandContext) {
+  function* (context?: NotebookCommandTarget) {
     const code = yield* VsCode;
     const executions = yield* CellExecutions;
     const notebook = Option.filterMap(

--- a/extension/src/commands/showNotebookMenu.ts
+++ b/extension/src/commands/showNotebookMenu.ts
@@ -1,6 +1,6 @@
 import { Effect, Option } from "effect";
 
-import type { NotebookCommandContext } from "../commands.ts";
+import type { NotebookToolbarContext } from "../commands.ts";
 import { MarimoConfigurationService } from "../config/MarimoConfigurationService.ts";
 import { getNotebookCommandEditor } from "../lib/getNotebookCommandEditor.ts";
 import { VsCode } from "../platform/VsCode.ts";
@@ -34,7 +34,7 @@ const NOTEBOOK_MENU_ITEMS = [
 ] as const;
 
 export const showNotebookMenu = Effect.fn("command.showNotebookMenu")(
-  function* (context?: NotebookCommandContext) {
+  function* (context?: NotebookToolbarContext) {
     const code = yield* VsCode;
     const selection = yield* code.window.showQuickPickItems(
       NOTEBOOK_MENU_ITEMS,

--- a/extension/src/commands/toggleAutoReload.ts
+++ b/extension/src/commands/toggleAutoReload.ts
@@ -1,7 +1,7 @@
-import type { NotebookCommandContext } from "../commands.ts";
+import type { NotebookToolbarContext } from "../commands.ts";
 import { createConfigToggle } from "../lib/createConfigToggle.ts";
 
-export const toggleAutoReload = (context?: NotebookCommandContext) =>
+export const toggleAutoReload = (context?: NotebookToolbarContext) =>
   createConfigToggle({
     context,
     configPath: "runtime.auto_reload",

--- a/extension/src/commands/toggleOnCellChange.ts
+++ b/extension/src/commands/toggleOnCellChange.ts
@@ -1,7 +1,7 @@
-import type { NotebookCommandContext } from "../commands.ts";
+import type { NotebookToolbarContext } from "../commands.ts";
 import { createConfigToggle } from "../lib/createConfigToggle.ts";
 
-export const toggleOnCellChange = (context?: NotebookCommandContext) =>
+export const toggleOnCellChange = (context?: NotebookToolbarContext) =>
   createConfigToggle({
     context,
     configPath: "runtime.on_cell_change",

--- a/extension/src/commands/updateActivePythonEnvironment.ts
+++ b/extension/src/commands/updateActivePythonEnvironment.ts
@@ -1,6 +1,6 @@
 import { Effect, Either, Option } from "effect";
 
-import type { NotebookCommandContext } from "../commands.ts";
+import type { NotebookToolbarContext } from "../commands.ts";
 import { NotebookRuntime } from "../kernel/NotebookRuntime.ts";
 import { getNotebookCommandEditor } from "../lib/getNotebookCommandEditor.ts";
 import { showErrorAndPromptLogs } from "../lib/showErrorAndPromptLogs.ts";
@@ -12,7 +12,7 @@ import { MarimoNotebookDocument } from "../schemas/MarimoNotebookDocument.ts";
 
 export const updateActivePythonEnvironment = Effect.fn(
   "command.updateActivePythonEnvironment",
-)(function* (context?: NotebookCommandContext) {
+)(function* (context?: NotebookToolbarContext) {
   const uv = yield* Uv;
   const code = yield* VsCode;
   const py = yield* PythonExtension;

--- a/extension/src/features/CellStatusBarProvider.ts
+++ b/extension/src/features/CellStatusBarProvider.ts
@@ -1,6 +1,7 @@
 import { Effect, Layer, Option, Stream } from "effect";
+import type * as vscode from "vscode";
 
-import { commandId } from "../commands.ts";
+import { toVscodeCommand } from "../commands.ts";
 import { MarimoCommands } from "../commands/MarimoCommands.ts";
 import { NOTEBOOK_TYPE, SETUP_CELL_NAME } from "../constants.ts";
 import { CellExecutions } from "../kernel/CellExecutions.ts";
@@ -48,7 +49,15 @@ export const CellStatusBarProviderLive = Layer.scopedDiscard(
                 code.NotebookCellStatusBarAlignment.Right,
               );
               item.tooltip = "Cell has been edited but not re-executed";
-              item.command = commandId(MarimoCommands.runStale);
+
+              // VS Code injects the cell for bare status-bar commands. Bind it
+              // explicitly so our typed command contract checks the argument.
+              const command: vscode.Command = toVscodeCommand(
+                MarimoCommands.runStale,
+                "Run stale cells",
+                raw,
+              );
+              item.command = command;
               return [item];
             }),
           );

--- a/extension/src/features/MarimoCodeLensProvider.ts
+++ b/extension/src/features/MarimoCodeLensProvider.ts
@@ -1,7 +1,7 @@
 import { Effect, Layer } from "effect";
 import type * as vscode from "vscode";
 
-import { commandId } from "../commands.ts";
+import { toVscodeCommand } from "../commands.ts";
 import { MarimoCommands } from "../commands/MarimoCommands.ts";
 import { VsCode } from "../platform/VsCode.ts";
 
@@ -68,11 +68,13 @@ export const MarimoCodeLensProviderLive = Layer.scopedDiscard(
 
         // Create a range at the start of the line
         const range = new code.Range(lineNumber, 0, lineNumber, 0);
-        const codeLens = new code.CodeLens(range, {
-          title: "Open as notebook",
-          command: commandId(MarimoCommands.openAsMarimoNotebook),
-          arguments: [],
-        });
+        const codeLens = new code.CodeLens(
+          range,
+          toVscodeCommand(
+            MarimoCommands.openAsMarimoNotebook,
+            "Open as notebook",
+          ),
+        );
 
         return [codeLens];
       },

--- a/extension/src/features/__tests__/CellStatusBarProvider.test.ts
+++ b/extension/src/features/__tests__/CellStatusBarProvider.test.ts
@@ -9,6 +9,8 @@ import {
   TestVsCode,
 } from "../../__mocks__/TestVsCode.ts";
 import { makeTestNotebookRuntime } from "../../__tests__/__utils__/TestMarimoClient.ts";
+import { toVscodeCommand } from "../../commands.ts";
+import { MarimoCommands } from "../../commands/MarimoCommands.ts";
 import { CellExecutions } from "../../kernel/CellExecutions.ts";
 import { MarimoNotebookCell } from "../../schemas/MarimoNotebookDocument.ts";
 import type * as Api from "../../schemas/Models.gen.ts";
@@ -115,6 +117,9 @@ it.effect(
       expect(stalenessItem).toBeDefined();
       expect(stalenessItem?.text).toContain("Stale");
       expect(stalenessItem?.tooltip).toContain("edited but not re-executed");
+      expect(stalenessItem?.command).toEqual(
+        toVscodeCommand(MarimoCommands.runStale, "Run stale cells", cell),
+      );
     }).pipe(Effect.provide(ctx.layer));
   }),
 );

--- a/extension/src/lib/__tests__/getNotebookCommandEditor.test.ts
+++ b/extension/src/lib/__tests__/getNotebookCommandEditor.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "@effect/vitest";
 import { Effect, Option } from "effect";
 
-import { TestVsCode } from "../../__mocks__/TestVsCode.ts";
+import { createNotebookCell, TestVsCode } from "../../__mocks__/TestVsCode.ts";
 import { getNotebookCommandEditor } from "../getNotebookCommandEditor.ts";
 
 describe("getNotebookCommandEditor", () => {
@@ -39,6 +39,31 @@ describe("getNotebookCommandEditor", () => {
       );
 
       expect(Option.getOrThrow(editor)).toBe(active);
+    }),
+  );
+
+  it.effect("resolves the notebook referenced by cell context", () =>
+    Effect.gen(function* () {
+      const target = TestVsCode.makeNotebookEditor("/test/target.py");
+      const active = TestVsCode.makeNotebookEditor("/test/active.py");
+      const vscode = yield* TestVsCode.make({
+        initialDocuments: [target.notebook, active.notebook],
+      });
+      yield* vscode.setActiveNotebookEditor(Option.some(target));
+      yield* vscode.setActiveNotebookEditor(Option.some(active));
+
+      const cell = createNotebookCell(
+        target.notebook,
+        { kind: 2, value: "x = 1", languageId: "python" },
+        0,
+      );
+      const editor = yield* getNotebookCommandEditor(cell).pipe(
+        Effect.provide(vscode.layer),
+      );
+
+      expect(Option.getOrThrow(editor).notebook.uri.toString()).toBe(
+        target.notebook.uri.toString(),
+      );
     }),
   );
 

--- a/extension/src/lib/createConfigToggle.ts
+++ b/extension/src/lib/createConfigToggle.ts
@@ -1,6 +1,6 @@
 import { Effect, Option } from "effect";
 
-import type { NotebookCommandContext } from "../commands.ts";
+import type { NotebookToolbarContext } from "../commands.ts";
 import { MarimoConfigurationService } from "../config/MarimoConfigurationService.ts";
 import { getNotebookCommandEditor } from "../lib/getNotebookCommandEditor.ts";
 import { showErrorAndPromptLogs } from "../lib/showErrorAndPromptLogs.ts";
@@ -21,7 +21,7 @@ export const createConfigToggle = <T extends string>({
   choices,
   getDisplayName,
 }: {
-  context: NotebookCommandContext | undefined;
+  context: NotebookToolbarContext | undefined;
   configPath: string;
   settingName: string;
   pickerTitle: string;

--- a/extension/src/lib/getNotebookCommandEditor.ts
+++ b/extension/src/lib/getNotebookCommandEditor.ts
@@ -1,6 +1,6 @@
 import { Effect, Option } from "effect";
 
-import type { NotebookCommandContext } from "../commands.ts";
+import type { NotebookCommandTarget } from "../commands.ts";
 import { VsCode } from "../platform/VsCode.ts";
 
 /**
@@ -9,11 +9,15 @@ import { VsCode } from "../platform/VsCode.ts";
  */
 export const getNotebookCommandEditor = Effect.fn(
   "command.getNotebookCommandEditor",
-)(function* (context?: NotebookCommandContext) {
+)(function* (context?: NotebookCommandTarget) {
   const code = yield* VsCode;
 
   if (context !== undefined) {
-    const target = context.notebookEditor.notebookUri.toString();
+    const target = (
+      "notebookEditor" in context
+        ? context.notebookEditor.notebookUri
+        : context.notebook.uri
+    ).toString();
     const editor = (yield* code.window.getVisibleNotebookEditors()).find(
       (candidate) => candidate.notebook.uri.toString() === target,
     );

--- a/extension/src/notebook/CellMetadataUIBindingService.ts
+++ b/extension/src/notebook/CellMetadataUIBindingService.ts
@@ -2,7 +2,7 @@ import { Effect, Option, Stream } from "effect";
 import type * as vscode from "vscode";
 
 import { assert } from "../assert.ts";
-import { commandId } from "../commands.ts";
+import { toVscodeCommand } from "../commands.ts";
 import { MarimoCommands } from "../commands/MarimoCommands.ts";
 import { NOTEBOOK_TYPE } from "../constants.ts";
 import { VsCode } from "../platform/VsCode.ts";
@@ -148,11 +148,11 @@ export class CellMetadataUIBindingService extends Effect.Service<CellMetadataUIB
                   binding.alignment,
                 );
                 item.tooltip = binding.getTooltip(value);
-                item.command = {
-                  command: commandId(MarimoCommands.updateCellMetadata),
-                  title: "Update cell metadata",
-                  arguments: [binding.id],
-                };
+                item.command = toVscodeCommand(
+                  MarimoCommands.updateCellMetadata,
+                  "Update cell metadata",
+                  binding.id,
+                );
 
                 return Effect.succeed([item]);
               },

--- a/extension/src/panel/sessions/SessionsView.ts
+++ b/extension/src/panel/sessions/SessionsView.ts
@@ -1,6 +1,6 @@
 import { Effect, Layer, Option, Stream } from "effect";
 
-import { commandId } from "../../commands.ts";
+import { toVscodeCommand } from "../../commands.ts";
 import { MarimoCommands } from "../../commands/MarimoCommands.ts";
 import { NOTEBOOK_TYPE } from "../../constants.ts";
 import { CellExecutions } from "../../kernel/CellExecutions.ts";
@@ -81,11 +81,11 @@ export const SessionsViewLive = Layer.scopedDiscard(
                   ? "loading~spin"
                   : "circle-outline",
             contextValue: "marimoSession",
-            command: {
-              command: commandId(MarimoCommands.openSession),
-              title: "Open Notebook",
-              arguments: [session],
-            },
+            command: toVscodeCommand(
+              MarimoCommands.openSession,
+              "Open Notebook",
+              session,
+            ),
             collapsibleState: "None",
             resourceUri: session.notebookUri,
           };

--- a/extension/tests/command-context.test.cjs
+++ b/extension/tests/command-context.test.cjs
@@ -1,0 +1,46 @@
+// @ts-check
+/// <reference types="mocha" />
+
+const NodeAssert = require("node:assert");
+const vscode = require("vscode");
+const tinyspy = require("tinyspy");
+
+const { createTestContext } = require("./helpers.cjs");
+
+suite("notebook command context", () => {
+  test("accepts the NotebookCell supplied by a cell status-bar command", async function () {
+    this.timeout(60_000);
+    await using ctx = createTestContext();
+    const notebook = await ctx.writeAndOpenNotebook();
+    await vscode.window.showNotebookDocument(notebook);
+
+    const originalCell = notebook.cellAt(0);
+
+    const warning = tinyspy.spyOn(
+      vscode.window,
+      "showWarningMessage",
+      async () => undefined,
+    );
+    const information = tinyspy.spyOn(
+      vscode.window,
+      "showInformationMessage",
+      async () => undefined,
+    );
+    try {
+      // The clickable "Stale" NotebookCellStatusBarItem uses a bare command
+      // string. VS Code prepends the item's NotebookCell when invoking it.
+      // oxlint-disable-next-line marimo/no-marimo-command-id-literals -- exercises the external VS Code seam
+      await vscode.commands.executeCommand("marimo.runStale", originalCell);
+
+      NodeAssert.strictEqual(warning.callCount, 0);
+      NodeAssert.strictEqual(information.callCount, 1);
+      NodeAssert.strictEqual(
+        information.calls[0]?.[0],
+        "No stale cells to run",
+      );
+    } finally {
+      warning.restore();
+      information.restore();
+    }
+  });
+});


### PR DESCRIPTION
VS Code supplies the originating `NotebookCell` when invoking a bare command from a notebook cell status item. The **Stale** item registered `marimo.runStale` this way, but the command schema only accepted the notebook-toolbar context, so decoding failed before the handler ran.

Accept the cell as a target for `runStale`, keep other notebook commands narrowed to the toolbar context, and bind VS Code command objects through the typed command contract. Adds integration coverage for the actual status-item invocation.

Fixes VSCODE-MARIMO-3H2 and VSCODE-MARIMO-3H7.