### PR TITLE
Add Markdown auto-export

### DIFF
--- a/extension/src/commands/__tests__/configureAutoExport.test.ts
+++ b/extension/src/commands/__tests__/configureAutoExport.test.ts
@@ -122,6 +122,41 @@ it.effect(
 );
 
 it.effect(
+  "reports when all automatic exports are disabled",
+  Effect.fn(function* () {
+    const information = yield* Ref.make(Option.none<string>());
+    const editor = TestVsCode.makeNotebookEditor("/test/report.py", {
+      data: {
+        cells: [],
+        metadata: MarimoNotebookDocument.createMetadata({
+          appConfig: { auto_download: ["html", "ipynb", "markdown"] },
+        }),
+      },
+    });
+    const vscode = yield* TestVsCode.make({
+      initialDocuments: [editor.notebook],
+      window: {
+        showQuickPickItemsMany: () => Effect.succeed(Option.some([])),
+        showInformationMessage: (message) =>
+          Ref.set(information, Option.some(message)).pipe(
+            Effect.as(Option.none()),
+          ),
+      },
+      workspace: {
+        applyEdit: () => Effect.succeed(true),
+      },
+    });
+
+    yield* vscode.setActiveNotebookEditor(Option.some(editor));
+    yield* configureAutoExport().pipe(Effect.provide(vscode.layer));
+
+    expect(yield* information).toEqual(
+      Option.some("Automatic exports disabled."),
+    );
+  }),
+);
+
+it.effect(
   "merges the selection into metadata changed while the picker is open",
   Effect.fn(function* () {
     const updatedMetadata = yield* Ref.make(

--- a/extension/src/commands/__tests__/configureAutoExport.test.ts
+++ b/extension/src/commands/__tests__/configureAutoExport.test.ts
@@ -16,9 +16,8 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 describe("mergeAutoDownloadFormats", () => {
-  it("updates HTML and IPYNB without removing latent Markdown export", () => {
+  it("updates all managed formats from the selection", () => {
     expect(mergeAutoDownloadFormats(["html", "markdown"], ["ipynb"])).toEqual([
-      "markdown",
       "ipynb",
     ]);
   });
@@ -31,10 +30,9 @@ describe("mergeAutoDownloadFormats", () => {
   });
 
   it("preserves the order of existing formats", () => {
-    expect(mergeAutoDownloadFormats(["markdown", "html"], ["html"])).toEqual([
-      "markdown",
-      "html",
-    ]);
+    expect(
+      mergeAutoDownloadFormats(["markdown", "html"], ["html", "markdown"]),
+    ).toEqual(["markdown", "html"]);
   });
 });
 
@@ -104,7 +102,11 @@ it.effect(
       window: {
         showQuickPickItemsMany: (items) =>
           Effect.succeed(
-            Option.some(items.filter((item) => item.label === "HTML")),
+            Option.some(
+              items.filter(
+                (item) => item.label === "HTML" || item.label === "Markdown",
+              ),
+            ),
           ),
       },
       workspace: {

--- a/extension/src/commands/configureAutoExport.ts
+++ b/extension/src/commands/configureAutoExport.ts
@@ -124,7 +124,7 @@ export const configureAutoExport = Effect.fn("command.configureAutoExport")(
     yield* code.window.showInformationMessage(
       label.length > 0
         ? `Automatic exports enabled for ${label}.`
-        : "Automatic HTML and IPYNB exports disabled.",
+        : "Automatic exports disabled.",
     );
   },
 );

--- a/extension/src/commands/configureAutoExport.ts
+++ b/extension/src/commands/configureAutoExport.ts
@@ -7,10 +7,10 @@ import { VsCode } from "../platform/VsCode.ts";
 import { MarimoNotebookDocument } from "../schemas/MarimoNotebookDocument.ts";
 import type { OwnedAppConfig } from "../schemas/Models.gen.ts";
 
-const FORMATS = ["html", "ipynb"] as const;
+const FORMATS = ["html", "ipynb", "markdown"] as const;
 
 const isManagedFormat = (format: string): format is AutoExportFormat =>
-  format === "html" || format === "ipynb";
+  format === "html" || format === "ipynb" || format === "markdown";
 
 export function mergeAutoDownloadFormats(
   current: OwnedAppConfig["auto_download"],
@@ -57,6 +57,12 @@ export const configureAutoExport = Effect.fn("command.configureAutoExport")(
           detail: "Save a Jupyter notebook with current outputs",
           value: "ipynb" as const,
           picked: current.includes("ipynb"),
+        },
+        {
+          label: "Markdown",
+          detail: "Save a Markdown representation of the notebook",
+          value: "markdown" as const,
+          picked: current.includes("markdown"),
         },
       ],
       {

--- a/extension/src/features/AutoExport.ts
+++ b/extension/src/features/AutoExport.ts
@@ -14,6 +14,7 @@ import {
 export const AUTO_EXPORT_INTERVAL = "5 seconds";
 
 export type AutoExportFormat = "html" | "ipynb" | "markdown";
+type AutoExportExtension = "html" | "ipynb" | "md";
 
 interface AutoExportState {
   readonly incarnation: object;
@@ -30,17 +31,19 @@ const initialState = (): AutoExportState => ({
 export function autoExportUri(
   code: VsCode,
   notebook: MarimoNotebookDocument,
-  format: AutoExportFormat | "md",
+  extension: AutoExportExtension,
 ) {
   const basename = NodePath.posix.basename(notebook.uri.path);
-  const extension = NodePath.posix.extname(basename);
+  const notebookExtension = NodePath.posix.extname(basename);
   const stem =
-    extension.length > 0 ? basename.slice(0, -extension.length) : basename;
+    notebookExtension.length > 0
+      ? basename.slice(0, -notebookExtension.length)
+      : basename;
   return code.Uri.joinPath(
     notebook.uri,
     "..",
     "__marimo__",
-    `${stem}.${format}`,
+    `${stem}.${extension}`,
   );
 }
 

--- a/extension/src/features/AutoExport.ts
+++ b/extension/src/features/AutoExport.ts
@@ -13,7 +13,7 @@ import {
 
 export const AUTO_EXPORT_INTERVAL = "5 seconds";
 
-export type AutoExportFormat = "html" | "ipynb";
+export type AutoExportFormat = "html" | "ipynb" | "markdown";
 
 interface AutoExportState {
   readonly incarnation: object;
@@ -24,13 +24,13 @@ interface AutoExportState {
 const initialState = (): AutoExportState => ({
   incarnation: {},
   generation: 0,
-  exported: { html: -1, ipynb: -1 },
+  exported: { html: -1, ipynb: -1, markdown: -1 },
 });
 
 export function autoExportUri(
   code: VsCode,
   notebook: MarimoNotebookDocument,
-  format: AutoExportFormat,
+  format: AutoExportFormat | "md",
 ) {
   const basename = NodePath.posix.basename(notebook.uri.path);
   const extension = NodePath.posix.extname(basename);
@@ -163,8 +163,8 @@ export const AutoExportLive = Layer.scopedDiscard(
 
         const metadata = yield* notebook.parseMetadata();
         const enabled = metadata.appConfig.auto_download;
-        const formats = (["html", "ipynb"] as const).filter((format) =>
-          enabled.includes(format),
+        const formats = (["html", "ipynb", "markdown"] as const).filter(
+          (format) => enabled.includes(format),
         );
         if (formats.length === 0) return;
 
@@ -220,23 +220,32 @@ export const AutoExportLive = Layer.scopedDiscard(
       notebook: MarimoNotebookDocument,
       format: AutoExportFormat,
     ) {
-      const content =
-        format === "html"
-          ? marimo.exportAsHtml({
-              notebookUri: notebook.id,
-              inner: {
-                download: false,
-                files: [],
-                includeCode: true,
-                assetUrl: null,
-              },
-            })
-          : marimo.exportAsIpynb({
-              notebookUri: notebook.id,
-              inner: {},
-            });
+      const content = (() => {
+        if (format === "html") {
+          return marimo.exportAsHtml({
+            notebookUri: notebook.id,
+            inner: {
+              download: false,
+              files: [],
+              includeCode: true,
+              assetUrl: null,
+            },
+          });
+        }
+        if (format === "ipynb") {
+          return marimo.exportAsIpynb({
+            notebookUri: notebook.id,
+            inner: {},
+          });
+        }
+        return marimo.exportAsMarkdown({
+          notebookUri: notebook.id,
+          inner: {},
+        });
+      })();
 
-      const uri = autoExportUri(code, notebook, format);
+      const extension = format === "markdown" ? "md" : format;
+      const uri = autoExportUri(code, notebook, extension);
       return content.pipe(
         Effect.andThen(Schema.decodeUnknown(Schema.String)),
         Effect.flatMap((value) =>

--- a/extension/src/features/__tests__/AutoExport.test.ts
+++ b/extension/src/features/__tests__/AutoExport.test.ts
@@ -36,6 +36,7 @@ const controller: NotebookController = {
 
 const withTestCtx = Effect.fn(function* (
   options: {
+    readonly autoDownload?: ReadonlyArray<"html" | "ipynb" | "markdown">;
     readonly execute?: (request: MarimoApiCall) => Effect.Effect<string>;
     readonly hasOutputs?: boolean;
     readonly hasRuntimeSession?: boolean;
@@ -58,7 +59,9 @@ const withTestCtx = Effect.fn(function* (
   const editor = TestVsCode.makeNotebookEditor("/test/report.py", {
     data: {
       metadata: MarimoNotebookDocument.createMetadata({
-        appConfig: { auto_download: ["html", "ipynb"] },
+        appConfig: {
+          auto_download: [...(options.autoDownload ?? ["html", "ipynb"])],
+        },
       }),
       cells: [
         {
@@ -111,7 +114,9 @@ const withTestCtx = Effect.fn(function* (
             Effect.succeed(
               request.method === "export-as-html"
                 ? "<html>report</html>"
-                : "{}",
+                : request.method === "export-as-markdown"
+                  ? "# Report"
+                  : "{}",
             ),
         ),
       ),
@@ -151,6 +156,25 @@ describe("autoExportUri", () => {
 });
 
 describe("AutoExport", () => {
+  it.scoped(
+    "exports Markdown to an md file",
+    Effect.fn(function* () {
+      const ctx = yield* withTestCtx({ autoDownload: ["markdown"] });
+
+      yield* Effect.gen(function* () {
+        yield* ctx.vscode.setActiveNotebookEditor(Option.some(ctx.editor));
+        yield* TestClock.adjust(AUTO_EXPORT_INTERVAL);
+
+        expect((yield* ctx.calls).map((call) => call.method)).toEqual([
+          "export-as-markdown",
+        ]);
+        expect(Object.fromEntries(yield* ctx.writes)).toEqual({
+          "file:///test/__marimo__/report.md": "# Report",
+        });
+      }).pipe(Effect.provide(ctx.layer));
+    }),
+  );
+
   it.scoped(
     "waits for a live runtime session before creating exports",
     Effect.fn(function* () {

--- a/extension/src/schemas/Models.gen.ts
+++ b/extension/src/schemas/Models.gen.ts
@@ -1395,6 +1395,19 @@ export const ExportAsIpynbPayload = Schema.Struct({
 });
 
 /**
+ * A request to export the notebook as Markdown.
+ */
+export const ExportAsMarkdownRequest = Schema.Struct({}).annotations({
+  identifier: "ExportAsMarkdownRequest",
+});
+export type ExportAsMarkdownRequest = typeof ExportAsMarkdownRequest.Type;
+
+export const ExportAsMarkdownPayload = Schema.Struct({
+  notebookUri: Schema.String,
+  inner: ExportAsMarkdownRequest,
+});
+
+/**
  * Every command accepted by the `marimo.api` transport.
  *
  * Generated from the `API_METHODS` registry in `src/marimo_lsp/api.py`,
@@ -1496,6 +1509,10 @@ export type MarimoApiCall =
   | {
       readonly method: "export-as-ipynb";
       readonly params: typeof ExportAsIpynbPayload.Encoded;
+    }
+  | {
+      readonly method: "export-as-markdown";
+      readonly params: typeof ExportAsMarkdownPayload.Encoded;
     };
 
 type Execute<E, R> = (call: MarimoApiCall) => Effect.Effect<unknown, E, R>;
@@ -1690,6 +1707,13 @@ export const makeApiClient = <E, R>(execute: Execute<E, R>) => ({
       execute,
       { method: "export-as-ipynb", params },
       ExportAsIpynbPayload,
+      Schema.String,
+    ),
+  exportAsMarkdown: (params: typeof ExportAsMarkdownPayload.Encoded) =>
+    dispatch(
+      execute,
+      { method: "export-as-markdown", params },
+      ExportAsMarkdownPayload,
       Schema.String,
     ),
 });

--- a/src/marimo_lsp/api.py
+++ b/src/marimo_lsp/api.py
@@ -19,8 +19,12 @@ from marimo._ast.parse import MarimoFileError
 from marimo._config.config import MarimoConfig  # noqa: TC002 - API introspection
 from marimo._config.manager import get_default_config_manager
 from marimo._convert.converters import MarimoConvert
-from marimo._export.exporter import Exporter
-from marimo._export.requests import HTMLExportRequest, IPYNBExportRequest
+from marimo._export.exporter import Exporter, export_markdown
+from marimo._export.requests import (
+    HTMLExportRequest,
+    IPYNBExportRequest,
+    MarkdownExportRequest,
+)
 from marimo._export.serialization import serialize_notebook_snapshot
 from marimo._runtime.commands import (
     ExecuteScratchpadCommand,
@@ -29,7 +33,7 @@ from marimo._runtime.commands import (
 from marimo._runtime.packages.package_manager import PackageDescription
 from marimo._runtime.packages.package_managers import create_package_manager
 from marimo._schemas.export import ExportAsHTMLRequest, to_html_export_options
-from marimo._schemas.export_options import IPYNBExportOptions
+from marimo._schemas.export_options import IPYNBExportOptions, MarkdownExportOptions
 from marimo._schemas.serialization import (
     AppInstantiation,
     Header,
@@ -54,6 +58,7 @@ from marimo_lsp.models import (
     ExecuteCellsRequest,
     ExecuteScratchRequest,
     ExportAsIpynbRequest,
+    ExportAsMarkdownRequest,
     GetConfigurationRequest,
     GetConfigurationResponse,
     InterruptRequest,
@@ -818,6 +823,28 @@ async def export_as_ipynb(
     )
     ipynb.setdefault("metadata", {}).setdefault("marimo", {})["session"] = session_data
     return json.dumps(ipynb)
+
+
+@marimo_api("export-as-markdown")
+async def export_as_markdown(
+    ctx: ApiContext,
+    args: NotebookCommand[ExportAsMarkdownRequest],
+) -> str:
+    """Export the notebook as Markdown."""
+    logger.info(f"export_as_markdown for {args.notebook_uri}")
+    session = ctx.sessions.get(args.notebook_uri)
+    assert session, f"No session in workspace for {args.notebook_uri}"
+
+    result = export_markdown(
+        MarkdownExportRequest(
+            notebook=session.app.to_ir(),
+            options=MarkdownExportOptions(
+                filename=session.filename,
+                source_filename=session.filename,
+            ),
+        )
+    )
+    return result.text
 
 
 API_METHODS = marimo_api.build()

--- a/src/marimo_lsp/models.py
+++ b/src/marimo_lsp/models.py
@@ -347,6 +347,10 @@ class ExportAsIpynbRequest(msgspec.Struct, rename="camel"):
     """A request to export the notebook as ipynb."""
 
 
+class ExportAsMarkdownRequest(msgspec.Struct, rename="camel"):
+    """A request to export the notebook as Markdown."""
+
+
 class ExecuteScratchRequest(msgspec.Struct, rename="camel"):
     """Execute arbitrary Python code outside the dependency graph."""
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -16,6 +16,7 @@ from marimo_lsp.api import (
     ApiContext,
     _restore_unknown_app_options,
     deserialize,
+    export_as_markdown,
     get_configuration,
     handle_api_command,
     list_sql_schemas,
@@ -27,6 +28,7 @@ from marimo_lsp.models import (
     DeserializeInvalidSyntax,
     DeserializeRequest,
     DeserializeSuccess,
+    ExportAsMarkdownRequest,
     GetConfigurationRequest,
     ListSQLSchemasRequest,
     ListSQLTablesRequest,
@@ -115,6 +117,40 @@ def test_restore_unknown_app_options_reports_non_literal_value() -> None:
             "import marimo\napp = marimo.App()\n",
             {"future_setting": value},
         )
+
+
+@pytest.mark.asyncio
+async def test_export_as_markdown() -> None:
+    source = """\
+import marimo
+
+__generated_with = "0.23.16"
+app = marimo.App()
+
+@app.cell
+def _():
+    x = 1
+    return (x,)
+
+if __name__ == "__main__":
+    app.run()
+"""
+    session = MagicMock()
+    session.filename = "/workspace/report.py"
+    session.app.to_ir.return_value = MarimoConvert.from_py(source).to_ir()
+    sessions = MagicMock()
+    sessions.get.return_value = session
+
+    markdown = await export_as_markdown(
+        _context(sessions),
+        NotebookCommand(
+            notebook_uri=NOTEBOOK_URI,
+            inner=ExportAsMarkdownRequest(),
+        ),
+    )
+
+    assert "title: Report" in markdown
+    assert "```python {.marimo}\nx = 1\n```" in markdown
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
marimo already treats markdown as a supported automatic-export format, while the extension only scheduled HTML and IPYNB.

These changes add the generated Markdown export endpoint, expose Markdown in the configuration picker, and write the resulting snapshot as a `.md` file beside the other automatic exports.