### PR TITLE
Keep Markdown cell inputs expanded

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -550,12 +550,12 @@
       "notebook/cell/title": [
         {
           "command": "marimo.hideCellCode",
-          "when": "notebookType == 'marimo-notebook' && !notebookCellInputIsCollapsed",
+          "when": "notebookType == 'marimo-notebook' && ((notebookCellType == 'code' && !notebookCellInputIsCollapsed) || notebookCellType == 'markup')",
           "group": "3_edit@1"
         },
         {
           "command": "marimo.showCellCode",
-          "when": "notebookType == 'marimo-notebook' && notebookCellInputIsCollapsed",
+          "when": "notebookType == 'marimo-notebook' && ((notebookCellType == 'code' && notebookCellInputIsCollapsed) || notebookCellType == 'markup')",
           "group": "3_edit@1"
         }
       ],

--- a/extension/package.json
+++ b/extension/package.json
@@ -550,12 +550,12 @@
       "notebook/cell/title": [
         {
           "command": "marimo.hideCellCode",
-          "when": "notebookType == 'marimo-notebook' && ((notebookCellType == 'code' && !notebookCellInputIsCollapsed) || notebookCellType == 'markup')",
+          "when": "notebookType == 'marimo-notebook' && notebookCellType == 'code' && !notebookCellInputIsCollapsed",
           "group": "3_edit@1"
         },
         {
           "command": "marimo.showCellCode",
-          "when": "notebookType == 'marimo-notebook' && ((notebookCellType == 'code' && notebookCellInputIsCollapsed) || notebookCellType == 'markup')",
+          "when": "notebookType == 'marimo-notebook' && notebookCellType == 'code' && notebookCellInputIsCollapsed",
           "group": "3_edit@1"
         }
       ],

--- a/extension/src/__tests__/extension.test.ts
+++ b/extension/src/__tests__/extension.test.ts
@@ -108,12 +108,12 @@ describe("package.json validation", () => {
     expect(pkg.contributes.menus["notebook/cell/title"]).toEqual([
       {
         command: commandId(hideCellCode.command),
-        when: "notebookType == 'marimo-notebook' && ((notebookCellType == 'code' && !notebookCellInputIsCollapsed) || notebookCellType == 'markup')",
+        when: "notebookType == 'marimo-notebook' && notebookCellType == 'code' && !notebookCellInputIsCollapsed",
         group: "3_edit@1",
       },
       {
         command: commandId(showCellCode.command),
-        when: "notebookType == 'marimo-notebook' && ((notebookCellType == 'code' && notebookCellInputIsCollapsed) || notebookCellType == 'markup')",
+        when: "notebookType == 'marimo-notebook' && notebookCellType == 'code' && notebookCellInputIsCollapsed",
         group: "3_edit@1",
       },
     ]);

--- a/extension/src/__tests__/extension.test.ts
+++ b/extension/src/__tests__/extension.test.ts
@@ -108,12 +108,12 @@ describe("package.json validation", () => {
     expect(pkg.contributes.menus["notebook/cell/title"]).toEqual([
       {
         command: commandId(hideCellCode.command),
-        when: "notebookType == 'marimo-notebook' && !notebookCellInputIsCollapsed",
+        when: "notebookType == 'marimo-notebook' && ((notebookCellType == 'code' && !notebookCellInputIsCollapsed) || notebookCellType == 'markup')",
         group: "3_edit@1",
       },
       {
         command: commandId(showCellCode.command),
-        when: "notebookType == 'marimo-notebook' && notebookCellInputIsCollapsed",
+        when: "notebookType == 'marimo-notebook' && ((notebookCellType == 'code' && notebookCellInputIsCollapsed) || notebookCellType == 'markup')",
         group: "3_edit@1",
       },
     ]);

--- a/extension/src/commands/__tests__/setCellCodeVisibility.test.ts
+++ b/extension/src/commands/__tests__/setCellCodeVisibility.test.ts
@@ -73,3 +73,55 @@ it.effect.each([
     ]);
   }),
 );
+
+it.effect.each([
+  { hidden: true, invoke: hideCellCode.invoke },
+  { hidden: false, invoke: showCellCode.invoke },
+])("persists markup hide_code=$hidden while keeping input expanded", (test) =>
+  Effect.gen(function* () {
+    const applied = yield* Ref.make(Option.none<vscode.WorkspaceEdit>());
+    const vscode = yield* TestVsCode.make({
+      workspace: {
+        applyEdit: (edit) =>
+          Ref.set(applied, Option.some(edit)).pipe(Effect.as(true)),
+      },
+    });
+    const uri = createNotebookUri("file:///test/notebook_mo.py");
+    const document = createTestNotebookDocument(uri, {
+      data: {
+        cells: [
+          {
+            kind: 1,
+            value: "# Markdown",
+            languageId: "markdown",
+            metadata: MarimoNotebookCell.createMetadata({
+              marimo: { options: { hide_code: !test.hidden } },
+              marimoRuntime: { stableId: "markdown" },
+            }),
+          },
+        ],
+      },
+    });
+    const cell = Option.some(MarimoNotebookCell.from(document.cellAt(0)));
+
+    yield* test.invoke(cell).pipe(Effect.provide(vscode.layer));
+
+    const workspaceEdit = Option.getOrThrow(yield* Ref.get(applied));
+    const replacement = getNotebookEdits(workspaceEdit, uri)[0]?.newCells[0];
+    const metadata = Option.getOrThrow(
+      MarimoNotebookCell.decodeMetadata(replacement?.metadata),
+    );
+    expect(metadata.marimo.options.hide_code).toBe(test.hidden);
+    expect(yield* vscode.executions).toEqual([
+      {
+        command: "notebook.cell.expandCellInput",
+        args: [
+          {
+            ranges: [{ start: 0, end: 1 }],
+            document: uri,
+          },
+        ],
+      },
+    ]);
+  }),
+);

--- a/extension/src/commands/setCellCodeVisibility.ts
+++ b/extension/src/commands/setCellCodeVisibility.ts
@@ -1,8 +1,11 @@
 import { Effect, Option } from "effect";
+import type * as vscode from "vscode";
 
 import { updateMarimoCellMetadata } from "../notebook/updateMarimoCellMetadata.ts";
 import { VsCode } from "../platform/VsCode.ts";
 import { MarimoNotebookCell } from "../schemas/MarimoNotebookDocument.ts";
+
+const MARKUP_CELL_KIND: vscode.NotebookCellKind = 1;
 
 /** Persist and immediately apply the visibility requested by a cell menu item. */
 const setCellCodeVisibility = Effect.fn("command.setCellCodeVisibility")(
@@ -14,17 +17,20 @@ const setCellCodeVisibility = Effect.fn("command.setCellCodeVisibility")(
       options: { ...metadata.options, hide_code: hidden },
     }));
 
-    // Apply the requested view state even when metadata already had this value,
-    // such as after a user manually expanded a persisted hidden cell.
-    yield* code.commands.executeVSCode(
-      hidden
-        ? "notebook.cell.collapseCellInput"
-        : "notebook.cell.expandCellInput",
-      {
-        ranges: [{ start: index, end: index + 1 }],
-        document: cell.notebook.uri,
-      },
-    );
+    // `hide_code` remains persisted marimo state for native markup cells, but
+    // their VS Code input must stay expanded. Code cells mirror the persisted
+    // value into the editor view.
+    const command =
+      cell.kind === MARKUP_CELL_KIND
+        ? "notebook.cell.expandCellInput"
+        : hidden
+          ? "notebook.cell.collapseCellInput"
+          : "notebook.cell.expandCellInput";
+
+    yield* code.commands.executeVSCode(command, {
+      ranges: [{ start: index, end: index + 1 }],
+      document: cell.notebook.uri,
+    });
   },
 );
 

--- a/extension/src/features/CellInputVisibilitySync.ts
+++ b/extension/src/features/CellInputVisibilitySync.ts
@@ -49,7 +49,9 @@ const cellRange = (cell: MarimoNotebookCell): CellRange => ({
 });
 
 /**
- * Returns one single-cell range per `hide_code` cell, in document order.
+ * Returns one single-cell range per code cell whose input should be hidden, in
+ * document order. Native markup cells are intentionally excluded even when
+ * their persisted marimo `hide_code` setting is true.
  *
  * It is a plain function rather than part of the layer below so the selection
  * logic can be tested without standing up a notebook editor.

--- a/extension/src/features/CellInputVisibilitySync.ts
+++ b/extension/src/features/CellInputVisibilitySync.ts
@@ -8,6 +8,7 @@ import {
   Ref,
   Stream,
 } from "effect";
+import type * as vscode from "vscode";
 
 import { VsCode } from "../platform/VsCode.ts";
 import {
@@ -28,6 +29,25 @@ export interface CellRange {
   readonly end: number;
 }
 
+const NotebookCellKind: {
+  readonly Markup: vscode.NotebookCellKind;
+  readonly Code: vscode.NotebookCellKind;
+} = {
+  Markup: 1,
+  Code: 2,
+};
+
+const isMarkupCell = (cell: MarimoNotebookCell) =>
+  cell.kind === NotebookCellKind.Markup;
+
+const isInputHidden = (cell: MarimoNotebookCell) =>
+  cell.kind === NotebookCellKind.Code && cell.isCodeHidden;
+
+const cellRange = (cell: MarimoNotebookCell): CellRange => ({
+  start: cell.index,
+  end: cell.index + 1,
+});
+
 /**
  * Returns one single-cell range per `hide_code` cell, in document order.
  *
@@ -37,9 +57,7 @@ export interface CellRange {
 export function hiddenInputCellRanges(
   cells: readonly MarimoNotebookCell[],
 ): CellRange[] {
-  return cells
-    .filter((cell) => cell.isCodeHidden)
-    .map((cell) => ({ start: cell.index, end: cell.index + 1 }));
+  return cells.filter(isInputHidden).map(cellRange);
 }
 
 type HiddenCodeSnapshot = HashMap.HashMap<NotebookCellId, boolean>;
@@ -50,7 +68,7 @@ function snapshotHiddenCode(
   let snapshot = HashMap.empty<NotebookCellId, boolean>();
   for (const cell of cells) {
     if (Option.isSome(cell.id)) {
-      snapshot = HashMap.set(snapshot, cell.id.value, cell.isCodeHidden);
+      snapshot = HashMap.set(snapshot, cell.id.value, isInputHidden(cell));
     }
   }
   return snapshot;
@@ -74,21 +92,42 @@ const CellInputVisibilitySyncEvent =
 function visibilityChanges(
   previous: Option.Option<HiddenCodeSnapshot>,
   cells: readonly MarimoNotebookCell[],
+  initialize: boolean,
 ): VisibilityChanges {
   if (Option.isNone(previous)) {
-    return { collapse: hiddenInputCellRanges(cells), expand: [] };
+    return {
+      collapse: hiddenInputCellRanges(cells),
+      expand: cells.filter(isMarkupCell).map(cellRange),
+    };
   }
 
   const collapse: CellRange[] = [];
   const expand: CellRange[] = [];
   for (const cell of cells) {
+    // `hide_code` is still persisted for marimo markdown cells, but a native
+    // VS Code markup cell must keep its editable input expanded. Reapply this
+    // on activation because VS Code does not expose the current view state.
+    if (isMarkupCell(cell)) {
+      const before = Option.flatMap(cell.id, (id) =>
+        HashMap.get(previous.value, id),
+      );
+      if (
+        initialize ||
+        Option.isNone(before) ||
+        Option.getOrElse(before, () => false)
+      ) {
+        expand.push(cellRange(cell));
+      }
+      continue;
+    }
+
     if (Option.isNone(cell.id)) continue;
 
     const before = HashMap.get(previous.value, cell.id.value);
-    const range = { start: cell.index, end: cell.index + 1 };
-    if (cell.isCodeHidden && !Option.getOrElse(before, () => false)) {
+    const range = cellRange(cell);
+    if (isInputHidden(cell) && !Option.getOrElse(before, () => false)) {
       collapse.push(range);
-    } else if (!cell.isCodeHidden && Option.isSome(before) && before.value) {
+    } else if (!isInputHidden(cell) && Option.isSome(before) && before.value) {
       expand.push(range);
     }
   }
@@ -119,7 +158,7 @@ export const CellInputVisibilitySyncLive = Layer.scopedDiscard(
         if (!initialize && Option.isNone(previous)) return;
 
         const cells = notebook.getCells();
-        const changes = visibilityChanges(previous, cells);
+        const changes = visibilityChanges(previous, cells, initialize);
         const next = snapshotHiddenCode(cells);
 
         yield* Effect.annotateCurrentSpan({
@@ -167,6 +206,9 @@ export const CellInputVisibilitySyncLive = Layer.scopedDiscard(
       Stream.fromEffect(code.window.getActiveNotebookEditor()),
       code.window.activeNotebookEditorChanges(),
     ).pipe(
+      // The current-editor read can race with the first change event. Keep the
+      // intervening `none` states so a real tab refocus still re-synchronizes.
+      Stream.changes,
       Stream.filterMap((editor) =>
         Option.filterMap(editor, (editor) =>
           MarimoNotebookDocument.tryFrom(editor.notebook),

--- a/extension/src/features/__tests__/CellInputVisibilitySync.test.ts
+++ b/extension/src/features/__tests__/CellInputVisibilitySync.test.ts
@@ -14,14 +14,14 @@ import {
   CellInputVisibilitySyncLive,
 } from "../CellInputVisibilitySync.ts";
 
-const cell = (index: number, hideCode: boolean) =>
+const cell = (index: number, hideCode: boolean, kind: 1 | 2 = 2) =>
   MarimoNotebookCell.from(
     createNotebookCell(
       createTestNotebookDocument("/test/notebook_mo.py"),
       {
-        kind: 2,
+        kind,
         value: "",
-        languageId: "python",
+        languageId: kind === 1 ? "markdown" : "python",
         metadata: MarimoNotebookCell.createMetadata({
           marimo: { options: { hide_code: hideCode } },
           marimoRuntime: { stableId: `cell-${index}` },
@@ -47,6 +47,10 @@ describe("hiddenInputCellRanges", () => {
 
   it("returns no ranges when no cell hides its code", () => {
     expect(hiddenInputCellRanges([cell(0, false)])).toEqual([]);
+  });
+
+  it("does not hide native markup cells with persisted hide_code", () => {
+    expect(hiddenInputCellRanges([cell(0, true, 1)])).toEqual([]);
   });
 });
 
@@ -81,15 +85,16 @@ const commandRanges = Effect.fn(function* (
 interface CellState {
   readonly stableId: string;
   readonly hideCode: boolean;
+  readonly kind?: 1 | 2;
 }
 
 const makeEditor = (cells: readonly CellState[]) =>
   TestVsCode.makeNotebookEditor("/test/notebook_mo.py", {
     data: {
-      cells: cells.map(({ stableId, hideCode: hide_code }) => ({
-        kind: 2,
+      cells: cells.map(({ stableId, hideCode: hide_code, kind = 2 }) => ({
+        kind,
         value: "",
-        languageId: "python",
+        languageId: kind === 1 ? "markdown" : "python",
         metadata: MarimoNotebookCell.createMetadata({
           marimo: { options: { hide_code } },
           marimoRuntime: { stableId },
@@ -152,6 +157,64 @@ describe("CellInputVisibilitySync", () => {
             { start: 2, end: 3 },
           ],
         ]);
+      }).pipe(Effect.provide(layer));
+    }),
+  );
+
+  it.scoped(
+    "expands markup cells while collapsing hidden code cells on activation",
+    Effect.fn(function* () {
+      const initial = [
+        { stableId: "code", hideCode: true },
+        { stableId: "markdown", hideCode: true, kind: 1 as const },
+      ];
+      const editor = makeEditor(initial);
+      const vscode = yield* TestVsCode.make({
+        initialDocuments: [editor.notebook],
+      });
+      const layer = CellInputVisibilitySyncLive.pipe(
+        Layer.provide(vscode.layer),
+      );
+      yield* vscode.setActiveNotebookEditor(Option.some(editor));
+
+      yield* Effect.gen(function* () {
+        yield* TestClock.adjust("1 millis");
+
+        expect(
+          yield* commandRanges(vscode, "notebook.cell.collapseCellInput"),
+        ).toEqual([[{ start: 0, end: 1 }]]);
+        expect(
+          yield* commandRanges(vscode, "notebook.cell.expandCellInput"),
+        ).toEqual([[{ start: 1, end: 2 }]]);
+      }).pipe(Effect.provide(layer));
+    }),
+  );
+
+  it.scoped(
+    "re-expands markup cells whenever the notebook becomes active",
+    Effect.fn(function* () {
+      const initial = [
+        { stableId: "markdown", hideCode: true, kind: 1 as const },
+      ];
+      const editor = makeEditor(initial);
+      const vscode = yield* TestVsCode.make({
+        initialDocuments: [editor.notebook],
+      });
+      const layer = CellInputVisibilitySyncLive.pipe(
+        Layer.provide(vscode.layer),
+      );
+      yield* vscode.setActiveNotebookEditor(Option.some(editor));
+
+      yield* Effect.gen(function* () {
+        yield* TestClock.adjust("1 millis");
+        yield* vscode.setActiveNotebookEditor(Option.none());
+        yield* TestClock.adjust("1 millis");
+        yield* vscode.setActiveNotebookEditor(Option.some(editor));
+        yield* TestClock.adjust("1 millis");
+
+        expect(
+          yield* commandRanges(vscode, "notebook.cell.expandCellInput"),
+        ).toEqual([[{ start: 0, end: 1 }], [{ start: 0, end: 1 }]]);
       }).pipe(Effect.provide(layer));
     }),
   );
@@ -254,6 +317,32 @@ describe("CellInputVisibilitySync", () => {
         expect(
           yield* commandRanges(vscode, "notebook.cell.expandCellInput"),
         ).toEqual([]);
+      }).pipe(Effect.provide(layer));
+    }),
+  );
+
+  it.scoped(
+    "expands a hidden code cell when it becomes markup",
+    Effect.fn(function* () {
+      const before = [{ stableId: "cell", hideCode: true }];
+      const after = [{ stableId: "cell", hideCode: true, kind: 1 as const }];
+      const editor = makeEditor(before);
+      const vscode = yield* TestVsCode.make({
+        initialDocuments: [editor.notebook],
+      });
+      const layer = CellInputVisibilitySyncLive.pipe(
+        Layer.provide(vscode.layer),
+      );
+
+      yield* Effect.gen(function* () {
+        yield* vscode.setActiveNotebookEditor(Option.some(editor));
+        yield* TestClock.adjust("1 millis");
+        yield* changeNotebook(vscode, before, after);
+        yield* TestClock.adjust("1 millis");
+
+        expect(
+          yield* commandRanges(vscode, "notebook.cell.expandCellInput"),
+        ).toEqual([[{ start: 0, end: 1 }]]);
       }).pipe(Effect.provide(layer));
     }),
   );

--- a/extension/src/notebook/NotebookSerializer.ts
+++ b/extension/src/notebook/NotebookSerializer.ts
@@ -324,6 +324,10 @@ function notebookDataToNotebookDocument(
           const name = cellMetadata.marimo.name;
           const config = (fallback: typeof Api.NotebookCellConfig.Type) =>
             hasOptions ? cellMetadata.marimo.options : fallback;
+          const markdownConfig = {
+            ...cellMetadata.marimo.options,
+            hide_code: cellMetadata.marimo.options.hide_code ?? true,
+          };
 
           // oxlint-disable-next-line typescript/no-unsafe-enum-comparison
           if (cell.kind === NotebookCellKind.Markup) {
@@ -339,7 +343,7 @@ function notebookDataToNotebookDocument(
                 code: result.code,
                 code_hash: null,
                 name,
-                config: config({ hide_code: true }),
+                config: markdownConfig,
               };
             }
             // Otherwise use the default wrapInMarkdown
@@ -348,7 +352,7 @@ function notebookDataToNotebookDocument(
               code: wrapInMarkdown(cell.value),
               code_hash: null,
               name,
-              config: config({ hide_code: true }),
+              config: markdownConfig,
             };
           }
 

--- a/extension/src/notebook/__tests__/NotebookSerializer.test.ts
+++ b/extension/src/notebook/__tests__/NotebookSerializer.test.ts
@@ -301,6 +301,7 @@ it.layer(NotebookSerializerLive, { timeout: 30_000 })(
       { name: "empty", metadata: {} },
       { name: "foreign-only", metadata: { foreign: { value: true } } },
       { name: "empty marimo", metadata: { marimo: {} } },
+      { name: "empty options", metadata: { marimo: { options: {} } } },
     ])("uses markdown defaults for a $name metadata envelope", ({ metadata }) =>
       Effect.gen(function* () {
         const { LanguageId } = yield* Constants;
@@ -317,6 +318,30 @@ it.layer(NotebookSerializerLive, { timeout: 30_000 })(
         });
 
         expect(new TextDecoder().decode(bytes)).toContain(
+          "@app.cell(hide_code=True)",
+        );
+      }),
+    );
+
+    it.effect(
+      "preserves an explicit hide_code=false for markdown",
+      Effect.fn(function* () {
+        const { LanguageId } = yield* Constants;
+        const serializer = yield* NotebookSerializer;
+        const bytes = yield* serializer.serializeEffect({
+          cells: [
+            {
+              kind: 1,
+              value: "# markdown",
+              languageId: LanguageId.Markdown,
+              metadata: {
+                marimo: { options: { hide_code: false } },
+              },
+            },
+          ],
+        });
+
+        expect(new TextDecoder().decode(bytes)).not.toContain(
           "@app.cell(hide_code=True)",
         );
       }),

--- a/extension/src/schemas/MarimoNotebookDocument.ts
+++ b/extension/src/schemas/MarimoNotebookDocument.ts
@@ -44,6 +44,7 @@ const notebookMetadataEquivalence = Schema.equivalence(
 );
 
 const parseOwnedAppConfig = Schema.decodeUnknown(Api.OwnedAppConfig);
+const MARKUP_CELL_KIND: vscode.NotebookCellKind = 1;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -231,18 +232,23 @@ export class MarimoNotebookCell {
   }
 
   /**
-   * Whether the cell's code is hidden via `@app.cell(hide_code=True)`.
+   * The cell's effective marimo code visibility setting.
    *
    * marimo stores the decorator's `hide_code` flag in the cell's config; the
-   * LSP deserialize path surfaces it as `metadata.options.hide_code`. VS Code
+   * LSP deserialize path surfaces it as `metadata.options.hide_code`. Native
+   * markup cells default to hidden code because their Python `mo.md` wrapper is
+   * projected away; explicit metadata always wins. VS Code
    * has no API to read or set the input-collapsed state, so this is the source
    * of truth for the one-way synchronization performed by
    * {@link CellInputVisibilitySyncLive} (issue #326).
    */
   get isCodeHidden() {
     return this.metadata.pipe(
-      Option.map((meta) => meta.marimo.options.hide_code === true),
-      Option.getOrElse(() => false),
+      Option.map(
+        (meta) =>
+          meta.marimo.options.hide_code ?? this.#raw.kind === MARKUP_CELL_KIND,
+      ),
+      Option.getOrElse(() => this.#raw.kind === MARKUP_CELL_KIND),
     );
   }
 

--- a/extension/src/schemas/__tests__/MarimoNotebookDocument.test.ts
+++ b/extension/src/schemas/__tests__/MarimoNotebookDocument.test.ts
@@ -20,6 +20,31 @@ const partialUpdate: MarimoUpdate = { name: "renamed" };
 void partialUpdate;
 
 describe("MarimoNotebookCell metadata updates", () => {
+  it.each([
+    { kind: 1 as const, hideCode: undefined, expected: true },
+    { kind: 1 as const, hideCode: false, expected: false },
+    { kind: 2 as const, hideCode: undefined, expected: false },
+    { kind: 2 as const, hideCode: true, expected: true },
+  ])(
+    "defaults hide_code by cell kind: $kind/$hideCode -> $expected",
+    ({ kind, hideCode, expected }) => {
+      const rawCell = createNotebookCell(
+        createTestNotebookDocument("file:///test/notebook_mo.py"),
+        {
+          kind,
+          value: "",
+          languageId: kind === 1 ? "markdown" : "python",
+          metadata: MarimoNotebookCell.createMetadata({
+            marimo: { options: { hide_code: hideCode } },
+          }),
+        },
+        0,
+      );
+
+      expect(MarimoNotebookCell.from(rawCell).isCodeHidden).toBe(expected);
+    },
+  );
+
   it("replaces complete persisted metadata while preserving runtime and foreign fields", () => {
     const metadata = {
       ...MarimoNotebookCell.createMetadata({


### PR DESCRIPTION
marimo persists Markdown cells with `hide_code=True`, but VS Code renders them as native markup cells. Treating that setting as collapsed input caused VS Code to render the source over the Markdown content.

Keep persisted code visibility independent from VS Code input state for markup cells. Markdown defaults to hidden code, and the existing Hide Code and Show Code actions update that setting while leaving the native cell expanded.

Closes #712