### PR TITLE
Introduce a ready kernel interface

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,45 @@
+# marimo Language Server
+
+marimo-lsp coordinates editor sessions with marimo kernels. The language server may run in native Python or WASM, while kernels always run in a selected native Python environment.
+
+## Language
+
+**Session**:
+A live notebook attachment backed by exactly one ready **Kernel**. A session owns notebook state and may remain alive while its editor is detached.
+_Avoid_: Kernel session, connection
+
+**Kernel**:
+A ready execution handle for one marimo runtime. It accepts commands, input, and interrupts and emits ordered operations.
+_Avoid_: Worker, host, connection
+
+**Selected Python**:
+The native Python executable chosen for a notebook's **Kernel**. Only code running in this environment may depend on its installed marimo version and native runtime support.
+_Avoid_: Host Python, system Python
+
+**Kernel bridge**:
+The private selected-Python program used only when the WASM language server cannot launch or connect to a **Kernel** itself. It owns marimo IPC and ZeroMQ while Node brokers its opaque stdin and stdout bytes.
+_Avoid_: Worker, native kernel host, kernel server
+
+**Native language server**:
+The marimo-lsp entrypoint running in native Python. It launches a **Kernel** and connects to marimo IPC directly, without a **Kernel bridge**.
+_Avoid_: Native host
+
+**WASM language server**:
+The bundled marimo-lsp entrypoint running in Pyodide. It reaches each **Kernel** through Node and a **Kernel bridge** in the **Selected Python** environment.
+_Avoid_: WASM kernel, Pyodide kernel
+
+## Flagged ambiguities
+
+**Worker** is not a domain term. It has referred to both the **Kernel** and the **Kernel bridge**; use the precise term instead.
+
+**Host** is not a domain term. Node supplies process mechanics, while the **Kernel bridge** owns marimo IPC; neither is a kernel host.
+
+## Example dialogue
+
+> **Developer:** When does a session become visible?
+>
+> **Domain expert:** Only after its kernel is ready. The native language server reaches it directly; the WASM language server reaches it through a kernel bridge running in the selected Python.
+>
+> **Developer:** Does Node decode kernel messages?
+>
+> **Domain expert:** No. Node brokers opaque bytes between the WASM language server and the kernel bridge. The Python endpoints own framing and message semantics.

--- a/src/marimo_lsp/__init__.py
+++ b/src/marimo_lsp/__init__.py
@@ -10,7 +10,11 @@ from marimo_lsp.server import create_server
 
 def main() -> None:
     """Run the marimo LSP server."""
-    server = create_server()
+    # Keep native runtime imports out of the importable package so the WASM
+    # entrypoint can provide its own kernel adapter.
+    from marimo_lsp.kernels.native import NativeKernels  # noqa: PLC0415
+
+    server = create_server(kernels=NativeKernels())
     logger = get_logger()
     logger.setLevel(logging.DEBUG)
     logger.addHandler(lsp_handler(server))

--- a/src/marimo_lsp/api.py
+++ b/src/marimo_lsp/api.py
@@ -240,7 +240,7 @@ async def run(
     args: SessionCommand[ExecuteCellsRequest],
 ) -> None:
     logger.info(f"run for {args.notebook_uri}")
-    session = ctx.sessions.start(
+    session = await ctx.sessions.start(
         args.notebook_uri, args.executable, args.working_directory
     )
     session.mark_running()
@@ -366,7 +366,7 @@ async def restart_session(
     args: NotebookCommand[RestartSessionRequest],
 ) -> None:
     logger.info(f"restart_session for {args.notebook_uri}")
-    restarted = ctx.sessions.restart(
+    restarted = await ctx.sessions.restart(
         args.notebook_uri,
         executable=args.inner.executable,
         working_directory=args.inner.working_directory,
@@ -428,7 +428,7 @@ async def execute_scratch(
         )
         return
 
-    session = ctx.sessions.start(
+    session = await ctx.sessions.start(
         args.notebook_uri, args.executable, args.working_directory
     )
     session.mark_running()

--- a/src/marimo_lsp/kernels/__init__.py
+++ b/src/marimo_lsp/kernels/__init__.py
@@ -1,0 +1,59 @@
+# Copyright 2026 Marimo. All rights reserved.
+
+"""Launch and communicate with marimo kernels."""
+
+from __future__ import annotations
+
+import typing
+
+if typing.TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from marimo._config.manager import MarimoConfigManager
+    from marimo._messaging.types import KernelMessage
+    from marimo._runtime.commands import CommandMessage
+
+    from marimo_lsp.app_file_manager import LspAppFileManager
+
+
+class Kernel(typing.Protocol):
+    """A live marimo kernel."""
+
+    executable: str
+    working_directory: str
+
+    def send(self, request: CommandMessage) -> None:
+        """Send a command to the kernel."""
+        ...
+
+    def input(self, text: str) -> None:
+        """Send a response to a kernel input request."""
+        ...
+
+    def interrupt(self) -> None:
+        """Interrupt the kernel."""
+        ...
+
+    def close(self) -> None:
+        """Close the kernel and its transport."""
+        ...
+
+
+class Kernels(typing.Protocol):
+    """Obtain ready marimo kernels."""
+
+    async def launch(
+        self,
+        *,
+        executable: str,
+        working_directory: str,
+        app_file_manager: LspAppFileManager,
+        config_manager: MarimoConfigManager,
+        receive: Callable[[KernelMessage], None],
+    ) -> Kernel:
+        """Launch a kernel and begin delivering its operations."""
+        ...
+
+
+class KernelOpenError(RuntimeError):
+    """A kernel failed before it became ready."""

--- a/src/marimo_lsp/kernels/manager.py
+++ b/src/marimo_lsp/kernels/manager.py
@@ -49,7 +49,7 @@ def launch_kernel(
     executable: str,
     args: ipc.KernelArgs,
     cwd: str | None = None,
-) -> PopenProcessLike:
+) -> Process:
     """Launch kernel as a subprocess."""
     cmd = [executable, "-m", "marimo._ipc.launch_kernel"]
     logger.info(f"Launching kernel subprocess: {' '.join(cmd)}")
@@ -96,10 +96,10 @@ def launch_kernel(
         raise RuntimeError(msg)
 
     logger.info(f"Kernel subprocess started successfully with PID: {process.pid}")
-    return PopenProcessLike(inner=process)
+    return Process(inner=process)
 
 
-class LspKernelManager(KernelManagerImpl):
+class Manager(KernelManagerImpl):
     """Kernel manager for marimo-lsp."""
 
     def __init__(  # noqa: PLR0913
@@ -159,7 +159,7 @@ class LspKernelManager(KernelManagerImpl):
         )
 
 
-class PopenProcessLike(ProcessLike):
+class Process(ProcessLike):
     """Wraps `subprocess.Popen` as a `ProcessLike`.
 
     Provides the `ProcessLike` protocol required by marimo's KernelManager.

--- a/src/marimo_lsp/kernels/native.py
+++ b/src/marimo_lsp/kernels/native.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import queue
 import threading
 import typing
@@ -13,6 +14,7 @@ from marimo._ipc import QueueManager as IpcQueues
 from marimo._session.managers import IPCQueueManagerImpl as IpcQueueManager
 
 from marimo_lsp.kernels.manager import Manager
+from marimo_lsp.loggers import get_logger
 
 if typing.TYPE_CHECKING:
     from collections.abc import Callable
@@ -22,6 +24,9 @@ if typing.TYPE_CHECKING:
     from marimo._runtime.commands import CommandMessage
 
     from marimo_lsp.app_file_manager import LspAppFileManager
+
+
+logger = get_logger()
 
 
 class NativeKernel:
@@ -76,9 +81,11 @@ class NativeKernel:
         if self._closed:
             return
         self._closed = True
-        if self._manager.kernel_task is not None:
-            self._manager.close_kernel()
-        self._queue_manager.close_queues()
+        try:
+            if self._manager.kernel_task is not None:
+                self._manager.close_kernel()
+        finally:
+            self._queue_manager.close_queues()
 
 
 class NativeKernels:
@@ -105,9 +112,27 @@ class NativeKernels:
             working_directory=working_directory,
         )
         kernel = NativeKernel(queue_manager, manager)
+        start_task = asyncio.create_task(asyncio.to_thread(kernel.start, receive))
+
+        def close_after_cancelled_start(task: asyncio.Task[None]) -> None:
+            with contextlib.suppress(BaseException):
+                task.result()
+            try:
+                kernel.close()
+            except Exception:
+                logger.exception("Error closing kernel after cancelled launch")
+
         try:
-            await asyncio.to_thread(kernel.start, receive)
-        except Exception:
-            kernel.close()
+            await asyncio.shield(start_task)
+        except asyncio.CancelledError:
+            # Cancelling `to_thread` cannot stop the worker. Close its kernel
+            # once startup finishes instead of abandoning the process.
+            start_task.add_done_callback(close_after_cancelled_start)
+            raise
+        except BaseException:
+            try:
+                kernel.close()
+            except Exception:
+                logger.exception("Error closing kernel after failed launch")
             raise
         return kernel

--- a/src/marimo_lsp/kernels/native.py
+++ b/src/marimo_lsp/kernels/native.py
@@ -1,0 +1,113 @@
+# Copyright 2026 Marimo. All rights reserved.
+
+"""Run kernels directly from native Python."""
+
+from __future__ import annotations
+
+import asyncio
+import queue
+import threading
+import typing
+
+from marimo._ipc import QueueManager as IpcQueues
+from marimo._session.managers import IPCQueueManagerImpl as IpcQueueManager
+
+from marimo_lsp.kernels.manager import Manager
+
+if typing.TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from marimo._config.manager import MarimoConfigManager
+    from marimo._messaging.types import KernelMessage
+    from marimo._runtime.commands import CommandMessage
+
+    from marimo_lsp.app_file_manager import LspAppFileManager
+
+
+class NativeKernel:
+    """Own a native marimo kernel and its direct IPC transport."""
+
+    def __init__(
+        self,
+        queue_manager: IpcQueueManager,
+        manager: Manager,
+    ) -> None:
+        self._queue_manager = queue_manager
+        self._manager = manager
+        self._closed = False
+        self._listener_thread: threading.Thread | None = None
+        self.executable = manager.executable
+        self.working_directory = manager.working_directory
+
+    def start(self, receive: Callable[[KernelMessage], None]) -> None:
+        """Start the kernel process and operation listener."""
+        self._manager.start_kernel()
+
+        def listen() -> None:
+            stream_queue = self._queue_manager.stream_queue
+            if stream_queue is None:
+                return
+            while not self._closed:
+                try:
+                    message = stream_queue.get(timeout=0.1)
+                    if message is None:
+                        return
+                    receive(message)
+                except queue.Empty:
+                    continue
+
+        self._listener_thread = threading.Thread(target=listen, daemon=True)
+        self._listener_thread.start()
+
+    def send(self, request: CommandMessage) -> None:
+        """Send a command over marimo IPC."""
+        self._queue_manager.put_control_request(request)
+
+    def input(self, text: str) -> None:
+        """Send an input response over marimo IPC."""
+        self._queue_manager.put_input(text)
+
+    def interrupt(self) -> None:
+        """Interrupt the kernel process."""
+        self._manager.interrupt_kernel()
+
+    def close(self) -> None:
+        """Close the kernel process and IPC queues."""
+        if self._closed:
+            return
+        self._closed = True
+        if self._manager.kernel_task is not None:
+            self._manager.close_kernel()
+        self._queue_manager.close_queues()
+
+
+class NativeKernels:
+    """Launch kernels with native Python process and IPC support."""
+
+    async def launch(
+        self,
+        *,
+        executable: str,
+        working_directory: str,
+        app_file_manager: LspAppFileManager,
+        config_manager: MarimoConfigManager,
+        receive: Callable[[KernelMessage], None],
+    ) -> NativeKernel:
+        """Launch a native kernel and connect directly to its IPC queues."""
+        ipc_queues, connection_info = IpcQueues.create()
+        queue_manager = IpcQueueManager.from_ipc(ipc_queues)
+        manager = Manager(
+            executable=executable,
+            queue_manager=queue_manager,
+            app_file_manager=app_file_manager,
+            config_manager=config_manager,
+            connection_info=connection_info,
+            working_directory=working_directory,
+        )
+        kernel = NativeKernel(queue_manager, manager)
+        try:
+            await asyncio.to_thread(kernel.start, receive)
+        except Exception:
+            kernel.close()
+            raise
+        return kernel

--- a/src/marimo_lsp/server.py
+++ b/src/marimo_lsp/server.py
@@ -23,8 +23,11 @@ from marimo_lsp.sessions import Sessions
 
 logger = get_logger()
 
+if typing.TYPE_CHECKING:
+    from marimo_lsp.kernels import Kernels
 
-def create_server() -> LanguageServer:  # noqa: C901, PLR0915
+
+def create_server(*, kernels: Kernels) -> LanguageServer:  # noqa: C901, PLR0915
     """Create the marimo LSP server."""
     server = LanguageServer(
         name="marimo-lsp",
@@ -44,7 +47,7 @@ def create_server() -> LanguageServer:  # noqa: C901, PLR0915
             save=True,
         ),
     )
-    sessions = Sessions(server)
+    sessions = Sessions(server, kernels=kernels)
     graph_registry = GraphUpdaterRegistry(server)
 
     # Register atexit handler to ensure kernel processes are cleaned up

--- a/src/marimo_lsp/sessions.py
+++ b/src/marimo_lsp/sessions.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import threading
 import time
@@ -25,6 +26,7 @@ from marimo._runtime.commands import (
 from marimo._session.state.session_view import SessionView
 
 from marimo_lsp.app_file_manager import LspAppFileManager, sync_app_with_workspace
+from marimo_lsp.kernels import KernelOpenError
 from marimo_lsp.loggers import get_logger
 from marimo_lsp.models import ListSessionsResponse, SessionInfo
 
@@ -347,6 +349,21 @@ class Sessions:
         self._kernels = kernels
         self._sessions: dict[str, Session] = {}
         self._lock = threading.RLock()
+        self._lifecycle_locks: dict[str, asyncio.Lock] = {}
+        self._lifecycle_versions: dict[str, int] = {}
+
+    def _lifecycle_lock(self, notebook_uri: str) -> asyncio.Lock:
+        with self._lock:
+            return self._lifecycle_locks.setdefault(notebook_uri, asyncio.Lock())
+
+    def _lifecycle_version(self, notebook_uri: str) -> int:
+        with self._lock:
+            return self._lifecycle_versions.get(notebook_uri, 0)
+
+    def _invalidate_lifecycle(self, notebook_uri: str) -> None:
+        self._lifecycle_versions[notebook_uri] = (
+            self._lifecycle_versions.get(notebook_uri, 0) + 1
+        )
 
     def __iter__(self) -> Iterator[Session]:
         """Iterate over the live sessions."""
@@ -387,19 +404,33 @@ class Sessions:
         A different executable replaces the existing session only after the
         replacement has started successfully.
         """
-        current = self.get(notebook_uri)
-        if current is not None and current.executable == executable:
-            current.attach()
-            return current
+        async with self._lifecycle_lock(notebook_uri):
+            current = self.get(notebook_uri)
+            if current is not None and current.executable == executable:
+                current.attach()
+                return current
 
-        replacement = await self._create(notebook_uri, executable, working_directory)
-        with self._lock:
-            self._sessions[notebook_uri] = replacement
-            replacement.set_on_change(self._notify_changed)
-        if current is not None:
-            self._close(current, notebook_uri)
-        self._notify_changed()
-        return replacement
+            version = self._lifecycle_version(notebook_uri)
+            replacement = await self._create(
+                notebook_uri, executable, working_directory
+            )
+            with self._lock:
+                if version != self._lifecycle_version(notebook_uri):
+                    superseded = True
+                else:
+                    superseded = False
+                    self._sessions[notebook_uri] = replacement
+                    replacement.set_on_change(self._notify_changed)
+            if superseded:
+                self._close(replacement, notebook_uri)
+                message = (
+                    f"Session changed while its kernel was starting: {notebook_uri}"
+                )
+                raise KernelOpenError(message)
+            if current is not None:
+                self._close(current, notebook_uri)
+            self._notify_changed()
+            return replacement
 
     async def _create(
         self,
@@ -423,12 +454,18 @@ class Sessions:
         initialization_id = str(uuid4())
         pending_messages: list[KernelMessage] = []
         session: Session | None = None
+        loop = asyncio.get_running_loop()
 
-        def receive(message: KernelMessage) -> None:
+        def deliver(message: KernelMessage) -> None:
             if session is None:
                 pending_messages.append(message)
             else:
                 session.accept_kernel_message(message)
+
+        def receive(message: KernelMessage) -> None:
+            # Kernel adapters may deliver from another thread. Serialize all
+            # state updates and language-server notifications on the LSP loop.
+            loop.call_soon_threadsafe(deliver, message)
 
         logger.info(f"Starting session for {notebook_uri}")
         kernel = await self._kernels.launch(
@@ -438,18 +475,29 @@ class Sessions:
             working_directory=working_directory,
             receive=receive,
         )
-        session = Session(
-            initialization_id=initialization_id,
-            notebook_uri=notebook_uri,
-            operation_sink=_OperationSink(self._server, notebook_uri),
-            kernel=kernel,
-            app_file_manager=app_file_manager,
-            config_manager=config_manager,
-            session_view=previous.session_view if previous else None,
-            started_at=previous.started_at if previous else None,
-        )
-        for message in pending_messages:
-            session.accept_kernel_message(message)
+        try:
+            session = Session(
+                initialization_id=initialization_id,
+                notebook_uri=notebook_uri,
+                operation_sink=_OperationSink(self._server, notebook_uri),
+                kernel=kernel,
+                app_file_manager=app_file_manager,
+                config_manager=config_manager,
+                session_view=previous.session_view if previous else None,
+                started_at=previous.started_at if previous else None,
+            )
+            for message in pending_messages:
+                session.accept_kernel_message(message)
+            pending_messages.clear()
+        except BaseException:
+            try:
+                if session is None:
+                    kernel.close()
+                else:
+                    session.close()
+            except Exception:
+                logger.exception("Error closing kernel after session creation failed")
+            raise
         return session
 
     async def restart(
@@ -461,40 +509,52 @@ class Sessions:
         create_if_missing: bool = False,
     ) -> Session | None:
         """Atomically replace a live session's kernel."""
-        current = self.get(notebook_uri)
-        if current is None:
-            if not create_if_missing:
+        async with self._lifecycle_lock(notebook_uri):
+            current = self.get(notebook_uri)
+            if current is None and not create_if_missing:
                 return None
-            replacement = await self._create(
-                notebook_uri, executable, working_directory
-            )
+
+            version = self._lifecycle_version(notebook_uri)
+            if current is None:
+                replacement = await self._create(
+                    notebook_uri, executable, working_directory
+                )
+            else:
+                replacement = await self._create(
+                    notebook_uri,
+                    current.executable,
+                    current.working_directory,
+                    previous=current,
+                )
+                if not current.attached:
+                    replacement.detach(notify=False)
+
             with self._lock:
-                self._sessions[notebook_uri] = replacement
-                replacement.set_on_change(self._notify_changed)
+                if version != self._lifecycle_version(notebook_uri):
+                    superseded = True
+                else:
+                    superseded = False
+                    self._sessions[notebook_uri] = replacement
+                    replacement.set_on_change(self._notify_changed)
+            if superseded:
+                self._close(replacement, notebook_uri)
+                message = (
+                    f"Session changed while its kernel was starting: {notebook_uri}"
+                )
+                raise KernelOpenError(message)
+            if current is not None:
+                self._close(current, notebook_uri)
             self._notify_changed()
             return replacement
-
-        replacement = await self._create(
-            notebook_uri,
-            current.executable,
-            current.working_directory,
-            previous=current,
-        )
-        if not current.attached:
-            replacement.detach(notify=False)
-        with self._lock:
-            self._sessions[notebook_uri] = replacement
-            replacement.set_on_change(self._notify_changed)
-        self._close(current, notebook_uri)
-        self._notify_changed()
-        return replacement
 
     def move(self, notebook_uri: str, new_notebook_uri: str) -> None:
         """Move a live session to a renamed notebook URI."""
         with self._lock:
+            self._invalidate_lifecycle(notebook_uri)
             session = self._sessions.pop(notebook_uri, None)
             if session is None:
                 return
+            self._invalidate_lifecycle(new_notebook_uri)
             replaced = self._sessions.pop(new_notebook_uri, None)
             self._sessions[new_notebook_uri] = session
         if replaced is not None:
@@ -531,6 +591,7 @@ class Sessions:
     def close(self, notebook_uri: str) -> None:
         """Close and forget a notebook's session."""
         with self._lock:
+            self._invalidate_lifecycle(notebook_uri)
             session = self._sessions.pop(notebook_uri, None)
         if session is None:
             return
@@ -551,6 +612,8 @@ class Sessions:
         """Close all live sessions."""
         logger.info("Closing all sessions")
         with self._lock:
+            for notebook_uri in self._lifecycle_locks:
+                self._invalidate_lifecycle(notebook_uri)
             live = self._sessions
             self._sessions = {}
         for notebook_uri, session in live.items():

--- a/src/marimo_lsp/sessions.py
+++ b/src/marimo_lsp/sessions.py
@@ -5,7 +5,6 @@
 from __future__ import annotations
 
 import json
-import queue
 import threading
 import time
 import typing
@@ -14,7 +13,6 @@ from uuid import uuid4
 
 import msgspec
 from marimo._config.manager import get_default_config_manager
-from marimo._ipc import QueueManager as IpcQueues
 from marimo._runtime.commands import (
     CodeCompletionCommand,
     CommandMessage,
@@ -24,11 +22,9 @@ from marimo._runtime.commands import (
     UpdateUIElementCommand,
     UpdateUserConfigCommand,
 )
-from marimo._session.managers import IPCQueueManagerImpl as IpcQueueManager
 from marimo._session.state.session_view import SessionView
 
 from marimo_lsp.app_file_manager import LspAppFileManager, sync_app_with_workspace
-from marimo_lsp.kernel_manager import LspKernelManager
 from marimo_lsp.loggers import get_logger
 from marimo_lsp.models import ListSessionsResponse, SessionInfo
 
@@ -44,10 +40,11 @@ if TYPE_CHECKING:
     from marimo._config.manager import MarimoConfigManager
     from marimo._messaging.types import KernelMessage
     from marimo._session.requests import InstantiateNotebookRequest
-    from marimo._session.types import QueueManager
     from marimo._types.ids import ConsumerId
     from pygls.lsp.server import LanguageServer
     from pygls.workspace import Workspace
+
+    from marimo_lsp.kernels import Kernel, Kernels
 
 
 logger = get_logger()
@@ -103,8 +100,7 @@ class Session:
         initialization_id: str,
         notebook_uri: str,
         operation_sink: _OperationSink,
-        queue_manager: QueueManager,
-        kernel_manager: LspKernelManager,
+        kernel: Kernel,
         app_file_manager: LspAppFileManager,
         config_manager: MarimoConfigManager,
         on_change: typing.Callable[[], None] | None = None,
@@ -119,43 +115,25 @@ class Session:
         self.session_view = session_view if session_view is not None else SessionView()
 
         self._operation_sink = operation_sink
-        self._queue_manager = queue_manager
-        self._kernel_manager = kernel_manager
         self._closed = False
-        self._listener_thread: threading.Thread | None = None
         self._runtime_config = config_manager.get_config(hide_secrets=False)
         self.started_at = started_at if started_at is not None else time.time()
         self._status: typing.Literal["idle", "running"] = "idle"
         self._on_change = on_change or (lambda: None)
         self._state_lock = threading.RLock()
 
-        try:
-            self._kernel_manager.start_kernel()
-        except Exception:
-            # Session construction transfers ownership of the IPC transport.
-            # Release it when startup fails before a Session can be returned.
-            if self._kernel_manager.kernel_task is not None:
-                try:
-                    self._kernel_manager.close_kernel()
-                except Exception:
-                    logger.exception("Error closing partially started kernel")
-            try:
-                self._queue_manager.close_queues()
-            except Exception:
-                logger.exception("Error closing queues after failed kernel start")
-            raise
-        self._start_message_listener()
+        self._kernel = kernel
         logger.info(f"Started session {initialization_id}")
 
     @property
     def executable(self) -> str:
         """Return the Python executable used by this session."""
-        return self._kernel_manager.executable
+        return self._kernel.executable
 
     @property
     def working_directory(self) -> str:
         """Return the configured kernel working directory."""
-        return self._kernel_manager.working_directory
+        return self._kernel.working_directory
 
     @property
     def attached(self) -> bool:
@@ -200,26 +178,13 @@ class Session:
             app=self._app_file_manager.app,
         )
 
-    def _start_message_listener(self) -> None:
-        """Start the background kernel-message listener."""
-
-        def listen() -> None:
-            stream_queue = self._queue_manager.stream_queue
-            if stream_queue is None:
-                return
-            while not self._closed:
-                try:
-                    msg = stream_queue.get(timeout=0.1)
-                    if msg is None:
-                        return
-                    self.session_view.add_raw_notification(msg)
-                    self._update_status(msg)
-                    self._operation_sink.notify(msg)
-                except queue.Empty:
-                    continue
-
-        self._listener_thread = threading.Thread(target=listen, daemon=True)
-        self._listener_thread.start()
+    def accept_kernel_message(self, message: KernelMessage) -> None:
+        """Record and forward an operation received from the kernel."""
+        if self._closed:
+            return
+        self.session_view.add_raw_notification(message)
+        self._update_status(message)
+        self._operation_sink.notify(message)
 
     def _update_status(self, message: KernelMessage) -> None:
         try:
@@ -267,11 +232,11 @@ class Session:
 
     def put_input(self, text: str) -> None:
         """Send user input to the kernel's stdin."""
-        self._queue_manager.input_queue.put(text)
+        self._kernel.input(text)
 
     def try_interrupt(self) -> None:
         """Interrupt the kernel."""
-        self._kernel_manager.interrupt_kernel()
+        self._kernel.interrupt()
 
     def put_control_request(
         self,
@@ -282,7 +247,7 @@ class Session:
         del from_consumer_id
         if not isinstance(request, CodeCompletionCommand):
             self.session_view.add_control_request(request)
-        self._queue_manager.put_control_request(request)
+        self._kernel.send(request)
 
     def _effective_runtime(self, config: MarimoConfig) -> MarimoConfig:
         if self.attached:
@@ -365,16 +330,21 @@ class Session:
         self._closed = True
         self._on_change = lambda: None
         logger.info(f"Closing session {self.initialization_id}")
-        self._kernel_manager.close_kernel()
-        self._queue_manager.close_queues()
+        self._kernel.close()
         self._operation_sink.detach()
 
 
 class Sessions:
     """The language server's collection of live kernel sessions."""
 
-    def __init__(self, server: LanguageServer) -> None:
+    def __init__(
+        self,
+        server: LanguageServer,
+        *,
+        kernels: Kernels,
+    ) -> None:
         self._server = server
+        self._kernels = kernels
         self._sessions: dict[str, Session] = {}
         self._lock = threading.RLock()
 
@@ -406,7 +376,7 @@ class Sessions:
         with self._lock:
             return self._sessions.get(notebook_uri)
 
-    def start(
+    async def start(
         self,
         notebook_uri: str,
         executable: str,
@@ -422,7 +392,7 @@ class Sessions:
             current.attach()
             return current
 
-        replacement = self._create(notebook_uri, executable, working_directory)
+        replacement = await self._create(notebook_uri, executable, working_directory)
         with self._lock:
             self._sessions[notebook_uri] = replacement
             replacement.set_on_change(self._notify_changed)
@@ -431,7 +401,7 @@ class Sessions:
         self._notify_changed()
         return replacement
 
-    def _create(
+    async def _create(
         self,
         notebook_uri: str,
         executable: str,
@@ -450,31 +420,39 @@ class Sessions:
             config_manager = get_default_config_manager(
                 current_path=app_file_manager.path
             )
-        ipc_queues, connection_info = IpcQueues.create()
-        queue_manager = IpcQueueManager.from_ipc(ipc_queues)
-        kernel_manager = LspKernelManager(
-            executable=executable,
-            queue_manager=queue_manager,
-            app_file_manager=app_file_manager,
-            config_manager=config_manager,
-            connection_info=connection_info,
-            working_directory=working_directory,
-        )
+        initialization_id = str(uuid4())
+        pending_messages: list[KernelMessage] = []
+        session: Session | None = None
+
+        def receive(message: KernelMessage) -> None:
+            if session is None:
+                pending_messages.append(message)
+            else:
+                session.accept_kernel_message(message)
 
         logger.info(f"Starting session for {notebook_uri}")
-        return Session(
-            initialization_id=str(uuid4()),
+        kernel = await self._kernels.launch(
+            executable=executable,
+            app_file_manager=app_file_manager,
+            config_manager=config_manager,
+            working_directory=working_directory,
+            receive=receive,
+        )
+        session = Session(
+            initialization_id=initialization_id,
             notebook_uri=notebook_uri,
             operation_sink=_OperationSink(self._server, notebook_uri),
-            queue_manager=queue_manager,
-            kernel_manager=kernel_manager,
+            kernel=kernel,
             app_file_manager=app_file_manager,
             config_manager=config_manager,
             session_view=previous.session_view if previous else None,
             started_at=previous.started_at if previous else None,
         )
+        for message in pending_messages:
+            session.accept_kernel_message(message)
+        return session
 
-    def restart(
+    async def restart(
         self,
         notebook_uri: str,
         *,
@@ -487,14 +465,16 @@ class Sessions:
         if current is None:
             if not create_if_missing:
                 return None
-            replacement = self._create(notebook_uri, executable, working_directory)
+            replacement = await self._create(
+                notebook_uri, executable, working_directory
+            )
             with self._lock:
                 self._sessions[notebook_uri] = replacement
                 replacement.set_on_change(self._notify_changed)
             self._notify_changed()
             return replacement
 
-        replacement = self._create(
+        replacement = await self._create(
             notebook_uri,
             current.executable,
             current.working_directory,

--- a/tests/test_native_kernel.py
+++ b/tests/test_native_kernel.py
@@ -8,14 +8,14 @@ from unittest.mock import Mock
 
 import pytest
 
-from marimo_lsp.kernel_manager import LspKernelManager
+from marimo_lsp.kernels.manager import Manager
 
 if TYPE_CHECKING:
     from pathlib import Path
 
 
-def _manager(notebook: Path, working_directory: str) -> LspKernelManager:
-    manager = LspKernelManager.__new__(LspKernelManager)
+def _manager(notebook: Path, working_directory: str) -> Manager:
+    manager = Manager.__new__(Manager)
     manager.executable = "/usr/bin/python"
     manager.connection_info = Mock()
     manager.configs = {}
@@ -30,7 +30,7 @@ def test_supplied_working_directory_reaches_launch_kernel(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     launch = Mock(return_value=Mock())
-    monkeypatch.setattr("marimo_lsp.kernel_manager.launch_kernel", launch)
+    monkeypatch.setattr("marimo_lsp.kernels.manager.launch_kernel", launch)
     selected = tmp_path / "selected"
     selected.mkdir()
 
@@ -45,7 +45,7 @@ def test_invalid_working_directory_is_rejected(
     kind: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     launch = Mock(return_value=Mock())
-    monkeypatch.setattr("marimo_lsp.kernel_manager.launch_kernel", launch)
+    monkeypatch.setattr("marimo_lsp.kernels.manager.launch_kernel", launch)
     if kind == "relative":
         selected = "relative/path"
     elif kind == "missing":

--- a/tests/test_native_kernel.py
+++ b/tests/test_native_kernel.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import threading
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
 from unittest.mock import Mock
@@ -9,6 +11,7 @@ from unittest.mock import Mock
 import pytest
 
 from marimo_lsp.kernels.manager import Manager
+from marimo_lsp.kernels.native import NativeKernels
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -60,3 +63,52 @@ def test_invalid_working_directory_is_rejected(
         manager.start_kernel()
 
     launch.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_launch_closes_kernel_after_start_finishes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    started = threading.Event()
+    finish = threading.Event()
+    closed = threading.Event()
+
+    class FakeKernel:
+        def __init__(self, *_args: object) -> None:
+            pass
+
+        def start(self, _receive: object) -> None:
+            started.set()
+            assert finish.wait(timeout=1)
+
+        def close(self) -> None:
+            closed.set()
+
+    monkeypatch.setattr(
+        "marimo_lsp.kernels.native.IpcQueues.create",
+        Mock(return_value=(Mock(), Mock())),
+    )
+    monkeypatch.setattr(
+        "marimo_lsp.kernels.native.IpcQueueManager.from_ipc", Mock(return_value=Mock())
+    )
+    monkeypatch.setattr("marimo_lsp.kernels.native.Manager", Mock(return_value=Mock()))
+    monkeypatch.setattr("marimo_lsp.kernels.native.NativeKernel", FakeKernel)
+
+    launch = asyncio.create_task(
+        NativeKernels().launch(
+            executable="python",
+            working_directory="/workspace",
+            app_file_manager=Mock(),
+            config_manager=Mock(),
+            receive=Mock(),
+        )
+    )
+    assert await asyncio.to_thread(started.wait, 1)
+
+    launch.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await launch
+    assert not closed.is_set()
+
+    finish.set()
+    assert await asyncio.to_thread(closed.wait, 1)

--- a/tests/test_native_kernel.py
+++ b/tests/test_native_kernel.py
@@ -66,6 +66,41 @@ def test_invalid_working_directory_is_rejected(
 
 
 @pytest.mark.asyncio
+async def test_failed_launch_closes_queues_without_a_started_kernel(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    queue_manager = Mock()
+    manager = Mock()
+    manager.kernel_task = None
+    manager.start_kernel.side_effect = RuntimeError("launch failed")
+
+    monkeypatch.setattr(
+        "marimo_lsp.kernels.native.IpcQueues.create",
+        Mock(return_value=(Mock(), Mock())),
+    )
+    monkeypatch.setattr(
+        "marimo_lsp.kernels.native.IpcQueueManager.from_ipc",
+        Mock(return_value=queue_manager),
+    )
+    monkeypatch.setattr(
+        "marimo_lsp.kernels.native.Manager",
+        Mock(return_value=manager),
+    )
+
+    with pytest.raises(RuntimeError, match="launch failed"):
+        await NativeKernels().launch(
+            executable="python",
+            working_directory="/workspace",
+            app_file_manager=Mock(),
+            config_manager=Mock(),
+            receive=Mock(),
+        )
+
+    manager.close_kernel.assert_not_called()
+    queue_manager.close_queues.assert_called_once_with()
+
+
+@pytest.mark.asyncio
 async def test_cancelled_launch_closes_kernel_after_start_finishes(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_process_cleanup.py
+++ b/tests/test_process_cleanup.py
@@ -2,7 +2,7 @@
 
 """Tests for process cleanup on shutdown.
 
-Verifies `PopenProcessLike` terminates subprocesses (including force-kill)
+Verifies the kernel `Process` terminates subprocesses (including force-kill).
 """
 
 from __future__ import annotations
@@ -15,7 +15,7 @@ import typing
 
 import pytest
 
-from marimo_lsp.kernel_manager import PopenProcessLike
+from marimo_lsp.kernels.manager import Process
 
 
 def process_exists(pid: int) -> bool:
@@ -79,7 +79,7 @@ def test_popen_terminate_graceful(
     long_running_process: subprocess.Popen[bytes],
 ) -> None:
     """Test that terminate() gracefully stops a process."""
-    wrapper = PopenProcessLike(long_running_process)
+    wrapper = Process(long_running_process)
     pid = wrapper.pid
 
     assert pid is not None
@@ -102,7 +102,7 @@ def test_popen_terminate_already_dead() -> None:
     )
     process.wait()
 
-    wrapper = PopenProcessLike(process)
+    wrapper = Process(process)
     wrapper.terminate()  # Should not raise
 
     assert not wrapper.is_alive()
@@ -116,7 +116,7 @@ def test_popen_terminate_force_kill(
     stubborn_process: subprocess.Popen[bytes],
 ) -> None:
     """Test that terminate() force-kills processes that ignore SIGTERM."""
-    wrapper = PopenProcessLike(stubborn_process)
+    wrapper = Process(stubborn_process)
     wrapper.TERMINATE_TIMEOUT = 0.5  # Shorter timeout for testing
 
     pid = wrapper.pid

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -250,7 +250,7 @@ async def test_file_notebook_did_close_detaches_session() -> None:
         ),
         patch.object(server_module.atexit, "register"),
     ):
-        server = server_module.create_server()
+        server = server_module.create_server(kernels=MagicMock())
 
     uri = "file:///test.py"
     did_close = server.protocol.fm.features[lsp.NOTEBOOK_DOCUMENT_DID_CLOSE]

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -4,9 +4,10 @@
 
 from __future__ import annotations
 
+import asyncio
 import copy
 import threading
-from typing import cast
+from typing import TYPE_CHECKING, cast
 from unittest.mock import AsyncMock, Mock
 
 import pytest
@@ -22,9 +23,13 @@ from marimo._session.managers import IPCQueueManagerImpl
 from marimo._session.state.session_view import SessionView
 from marimo._types.ids import CellId_t, RequestId, UIElementId
 
+from marimo_lsp.kernels import KernelOpenError
 from marimo_lsp.kernels.native import NativeKernel
 from marimo_lsp.models import SessionInfo
 from marimo_lsp.sessions import Session, Sessions, _OperationSink
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 def _make_session() -> tuple[Session, Mock]:
@@ -284,6 +289,151 @@ async def test_failed_replacement_preserves_existing_session() -> None:
 
     assert sessions.get("file:///test.py") is current
     current.close.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_starts_share_one_kernel_launch() -> None:
+    sessions = Sessions(Mock(), kernels=Mock())
+    launch_started = asyncio.Event()
+    finish_launch = asyncio.Event()
+    replacement = Mock(spec=Session)
+    replacement.executable = "/usr/bin/python"
+    replacement.describe.return_value = Mock()
+
+    async def create(*_args: object, **_kwargs: object) -> Session:
+        launch_started.set()
+        await finish_launch.wait()
+        return replacement
+
+    sessions._create = AsyncMock(side_effect=create)
+    sessions._notify_changed = Mock()
+
+    first = asyncio.create_task(
+        sessions.start("file:///test.py", "/usr/bin/python", "/workspace")
+    )
+    await launch_started.wait()
+    second = asyncio.create_task(
+        sessions.start("file:///test.py", "/usr/bin/python", "/workspace")
+    )
+    await asyncio.sleep(0)
+
+    sessions._create.assert_awaited_once()
+    finish_launch.set()
+
+    assert await first is replacement
+    assert await second is replacement
+    sessions._create.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_close_during_start_discards_launched_kernel() -> None:
+    sessions = Sessions(Mock(), kernels=Mock())
+    launch_started = asyncio.Event()
+    finish_launch = asyncio.Event()
+    replacement = Mock(spec=Session)
+
+    async def create(*_args: object, **_kwargs: object) -> Session:
+        launch_started.set()
+        await finish_launch.wait()
+        return replacement
+
+    sessions._create = AsyncMock(side_effect=create)
+    start = asyncio.create_task(
+        sessions.start("file:///test.py", "/usr/bin/python", "/workspace")
+    )
+    await launch_started.wait()
+
+    sessions.close("file:///test.py")
+    finish_launch.set()
+
+    with pytest.raises(KernelOpenError, match="changed while its kernel was starting"):
+        await start
+    assert sessions.get("file:///test.py") is None
+    replacement.close.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_session_creation_failure_closes_launched_kernel() -> None:
+    kernel = Mock()
+    kernels = Mock()
+    kernels.launch = AsyncMock(return_value=kernel)
+    sessions = Sessions(Mock(), kernels=kernels)
+    previous = Mock(spec=Session)
+    previous.app_file_manager = Mock()
+    previous.config_manager = Mock()
+    previous.config_manager.get_config.side_effect = RuntimeError("bad config")
+    previous.session_view = Mock()
+    previous.started_at = 42
+
+    with pytest.raises(RuntimeError, match="bad config"):
+        await sessions._create(
+            "file:///test.py",
+            "/usr/bin/python",
+            "/workspace",
+            previous=previous,
+        )
+
+    kernel.close.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_startup_message_handoff_preserves_order(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    first = KernelMessage(b'{"op": "first"}')
+    second = KernelMessage(b'{"op": "second"}')
+    third = KernelMessage(b'{"op": "third"}')
+    kernel = Mock()
+    receive_callback: list[Callable[[KernelMessage], None]] = []
+
+    async def launch(**kwargs: object) -> object:
+        receive = cast("Callable[[KernelMessage], None]", kwargs["receive"])
+        receive_callback.append(receive)
+        delivered = threading.Event()
+
+        def deliver_initial_messages() -> None:
+            receive(first)
+            receive(second)
+            delivered.set()
+
+        threading.Thread(target=deliver_initial_messages, daemon=True).start()
+        assert await asyncio.to_thread(delivered.wait, 1)
+        return kernel
+
+    kernels = Mock()
+    kernels.launch = AsyncMock(side_effect=launch)
+    sessions = Sessions(Mock(), kernels=kernels)
+    previous = Mock(spec=Session)
+    previous.app_file_manager = Mock()
+    previous.config_manager = Mock()
+    previous.config_manager.get_config.return_value = DEFAULT_CONFIG
+    previous.session_view = Mock()
+    previous.started_at = 42
+    loop_thread = threading.get_ident()
+    observed: list[tuple[KernelMessage, int]] = []
+    third_delivered = asyncio.Event()
+
+    def accept(_session: Session, message: KernelMessage) -> None:
+        observed.append((message, threading.get_ident()))
+        if message == third:
+            third_delivered.set()
+
+    monkeypatch.setattr(Session, "accept_kernel_message", accept)
+
+    await sessions._create(
+        "file:///test.py",
+        "/usr/bin/python",
+        "/workspace",
+        previous=previous,
+    )
+    threading.Thread(target=receive_callback[0], args=(third,), daemon=True).start()
+    await asyncio.wait_for(third_delivered.wait(), timeout=1)
+
+    assert observed == [
+        (first, loop_thread),
+        (second, loop_thread),
+        (third, loop_thread),
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import copy
 import threading
 from typing import cast
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 from marimo._config.config import DEFAULT_CONFIG, MarimoConfig, RuntimeConfig
@@ -22,6 +22,7 @@ from marimo._session.managers import IPCQueueManagerImpl
 from marimo._session.state.session_view import SessionView
 from marimo._types.ids import CellId_t, RequestId, UIElementId
 
+from marimo_lsp.kernels.native import NativeKernel
 from marimo_lsp.models import SessionInfo
 from marimo_lsp.sessions import Session, Sessions, _OperationSink
 
@@ -29,7 +30,10 @@ from marimo_lsp.sessions import Session, Sessions, _OperationSink
 def _make_session() -> tuple[Session, Mock]:
     session = Session.__new__(Session)
     ipc_queue_manager = Mock()
-    session._queue_manager = IPCQueueManagerImpl.from_ipc(ipc_queue_manager)
+    session._kernel = NativeKernel(
+        IPCQueueManagerImpl.from_ipc(ipc_queue_manager),
+        Mock(executable="python", working_directory="/workspace"),
+    )
     session.session_view = SessionView()
     session._on_change = Mock()
     session._status = "idle"
@@ -128,29 +132,6 @@ def test_detach_only_overrides_auto_reload() -> None:
     assert session.attached
 
 
-def test_failed_kernel_start_closes_replacement_resources() -> None:
-    queue_manager = Mock()
-    kernel_manager = Mock()
-    kernel_manager.kernel_task = Mock()
-    kernel_manager.start_kernel.side_effect = RuntimeError("failed to start")
-    config_manager = Mock()
-    config_manager.get_config.return_value = DEFAULT_CONFIG
-
-    with pytest.raises(RuntimeError, match="failed to start"):
-        Session(
-            initialization_id="session",
-            notebook_uri="file:///test.py",
-            operation_sink=Mock(),
-            queue_manager=queue_manager,
-            kernel_manager=kernel_manager,
-            app_file_manager=Mock(),
-            config_manager=config_manager,
-        )
-
-    kernel_manager.close_kernel.assert_called_once_with()
-    queue_manager.close_queues.assert_called_once_with()
-
-
 def test_detached_session_keeps_auto_reload_paused_after_config_update() -> None:
     session, queue_manager = _make_session()
     session._config_manager = Mock()
@@ -204,7 +185,7 @@ def test_session_status_tracks_running_and_completed_operations() -> None:
 
 def test_sessions_changed_notification_contains_public_snapshot() -> None:
     server = Mock()
-    sessions = Sessions(server)
+    sessions = Sessions(server, kernels=Mock())
     session = Mock(spec=Session)
     session.describe.return_value = SessionInfo(
         session_id="session",
@@ -239,28 +220,30 @@ def test_sessions_changed_notification_contains_public_snapshot() -> None:
     )
 
 
-def test_start_reuses_session_with_same_executable() -> None:
-    sessions = Sessions(Mock())
+@pytest.mark.asyncio
+async def test_start_reuses_session_with_same_executable() -> None:
+    sessions = Sessions(Mock(), kernels=Mock())
     current = Mock(spec=Session)
     current.executable = "/usr/bin/python"
     sessions._sessions["file:///test.py"] = current
-    sessions._create = Mock()
+    sessions._create = AsyncMock()
 
-    result = sessions.start("file:///test.py", "/usr/bin/python", "/workspace")
+    result = await sessions.start("file:///test.py", "/usr/bin/python", "/workspace")
 
     assert result is current
     current.attach.assert_called_once_with()
     sessions._create.assert_not_called()
 
 
-def test_start_reuses_same_executable_despite_new_working_directory() -> None:
-    sessions = Sessions(Mock())
+@pytest.mark.asyncio
+async def test_start_reuses_same_executable_despite_new_working_directory() -> None:
+    sessions = Sessions(Mock(), kernels=Mock())
     current = Mock(spec=Session)
     current.executable = "/usr/bin/python"
     sessions._sessions["file:///test.py"] = current
-    sessions._create = Mock()
+    sessions._create = AsyncMock()
 
-    result = sessions.start(
+    result = await sessions.start(
         "file:///test.py", "/usr/bin/python", "/new/working/directory"
     )
 
@@ -269,17 +252,18 @@ def test_start_reuses_same_executable_despite_new_working_directory() -> None:
     sessions._create.assert_not_called()
 
 
-def test_start_replaces_session_after_replacement_starts() -> None:
-    sessions = Sessions(Mock())
+@pytest.mark.asyncio
+async def test_start_replaces_session_after_replacement_starts() -> None:
+    sessions = Sessions(Mock(), kernels=Mock())
     current = Mock(spec=Session)
     current.executable = "/old/python"
     replacement = Mock(spec=Session)
     replacement.describe.return_value = Mock()
     sessions._sessions["file:///test.py"] = current
-    sessions._create = Mock(return_value=replacement)
+    sessions._create = AsyncMock(return_value=replacement)
     sessions._notify_changed = Mock()
 
-    result = sessions.start("file:///test.py", "/new/python", "/workspace")
+    result = await sessions.start("file:///test.py", "/new/python", "/workspace")
 
     assert result is replacement
     assert sessions.get("file:///test.py") is replacement
@@ -287,22 +271,24 @@ def test_start_replaces_session_after_replacement_starts() -> None:
     sessions._notify_changed.assert_called_once_with()
 
 
-def test_failed_replacement_preserves_existing_session() -> None:
-    sessions = Sessions(Mock())
+@pytest.mark.asyncio
+async def test_failed_replacement_preserves_existing_session() -> None:
+    sessions = Sessions(Mock(), kernels=Mock())
     current = Mock(spec=Session)
     current.executable = "/old/python"
     sessions._sessions["file:///test.py"] = current
-    sessions._create = Mock(side_effect=RuntimeError("failed to start"))
+    sessions._create = AsyncMock(side_effect=RuntimeError("failed to start"))
 
     with pytest.raises(RuntimeError, match="failed to start"):
-        sessions.start("file:///test.py", "/new/python", "/workspace")
+        await sessions.start("file:///test.py", "/new/python", "/workspace")
 
     assert sessions.get("file:///test.py") is current
     current.close.assert_not_called()
 
 
-def test_restart_replaces_kernel_without_reloading_closed_notebook() -> None:
-    sessions = Sessions(Mock())
+@pytest.mark.asyncio
+async def test_restart_replaces_kernel_without_reloading_closed_notebook() -> None:
+    sessions = Sessions(Mock(), kernels=Mock())
     current = Mock(spec=Session)
     current.executable = "/usr/bin/python"
     current.working_directory = "/workspace"
@@ -311,10 +297,10 @@ def test_restart_replaces_kernel_without_reloading_closed_notebook() -> None:
     current.started_at = 42
     replacement = Mock(spec=Session)
     sessions._sessions["file:///test.py"] = current
-    sessions._create = Mock(return_value=replacement)
+    sessions._create = AsyncMock(return_value=replacement)
     sessions._notify_changed = Mock()
 
-    result = sessions.restart(
+    result = await sessions.restart(
         "file:///test.py",
         executable="/usr/bin/python",
         working_directory="/workspace",
@@ -332,13 +318,14 @@ def test_restart_replaces_kernel_without_reloading_closed_notebook() -> None:
     sessions._notify_changed.assert_called_once_with()
 
 
-def test_restore_uses_requested_working_directory() -> None:
-    sessions = Sessions(Mock())
+@pytest.mark.asyncio
+async def test_restore_uses_requested_working_directory() -> None:
+    sessions = Sessions(Mock(), kernels=Mock())
     replacement = Mock(spec=Session)
-    sessions._create = Mock(return_value=replacement)
+    sessions._create = AsyncMock(return_value=replacement)
     sessions._notify_changed = Mock()
 
-    result = sessions.restart(
+    result = await sessions.restart(
         "file:///test.py",
         executable="/usr/bin/python",
         working_directory="/workspace",
@@ -351,11 +338,12 @@ def test_restore_uses_requested_working_directory() -> None:
     )
 
 
-def test_restart_does_not_restore_a_missing_session() -> None:
-    sessions = Sessions(Mock())
-    sessions._create = Mock()
+@pytest.mark.asyncio
+async def test_restart_does_not_restore_a_missing_session() -> None:
+    sessions = Sessions(Mock(), kernels=Mock())
+    sessions._create = AsyncMock()
 
-    result = sessions.restart(
+    result = await sessions.restart(
         "file:///test.py",
         executable="/usr/bin/python",
         working_directory="/workspace",
@@ -368,7 +356,7 @@ def test_restart_does_not_restore_a_missing_session() -> None:
 def test_move_preserves_live_session() -> None:
     server = Mock()
     server.workspace.notebook_documents = {}
-    sessions = Sessions(server)
+    sessions = Sessions(server, kernels=Mock())
     current = Mock(spec=Session)
     sessions._sessions["file:///old.py"] = current
     sessions._notify_changed = Mock()
@@ -382,7 +370,7 @@ def test_move_preserves_live_session() -> None:
 
 
 def test_close_all_clears_collection_and_notifies_once() -> None:
-    sessions = Sessions(Mock())
+    sessions = Sessions(Mock(), kernels=Mock())
     first = Mock(spec=Session)
     second = Mock(spec=Session)
     sessions._sessions = {


### PR DESCRIPTION
Sessions constructed marimo IPC queues and the native kernel manager directly. That coupled session state to one transport and made it impossible to run the language server somewhere that cannot open ZeroMQ sockets or spawn Python itself.

Make kernel launch an explicit part of server composition:

```python
class Kernels(Protocol):
    async def launch(...) -> Kernel: ...

class Kernel(Protocol):
    def send(self, request: CommandMessage) -> None: ...
    def input(self, text: str) -> None: ...
    def interrupt(self) -> None: ...
    def close(self) -> None: ...
```

`Kernels.launch` returns only after the kernel is ready. `Session` owns that ready kernel without knowing how it was launched, while the native entrypoint explicitly supplies `NativeKernels`. Operations received during asynchronous startup are buffered until the session is published.