### PR TITLE
Preserve compatible marimo app config

### DIFF
--- a/extension/src/commands/__tests__/configureAutoExport.test.ts
+++ b/extension/src/commands/__tests__/configureAutoExport.test.ts
@@ -174,7 +174,7 @@ it.effect(
     const parsed = yield* MarimoNotebookDocument.from(
       updated.notebook,
     ).parseMetadata();
-    expect(parsed.appConfig.width).toBe("full");
+    expect(parsed.appConfig).toMatchObject({ width: "full" });
     expect(parsed.appConfig.auto_download).toEqual(["ipynb"]);
   }),
 );

--- a/extension/src/commands/configureAutoExport.ts
+++ b/extension/src/commands/configureAutoExport.ts
@@ -5,7 +5,7 @@ import type { AutoExportFormat } from "../features/AutoExport.ts";
 import { getNotebookCommandEditor } from "../lib/getNotebookCommandEditor.ts";
 import { VsCode } from "../platform/VsCode.ts";
 import { MarimoNotebookDocument } from "../schemas/MarimoNotebookDocument.ts";
-import type { _AppConfig } from "../schemas/Models.gen.ts";
+import type { OwnedAppConfig } from "../schemas/Models.gen.ts";
 
 const FORMATS = ["html", "ipynb"] as const;
 
@@ -13,9 +13,9 @@ const isManagedFormat = (format: string): format is AutoExportFormat =>
   format === "html" || format === "ipynb";
 
 export function mergeAutoDownloadFormats(
-  current: _AppConfig["auto_download"],
+  current: OwnedAppConfig["auto_download"],
   selected: ReadonlyArray<AutoExportFormat>,
-): _AppConfig["auto_download"] {
+): OwnedAppConfig["auto_download"] {
   const retained = current.filter(
     (format) => !isManagedFormat(format) || selected.includes(format),
   );

--- a/extension/src/schemas/MarimoNotebookDocument.ts
+++ b/extension/src/schemas/MarimoNotebookDocument.ts
@@ -43,6 +43,8 @@ const notebookMetadataEquivalence = Schema.equivalence(
   Api.MarimoNotebookMetadata,
 );
 
+const parseOwnedAppConfig = Schema.decodeUnknown(Api.OwnedAppConfig);
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -385,6 +387,12 @@ export class MarimoNotebookDocument {
     const raw = asRecord(this.#raw.metadata);
     return parseNotebookMetadata(
       Object.hasOwn(raw, "marimo") ? raw.marimo : {},
+    ).pipe(
+      Effect.flatMap((metadata) =>
+        parseOwnedAppConfig(metadata.appConfig).pipe(
+          Effect.map((appConfig) => ({ ...metadata, appConfig })),
+        ),
+      ),
     );
   }
 

--- a/extension/src/schemas/Models.gen.ts
+++ b/extension/src/schemas/Models.gen.ts
@@ -31,6 +31,22 @@ export const PackageSource = Schema.Union(VenvSource, ScriptSource).annotations(
 export type PackageSource = typeof PackageSource.Type;
 
 /**
+ * App options understood by the extension, projected from ``AppConfig``.
+ *
+ * Codegen preserves excess properties in TypeScript so parsing this owned
+ * subset never discards options belonging to marimo or a future extension.
+ */
+export const OwnedAppConfig = Schema.Struct({
+  auto_download: Schema.optionalWith(Schema.Array(Schema.String), {
+    default: () => [],
+  }),
+}).annotations({
+  identifier: "OwnedAppConfig",
+  parseOptions: { onExcessProperty: "preserve" as const },
+});
+export type OwnedAppConfig = typeof OwnedAppConfig.Type;
+
+/**
  * Configuration for a notebook cell
  */
 export const NotebookCellConfig = Schema.Struct({
@@ -143,40 +159,6 @@ export const CellMetadata = Schema.Struct({
 export type CellMetadata = typeof CellMetadata.Type;
 
 /**
- * Program-specific configuration.
- *
- * Configuration for frontends or runtimes that is specific to
- * a single marimo program.
- */
-export const _AppConfig = Schema.Struct({
-  width: Schema.optionalWith(
-    Schema.Literal("columns", "compact", "full", "medium", "normal"),
-    { default: () => "compact" },
-  ),
-  app_title: Schema.optionalWith(Schema.NullOr(Schema.String), {
-    default: () => null,
-  }),
-  layout_file: Schema.optionalWith(Schema.NullOr(Schema.String), {
-    default: () => null,
-  }),
-  css_file: Schema.optionalWith(Schema.NullOr(Schema.String), {
-    default: () => null,
-  }),
-  html_head_file: Schema.optionalWith(Schema.NullOr(Schema.String), {
-    default: () => null,
-  }),
-  auto_download: Schema.optionalWith(
-    Schema.Array(Schema.Literal("html", "ipynb", "markdown")),
-    { default: () => [] },
-  ),
-  sql_output: Schema.optionalWith(
-    Schema.Literal("auto", "lazy-polars", "native", "pandas", "polars"),
-    { default: () => "auto" },
-  ),
-}).annotations({ identifier: "_AppConfig" });
-export type _AppConfig = typeof _AppConfig.Type;
-
-/**
  * Metadata about the notebook
  */
 export const NotebookMetadata = Schema.Struct({
@@ -188,9 +170,10 @@ export type NotebookMetadata = typeof NotebookMetadata.Type;
  * Persisted marimo-owned metadata on an LSP notebook document.
  */
 export const MarimoNotebookMetadata = Schema.Struct({
-  appConfig: Schema.optionalWith(_AppConfig, {
-    default: () => _AppConfig.make(),
-  }),
+  appConfig: Schema.optionalWith(
+    Schema.Record({ key: Schema.String, value: Schema.Unknown }),
+    { default: () => ({}) },
+  ),
   header: Schema.optionalWith(Schema.NullOr(Schema.String), {
     default: () => null,
   }),
@@ -241,9 +224,10 @@ export type NotebookV1 = typeof NotebookV1.Type;
  */
 export const NotebookDocument = Schema.Struct({
   notebook: NotebookV1,
-  appConfig: Schema.optionalWith(_AppConfig, {
-    default: () => _AppConfig.make(),
-  }),
+  appConfig: Schema.optionalWith(
+    Schema.Record({ key: Schema.String, value: Schema.Unknown }),
+    { default: () => ({}) },
+  ),
   header: Schema.optionalWith(Schema.NullOr(Schema.String), {
     default: () => null,
   }),
@@ -750,9 +734,10 @@ export type SerializeResponse = typeof SerializeResponse.Type;
 
 export const SerializePayload = Schema.Struct({
   notebook: NotebookV1,
-  appConfig: Schema.optionalWith(_AppConfig, {
-    default: () => _AppConfig.make(),
-  }),
+  appConfig: Schema.optionalWith(
+    Schema.Record({ key: Schema.String, value: Schema.Unknown }),
+    { default: () => ({}) },
+  ),
   header: Schema.optionalWith(Schema.NullOr(Schema.String), {
     default: () => null,
   }),

--- a/extension/src/schemas/__tests__/MarimoNotebookDocument.test.ts
+++ b/extension/src/schemas/__tests__/MarimoNotebookDocument.test.ts
@@ -80,3 +80,47 @@ describe("MarimoNotebookCell metadata updates", () => {
     },
   );
 });
+
+describe("MarimoNotebookDocument app config", () => {
+  it("validates owned options and preserves options it does not understand", () => {
+    const raw = createTestNotebookDocument("file:///test/notebook_mo.py", {
+      data: {
+        cells: [],
+        metadata: {
+          marimo: {
+            appConfig: {
+              auto_download: ["html", "future-format"],
+              width: "wide",
+              future_setting: { answer: 42 },
+            },
+          },
+        },
+      },
+    });
+
+    const parsed = Effect.runSync(
+      MarimoNotebookDocument.from(raw).parseMetadata(),
+    );
+    expect(parsed.appConfig.auto_download).toEqual(["html", "future-format"]);
+    expect(parsed.appConfig).toMatchObject({
+      width: "wide",
+      future_setting: { answer: 42 },
+    });
+  });
+
+  it("rejects invalid values for the option owned by the extension", () => {
+    const raw = createTestNotebookDocument("file:///test/notebook_mo.py", {
+      data: {
+        cells: [],
+        metadata: {
+          marimo: { appConfig: { auto_download: [42] } },
+        },
+      },
+    });
+
+    const result = Effect.runSync(
+      Effect.either(MarimoNotebookDocument.from(raw).parseMetadata()),
+    );
+    expect(Either.isLeft(result)).toBe(true);
+  });
+});

--- a/extension/src/schemas/__tests__/Models.gen.test.ts
+++ b/extension/src/schemas/__tests__/Models.gen.test.ts
@@ -133,7 +133,7 @@ describe("Models.gen (msgspec → Effect Schema codegen)", () => {
     });
   });
 
-  it("models the notebook wire document without an opaque record", () => {
+  it("preserves app constructor options as an open record", () => {
     const decoded = Schema.decodeUnknownSync(NotebookDocument)({
       notebook: {
         version: "1",
@@ -148,12 +148,16 @@ describe("Models.gen (msgspec → Effect Schema codegen)", () => {
           },
         ],
       },
-      appConfig: { width: "full" },
+      appConfig: { width: "full", future_setting: { answer: 42 } },
       header: null,
     });
 
     expect(decoded.notebook.cells[0]?.config.hide_code).toBe(true);
     expect(decoded.appConfig?.width).toBe("full");
+    expect(decoded.appConfig?.future_setting).toEqual({ answer: 42 });
+    expect(
+      Schema.encodeSync(NotebookDocument)(decoded).appConfig?.future_setting,
+    ).toEqual({ answer: 42 });
   });
 
   it.effect("requires JSON null for fire-and-forget responses", () =>

--- a/scripts/codegen/effect_schemas.py
+++ b/scripts/codegen/effect_schemas.py
@@ -51,6 +51,7 @@ class _Inner(msgspec.Struct):
 # (exported name, type) pairs. The emitter topologically orders dependencies.
 CONCRETE: list[tuple[str, type | object]] = [
     ("PackageSource", models.PackageSource),
+    ("OwnedAppConfig", models.OwnedAppConfig),
     ("CellMetadata", models.CellMetadata),
     ("NotebookDocumentMetadata", models.NotebookDocumentMetadata),
     ("NotebookDocument", models.NotebookDocument),

--- a/src/marimo_lsp/api.py
+++ b/src/marimo_lsp/api.py
@@ -4,9 +4,11 @@
 
 from __future__ import annotations
 
+import ast
 import dataclasses
 import inspect
 import json
+import keyword
 import typing
 from typing import TYPE_CHECKING, cast
 
@@ -89,6 +91,11 @@ if TYPE_CHECKING:
     from pygls.lsp.server import LanguageServer
 
     from marimo_lsp.sessions import Sessions
+
+
+_APP_CONFIG_FIELD_NAMES = frozenset(
+    field.name for field in dataclasses.fields(_AppConfig)
+)
 
 
 __all__ = ["API_METHODS", "ApiBuilder", "ApiMethod", "handle_api_command"]
@@ -549,12 +556,83 @@ def _package_manager_for(source: VenvSource | ScriptSource) -> LspPackageManager
 @marimo_api("serialize")
 async def serialize(_ctx: ApiContext, args: NotebookDocument) -> SerializeResponse:
     ir = MarimoConvert.from_notebook_v1(args.notebook).to_ir()
+    known_options = {
+        name: value
+        for name, value in args.app_config.items()
+        if name in _APP_CONFIG_FIELD_NAMES
+    }
     ir = dataclasses.replace(
         ir,
-        app=AppInstantiation(options=args.app_config.asdict()),
+        app=AppInstantiation(options=known_options),
         header=Header(value=args.header) if args.header is not None else None,
     )
-    return SerializeResponse(source=MarimoConvert.from_ir(ir).to_py())
+    source = MarimoConvert.from_ir(ir).to_py()
+    return SerializeResponse(
+        source=_restore_unknown_app_options(source, args.app_config)
+    )
+
+
+def _restore_unknown_app_options(source: str, options: dict[str, object]) -> str:
+    """Restore opaque options dropped by marimo's current code generator.
+
+    Marimo parses unknown literal kwargs, but ``generate_filecontents_from_ir``
+    projects them through its installed ``_AppConfig`` and loses them. Replace
+    only the generated ``marimo.App(...)`` expression so future options survive
+    a save without reformatting the rest of the notebook.
+    """
+    known_options = _APP_CONFIG_FIELD_NAMES
+    unknown_options = [
+        (name, value) for name, value in options.items() if name not in known_options
+    ]
+    if not unknown_options:
+        return source
+
+    rendered_options: list[str] = []
+    for name, value in unknown_options:
+        if not name.isidentifier() or keyword.iskeyword(name):
+            msg = f"App config key cannot be represented as a keyword: {name!r}"
+            raise ValueError(msg)
+        rendered = repr(value)
+        try:
+            ast.literal_eval(rendered)
+        except (ValueError, SyntaxError) as error:
+            msg = f"App config value is not a Python literal: {name!r}={rendered}"
+            raise ValueError(msg) from error
+        rendered_options.append(f"{name}={rendered}")
+
+    tree = ast.parse(source)
+    call = next(
+        (
+            node.value
+            for node in tree.body
+            if isinstance(node, ast.Assign)
+            and any(
+                isinstance(target, ast.Name) and target.id == "app"
+                for target in node.targets
+            )
+            and isinstance(node.value, ast.Call)
+            and isinstance(node.value.func, ast.Attribute)
+            and isinstance(node.value.func.value, ast.Name)
+            and node.value.func.value.id == "marimo"
+            and node.value.func.attr == "App"
+        ),
+        None,
+    )
+    if call is None or call.end_lineno is None or call.end_col_offset is None:
+        msg = "Generated notebook did not contain marimo.App(...)"
+        raise ValueError(msg)
+
+    lines = source.splitlines(keepends=True)
+
+    def offset(line_number: int, byte_column: int) -> int:
+        line = lines[line_number - 1]
+        char_column = len(line.encode()[:byte_column].decode())
+        return sum(map(len, lines[: line_number - 1])) + char_column
+
+    end = offset(call.end_lineno, call.end_col_offset)
+    separator = ", " if call.args or call.keywords else ""
+    insertion = f"{separator}{', '.join(rendered_options)}"
+    return f"{source[: end - 1]}{insertion}{source[end - 1 :]}"
 
 
 @marimo_api("deserialize")
@@ -578,7 +656,7 @@ async def deserialize(
     return DeserializeSuccess(
         notebook=NotebookDocument(
             notebook=converter.to_notebook_v1(),
-            app_config=_AppConfig.from_untrusted_dict(ir.app.options),
+            app_config={**_AppConfig().asdict(), **ir.app.options},
             header=ir.header.value if ir.header is not None else None,
         )
     )

--- a/src/marimo_lsp/app_file_manager.py
+++ b/src/marimo_lsp/app_file_manager.py
@@ -179,7 +179,7 @@ def sync_app_with_workspace(
     notebook = find_notebook_document(workspace, notebook_uri)
 
     metadata = decode_notebook_document_metadata(notebook)
-    app_options = metadata.app_config.asdict()
+    app_options = metadata.app_config
     if app is None:
         app = InternalApp(App(**app_options))
 

--- a/src/marimo_lsp/models.py
+++ b/src/marimo_lsp/models.py
@@ -12,7 +12,6 @@ import msgspec
 # These stay runtime imports (noqa: TC002) even though they only appear in
 # annotations: msgspec resolves the stringified annotations when the structs
 # are first encoded/inspected, which fails under TYPE_CHECKING-only imports.
-from marimo._ast.app_config import _AppConfig
 from marimo._config.config import MarimoConfig  # noqa: TC002
 from marimo._convert.common.format import DEFAULT_MARKDOWN_PREFIX
 from marimo._runtime.packages.package_manager import PackageDescription  # noqa: TC002
@@ -32,6 +31,27 @@ T = typing.TypeVar("T", bound=msgspec.Struct)
 # `sourceProjections.sql.engine` for the implicit default engine. We must not
 # emit `engine=__marimo_duckdb` when round-tripping these cells.
 DEFAULT_SQL_ENGINE = "__marimo_duckdb"
+
+
+# Opaque ``marimo.App`` constructor options preserved across the wire.
+#
+# Marimo deliberately accepts ``**kwargs`` for forward/backward compatibility:
+# unknown keys are ignored by the installed runtime, while known keys accept
+# legacy values. The extension should therefore type and validate only options
+# it owns instead of duplicating marimo's evolving private ``_AppConfig``.
+type AppConfig = dict[str, object]
+
+
+class OwnedAppConfig(msgspec.Struct):
+    """App options understood by the extension, projected from ``AppConfig``.
+
+    Codegen preserves excess properties in TypeScript so parsing this owned
+    subset never discards options belonging to marimo or a future extension.
+    """
+
+    __preserve_unknown_fields__: typing.ClassVar[bool] = True
+
+    auto_download: list[str] = msgspec.field(default_factory=list)
 
 
 class NotebookCommand(msgspec.Struct, typing.Generic[T], rename="camel"):  # noqa: UP046
@@ -187,7 +207,7 @@ class MarimoNotebookMetadata(
 ):
     """Persisted marimo-owned metadata on an LSP notebook document."""
 
-    app_config: _AppConfig = msgspec.field(default_factory=_AppConfig)
+    app_config: AppConfig = msgspec.field(default_factory=dict)
     header: str | None = None
     notebook_metadata: NotebookMetadata = msgspec.field(default_factory=dict)
 
@@ -206,7 +226,7 @@ class NotebookDocument(msgspec.Struct, rename="camel"):
     """Strict JSON notebook data plus source-level application metadata."""
 
     notebook: NotebookV1
-    app_config: _AppConfig = msgspec.field(default_factory=_AppConfig)
+    app_config: AppConfig = msgspec.field(default_factory=dict)
     header: str | None = None
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,19 +2,22 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 from unittest.mock import MagicMock, patch
 
 import msgspec
 import pytest
 from marimo._config.config import DEFAULT_CONFIG
+from marimo._convert.converters import MarimoConvert
 from marimo._types.ids import RequestId
 
 from marimo_lsp.api import (
     ApiBuilder,
     ApiContext,
+    _restore_unknown_app_options,
     deserialize,
     get_configuration,
+    handle_api_command,
     list_sql_schemas,
     list_sql_tables,
     update_configuration,
@@ -52,6 +55,66 @@ if __name__ == "__main__":
     result = await deserialize(_context(MagicMock()), DeserializeRequest(source=source))
 
     assert isinstance(result, DeserializeSuccess)
+
+
+@pytest.mark.asyncio
+async def test_legacy_and_unknown_app_config_round_trip_over_api_wire() -> None:
+    source = """\
+import marimo
+
+app = marimo.App(
+    width="wide",
+    auto_download=["html"],
+    future_setting="keep",
+    asdict="method-name collision",
+)
+
+if __name__ == "__main__":
+    app.run()
+"""
+
+    deserialized = cast(
+        "dict[str, object]",
+        await handle_api_command(
+            MagicMock(),
+            MagicMock(),
+            "deserialize",
+            {"source": source},
+        ),
+    )
+    deserialized_notebook = cast("dict[str, object]", deserialized["notebook"])
+    app_config = cast("dict[str, object]", deserialized_notebook["appConfig"])
+    assert app_config["width"] == "wide"
+    assert app_config["auto_download"] == ["html"]
+    assert app_config["future_setting"] == "keep"
+    assert app_config["asdict"] == "method-name collision"
+
+    serialized = cast(
+        "dict[str, object]",
+        await handle_api_command(
+            MagicMock(),
+            MagicMock(),
+            "serialize",
+            deserialized_notebook,
+        ),
+    )
+    serialized_source = serialized["source"]
+    assert isinstance(serialized_source, str)
+    reparsed_options = MarimoConvert.from_py(serialized_source).to_ir().app.options
+    assert reparsed_options["width"] == "wide"
+    assert reparsed_options["auto_download"] == ["html"]
+    assert reparsed_options["future_setting"] == "keep"
+    assert reparsed_options["asdict"] == "method-name collision"
+
+
+def test_restore_unknown_app_options_reports_non_literal_value() -> None:
+    value = object()
+
+    with pytest.raises(ValueError, match=r"future_setting.*object"):
+        _restore_unknown_app_options(
+            "import marimo\napp = marimo.App()\n",
+            {"future_setting": value},
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/test_app_file_manager.py
+++ b/tests/test_app_file_manager.py
@@ -107,6 +107,21 @@ class TestSyncAppWithWorkspace:
         assert app.config.width == "medium"
         assert app.config.sql_output == "polars"
 
+    def test_runtime_ignores_unknown_app_options(self) -> None:
+        uri = "file:///test/notebook.py"
+        ws = _make_workspace_with_metadata(
+            uri,
+            metadata={
+                "marimo": {
+                    "appConfig": {"width": "wide", "future_setting": True},
+                }
+            },
+        )
+
+        app = sync_app_with_workspace(workspace=ws, notebook_uri=uri, app=None)
+        assert app.config.width == "wide"
+        assert not hasattr(app.config, "future_setting")
+
     def test_ignores_foreign_top_level_metadata(self) -> None:
         uri = "file:///test/notebook.py"
         ws = _make_workspace_with_metadata(


### PR DESCRIPTION
Fix notebook open failures caused by the extension rejecting app config that marimo still accepts, including legacy values such as `width="wide"`.

`marimo.App` intentionally accepts `**kwargs` and applies recognized settings without runtime value validation so notebooks remain resilient across versions. Unknown settings are ignored by the installed marimo runtime. These changes mirror that contract at the extension boundary, and only validating config we handle/write.