### PR TITLE
Synchronize disabled cells with live kernels

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -351,6 +351,20 @@
         "enablement": "notebookType == 'marimo-notebook'"
       },
       {
+        "command": "marimo.disableCell",
+        "title": "Disable Cell",
+        "category": "marimo",
+        "icon": "$(circle-slash)",
+        "enablement": "notebookType == 'marimo-notebook'"
+      },
+      {
+        "command": "marimo.enableCell",
+        "title": "Enable Cell",
+        "category": "marimo",
+        "icon": "$(circle-large-outline)",
+        "enablement": "notebookType == 'marimo-notebook'"
+      },
+      {
         "command": "marimo.openSession",
         "title": "Open Notebook",
         "category": "marimo",
@@ -493,6 +507,14 @@
         {
           "command": "marimo.updateCellMetadata",
           "when": "never"
+        },
+        {
+          "command": "marimo.disableCell",
+          "when": "never"
+        },
+        {
+          "command": "marimo.enableCell",
+          "when": "never"
         }
       ],
       "file/newFile": [
@@ -567,6 +589,11 @@
           "command": "marimo.showCellCode",
           "when": "notebookType == 'marimo-notebook' && notebookCellType == 'code' && notebookCellInputIsCollapsed",
           "group": "3_edit@1"
+        },
+        {
+          "command": "marimo.disableCell",
+          "when": "notebookType == 'marimo-notebook' && notebookCellType == 'code'",
+          "group": "3_edit@2"
         }
       ],
       "editor/title": [

--- a/extension/src/__tests__/extension.test.ts
+++ b/extension/src/__tests__/extension.test.ts
@@ -10,6 +10,7 @@ import { TestTelemetryLive } from "../__mocks__/TestTelemetry.ts";
 import { TestTyLanguageServerLive } from "../__mocks__/TestTyLanguageServer.ts";
 import { TestVsCode } from "../__mocks__/TestVsCode.ts";
 import { commandId } from "../commands.ts";
+import disableCell from "../commands/disableCell.ts";
 import hideCellCode from "../commands/hideCellCode.ts";
 import showCellCode from "../commands/showCellCode.ts";
 import { NOTEBOOK_TYPE } from "../constants.ts";
@@ -115,6 +116,11 @@ describe("package.json validation", () => {
         command: commandId(showCellCode.command),
         when: "notebookType == 'marimo-notebook' && notebookCellType == 'code' && notebookCellInputIsCollapsed",
         group: "3_edit@1",
+      },
+      {
+        command: commandId(disableCell.command),
+        when: "notebookType == 'marimo-notebook' && notebookCellType == 'code'",
+        group: "3_edit@2",
       },
     ]);
   });

--- a/extension/src/commands/CommandIds.gen.ts
+++ b/extension/src/commands/CommandIds.gen.ts
@@ -35,7 +35,7 @@ export const CommandIds = {
 export const CommandSurfaces = {
   createSetupCell: ["commandPalette"],
   debugCell: ["commandPalette"],
-  disableCell: ["commandPalette", "notebookCellTitle"],
+  disableCell: ["notebookCellTitle"],
   enableCell: [],
   exportStaticHTML: ["commandPalette"],
   hideCellCode: ["commandPalette", "notebookCellTitle"],

--- a/extension/src/commands/CommandIds.gen.ts
+++ b/extension/src/commands/CommandIds.gen.ts
@@ -6,6 +6,8 @@
 export const CommandIds = {
   createSetupCell: "marimo.createSetupCell",
   debugCell: "marimo.debugCell",
+  disableCell: "marimo.disableCell",
+  enableCell: "marimo.enableCell",
   exportStaticHTML: "marimo.exportStaticHTML",
   hideCellCode: "marimo.hideCellCode",
   newMarimoNotebook: "marimo.newMarimoNotebook",
@@ -33,6 +35,8 @@ export const CommandIds = {
 export const CommandSurfaces = {
   createSetupCell: ["commandPalette"],
   debugCell: ["commandPalette"],
+  disableCell: ["commandPalette", "notebookCellTitle"],
+  enableCell: [],
   exportStaticHTML: ["commandPalette"],
   hideCellCode: ["commandPalette", "notebookCellTitle"],
   newMarimoNotebook: ["commandPalette", "fileNew"],

--- a/extension/src/commands/MarimoCommands.ts
+++ b/extension/src/commands/MarimoCommands.ts
@@ -127,6 +127,17 @@ export const MarimoCommands = {
     CommandIds.shutdownSession,
     Invocation.ViewItemContext.argument(SessionCommandTarget),
   ),
+  disableCell: command(
+    CommandIds.disableCell,
+    Invocation.join(
+      Invocation.CommandPalette.notebookCell,
+      Invocation.NotebookCellTitle.notebookCell,
+    ),
+  ),
+  enableCell: command(
+    CommandIds.enableCell,
+    Invocation.NotebookCellStatusBar.notebookCell,
+  ),
   updateActivePythonEnvironment: command(
     CommandIds.updateActivePythonEnvironment,
     Invocation.CommandPalette.notebook,

--- a/extension/src/commands/MarimoCommands.ts
+++ b/extension/src/commands/MarimoCommands.ts
@@ -129,10 +129,7 @@ export const MarimoCommands = {
   ),
   disableCell: command(
     CommandIds.disableCell,
-    Invocation.join(
-      Invocation.CommandPalette.notebookCell,
-      Invocation.NotebookCellTitle.notebookCell,
-    ),
+    Invocation.NotebookCellTitle.notebookCell,
   ),
   enableCell: command(
     CommandIds.enableCell,

--- a/extension/src/commands/__tests__/setCellDisabled.test.ts
+++ b/extension/src/commands/__tests__/setCellDisabled.test.ts
@@ -1,0 +1,92 @@
+import { expect, it } from "@effect/vitest";
+import { Effect, Option, Ref } from "effect";
+import type * as vscode from "vscode";
+
+import {
+  createNotebookUri,
+  createTestNotebookDocument,
+  getNotebookEdits,
+  TestVsCode,
+} from "../../__mocks__/TestVsCode.ts";
+import { MarimoNotebookCell } from "../../schemas/MarimoNotebookDocument.ts";
+import disableCell from "../disableCell.ts";
+import enableCell from "../enableCell.ts";
+
+it.effect.each([
+  { initial: false, command: disableCell, expected: true },
+  { initial: true, command: enableCell, expected: false },
+])("sets disabled=$expected", ({ initial, command, expected }) =>
+  Effect.gen(function* () {
+    const applied = yield* Ref.make(Option.none<vscode.WorkspaceEdit>());
+    const vscode = yield* TestVsCode.make({
+      workspace: {
+        applyEdit: (edit) =>
+          Ref.set(applied, Option.some(edit)).pipe(Effect.as(true)),
+      },
+    });
+    const uri = createNotebookUri("file:///test/notebook_mo.py");
+    const document = createTestNotebookDocument(uri, {
+      data: {
+        cells: [
+          {
+            kind: 2,
+            value: "x = 1",
+            languageId: "mo-python",
+            metadata: MarimoNotebookCell.createMetadata({
+              marimo: { options: { disabled: initial, hide_code: true } },
+              marimoRuntime: { stableId: "cell-1" },
+            }),
+          },
+        ],
+      },
+    });
+
+    yield* command
+      .invoke(Option.some(MarimoNotebookCell.from(document.cellAt(0))))
+      .pipe(Effect.provide(vscode.layer));
+
+    const workspaceEdit = Option.getOrThrow(yield* Ref.get(applied));
+    const replacement = getNotebookEdits(workspaceEdit, uri)[0]?.newCells[0];
+    const metadata = Option.getOrThrow(
+      MarimoNotebookCell.decodeMetadata(replacement?.metadata),
+    );
+    expect(metadata.marimo.options).toMatchObject({
+      disabled: expected,
+      hide_code: true,
+    });
+  }),
+);
+
+it.effect.each([
+  { marimo: { name: "setup" } },
+  { marimoRuntime: { stableId: "setup" } },
+])("does not disable the setup cell identified by metadata", (metadata) =>
+  Effect.gen(function* () {
+    const applied = yield* Ref.make(Option.none<vscode.WorkspaceEdit>());
+    const vscode = yield* TestVsCode.make({
+      workspace: {
+        applyEdit: (edit) =>
+          Ref.set(applied, Option.some(edit)).pipe(Effect.as(true)),
+      },
+    });
+    const uri = createNotebookUri("file:///test/notebook_mo.py");
+    const document = createTestNotebookDocument(uri, {
+      data: {
+        cells: [
+          {
+            kind: 2,
+            value: "x = 1",
+            languageId: "mo-python",
+            metadata: MarimoNotebookCell.createMetadata(metadata),
+          },
+        ],
+      },
+    });
+
+    yield* disableCell
+      .invoke(Option.some(MarimoNotebookCell.from(document.cellAt(0))))
+      .pipe(Effect.provide(vscode.layer));
+
+    expect(Option.isNone(yield* Ref.get(applied))).toBe(true);
+  }),
+);

--- a/extension/src/commands/disableCell.ts
+++ b/extension/src/commands/disableCell.ts
@@ -1,0 +1,7 @@
+import { defineCommand } from "../commands.ts";
+import { MarimoCommands } from "./MarimoCommands.ts";
+import { setCellDisabled } from "./setCellDisabled.ts";
+
+export default defineCommand(MarimoCommands.disableCell, (cell) =>
+  setCellDisabled(cell, true),
+);

--- a/extension/src/commands/enableCell.ts
+++ b/extension/src/commands/enableCell.ts
@@ -1,0 +1,7 @@
+import { defineCommand } from "../commands.ts";
+import { MarimoCommands } from "./MarimoCommands.ts";
+import { setCellDisabled } from "./setCellDisabled.ts";
+
+export default defineCommand(MarimoCommands.enableCell, (cell) =>
+  setCellDisabled(cell, false),
+);

--- a/extension/src/commands/setCellDisabled.ts
+++ b/extension/src/commands/setCellDisabled.ts
@@ -1,0 +1,21 @@
+import { Effect, Option } from "effect";
+
+import { SETUP_CELL_NAME } from "../constants.ts";
+import { updateMarimoCellMetadata } from "../notebook/updateMarimoCellMetadata.ts";
+import type { MarimoNotebookCell } from "../schemas/MarimoNotebookDocument.ts";
+
+export const setCellDisabled = Effect.fn("command.setCellDisabled")(function* (
+  cell: Option.Option<MarimoNotebookCell>,
+  disabled: boolean,
+) {
+  if (Option.isNone(cell) || cell.value.isDisabled === disabled) return;
+  const isSetupCell =
+    Option.contains(cell.value.name, SETUP_CELL_NAME) ||
+    Option.contains(cell.value.stableId, SETUP_CELL_NAME);
+  if (disabled && isSetupCell) return;
+
+  yield* updateMarimoCellMetadata(cell.value, (metadata) => ({
+    ...metadata,
+    options: { ...metadata.options, disabled },
+  }));
+});

--- a/extension/src/features/CellStatusBarProvider.ts
+++ b/extension/src/features/CellStatusBarProvider.ts
@@ -1,6 +1,7 @@
 import { Effect, Layer, Option, Stream } from "effect";
 import type * as vscode from "vscode";
 
+import enableCell from "../commands/enableCell.ts";
 import runStale from "../commands/runStale.ts";
 import { NOTEBOOK_TYPE, SETUP_CELL_NAME } from "../constants.ts";
 import { CellExecutions } from "../kernel/CellExecutions.ts";
@@ -90,6 +91,30 @@ export const CellStatusBarProviderLive = Layer.scopedDiscard(
             code.NotebookCellStatusBarAlignment.Left,
           );
           item.tooltip = `Cell name: ${name.value}`;
+          return Effect.succeed([item]);
+        },
+        changes: metadataChanges,
+      },
+    );
+
+    // Disabled provider — direct cells can be re-enabled from their status.
+    yield* code.notebooks.registerNotebookCellStatusBarItemProvider(
+      NOTEBOOK_TYPE,
+      {
+        provideCellStatusBarItems(raw) {
+          const cell = MarimoNotebookCell.from(raw);
+          if (!cell.isDisabled) return Effect.succeed([]);
+
+          const item = new code.NotebookCellStatusBarItem(
+            "$(circle-slash) Disabled",
+            code.NotebookCellStatusBarAlignment.Right,
+          );
+          item.tooltip = "Cell is disabled; click to enable";
+          item.command = code.commands.bind(
+            enableCell.command,
+            "Enable cell",
+            raw,
+          );
           return Effect.succeed([item]);
         },
         changes: metadataChanges,

--- a/extension/src/features/RegisterCommands.ts
+++ b/extension/src/features/RegisterCommands.ts
@@ -2,6 +2,8 @@ import { Effect, Either, Layer, Stream } from "effect";
 
 import createSetupCell from "../commands/createSetupCell.ts";
 import debugCell from "../commands/debugCell.ts";
+import disableCell from "../commands/disableCell.ts";
+import enableCell from "../commands/enableCell.ts";
 import exportNotebookAsHtml from "../commands/exportNotebookAsHtml.ts";
 import hideCellCode from "../commands/hideCellCode.ts";
 import newMarimoNotebook from "../commands/newMarimoNotebook.ts";
@@ -38,6 +40,8 @@ export const RegisterCommandsLive = Layer.scopedDiscard(
     yield* code.commands.register(debugCell);
     yield* code.commands.register(hideCellCode);
     yield* code.commands.register(showCellCode);
+    yield* code.commands.register(disableCell);
+    yield* code.commands.register(enableCell);
     yield* code.commands.register(restartKernel);
     yield* code.commands.register(restartLsp);
     yield* code.commands.register(showDiagnostics);

--- a/extension/src/features/__tests__/CellStatusBarProvider.test.ts
+++ b/extension/src/features/__tests__/CellStatusBarProvider.test.ts
@@ -10,6 +10,7 @@ import {
 } from "../../__mocks__/TestVsCode.ts";
 import { makeTestNotebookRuntime } from "../../__tests__/__utils__/TestMarimoClient.ts";
 import { commandId } from "../../commands.ts";
+import enableCell from "../../commands/enableCell.ts";
 import runStale from "../../commands/runStale.ts";
 import { CellExecutions } from "../../kernel/CellExecutions.ts";
 import { MarimoNotebookCell } from "../../schemas/MarimoNotebookDocument.ts";
@@ -217,6 +218,55 @@ it.effect(
       expect(nameItems.some((item) => item.text.includes("my_cell"))).toBe(
         true,
       );
+    }).pipe(Effect.provide(ctx.layer));
+  }),
+);
+
+it.effect(
+  "shows an enable action only for disabled cells",
+  Effect.fn(function* () {
+    const ctx = yield* withTestCtx();
+    yield* Effect.gen(function* () {
+      const enabled = createMockCell(notebookUri, {
+        marimo: { options: { disabled: false } },
+        marimoRuntime: { stableId: "enabled" },
+      });
+      const disabled = createMockCell(notebookUri, {
+        marimo: { options: { disabled: true } },
+        marimoRuntime: { stableId: "disabled" },
+      });
+      const providers = yield* ctx.vscode.getRegisteredStatusBarItemProviders();
+
+      const enabledItems = yield* Effect.forEach(providers, (provider) =>
+        provider.provideCellStatusBarItems(enabled),
+      );
+      expect(
+        enabledItems
+          .flat()
+          .some(
+            (item) =>
+              typeof item.command !== "string" &&
+              item.command?.command === commandId(enableCell.command),
+          ),
+      ).toBe(false);
+
+      const disabledItems = yield* Effect.forEach(providers, (provider) =>
+        provider.provideCellStatusBarItems(disabled),
+      );
+      const item = disabledItems
+        .flat()
+        .find(
+          (item) =>
+            typeof item.command !== "string" &&
+            item.command?.command === commandId(enableCell.command),
+        );
+      expect(item?.text).toBe("$(circle-slash) Disabled");
+      expect(item?.tooltip).toBe("Cell is disabled; click to enable");
+      expect(item?.command).toEqual({
+        command: commandId(enableCell.command),
+        title: "Enable cell",
+        arguments: [disabled],
+      });
     }).pipe(Effect.provide(ctx.layer));
   }),
 );

--- a/extension/src/lib/__tests__/extractExecuteCodeRequest.test.ts
+++ b/extension/src/lib/__tests__/extractExecuteCodeRequest.test.ts
@@ -80,47 +80,39 @@ describe("extractExecuteCodeRequest", () => {
     }).pipe(Effect.provide(Constants.Default)),
   );
 
-  // Regression test for https://github.com/marimo-team/marimo-lsp/issues/154
-  // A cell authored as `@app.cell(disabled=True)` reaches the extension with
-  // metadata.options = { disabled: true } (set by NotebookSerializer from the
-  // LSP server's deserialize response). It must NOT be sent for execution.
-  it.effect(
-    "excludes cells disabled via @app.cell(disabled=True) (issue #154)",
-    () =>
-      Effect.gen(function* () {
-        const { LanguageId } = yield* Constants;
+  // Disabled cells still submit edited code to marimo. The runtime updates its
+  // graph before enforcing the disabled config, matching marimo's editor.
+  it.effect("includes disabled cells", () =>
+    Effect.gen(function* () {
+      const { LanguageId } = yield* Constants;
 
-        const enabled = createRawCell(
-          "x = 1",
-          { marimoRuntime: { stableId: "cell-enabled" } },
-          0,
-        );
-        const disabled = createRawCell(
-          'print("RAN")',
-          {
-            marimo: { options: { disabled: true } },
-            marimoRuntime: { stableId: "cell-disabled" },
-          },
-          1,
-        );
+      const enabled = createRawCell(
+        "x = 1",
+        { marimoRuntime: { stableId: "cell-enabled" } },
+        0,
+      );
+      const disabled = createRawCell(
+        'print("RAN")',
+        {
+          marimo: { options: { disabled: true } },
+          marimoRuntime: { stableId: "cell-disabled" },
+        },
+        1,
+      );
 
-        const request = extractExecuteCodeRequest(
-          [enabled, disabled],
-          LanguageId,
-        );
+      const request = extractExecuteCodeRequest(
+        [enabled, disabled],
+        LanguageId,
+      );
 
-        expect(Option.isSome(request)).toBe(true);
-        const { codes, cellIds } = Option.getOrThrow(request);
-        expect(cellIds).toContain("cell-enabled");
-        expect(cellIds).not.toContain("cell-disabled");
-        expect(codes).not.toContain('print("RAN")');
-      }).pipe(Effect.provide(Constants.Default)),
+      expect(Option.getOrThrow(request)).toEqual({
+        codes: ["x = 1", 'print("RAN")'],
+        cellIds: ["cell-enabled", "cell-disabled"],
+      });
+    }).pipe(Effect.provide(Constants.Default)),
   );
 
-  // Once disabled cells are filtered, a selection of only disabled cells
-  // produces an empty request, which must be Option.none() so the controller
-  // stops instead of sending an empty execute-cells request (issue #154).
-  it.effect("returns none when every selected cell is disabled", () =>
+  it.effect("submits a selection containing only a disabled cell", () =>
     Effect.gen(function* () {
       const { LanguageId } = yield* Constants;
 
@@ -135,7 +127,10 @@ describe("extractExecuteCodeRequest", () => {
 
       const request = extractExecuteCodeRequest([disabled], LanguageId);
 
-      expect(Option.isNone(request)).toBe(true);
+      expect(Option.getOrThrow(request)).toEqual({
+        codes: ['print("RAN")'],
+        cellIds: ["cell-disabled"],
+      });
     }).pipe(Effect.provide(Constants.Default)),
   );
 });

--- a/extension/src/lib/extractExecuteCodeRequest.ts
+++ b/extension/src/lib/extractExecuteCodeRequest.ts
@@ -22,11 +22,6 @@ export function extractExecuteCodeRequest(
       continue;
     }
 
-    // Disabled cells (`@app.cell(disabled=True)`) must not run (issue #154).
-    if (cell.isDisabled) {
-      continue;
-    }
-
     const code = getCellExecutableCode(cell, LanguageId);
     const cellId = cell.id.value;
 
@@ -35,7 +30,6 @@ export function extractExecuteCodeRequest(
   }
 
   if (codes.length === 0) {
-    // no request — e.g. a selection of only disabled cells (issue #154)
     return Option.none();
   }
 

--- a/extension/src/schemas/MarimoNotebookDocument.ts
+++ b/extension/src/schemas/MarimoNotebookDocument.ts
@@ -222,7 +222,8 @@ export class MarimoNotebookCell {
    *
    * marimo stores the decorator's `disabled` flag in the cell's config; the
    * LSP deserialize path surfaces it as `metadata.options.disabled`. Disabled
-   * cells must not be sent for execution (issue #154).
+   * cell source is still sent to keep the runtime graph current; marimo
+   * enforces the disabled state when handling the execution request.
    */
   get isDisabled() {
     return this.metadata.pipe(

--- a/src/marimo_lsp/api.py
+++ b/src/marimo_lsp/api.py
@@ -243,6 +243,10 @@ async def run(
     session = await ctx.sessions.start(
         args.notebook_uri, args.executable, args.working_directory
     )
+    # Reconcile document metadata before enqueueing execution. LSP change
+    # notifications normally keep the session synchronized, but doing it here
+    # provides an ordering barrier when a metadata edit immediately precedes a run.
+    session.sync(ctx.ls.workspace)
     session.mark_running()
 
     session.instantiate(

--- a/src/marimo_lsp/sessions.py
+++ b/src/marimo_lsp/sessions.py
@@ -20,6 +20,7 @@ from marimo._runtime.commands import (
     CreateNotebookCommand,
     ExecuteCellCommand,
     HTTPRequest,
+    UpdateCellConfigCommand,
     UpdateUIElementCommand,
     UpdateUserConfigCommand,
 )
@@ -182,11 +183,32 @@ class Session:
 
     def sync(self, workspace: Workspace) -> None:
         """Synchronize the live app with the current notebook document."""
+        previous_configs = {
+            cell_id: config.asdict()
+            for cell_id, config in self._app_file_manager.app.cell_manager.config_map().items()
+        }
         sync_app_with_workspace(
             workspace=workspace,
             notebook_uri=self._notebook_uri,
             app=self._app_file_manager.app,
         )
+        current_configs = {
+            cell_id: config.asdict()
+            for cell_id, config in self._app_file_manager.app.cell_manager.config_map().items()
+        }
+        changed_configs = {
+            cell_id: config
+            for cell_id, config in current_configs.items()
+            if previous_configs.get(cell_id) != config
+        }
+        # marimo 0.23.16 only schedules the stale closure from the last
+        # enabled cell in a batched UpdateCellConfigCommand. Forward each
+        # change separately so every newly enabled cell is considered.
+        for cell_id, config in changed_configs.items():
+            self.put_control_request(
+                UpdateCellConfigCommand(configs={cell_id: config}),
+                from_consumer_id=None,
+            )
 
     def accept_kernel_message(self, message: KernelMessage) -> None:
         """Record and forward an operation received from the kernel."""

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -202,7 +202,8 @@ async def test_enabling_disabled_cell_runs_registered_source(
             initial_run_completed.set()
         console = getattr(operation, "console", None)
         if (
-            getattr(operation, "cell_id", None) == "cell1"
+            console is not None
+            and getattr(operation, "cell_id", None) == "cell1"
             and getattr(console, "channel", None) == "stdout"
             and not stdout.done()
         ):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -186,6 +186,95 @@ async def test_notebook_did_change(client: LanguageClient) -> None:
 
 
 @pytest.mark.asyncio
+async def test_enabling_disabled_cell_runs_registered_source(
+    client: LanguageClient,
+) -> None:
+    uri = "file:///disabled_sync_test.py"
+    cell_uri = f"{uri}#cell1"
+    source = 'print("registered while disabled")'
+    initial_run_completed = asyncio.Event()
+    stdout: asyncio.Future[str] = asyncio.get_running_loop().create_future()
+
+    @client.feature("marimo/operation")
+    def _(params: Any) -> None:  # noqa: ANN401
+        operation = getattr(params, "operation", None)
+        if getattr(operation, "op", None) == "completed-run":
+            initial_run_completed.set()
+        console = getattr(operation, "console", None)
+        if (
+            getattr(operation, "cell_id", None) == "cell1"
+            and getattr(console, "channel", None) == "stdout"
+            and not stdout.done()
+        ):
+            stdout.set_result(console.data)
+
+    def cell(*, disabled: bool) -> lsp.NotebookCell:
+        return lsp.NotebookCell(
+            kind=lsp.NotebookCellKind.Code,
+            document=cell_uri,
+            metadata=cast(
+                "lsp.LSPObject",
+                {
+                    "marimo": {"options": {"disabled": disabled}},
+                    "marimoRuntime": {"stableId": "cell1"},
+                },
+            ),
+        )
+
+    client.notebook_document_did_open(
+        lsp.DidOpenNotebookDocumentParams(
+            notebook_document=lsp.NotebookDocument(
+                uri=uri,
+                notebook_type="marimo-notebook",
+                version=1,
+                cells=[cell(disabled=True)],
+            ),
+            cell_text_documents=[
+                lsp.TextDocumentItem(
+                    uri=cell_uri,
+                    language_id="python",
+                    version=1,
+                    text=source,
+                )
+            ],
+        )
+    )
+
+    await client.workspace_execute_command_async(
+        lsp.ExecuteCommandParams(
+            command="marimo.api",
+            arguments=[
+                {
+                    "method": "execute-cells",
+                    "params": {
+                        "notebookUri": uri,
+                        "executable": sys.executable,
+                        "workingDirectory": str(Path.cwd()),
+                        "inner": {"cellIds": ["cell1"], "codes": [source]},
+                    },
+                }
+            ],
+        )
+    )
+    await asyncio.wait_for(initial_run_completed.wait(), timeout=5)
+    assert not stdout.done()
+
+    client.notebook_document_did_change(
+        lsp.DidChangeNotebookDocumentParams(
+            notebook_document=lsp.VersionedNotebookDocumentIdentifier(
+                uri=uri,
+                version=2,
+            ),
+            change=lsp.NotebookDocumentChangeEvent(
+                cells=lsp.NotebookDocumentCellChanges(data=[cell(disabled=False)])
+            ),
+        )
+    )
+
+    assert await asyncio.wait_for(stdout, timeout=5) == "registered while disabled\n"
+
+
+@pytest.mark.asyncio
 async def test_notebook_did_save(client: LanguageClient) -> None:
     """Test saving a notebook document."""
     client.notebook_document_did_open(

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -8,7 +8,7 @@ import asyncio
 import copy
 import threading
 from typing import TYPE_CHECKING, cast
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import ANY, AsyncMock, Mock
 
 import pytest
 from marimo._config.config import DEFAULT_CONFIG, MarimoConfig, RuntimeConfig
@@ -16,6 +16,7 @@ from marimo._messaging.types import KernelMessage
 from marimo._runtime.commands import (
     CodeCompletionCommand,
     StopKernelCommand,
+    UpdateCellConfigCommand,
     UpdateUIElementCommand,
     UpdateUserConfigCommand,
 )
@@ -66,6 +67,73 @@ def test_control_requests_update_live_session_snapshot() -> None:
 
     assert session.session_view.ui_values == {UIElementId("slider"): 1}
     assert session.session_view.needs_export("html")
+
+
+def test_sync_forwards_changed_document_configs_to_the_kernel() -> None:
+    session, queue_manager = _make_session()
+    session._notebook_uri = "file:///test.py"
+    session._app_file_manager = Mock()
+    session._app_file_manager.app.cell_manager.config_map.side_effect = [
+        {CellId_t("cell-1"): Mock(asdict=Mock(return_value={"disabled": True}))},
+        {CellId_t("cell-1"): Mock(asdict=Mock(return_value={"disabled": False}))},
+    ]
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        sync = Mock()
+        monkeypatch.setattr("marimo_lsp.sessions.sync_app_with_workspace", sync)
+        session.sync(Mock())
+
+    sync.assert_called_once_with(
+        workspace=ANY,
+        notebook_uri="file:///test.py",
+        app=session._app_file_manager.app,
+    )
+    command = queue_manager.control_queue.put.call_args.args[0]
+    assert isinstance(command, UpdateCellConfigCommand)
+    assert command.configs == {CellId_t("cell-1"): {"disabled": False}}
+
+
+def test_sync_forwards_each_changed_config_separately() -> None:
+    session, queue_manager = _make_session()
+    session._notebook_uri = "file:///test.py"
+    session._app_file_manager = Mock()
+    session._app_file_manager.app.cell_manager.config_map.side_effect = [
+        {
+            CellId_t("cell-1"): Mock(asdict=Mock(return_value={"disabled": True})),
+            CellId_t("cell-2"): Mock(asdict=Mock(return_value={"disabled": True})),
+        },
+        {
+            CellId_t("cell-1"): Mock(asdict=Mock(return_value={"disabled": False})),
+            CellId_t("cell-2"): Mock(asdict=Mock(return_value={"disabled": False})),
+        },
+    ]
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr("marimo_lsp.sessions.sync_app_with_workspace", Mock())
+        session.sync(Mock())
+
+    commands = [call.args[0] for call in queue_manager.control_queue.put.call_args_list]
+    assert [command.configs for command in commands] == [
+        {CellId_t("cell-1"): {"disabled": False}},
+        {CellId_t("cell-2"): {"disabled": False}},
+    ]
+
+
+def test_sync_does_not_notify_kernel_when_configs_are_unchanged() -> None:
+    session, queue_manager = _make_session()
+    session._notebook_uri = "file:///test.py"
+    config = Mock(asdict=Mock(return_value={"disabled": True}))
+    session._app_file_manager = Mock()
+    session._app_file_manager.app.cell_manager.config_map.side_effect = [
+        {CellId_t("cell-1"): config},
+        {CellId_t("cell-1"): config},
+    ]
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr("marimo_lsp.sessions.sync_app_with_workspace", Mock())
+        session.sync(Mock())
+
+    queue_manager.control_queue.put.assert_not_called()
 
 
 def test_regular_commands_are_routed_to_control_queue_only() -> None:


### PR DESCRIPTION
Disabled cells were filtered before execution requests reached marimo. This prevented their latest source from being registered in the live graph, so changing `disabled` metadata could leave the kernel stale until restart. The extension also had no notebook-native way to change the disabled state.

Keep the LSP notebook document as the source of truth, synchronize cell config changes into the live kernel, and submit disabled cell source while leaving marimo to enforce its runtime semantics.

Add a **Disable Cell** action and a clickable **Disabled** status item that re-enables the cell.

Closes #715