### PR TITLE
Add execution context to Sentry errors

### DIFF
--- a/extension/src/kernel/NotebookRuntime.ts
+++ b/extension/src/kernel/NotebookRuntime.ts
@@ -452,17 +452,16 @@ export class NotebookRuntime extends Effect.Service<NotebookRuntime>()(
               ) {
                 return;
               }
+              yield* Effect.annotateCurrentSpan(
+                "operation.type",
+                message.operation.op,
+              );
               yield* Effect.raceFirst(
                 processOperation(message, {
                   forNotebook,
                   session: message.session,
                   ...options,
                 }).pipe(
-                  Effect.annotateLogs({
-                    notebookUri: message.notebookUri,
-                    operation: message.operation.op,
-                  }),
-                  Effect.withSpan("process-operation"),
                   Effect.catchAllCause(
                     Effect.fn(function* (cause) {
                       yield* Effect.logError(
@@ -475,6 +474,9 @@ export class NotebookRuntime extends Effect.Service<NotebookRuntime>()(
                       );
                     }),
                   ),
+                  Effect.annotateLogs({
+                    "operation.type": message.operation.op,
+                  }),
                 ),
                 Deferred.await(message.session.invalidated),
               );

--- a/extension/src/platform/VsCode.ts
+++ b/extension/src/platform/VsCode.ts
@@ -314,6 +314,30 @@ type ContextMap = {
   "marimo.notebook.hasKernel": boolean;
 };
 
+const isExpectedCancellation = (cause: Cause.Cause<unknown>) =>
+  Cause.isInterruptedOnly(cause) ||
+  [...Cause.defects(cause)].some(
+    (defect: unknown) => defect instanceof Error && defect.name === "Canceled",
+  );
+
+export const withCommandContext = (command: MarimoCommand) => {
+  const wireId = commandId(command);
+  return <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+    effect.pipe(
+      Effect.tapErrorCause((cause) =>
+        isExpectedCancellation(cause) ? Effect.void : Effect.logError(cause),
+      ),
+      Effect.withSpan("command", {
+        attributes: {
+          "command.id": wireId,
+        },
+      }),
+      Effect.annotateLogs({
+        "command.id": wireId,
+      }),
+    );
+};
+
 export class Commands extends Effect.Service<Commands>()("Commands", {
   dependencies: [Window.Default],
   scoped: Effect.gen(function* () {
@@ -353,17 +377,10 @@ export class Commands extends Effect.Service<Commands>()("Commands", {
                 // Skip logging for interruptions/cancellations (e.g., user
                 // cancels a progress dialog, VS Code disposes resources
                 // during kernel restart). These are expected and not errors.
-                if (
-                  Cause.isInterruptedOnly(cause) ||
-                  [...Cause.defects(cause)].some(
-                    (defect: unknown) =>
-                      defect instanceof Error && defect.name === "Canceled",
-                  )
-                ) {
+                if (isExpectedCancellation(cause)) {
                   yield* PubSub.publish(commandPubSub, Either.left(wireId));
                   return;
                 }
-                yield* Effect.logError(cause);
                 yield* PubSub.publish(commandPubSub, Either.left(wireId));
                 yield* win.showWarningMessage(
                   `Something went wrong in ${JSON.stringify(wireId)}. See marimo logs for more info.`,
@@ -381,10 +398,12 @@ export class Commands extends Effect.Service<Commands>()("Commands", {
       command: MarimoCommand<Args, A>,
       fn: (...args: Args) => Effect.Effect<A, E, R>,
     ) {
-      return registerImplementation(commandId(command), (args) =>
+      const wireId = commandId(command);
+      return registerImplementation(wireId, (args) =>
         decodeCommandArguments(command, args).pipe(
           Effect.flatMap((decoded) => fn(...decoded)),
           Effect.flatMap((result) => decodeCommandResult(command, result)),
+          withCommandContext(command),
         ),
       );
     }

--- a/extension/src/platform/__tests__/Commands.test.ts
+++ b/extension/src/platform/__tests__/Commands.test.ts
@@ -1,8 +1,39 @@
 import { describe, expect, it } from "@effect/vitest";
-import { Effect, Either, PubSub, Queue } from "effect";
+import { Effect, Either, Logger, PubSub, Queue } from "effect";
 
 import { commandId } from "../../commands.ts";
 import { MarimoCommands } from "../../commands/MarimoCommands.ts";
+import { withCommandContext } from "../VsCode.ts";
+
+describe("command error context", () => {
+  it.effect("logs failures with their command span", () => {
+    const logs: Array<Record<string, unknown>> = [];
+    const wireId = commandId(MarimoCommands.runStale);
+    const logger = Logger.make(({ annotations }) => {
+      logs.push(Object.fromEntries(annotations));
+    });
+
+    return Effect.fail(new Error("invalid command argument")).pipe(
+      withCommandContext(MarimoCommands.runStale),
+      Effect.exit,
+      Effect.provide(
+        Logger.replace(
+          Logger.defaultLogger,
+          Logger.withSpanAnnotations(logger),
+        ),
+      ),
+      Effect.tap(() =>
+        Effect.sync(() => {
+          expect(logs).toHaveLength(1);
+          expect(logs[0]).toMatchObject({
+            "command.id": wireId,
+            "effect.spanName": "command",
+          });
+        }),
+      ),
+    );
+  });
+});
 
 describe("Commands pubsub", () => {
   it.effect(


### PR DESCRIPTION
Command and notebook-operation failures currently reach Sentry after their execution context has been lost, leaving errors such as `ParseError` or `EPIPE` without the command or operation that triggered them.

Wrap typed command invocations in an Effect span and annotate error logs with the derived `command.id`. Annotate the existing `NotebookRuntime.processOperation` span and log scope with the safe `operation.type`, excluding notebook URIs and operation payloads.

Addresses missing execution context in current Sentry command and notebook-operation reports.