### PR TITLE
Handle cell-container command contexts

### DIFF
--- a/extension/src/commands/Invocation.ts
+++ b/extension/src/commands/Invocation.ts
@@ -118,6 +118,10 @@ const NotebookToolbarContextSchema = Schema.declare<NotebookToolbarContext>(
   { identifier: "vscode.NotebookToolbarContext" },
 );
 
+const NotebookCellContainerContext = Schema.Struct({
+  from: Schema.Literal("cellContainer"),
+});
+
 const notebookFromEditor = (
   editor: vscode.NotebookEditor,
 ): Option.Option<NotebookTarget> =>
@@ -163,6 +167,19 @@ const activeNotebookCell = Effect.gen(function* () {
   return Option.fromNullable(
     notebook.value.getCells()[editor.value.selection.start],
   );
+});
+
+const notebookCellFromTitle = Effect.fn(function* (value: unknown) {
+  const cell = Schema.decodeUnknownOption(VscodeNotebookCellSchema)(value);
+  if (Option.isSome(cell)) {
+    return Option.some(MarimoNotebookCell.from(cell.value));
+  }
+
+  // VS Code may pass this context marker instead of the cell when a notebook
+  // cell title command is invoked from the cell container. In that case the
+  // targeted cell is the active editor's selected cell.
+  yield* Schema.decodeUnknown(NotebookCellContainerContext)(value);
+  return yield* activeNotebookCell;
 });
 
 const commandPalette = {
@@ -215,19 +232,22 @@ const notebookCellTitle = {
     [notebook: Option.Option<NotebookTarget>],
     VsCode
   >("notebookCellTitle", true, 1, (args) =>
-    Schema.decodeUnknown(VscodeNotebookCellSchema)(args[0]).pipe(
-      Effect.flatMap(notebookFromCell),
+    notebookCellFromTitle(args[0]).pipe(
+      Effect.flatMap(
+        Option.match({
+          onNone: () => Effect.succeed(Option.none<NotebookTarget>()),
+          onSome: (cell) => notebookForUri(cell.notebook.uri),
+        }),
+      ),
       Effect.map((notebook) => [notebook]),
     ),
   ),
   notebookCell: makeAdapter<
     [cell: vscode.NotebookCell],
     [cell: Option.Option<MarimoNotebookCell>],
-    never
+    VsCode
   >("notebookCellTitle", true, 1, (args) =>
-    Schema.decodeUnknown(VscodeNotebookCellSchema)(args[0]).pipe(
-      Effect.map((cell) => [Option.some(MarimoNotebookCell.from(cell))]),
-    ),
+    notebookCellFromTitle(args[0]).pipe(Effect.map((cell) => [cell])),
   ),
 } as const;
 

--- a/extension/src/commands/__tests__/CommandDefinitions.test.ts
+++ b/extension/src/commands/__tests__/CommandDefinitions.test.ts
@@ -9,6 +9,7 @@ import {
   decodeCommandArguments,
 } from "../../commands.ts";
 import { CommandIds, CommandSurfaces } from "../CommandIds.gen.ts";
+import hideCellCode from "../hideCellCode.ts";
 import { MarimoCommands } from "../MarimoCommands.ts";
 
 describe("command definitions", () => {
@@ -28,8 +29,9 @@ describe("command definitions", () => {
     expect(actual).toEqual(CommandSurfaces);
   });
 
-  it.effect("ignores VS Code metadata for a no-target command", () =>
-    Effect.gen(function* () {
+  it.effect(
+    "ignores VS Code metadata for a no-target command",
+    Effect.fn(function* () {
       const args = yield* decodeCommandArguments(MarimoCommands.restartLsp, [
         { injectedBy: "commandPalette" },
       ]);
@@ -37,8 +39,9 @@ describe("command definitions", () => {
     }),
   );
 
-  it.effect("normalizes a cell-status invocation to its exact notebook", () =>
-    Effect.gen(function* () {
+  it.effect(
+    "normalizes a cell-status invocation to its exact notebook",
+    Effect.fn(function* () {
       const editor = TestVsCode.makeNotebookEditor("/test/notebook_mo.py");
       const vscode = yield* TestVsCode.make({
         initialDocuments: [editor.notebook],
@@ -61,8 +64,9 @@ describe("command definitions", () => {
     }),
   );
 
-  it.effect("normalizes a cell-title invocation to a marimo cell", () =>
-    Effect.gen(function* () {
+  it.effect(
+    "normalizes a cell-title invocation to a marimo cell",
+    Effect.fn(function* () {
       const editor = TestVsCode.makeNotebookEditor("/test/notebook_mo.py");
       const vscode = yield* TestVsCode.make();
       const cell = createNotebookCell(
@@ -80,30 +84,78 @@ describe("command definitions", () => {
     }),
   );
 
-  it.effect.each([MarimoCommands.hideCellCode, MarimoCommands.showCellCode])(
-    "resolves an omitted cell target to the active cell",
-    (command) =>
-      Effect.gen(function* () {
-        const editor = TestVsCode.makeNotebookEditor("/test/notebook_mo.py", {
-          data: {
-            cells: [{ kind: 2, value: "x = 1", languageId: "python" }],
+  it.effect(
+    "handles a cell-container invocation using the active cell",
+    Effect.fn(function* () {
+      const editor = TestVsCode.makeNotebookEditor("/test/notebook_mo.py", {
+        data: {
+          cells: [{ kind: 2, value: "x = 1", languageId: "python" }],
+        },
+      });
+      const vscode = yield* TestVsCode.make({
+        initialDocuments: [editor.notebook],
+      });
+      yield* vscode.setActiveNotebookEditor(Option.some(editor));
+
+      const [target] = yield* decodeCommandArguments(
+        MarimoCommands.hideCellCode,
+        [{ from: "cellContainer" }],
+      ).pipe(Effect.provide(vscode.layer));
+
+      expect(Option.getOrThrow(target).index).toBe(0);
+      yield* hideCellCode.invoke(target).pipe(Effect.provide(vscode.layer));
+      expect(yield* vscode.executions).toContainEqual({
+        command: "notebook.cell.collapseCellInput",
+        args: [
+          {
+            ranges: [{ start: 0, end: 1 }],
+            document: editor.notebook.uri,
           },
-        });
-        const vscode = yield* TestVsCode.make({
-          initialDocuments: [editor.notebook],
-        });
-        yield* vscode.setActiveNotebookEditor(Option.some(editor));
-
-        const [target] = yield* decodeCommandArguments(command, []).pipe(
-          Effect.provide(vscode.layer),
-        );
-
-        expect(Option.getOrThrow(target).index).toBe(0);
-      }),
+        ],
+      });
+    }),
   );
 
-  it.effect("preserves a resource argument after joining surfaces", () =>
-    Effect.gen(function* () {
+  it.effect(
+    "ignores a cell-container invocation without an active cell",
+    Effect.fn(function* () {
+      const vscode = yield* TestVsCode.make();
+
+      const [target] = yield* decodeCommandArguments(
+        MarimoCommands.hideCellCode,
+        [{ from: "cellContainer" }],
+      ).pipe(Effect.provide(vscode.layer));
+
+      expect(Option.isNone(target)).toBe(true);
+      yield* hideCellCode.invoke(target).pipe(Effect.provide(vscode.layer));
+      expect(yield* vscode.executions).toEqual([]);
+    }),
+  );
+
+  it.effect.each([MarimoCommands.hideCellCode, MarimoCommands.showCellCode])(
+    "resolves an omitted cell target to the active cell",
+    Effect.fn(function* (command) {
+      const editor = TestVsCode.makeNotebookEditor("/test/notebook_mo.py", {
+        data: {
+          cells: [{ kind: 2, value: "x = 1", languageId: "python" }],
+        },
+      });
+      const vscode = yield* TestVsCode.make({
+        initialDocuments: [editor.notebook],
+      });
+      yield* vscode.setActiveNotebookEditor(Option.some(editor));
+
+      const [target] = yield* decodeCommandArguments(command, []).pipe(
+        Effect.provide(vscode.layer),
+      );
+
+      expect(Option.getOrThrow(target).index).toBe(0);
+    }),
+  );
+
+  it.effect(
+    "preserves a resource argument after joining surfaces",
+    Effect.fn(function* () {
       const args = yield* decodeCommandArguments(
         MarimoCommands.openAsMarimoNotebook,
         ["file:///notebook.py"],


### PR DESCRIPTION
Fix code visibility command failures tracked by VSCODE-MARIMO-3HT. VS Code can invoke notebook cell-title commands with a `{"from":"cellContainer"}` context marker instead of a `NotebookCell`, which the typed command adapter rejected.

Accept the marker and resolve it to the selected cell in the active marimo notebook. Keep direct cell invocations strict, safely ignore the marker when no active cell exists, and cover both the successful command path and inactive-editor behavior.