### PR TITLE
Introduce host-specific capability overrides

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -36,6 +36,7 @@
     "@marimo-team/openapi": "link:../../marimo/packages/openapi",
     "@marimo-team/smart-cells": "link:../../marimo/packages/smart-cells",
     "@oxlint/plugins": "^1.77.0",
+    "@posit-dev/positron": "0.2.4",
     "@sentry/node": "^9.47.1",
     "@std/semver": "jsr:^1.0.8",
     "@std/toml": "jsr:^1.0.11",

--- a/extension/pnpm-lock.yaml
+++ b/extension/pnpm-lock.yaml
@@ -33,6 +33,9 @@ importers:
       '@oxlint/plugins':
         specifier: ^1.77.0
         version: 1.77.0
+      '@posit-dev/positron':
+        specifier: 0.2.4
+        version: 0.2.4(@types/vscode@1.108.1)
       '@sentry/node':
         specifier: ^9.47.1
         version: 9.47.1(supports-color@8.1.1)
@@ -1065,6 +1068,12 @@ packages:
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
+
+  '@posit-dev/positron@0.2.4':
+    resolution: {integrity: sha512-9dqxnWdPp4deJqWAatQravonSOiUYuP9+gRkwcDrmffdodalIjb9N3fsU2T/KOzW9iAnuoufUBLDyyEbWPZwhg==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@types/vscode': ^1.74.0
 
   '@posthog/core@1.46.6':
     resolution: {integrity: sha512-m7iLFU7Cx4IjsUG6wQE3AJRzCFW/tUDCMIWhifvogLCxRAD6pELnqWHqshUB83KcTpxKnFACOQVMxmzzeO98dg==}
@@ -3518,6 +3527,10 @@ snapshots:
     optional: true
 
   '@polka/url@1.0.0-next.29': {}
+
+  '@posit-dev/positron@0.2.4(@types/vscode@1.108.1)':
+    dependencies:
+      '@types/vscode': 1.108.1
 
   '@posthog/core@1.46.6':
     dependencies:

--- a/extension/pnpm-lock.yaml
+++ b/extension/pnpm-lock.yaml
@@ -33,6 +33,9 @@ importers:
       '@oxlint/plugins':
         specifier: ^1.77.0
         version: 1.77.0
+      '@posit-dev/positron':
+        specifier: 0.2.4
+        version: 0.2.4(@types/vscode@1.108.1)
       '@sentry/node':
         specifier: ^9.47.1
         version: 9.47.1(supports-color@8.1.1)
@@ -1062,6 +1065,12 @@ packages:
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
+
+  '@posit-dev/positron@0.2.4':
+    resolution: {integrity: sha512-9dqxnWdPp4deJqWAatQravonSOiUYuP9+gRkwcDrmffdodalIjb9N3fsU2T/KOzW9iAnuoufUBLDyyEbWPZwhg==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@types/vscode': ^1.74.0
 
   '@posthog/core@1.46.6':
     resolution: {integrity: sha512-m7iLFU7Cx4IjsUG6wQE3AJRzCFW/tUDCMIWhifvogLCxRAD6pELnqWHqshUB83KcTpxKnFACOQVMxmzzeO98dg==}
@@ -3525,6 +3534,10 @@ snapshots:
     optional: true
 
   '@polka/url@1.0.0-next.29': {}
+
+  '@posit-dev/positron@0.2.4(@types/vscode@1.108.1)':
+    dependencies:
+      '@types/vscode': 1.108.1
 
   '@posthog/core@1.46.6':
     dependencies:

--- a/extension/src/commands/showMarimoMenu.ts
+++ b/extension/src/commands/showMarimoMenu.ts
@@ -5,12 +5,14 @@ import { defineCommand } from "../commands.ts";
 import { Links } from "../lib/links.ts";
 import { openExternalUrl } from "../lib/openExternalUrl.ts";
 import { VsCode } from "../platform/VsCode.ts";
+import { WebPreview } from "../platform/WebPreview.ts";
 import { MarimoCommands } from "./MarimoCommands.ts";
 import openTutorial from "./openTutorial.ts";
 import showDiagnostics from "./showDiagnostics.ts";
 
 const handler = Effect.fn("command.showMarimoMenu")(function* () {
   const code = yield* VsCode;
+  const webPreview = yield* WebPreview;
   const selection = yield* code.window.showQuickPickItems(
     [
       {
@@ -35,7 +37,7 @@ const handler = Effect.fn("command.showMarimoMenu")(function* () {
 
   switch (selection.value.value) {
     case "documentation":
-      yield* openExternalUrl(Links.documentation);
+      yield* webPreview.open(Links.documentation);
       break;
     case "tutorials":
       yield* code.commands.execute(openTutorial.command);

--- a/extension/src/features/Main.ts
+++ b/extension/src/features/Main.ts
@@ -28,6 +28,7 @@ import { VariablesViewLive } from "../panel/variables/VariablesView.ts";
 import { Api, type MarimoApi } from "../platform/Api.ts";
 import { Constants } from "../platform/Constants.ts";
 import { GitHubClient } from "../platform/GitHubClient.ts";
+import { HostPlatform } from "../platform/HostPlatform.ts";
 import { OutputChannel } from "../platform/OutputChannel.ts";
 import { ExtensionContext, Storage } from "../platform/Storage.ts";
 import type { VsCode } from "../platform/VsCode.ts";
@@ -135,8 +136,12 @@ export function makeExtension(
         throw new Error("Extension is already active");
       }
 
+      const dependencies = Layer.empty.pipe(
+        Layer.provideMerge(HostPlatform.Live),
+        Layer.provideMerge(layer),
+      );
       const appLayer = Layer.provide(
-        Layer.provide(MainLive, layer),
+        Layer.provide(MainLive, dependencies),
         Layer.succeed(ExtensionContext, context),
       ).pipe(
         Layer.merge(Layer.succeed(References.MinimumLogLevel, minimumLogLevel)),

--- a/extension/src/platform/HostPlatform.ts
+++ b/extension/src/platform/HostPlatform.ts
@@ -1,0 +1,32 @@
+import { type PositronApi, tryAcquirePositronApi } from "@posit-dev/positron";
+import { Effect, Layer } from "effect";
+
+import { VsCode } from "./VsCode.ts";
+import { WebPreview } from "./WebPreview.ts";
+
+const makePositronAdapter = (positron: PositronApi) =>
+  Layer.effect(
+    WebPreview,
+    Effect.gen(function* () {
+      const code = yield* VsCode;
+      return WebPreview.of({
+        open: Effect.fn("WebPreview.open")(function* (url: string) {
+          const uri = yield* Effect.fromResult(code.utils.parseUri(url));
+          yield* Effect.sync(() => positron.window.previewUrl(uri));
+        }),
+      });
+    }),
+  );
+
+/**
+ * Selects host-specific implementations for extension capabilities.
+ *
+ * Keep product detection here so feature modules never branch on whether they
+ * are running in VS Code, Positron, or another compatible editor.
+ */
+export const HostPlatform = {
+  Live: Layer.suspend(() => {
+    const positron = tryAcquirePositronApi();
+    return positron ? makePositronAdapter(positron) : WebPreview.layer;
+  }),
+};

--- a/extension/src/platform/WebPreview.ts
+++ b/extension/src/platform/WebPreview.ts
@@ -1,0 +1,19 @@
+import { Context, Effect, Layer } from "effect";
+
+import { VsCode } from "./VsCode.ts";
+
+/** Opens web content using the presentation preferred by the current host. */
+export class WebPreview extends Context.Service<WebPreview>()("WebPreview", {
+  make: Effect.gen(function* () {
+    const code = yield* VsCode;
+    return {
+      /** Show web content in the default external browser. */
+      open: Effect.fn("WebPreview.open")(function* (url: string) {
+        const uri = yield* Effect.fromResult(code.utils.parseUri(url));
+        yield* code.env.openExternal(uri);
+      }),
+    };
+  }),
+}) {
+  static readonly layer = Layer.effect(this, this.make);
+}

--- a/extension/src/platform/__tests__/WebPreview.test.ts
+++ b/extension/src/platform/__tests__/WebPreview.test.ts
@@ -1,0 +1,56 @@
+import { expect, it } from "@effect/vitest";
+import { Effect, Layer, Ref } from "effect";
+import { afterEach, vi } from "vitest";
+
+import { TestVsCode } from "../../__mocks__/TestVsCode.ts";
+import { HostPlatform } from "../HostPlatform.ts";
+import { WebPreview } from "../WebPreview.ts";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+it.effect(
+  "previews URLs externally in VS Code",
+  Effect.fn(function* () {
+    const opened = yield* Ref.make<ReadonlyArray<string>>([]);
+    const vscode = yield* TestVsCode.make({
+      env: {
+        openExternal: (uri) =>
+          Ref.update(opened, (urls) => [...urls, uri.toString(true)]).pipe(
+            Effect.as(true),
+          ),
+      },
+    });
+    const layer = HostPlatform.Live.pipe(Layer.provide(vscode.layer));
+
+    yield* Effect.gen(function* () {
+      const preview = yield* WebPreview;
+      yield* preview.open("https://docs.marimo.io");
+    }).pipe(Effect.provide(layer));
+
+    expect(yield* Ref.get(opened)).toEqual(["https://docs.marimo.io/"]);
+  }),
+);
+
+it.effect(
+  "previews URLs in the Positron viewer",
+  Effect.fn(function* () {
+    const previewUrl = vi.fn();
+    vi.stubGlobal("acquirePositronApi", () => ({
+      window: { previewUrl },
+    }));
+    const vscode = yield* TestVsCode.make();
+    const layer = HostPlatform.Live.pipe(Layer.provide(vscode.layer));
+
+    yield* Effect.gen(function* () {
+      const preview = yield* WebPreview;
+      yield* preview.open("https://docs.marimo.io");
+    }).pipe(Effect.provide(layer));
+
+    expect(previewUrl).toHaveBeenCalledOnce();
+    expect(previewUrl.mock.calls[0][0].toString(true)).toBe(
+      "https://docs.marimo.io/",
+    );
+  }),
+);


### PR DESCRIPTION
Positron is built on Code OSS, the open-source core of VS Code, so most of the marimo extension can work there without changes. Positron also adds data-science-specific APIs that can provide a better execution path for some behaviors. For example, `positron.window.previewUrl` can show documentation in the Positron Viewer instead of using our existing external-browser path.

Checking for Positron at each call site would spread host-specific branches throughout the extension. That would couple otherwise general features to one editor, repeat capability detection, and make each integration harder to test or replace. We instead want to add these enhancements incrementally while keeping the rest of the extension independent of the host.

The proposed foundation moves a host behavior behind a narrow Effect service with a VS Code default, e.g.:

```ts
export class WebPreview extends Effect.Service<WebPreview>()("WebPreview", {
  effect: Effect.gen(function* () {
    const code = yield* VsCode;
    return {
      open: Effect.fn("WebPreview.open")(function* (url: string) {
        const uri = yield* code.utils.parseUri(url);
        yield* code.env.openExternal(uri);
      }),
    };
  }),
}) {}
```

An Effect service can be read here as an injectable interface with a default implementation. Feature code depends on the capability rather than the editor providing it.

At the top level, `HostPlatform` detects Positron _once_ and substitutes only the implementations for which Positron has a preferred path:

```ts
const positron = tryAcquirePositronApi();
return positron
  ? makePositronAdapter(positron)
  : WebPreview.Default;
```

The rest of the extension can then prefer the shared capability without checking the host:

```ts
const preview = yield* WebPreview;
yield* preview.open(url);
```

Because the base implementations use VS Code APIs, they should continue to work across compatible Code OSS-based editors. Positron, or another compatible host, can selectively replace capabilities where it offers a better experience. This spike implements only web preview so that we can evaluate and communicate the pattern before committing to broader integrations.