### PR TITLE
Only replay code-mode document transactions

### DIFF
--- a/extension/src/notebook/__tests__/transactionPlan.test.ts
+++ b/extension/src/notebook/__tests__/transactionPlan.test.ts
@@ -4,6 +4,7 @@ import { cellId as cid } from "../../lib/__tests__/branded.ts";
 import type { DocumentChange } from "../../types.ts";
 import type { LanguageIds } from "../classifyCellCode.ts";
 import {
+  changesForEditor,
   computeDesiredCells,
   diffToReplaceRange,
   type PlanCell,
@@ -238,6 +239,22 @@ describe("computeDesiredCells", () => {
     expect(desired[0].sourceProjections?.markdown).toEqual({
       quotePrefix: "r",
     });
+  });
+});
+
+describe("changesForEditor", () => {
+  it.each(["frontend", "kernel", "file-watch", "cell-manager"])(
+    "drops %s transactions",
+    (source) => {
+      expect(
+        changesForEditor([setCode("a", "x = 2"), reorder("b", "a")], source),
+      ).toEqual([]);
+    },
+  );
+
+  it("keeps code-mode transactions", () => {
+    const changes = [setCode("a", "x = 2"), reorder("b", "a")];
+    expect(changesForEditor(changes, "code-mode")).toEqual(changes);
   });
 });
 

--- a/extension/src/notebook/applyDocumentTransaction.ts
+++ b/extension/src/notebook/applyDocumentTransaction.ts
@@ -20,6 +20,7 @@ import {
 import * as Api from "../schemas/Models.gen.ts";
 import type { DocumentTransactionNotification } from "../types.ts";
 import {
+  changesForEditor,
   computeDesiredCells,
   diffToReplaceRange,
   type PlanCell,
@@ -73,7 +74,11 @@ export const applyDocumentTransaction = Effect.fn(
     }
   }
 
-  const desired = computeDesiredCells(current, transaction.changes, LanguageId);
+  const desired = computeDesiredCells(
+    current,
+    changesForEditor(transaction.changes, transaction.source),
+    LanguageId,
+  );
   const range = diffToReplaceRange(current, desired);
   if (range == null) return;
 

--- a/extension/src/notebook/transactionPlan.ts
+++ b/extension/src/notebook/transactionPlan.ts
@@ -60,6 +60,18 @@ export interface ReplaceRange {
   readonly cells: readonly PlanCell[];
 }
 
+/**
+ * Keep non-code-mode writers from changing the editor document. VS Code's LSP
+ * notebook is the source of truth; code mode is the sole remote writer whose
+ * explicit document edits are replayed.
+ */
+export function changesForEditor(
+  changes: readonly DocumentChange[],
+  source: string,
+): readonly DocumentChange[] {
+  return source === "code-mode" ? changes : [];
+}
+
 /** Apply CellConfig's documented defaults so wire configs land in the normalized shape. */
 const normalizeConfig = (config: CellConfig): typeof PlanCellConfig.Type => ({
   column: config.column ?? null,


### PR DESCRIPTION
VS Code and LSP own the notebook document, but kernel startup also sends a document transaction from a snapshot that can omit recently added cells. Replaying that stale transaction moved those cells to the end and could leave duplicate cell IDs.

The transaction replay path was introduced in #582 for marimo-pair, but it replayed transactions from every source.

These changes only replay transactions produced by `code-mode`, where marimo-pair intentionally edits the document, ignoring transactions from every other source.

Closes #708