### PR TITLE
Run marimo-lsp with a WASM kernel adapter

### DIFF
--- a/extension/resources/wasm/__init__.py
+++ b/extension/resources/wasm/__init__.py
@@ -1,0 +1,3 @@
+# Copyright 2026 Marimo. All rights reserved.
+
+"""Resources used by the WASM language server."""

--- a/extension/resources/wasm/kernel.py
+++ b/extension/resources/wasm/kernel.py
@@ -25,6 +25,7 @@ from marimo._runtime.commands import StopKernelCommand
 from marimo._session.managers import IPCQueueManagerImpl
 from protocol import (
     HEADER_SIZE,
+    MAX_FRAME_SIZE,
     Close,
     Control,
     Error,
@@ -53,6 +54,9 @@ def _read_frame() -> ToBridge | None:
     if not header:
         return None
     length = read_header(header)
+    if length > MAX_FRAME_SIZE:
+        msg = f"Kernel frame exceeds {MAX_FRAME_SIZE} bytes"
+        raise ValueError(msg)
     payload = sys.stdin.buffer.read(length)
     if len(payload) != length:
         message = "Incomplete kernel frame payload"

--- a/extension/resources/wasm/kernel.py
+++ b/extension/resources/wasm/kernel.py
@@ -162,7 +162,7 @@ class _Bridge:
         assert self._queues is not None
         interrupt_queue = self._queues.win32_interrupt_queue
         if sys.platform == "win32" and interrupt_queue is not None:
-            interrupt_queue.put_nowait(item=True)
+            interrupt_queue.put_nowait(True)  # noqa: FBT003
         else:
             os.kill(self._process.pid, signal.SIGINT)
 

--- a/extension/resources/wasm/kernel.py
+++ b/extension/resources/wasm/kernel.py
@@ -1,0 +1,216 @@
+# Copyright 2026 Marimo. All rights reserved.
+
+"""Run a marimo kernel behind the WASM language server's stdio protocol.
+
+This script runs in the notebook's selected Python. It owns marimo IPC and
+ZeroMQ; Node only brokers its opaque stdin and stdout bytes.
+"""
+
+from __future__ import annotations
+
+import atexit
+import contextlib
+import os
+import signal
+import subprocess
+import sys
+import threading
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import marimo._ipc as ipc
+import msgspec
+from marimo._runtime.commands import StopKernelCommand
+from marimo._session.managers import IPCQueueManagerImpl
+from protocol import (
+    HEADER_SIZE,
+    Close,
+    Control,
+    Error,
+    FromBridge,
+    Input,
+    Interrupt,
+    Log,
+    Operation,
+    Ready,
+    Start,
+    ToBridge,
+    encode,
+    read_header,
+)
+
+if TYPE_CHECKING:
+    from marimo._messaging.types import KernelMessage
+
+_write_lock = threading.Lock()
+_decoder = msgspec.json.Decoder(ToBridge)
+
+
+def _read_frame() -> ToBridge | None:
+    header = sys.stdin.buffer.read(HEADER_SIZE)
+    if not header:
+        return None
+    length = read_header(header)
+    payload = sys.stdin.buffer.read(length)
+    if len(payload) != length:
+        message = "Incomplete kernel frame payload"
+        raise EOFError(message)
+    return _decoder.decode(payload)
+
+
+def _write_frame(message: FromBridge) -> None:
+    frame = encode(message)
+    with _write_lock:
+        sys.stdout.buffer.write(frame)
+        sys.stdout.buffer.flush()
+
+
+class _Bridge:
+    """Own one native kernel and its marimo IPC queues."""
+
+    def __init__(self) -> None:
+        self._queues: IPCQueueManagerImpl | None = None
+        self._ipc_queues: ipc.QueueManager | None = None
+        self._process: subprocess.Popen[bytes] | None = None
+        self._closed = False
+
+    def start(self, message: Start) -> None:
+        """Create queues and start the kernel subprocess."""
+        working_directory = message.working_directory
+        path = Path(working_directory)
+        if not path.is_absolute() or not path.is_dir():
+            msg = f"Invalid kernel working directory: {working_directory}"
+            raise ValueError(msg)
+
+        ipc_queues, connection_info = ipc.QueueManager.create()
+        self._ipc_queues = ipc_queues
+        self._queues = IPCQueueManagerImpl.from_ipc(ipc_queues)
+
+        kernel_args = msgspec.structs.replace(
+            message.kernel_args,
+            connection_info=connection_info,
+            parent_pid=os.getpid(),
+        )
+
+        self._process = subprocess.Popen(
+            [sys.executable, "-m", "marimo._ipc.launch_kernel"],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=working_directory,
+        )
+        assert self._process.stdin is not None
+        assert self._process.stdout is not None
+        self._process.stdin.write(kernel_args.encode_json())
+        self._process.stdin.flush()
+        self._process.stdin.close()
+
+        ready = self._process.stdout.readline().decode(errors="replace").strip()
+        if ready != "KERNEL_READY":
+            error = self._read_kernel_stderr()
+            msg = f"Expected KERNEL_READY, received {ready!r}. {error}".strip()
+            raise RuntimeError(msg)
+
+        threading.Thread(target=self._forward_operations, daemon=True).start()
+        threading.Thread(target=self._forward_stderr, daemon=True).start()
+        _write_frame(Ready())
+
+    def _forward_operations(self) -> None:
+        assert self._queues is not None
+        stream = self._queues.stream_queue
+        if stream is None:
+            return
+        while not self._closed:
+            message: KernelMessage | None = stream.get()
+            if message is None:
+                return
+            _write_frame(Operation(message=msgspec.Raw(message)))
+
+    def _forward_stderr(self) -> None:
+        if self._process is None or self._process.stderr is None:
+            return
+        for line in self._process.stderr:
+            _write_frame(Log(message=line.decode(errors="replace").rstrip()))
+
+    def _read_kernel_stderr(self) -> str:
+        if self._process is None or self._process.stderr is None:
+            return ""
+        return self._process.stderr.read().decode(errors="replace")
+
+    def handle(self, message: ToBridge) -> bool:
+        """Apply one command and return whether to keep reading."""
+        if isinstance(message, Control):
+            assert self._queues is not None
+            self._queues.put_control_request(message.request)
+        elif isinstance(message, Input):
+            assert self._queues is not None
+            self._queues.put_input(message.text)
+        elif isinstance(message, Interrupt):
+            self.interrupt()
+        elif isinstance(message, Close):
+            self.close()
+            return False
+        else:
+            msg = f"Unexpected start message after kernel launch: {message!r}"
+            raise TypeError(msg)
+        return True
+
+    def interrupt(self) -> None:
+        """Interrupt the running kernel."""
+        if self._process is None or self._process.poll() is not None:
+            return
+        assert self._queues is not None
+        interrupt_queue = self._queues.win32_interrupt_queue
+        if sys.platform == "win32" and interrupt_queue is not None:
+            interrupt_queue.put_nowait(item=True)
+        else:
+            os.kill(self._process.pid, signal.SIGINT)
+
+    def close(self) -> None:
+        """Stop the kernel and release its queues."""
+        if self._closed:
+            return
+        self._closed = True
+        if self._queues is not None:
+            with contextlib.suppress(Exception):
+                self._queues.put_control_request(StopKernelCommand())
+        if self._process is not None and self._process.poll() is None:
+            try:
+                self._process.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                self._process.terminate()
+                try:
+                    self._process.wait(timeout=2)
+                except subprocess.TimeoutExpired:
+                    self._process.kill()
+        if self._ipc_queues is not None:
+            self._ipc_queues.close_queues()
+
+
+def _read_start_frame() -> Start:
+    start = _read_frame()
+    if not isinstance(start, Start):
+        msg = "Expected start frame"
+        raise TypeError(msg)
+    return start
+
+
+def main() -> None:
+    """Serve kernel requests until the language server closes stdin."""
+    bridge = _Bridge()
+    atexit.register(bridge.close)
+    try:
+        bridge.start(_read_start_frame())
+        while True:
+            message = _read_frame()
+            if message is None or not bridge.handle(message):
+                break
+    except Exception as error:
+        _write_frame(Error(message=str(error)))
+        raise
+    finally:
+        bridge.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/extension/resources/wasm/kernel.py
+++ b/extension/resources/wasm/kernel.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import atexit
 import contextlib
 import os
+import queue
 import signal
 import subprocess
 import sys
@@ -44,6 +45,7 @@ if TYPE_CHECKING:
 
 _write_lock = threading.Lock()
 _decoder = msgspec.json.Decoder(ToBridge)
+KERNEL_READY_TIMEOUT = 10.0
 
 
 def _read_frame() -> ToBridge | None:
@@ -105,15 +107,42 @@ class _Bridge:
         self._process.stdin.flush()
         self._process.stdin.close()
 
-        ready = self._process.stdout.readline().decode(errors="replace").strip()
+        # Drain stderr before waiting for readiness so a noisy child cannot
+        # fill its pipe and deadlock startup.
+        threading.Thread(target=self._forward_stderr, daemon=True).start()
+        ready = self._wait_for_kernel_ready()
         if ready != "KERNEL_READY":
-            error = self._read_kernel_stderr()
-            msg = f"Expected KERNEL_READY, received {ready!r}. {error}".strip()
+            msg = f"Expected KERNEL_READY, received {ready!r}"
             raise RuntimeError(msg)
 
         threading.Thread(target=self._forward_operations, daemon=True).start()
-        threading.Thread(target=self._forward_stderr, daemon=True).start()
         _write_frame(Ready())
+
+    def _wait_for_kernel_ready(
+        self,
+        timeout: float = KERNEL_READY_TIMEOUT,
+    ) -> str:
+        """Read the readiness line without allowing startup to hang forever."""
+        assert self._process is not None
+        assert self._process.stdout is not None
+        result: queue.Queue[str | Exception] = queue.Queue(maxsize=1)
+
+        def read_ready() -> None:
+            try:
+                ready = self._process.stdout.readline().decode(errors="replace").strip()
+                result.put(ready)
+            except Exception as error:  # noqa: BLE001
+                result.put(error)
+
+        threading.Thread(target=read_ready, daemon=True).start()
+        try:
+            ready = result.get(timeout=timeout)
+        except queue.Empty as error:
+            msg = f"Kernel did not become ready within {timeout:g} seconds"
+            raise TimeoutError(msg) from error
+        if isinstance(ready, Exception):
+            raise ready
+        return ready
 
     def _forward_operations(self) -> None:
         assert self._queues is not None
@@ -131,11 +160,6 @@ class _Bridge:
             return
         for line in self._process.stderr:
             _write_frame(Log(message=line.decode(errors="replace").rstrip()))
-
-    def _read_kernel_stderr(self) -> str:
-        if self._process is None or self._process.stderr is None:
-            return ""
-        return self._process.stderr.read().decode(errors="replace")
 
     def handle(self, message: ToBridge) -> bool:
         """Apply one command and return whether to keep reading."""

--- a/extension/resources/wasm/protocol.py
+++ b/extension/resources/wasm/protocol.py
@@ -1,0 +1,137 @@
+# Copyright 2026 Marimo. All rights reserved.
+
+# Generated from `src/marimo_lsp/wasm/protocol.py` by `scripts.codegen`.
+# Regenerate with `just codegen`.
+"""Typed messages exchanged with the selected-Python kernel bridge."""
+
+from __future__ import annotations
+
+import struct
+from typing import TYPE_CHECKING, Literal
+
+import marimo._ipc as ipc
+import msgspec
+
+# msgspec resolves these postponed annotations when it constructs decoders.
+from marimo._ipc.types import ConnectionInfo  # noqa: TC002
+from marimo._runtime.commands import CommandMessage  # noqa: TC002
+
+if TYPE_CHECKING:
+    from typing_extensions import TypeForm
+
+VERSION = 1
+_HEADER = struct.Struct(">I")
+HEADER_SIZE = _HEADER.size
+
+
+class Ready(msgspec.Struct, tag="ready", tag_field="type", rename="camel"):
+    """The kernel bridge is ready."""
+
+    version: Literal[1] = VERSION
+
+
+class Operation(msgspec.Struct, tag="operation", tag_field="type", rename="camel"):
+    """An opaque marimo kernel operation."""
+
+    message: msgspec.Raw
+    version: Literal[1] = VERSION
+
+
+class Error(msgspec.Struct, tag="error", tag_field="type", rename="camel"):
+    """The kernel bridge failed."""
+
+    message: str
+    version: Literal[1] = VERSION
+
+
+class Log(msgspec.Struct, tag="log", tag_field="type", rename="camel"):
+    """A kernel log line."""
+
+    message: str
+    version: Literal[1] = VERSION
+
+
+type FromBridge = Ready | Operation | Error | Log
+
+
+class KernelLaunchArgs(ipc.KernelArgs):
+    """Kernel arguments before the selected Python binds its IPC sockets.
+
+    TODO: Replace this compatibility shim when marimo._ipc separates portable
+    kernel arguments from the connection information required to launch them.
+    """
+
+    connection_info: ConnectionInfo | None = None
+
+
+class Start(msgspec.Struct, tag="start", tag_field="type", rename="camel"):
+    """Start a kernel."""
+
+    working_directory: str
+    kernel_args: KernelLaunchArgs
+    version: Literal[1] = VERSION
+
+
+class Control(msgspec.Struct, tag="control", tag_field="type", rename="camel"):
+    """Send a marimo command."""
+
+    request: CommandMessage
+    version: Literal[1] = VERSION
+
+
+class Input(msgspec.Struct, tag="input", tag_field="type", rename="camel"):
+    """Respond to a kernel input request."""
+
+    text: str
+    version: Literal[1] = VERSION
+
+
+class Interrupt(msgspec.Struct, tag="interrupt", tag_field="type", rename="camel"):
+    """Interrupt the kernel."""
+
+    version: Literal[1] = VERSION
+
+
+class Close(msgspec.Struct, tag="close", tag_field="type", rename="camel"):
+    """Close the kernel."""
+
+    version: Literal[1] = VERSION
+
+
+type ToBridge = Start | Control | Input | Interrupt | Close
+
+
+def encode(message: FromBridge | ToBridge) -> bytes:
+    """Encode one length-prefixed protocol message."""
+    payload = msgspec.json.encode(message)
+    return _HEADER.pack(len(payload)) + payload
+
+
+def read_header(header: bytes | bytearray) -> int:
+    """Decode a complete frame header into its payload length."""
+    if len(header) != _HEADER.size:
+        message = "Incomplete kernel frame header"
+        raise EOFError(message)
+    return _HEADER.unpack(header)[0]
+
+
+class Decoder[Message]:
+    """Decode length-prefixed messages across arbitrary byte chunks."""
+
+    def __init__(self, message_type: TypeForm[Message]) -> None:
+        self._buffer = bytearray()
+        self._decoder = msgspec.json.Decoder(message_type)
+
+    def feed(self, chunk: bytes) -> list[Message]:
+        """Decode every complete message in a chunk."""
+        self._buffer.extend(chunk)
+        messages: list[Message] = []
+        while len(self._buffer) >= _HEADER.size:
+            length = read_header(self._buffer[: _HEADER.size])
+            frame_length = _HEADER.size + length
+            if len(self._buffer) < frame_length:
+                break
+            payload = bytes(self._buffer[_HEADER.size : frame_length])
+            del self._buffer[:frame_length]
+            messages.append(self._decoder.decode(payload))
+        return messages

--- a/extension/resources/wasm/protocol.py
+++ b/extension/resources/wasm/protocol.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
 VERSION = 1
 _HEADER = struct.Struct(">I")
 HEADER_SIZE = _HEADER.size
+MAX_FRAME_SIZE = 64 * 1024 * 1024
 
 
 class Ready(msgspec.Struct, tag="ready", tag_field="type", rename="camel"):
@@ -104,6 +105,9 @@ type ToBridge = Start | Control | Input | Interrupt | Close
 def encode(message: FromBridge | ToBridge) -> bytes:
     """Encode one length-prefixed protocol message."""
     payload = msgspec.json.encode(message)
+    if len(payload) > MAX_FRAME_SIZE:
+        msg = f"Kernel frame exceeds {MAX_FRAME_SIZE} bytes"
+        raise ValueError(msg)
     return _HEADER.pack(len(payload)) + payload
 
 
@@ -128,6 +132,10 @@ class Decoder[Message]:
         messages: list[Message] = []
         while len(self._buffer) >= _HEADER.size:
             length = read_header(self._buffer[: _HEADER.size])
+            if length > MAX_FRAME_SIZE:
+                self._buffer.clear()
+                msg = f"Kernel frame exceeds {MAX_FRAME_SIZE} bytes"
+                raise ValueError(msg)
             frame_length = _HEADER.size + length
             if len(self._buffer) < frame_length:
                 break

--- a/scripts/codegen/__main__.py
+++ b/scripts/codegen/__main__.py
@@ -8,8 +8,13 @@ import argparse
 import pathlib
 from collections.abc import Callable
 
-from scripts.codegen import effect_schemas, extension_commands, extension_constants
-from scripts.codegen.output import write_typescript
+from scripts.codegen import (
+    effect_schemas,
+    extension_commands,
+    extension_constants,
+    wasm_protocol,
+)
+from scripts.codegen.output import write_text, write_typescript
 
 Generator = tuple[str, pathlib.Path, Callable[[], str]]
 
@@ -45,6 +50,17 @@ def main() -> int:
         else:
             drifted.append(output)
             print(f"✗ {label}: {output} is out of date")
+
+    current = write_text(
+        wasm_protocol.OUTPUT,
+        wasm_protocol.generate(),
+        check=check,
+    )
+    if current:
+        print(f"✓ {wasm_protocol.LABEL}: {wasm_protocol.OUTPUT}")
+    else:
+        drifted.append(wasm_protocol.OUTPUT)
+        print(f"✗ {wasm_protocol.LABEL}: {wasm_protocol.OUTPUT} is out of date")
 
     if drifted:
         print("Run `just codegen` to regenerate checked-in sources.")

--- a/scripts/codegen/output.py
+++ b/scripts/codegen/output.py
@@ -11,6 +11,22 @@ ROOT = pathlib.Path(__file__).parents[2]
 EXTENSION = ROOT / "extension"
 
 
+def write_text(
+    output: pathlib.Path,
+    source: str,
+    *,
+    check: bool,
+) -> bool:
+    """Write generated text or report whether the checked-in copy is current."""
+    if output.exists() and output.read_text(encoding="utf-8") == source:
+        return True
+    if check:
+        return False
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(source, encoding="utf-8")
+    return True
+
+
 def write_typescript(
     output: pathlib.Path,
     source: str,

--- a/scripts/codegen/wasm_protocol.py
+++ b/scripts/codegen/wasm_protocol.py
@@ -1,0 +1,23 @@
+# Copyright 2026 Marimo. All rights reserved.
+
+"""Vendor the typed WASM kernel protocol beside the standalone bridge."""
+
+from __future__ import annotations
+
+from scripts.codegen.output import EXTENSION, ROOT
+
+LABEL = "WASM kernel protocol"
+SOURCE = ROOT / "src" / "marimo_lsp" / "wasm" / "protocol.py"
+OUTPUT = EXTENSION / "resources" / "wasm" / "protocol.py"
+
+
+def generate() -> str:
+    """Return the standalone copy with a generated-file warning."""
+    source = SOURCE.read_text(encoding="utf-8")
+    copyright_line, remainder = source.split("\n", 1)
+    return (
+        f"{copyright_line}\n\n"
+        "# Generated from `src/marimo_lsp/wasm/protocol.py` by `scripts.codegen`.\n"
+        "# Regenerate with `just codegen`.\n"
+        f"{remainder.lstrip()}"
+    )

--- a/src/marimo_lsp/sessions.py
+++ b/src/marimo_lsp/sessions.py
@@ -52,6 +52,11 @@ if TYPE_CHECKING:
 logger = get_logger()
 
 
+def _raise_kernel_failure(_session: Session, error: str) -> None:
+    """Turn a terminal failure before publication into a launch failure."""
+    raise KernelOpenError(error)
+
+
 class _OperationSink:
     """Forward operations to the single attached language-server client."""
 
@@ -503,6 +508,7 @@ class Sessions:
                 session_view=previous.session_view if previous else None,
                 started_at=previous.started_at if previous else None,
             )
+            session.set_on_kernel_failure(_raise_kernel_failure)
             for message in pending_messages:
                 session.accept_kernel_message(message)
             pending_messages.clear()

--- a/src/marimo_lsp/sessions.py
+++ b/src/marimo_lsp/sessions.py
@@ -122,6 +122,9 @@ class Session:
         self.started_at = started_at if started_at is not None else time.time()
         self._status: typing.Literal["idle", "running"] = "idle"
         self._on_change = on_change or (lambda: None)
+        self._on_kernel_failure: typing.Callable[[Session, str], None] = (
+            lambda _session, _error: None
+        )
         self._state_lock = threading.RLock()
 
         self._kernel = kernel
@@ -185,14 +188,16 @@ class Session:
         if self._closed:
             return
         self.session_view.add_raw_notification(message)
-        self._update_status(message)
+        kernel_error = self._update_status(message)
         self._operation_sink.notify(message)
+        if kernel_error is not None:
+            self._on_kernel_failure(self, kernel_error)
 
-    def _update_status(self, message: KernelMessage) -> None:
+    def _update_status(self, message: KernelMessage) -> str | None:
         try:
             operation = json.loads(message)
         except json.JSONDecodeError:
-            return
+            return None
 
         if operation.get("op") == "completed-run":
             self._set_status("idle")
@@ -201,6 +206,9 @@ class Session:
             "running",
         }:
             self._set_status("running")
+        elif operation.get("op") == "kernel-startup-error":
+            return str(operation.get("error", "Kernel bridge failed"))
+        return None
 
     def _set_status(self, status: typing.Literal["idle", "running"]) -> None:
         with self._state_lock:
@@ -231,6 +239,14 @@ class Session:
         """Install the callback after the session joins its owning collection."""
         with self._state_lock:
             self._on_change = on_change
+
+    def set_on_kernel_failure(
+        self,
+        on_kernel_failure: typing.Callable[[Session, str], None],
+    ) -> None:
+        """Install the callback for a terminal kernel transport failure."""
+        with self._state_lock:
+            self._on_kernel_failure = on_kernel_failure
 
     def put_input(self, text: str) -> None:
         """Send user input to the kernel's stdin."""
@@ -421,6 +437,7 @@ class Sessions:
                     superseded = False
                     self._sessions[notebook_uri] = replacement
                     replacement.set_on_change(self._notify_changed)
+                    replacement.set_on_kernel_failure(self._kernel_failed)
             if superseded:
                 self._close(replacement, notebook_uri)
                 message = (
@@ -536,6 +553,7 @@ class Sessions:
                     superseded = False
                     self._sessions[notebook_uri] = replacement
                     replacement.set_on_change(self._notify_changed)
+                    replacement.set_on_kernel_failure(self._kernel_failed)
             if superseded:
                 self._close(replacement, notebook_uri)
                 message = (
@@ -607,6 +625,20 @@ class Sessions:
             session.close()
         except Exception:
             logger.exception(f"Error closing session for {notebook_uri}")
+
+    def _kernel_failed(self, failed: Session, error: str) -> None:
+        """Remove a session whose ready kernel transport terminated."""
+        with self._lock:
+            notebook_uri = next(
+                (uri for uri, session in self._sessions.items() if session is failed),
+                None,
+            )
+            if notebook_uri is None:
+                return
+            self._sessions.pop(notebook_uri)
+        logger.error(f"Kernel failed for {notebook_uri}: {error}")
+        self._close(failed, notebook_uri)
+        self._notify_changed()
 
     def close_all(self) -> None:
         """Close all live sessions."""

--- a/src/marimo_lsp/wasm/__init__.py
+++ b/src/marimo_lsp/wasm/__init__.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import logging
 import typing
 
@@ -51,12 +53,28 @@ class WasmServer:
         logger.setLevel(logging.DEBUG)
         logger.addHandler(lsp_handler(self._server))
 
-    def handle_message(self, message_json: str) -> None:
-        """Deserialize and dispatch one complete JSON-RPC message."""
+    async def handle_message(self, message_json: str) -> None:
+        """Deserialize, dispatch, and drive one JSON-RPC message to completion."""
         message = self._server.protocol.structure_message(
             msgspec.json.decode(message_json)
         )
         self._server.protocol.handle_message(message)
+
+        # pygls schedules coroutine handlers on the current event loop. Its
+        # regular transports own that loop, but this bridge is called directly
+        # from JavaScript, so keep the loop alive until a request completes.
+        message_id = getattr(message, "id", None)
+        pending = self._server.protocol._request_futures.get(message_id)  # noqa: SLF001
+        if pending is None:
+            # Give coroutine notification handlers an opportunity to run.
+            await asyncio.sleep(0)
+            return
+
+        with contextlib.suppress(BaseException):
+            if isinstance(pending, asyncio.Future):
+                await asyncio.shield(pending)
+            else:
+                await asyncio.wrap_future(pending)
 
     def close(self) -> None:
         """Release sessions and protocol resources."""

--- a/src/marimo_lsp/wasm/__init__.py
+++ b/src/marimo_lsp/wasm/__init__.py
@@ -20,6 +20,8 @@ if typing.TYPE_CHECKING:
 
     from pygls.lsp.server import LanguageServer
 
+    from marimo_lsp.loggers import LspLoggingHandler
+
 
 class _MessageWriter:
     """Adapt pygls writes to a host-provided JSON message callback."""
@@ -51,7 +53,9 @@ class WasmServer:
         )
         logger = get_logger()
         logger.setLevel(logging.DEBUG)
-        logger.addHandler(lsp_handler(self._server))
+        self._log_handler: LspLoggingHandler = lsp_handler(self._server)
+        logger.addHandler(self._log_handler)
+        self._closed = False
 
     async def handle_message(self, message_json: str) -> None:
         """Deserialize, dispatch, and drive one JSON-RPC message to completion."""
@@ -78,7 +82,14 @@ class WasmServer:
 
     def close(self) -> None:
         """Release sessions and protocol resources."""
-        self._server.shutdown()
+        if self._closed:
+            return
+        self._closed = True
+        try:
+            self._kernels.close_all()
+            self._server.shutdown()
+        finally:
+            get_logger().removeHandler(self._log_handler)
 
     def handle_kernel_bytes(self, process_id: str, chunk: bytes) -> None:
         """Route opaque process bytes into their WASM kernel."""

--- a/src/marimo_lsp/wasm/__init__.py
+++ b/src/marimo_lsp/wasm/__init__.py
@@ -1,0 +1,84 @@
+# Copyright 2026 Marimo. All rights reserved.
+
+"""Run marimo-lsp under Pyodide."""
+
+from __future__ import annotations
+
+import logging
+import typing
+
+import msgspec
+
+from marimo_lsp.loggers import get_logger, lsp_handler
+from marimo_lsp.server import create_server
+from marimo_lsp.wasm.kernels import ProcessCallbacks, WasmKernels
+
+if typing.TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from pygls.lsp.server import LanguageServer
+
+
+class _MessageWriter:
+    """Adapt pygls writes to a host-provided JSON message callback."""
+
+    def __init__(self, write_message: Callable[[str], None]) -> None:
+        self._write_message = write_message
+
+    def write(self, data: bytes) -> None:
+        """Write one complete JSON-RPC message."""
+        self._write_message(data.decode("utf-8"))
+
+    def close(self) -> None:
+        """Leave the host-owned output stream open."""
+
+
+class WasmServer:
+    """Drive pygls one JSON-RPC message at a time from JavaScript."""
+
+    def __init__(
+        self,
+        write_message: Callable[[str], None],
+        process_callbacks: ProcessCallbacks,
+    ) -> None:
+        self._kernels = WasmKernels(process_callbacks)
+        self._server: LanguageServer = create_server(kernels=self._kernels)
+        self._server.protocol.set_writer(
+            _MessageWriter(write_message),
+            include_headers=False,
+        )
+        logger = get_logger()
+        logger.setLevel(logging.DEBUG)
+        logger.addHandler(lsp_handler(self._server))
+
+    def handle_message(self, message_json: str) -> None:
+        """Deserialize and dispatch one complete JSON-RPC message."""
+        message = self._server.protocol.structure_message(
+            msgspec.json.decode(message_json)
+        )
+        self._server.protocol.handle_message(message)
+
+    def close(self) -> None:
+        """Release sessions and protocol resources."""
+        self._server.shutdown()
+
+    def handle_kernel_bytes(self, process_id: str, chunk: bytes) -> None:
+        """Route opaque process bytes into their WASM kernel."""
+        self._kernels.accept(process_id, bytes(chunk))
+
+    def handle_kernel_exit(
+        self,
+        process_id: str,
+        code: int | None,
+        signal: str | None,
+    ) -> None:
+        """Route a native process exit into its WASM kernel."""
+        self._kernels.exited(process_id, code, signal)
+
+
+def create_bridge(
+    write_message: Callable[[str], None],
+    process_callbacks: ProcessCallbacks,
+) -> WasmServer:
+    """Create the message boundary exported to JavaScript."""
+    return WasmServer(write_message, process_callbacks)

--- a/src/marimo_lsp/wasm/kernels.py
+++ b/src/marimo_lsp/wasm/kernels.py
@@ -1,0 +1,236 @@
+# Copyright 2026 Marimo. All rights reserved.
+
+"""Run native kernels from the WASM language server."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import typing
+from uuid import uuid4
+
+from marimo._config.settings import GLOBAL_SETTINGS
+from marimo._messaging.types import KernelMessage
+from marimo._runtime.commands import AppMetadata
+
+from marimo_lsp.kernels import KernelOpenError
+from marimo_lsp.loggers import get_logger
+from marimo_lsp.wasm.protocol import (
+    Close,
+    Control,
+    Decoder,
+    Error,
+    FromBridge,
+    Input,
+    Interrupt,
+    KernelLaunchArgs,
+    Log,
+    Operation,
+    Ready,
+    Start,
+    ToBridge,
+    encode,
+)
+
+if typing.TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from marimo._config.manager import MarimoConfigManager
+    from marimo._runtime.commands import CommandMessage
+
+    from marimo_lsp.app_file_manager import LspAppFileManager
+    from marimo_lsp.kernels import Kernel
+
+
+logger = get_logger()
+
+
+class ProcessCallbacks(typing.Protocol):
+    """Opaque native process support supplied by JavaScript."""
+
+    def spawn(
+        self,
+        process_id: str,
+        executable: str,
+        working_directory: str,
+    ) -> None:
+        """Start a selected-Python kernel bridge."""
+        ...
+
+    def write(self, process_id: str, chunk: bytes) -> None:
+        """Write opaque bytes to a kernel bridge."""
+        ...
+
+    def close(self, process_id: str) -> None:
+        """Close a kernel bridge's input."""
+        ...
+
+
+class WasmKernel:
+    """A native kernel reached through opaque process bytes."""
+
+    def __init__(  # noqa: PLR0913
+        self,
+        *,
+        callbacks: ProcessCallbacks,
+        process_id: str,
+        executable: str,
+        working_directory: str,
+        receive: Callable[[KernelMessage], None],
+        on_close: Callable[[], None],
+    ) -> None:
+        self._callbacks = callbacks
+        self._process_id = process_id
+        self._receive = receive
+        self._on_close = on_close
+        self._decoder = Decoder(FromBridge)
+        self._ready = asyncio.get_running_loop().create_future()
+        self._closed = False
+        self.executable = executable
+        self.working_directory = working_directory
+
+    def accept(self, chunk: bytes) -> None:
+        """Decode operations received from the kernel bridge."""
+        if self._closed:
+            return
+        for message in self._decoder.feed(chunk):
+            if isinstance(message, Ready):
+                if not self._ready.done():
+                    self._ready.set_result(None)
+            elif isinstance(message, Operation):
+                self._receive(KernelMessage(bytes(message.message)))
+            elif isinstance(message, Error):
+                self._fail(message.message)
+            elif isinstance(message, Log):
+                logger.info(message.message)
+
+    def exited(self, code: int | None, signal: str | None) -> None:
+        """Report an unexpected kernel bridge exit."""
+        if not self._closed:
+            self._fail(
+                f"Kernel bridge exited unexpectedly (code={code}, signal={signal})"
+            )
+
+    async def wait_ready(self) -> None:
+        """Wait until the kernel bridge reports readiness."""
+        await self._ready
+
+    def abort(self) -> None:
+        """Release a kernel bridge that failed before readiness."""
+        if self._closed:
+            return
+        self._closed = True
+        self._callbacks.close(self._process_id)
+        self._on_close()
+
+    def _fail(self, error: str) -> None:
+        if not self._ready.done():
+            self._ready.set_exception(KernelOpenError(error))
+            return
+        self._receive(
+            KernelMessage(
+                json.dumps({"op": "kernel-startup-error", "error": error}).encode()
+            )
+        )
+
+    def _write(self, message: ToBridge) -> None:
+        self._callbacks.write(self._process_id, encode(message))
+
+    def send(self, request: CommandMessage) -> None:
+        """Send a command to the kernel."""
+        self._write(Control(request=request))
+
+    def input(self, text: str) -> None:
+        """Send an input response to the kernel."""
+        self._write(Input(text=text))
+
+    def interrupt(self) -> None:
+        """Interrupt the kernel."""
+        self._write(Interrupt())
+
+    def close(self) -> None:
+        """Close the kernel bridge."""
+        if self._closed:
+            return
+        self._closed = True
+        self._write(Close())
+        self._callbacks.close(self._process_id)
+        self._on_close()
+
+
+class WasmKernels:
+    """Launch native kernels for the WASM language server."""
+
+    def __init__(self, callbacks: ProcessCallbacks) -> None:
+        self._callbacks = callbacks
+        self._kernels: dict[str, WasmKernel] = {}
+
+    async def launch(
+        self,
+        *,
+        executable: str,
+        working_directory: str,
+        app_file_manager: LspAppFileManager,
+        config_manager: MarimoConfigManager,
+        receive: Callable[[KernelMessage], None],
+    ) -> Kernel:
+        """Launch a kernel through JavaScript's native process support."""
+        process_id = str(uuid4())
+
+        def forget() -> None:
+            self._kernels.pop(process_id, None)
+
+        kernel = WasmKernel(
+            callbacks=self._callbacks,
+            process_id=process_id,
+            executable=executable,
+            working_directory=working_directory,
+            receive=receive,
+            on_close=forget,
+        )
+        self._kernels[process_id] = kernel
+        try:
+            self._callbacks.spawn(process_id, executable, working_directory)
+            self._callbacks.write(
+                process_id,
+                encode(
+                    Start(
+                        working_directory=working_directory,
+                        kernel_args=KernelLaunchArgs(
+                            configs=app_file_manager.app.cell_manager.config_map(),
+                            app_metadata=AppMetadata(
+                                query_params={},
+                                filename=app_file_manager.path,
+                                cli_args={},
+                                argv=None,
+                                app_config=app_file_manager.app.config,
+                            ),
+                            user_config=config_manager.get_config(hide_secrets=False),
+                            log_level=GLOBAL_SETTINGS.LOG_LEVEL,
+                            profile_path=None,
+                        ),
+                    )
+                ),
+            )
+            await kernel.wait_ready()
+        except Exception:
+            kernel.abort()
+            raise
+        return kernel
+
+    def accept(self, process_id: str, chunk: bytes) -> None:
+        """Deliver opaque stdout bytes to their WASM kernel."""
+        kernel = self._kernels.get(process_id)
+        if kernel is not None:
+            kernel.accept(chunk)
+
+    def exited(
+        self,
+        process_id: str,
+        code: int | None,
+        signal: str | None,
+    ) -> None:
+        """Report a kernel bridge exit to its WASM kernel."""
+        kernel = self._kernels.pop(process_id, None)
+        if kernel is not None:
+            kernel.exited(code, signal)

--- a/src/marimo_lsp/wasm/kernels.py
+++ b/src/marimo_lsp/wasm/kernels.py
@@ -108,7 +108,8 @@ class WasmKernel:
         """Report an unexpected kernel bridge exit."""
         if not self._closed:
             self._fail(
-                f"Kernel bridge exited unexpectedly (code={code}, signal={signal})"
+                f"Kernel bridge exited unexpectedly (code={code}, signal={signal})",
+                close_process=False,
             )
 
     async def wait_ready(self) -> None:
@@ -117,21 +118,38 @@ class WasmKernel:
 
     def abort(self) -> None:
         """Release a kernel bridge that failed before readiness."""
+        self._release(close_process=True)
+
+    def _fail(self, error: str, *, close_process: bool = True) -> None:
+        if not self._ready.done():
+            self._ready.set_exception(KernelOpenError(error))
+        else:
+            self._receive(
+                KernelMessage(
+                    json.dumps({"op": "kernel-startup-error", "error": error}).encode()
+                )
+            )
+        self._release(close_process=close_process)
+
+    def _release(
+        self,
+        *,
+        close_process: bool,
+        request_close: bool = False,
+    ) -> None:
+        """Release the bridge exactly once, even when a close write fails."""
         if self._closed:
             return
         self._closed = True
-        self._callbacks.close(self._process_id)
-        self._on_close()
-
-    def _fail(self, error: str) -> None:
-        if not self._ready.done():
-            self._ready.set_exception(KernelOpenError(error))
-            return
-        self._receive(
-            KernelMessage(
-                json.dumps({"op": "kernel-startup-error", "error": error}).encode()
-            )
-        )
+        try:
+            if request_close:
+                self._write(Close())
+        finally:
+            try:
+                if close_process:
+                    self._callbacks.close(self._process_id)
+            finally:
+                self._on_close()
 
     def _write(self, message: ToBridge) -> None:
         self._callbacks.write(self._process_id, encode(message))
@@ -150,12 +168,7 @@ class WasmKernel:
 
     def close(self) -> None:
         """Close the kernel bridge."""
-        if self._closed:
-            return
-        self._closed = True
-        self._write(Close())
-        self._callbacks.close(self._process_id)
-        self._on_close()
+        self._release(close_process=True, request_close=True)
 
 
 class WasmKernels:
@@ -213,7 +226,7 @@ class WasmKernels:
                 ),
             )
             await kernel.wait_ready()
-        except Exception:
+        except BaseException:
             kernel.abort()
             raise
         return kernel
@@ -231,6 +244,6 @@ class WasmKernels:
         signal: str | None,
     ) -> None:
         """Report a kernel bridge exit to its WASM kernel."""
-        kernel = self._kernels.pop(process_id, None)
+        kernel = self._kernels.get(process_id)
         if kernel is not None:
             kernel.exited(code, signal)

--- a/src/marimo_lsp/wasm/kernels.py
+++ b/src/marimo_lsp/wasm/kernels.py
@@ -247,3 +247,12 @@ class WasmKernels:
         kernel = self._kernels.get(process_id)
         if kernel is not None:
             kernel.exited(code, signal)
+
+    def close_all(self) -> None:
+        """Close every tracked kernel bridge."""
+        for kernel in tuple(self._kernels.values()):
+            try:
+                kernel.close()
+            except Exception:
+                logger.exception("Error closing WASM kernel bridge")
+        self._kernels.clear()

--- a/src/marimo_lsp/wasm/protocol.py
+++ b/src/marimo_lsp/wasm/protocol.py
@@ -1,0 +1,135 @@
+# Copyright 2026 Marimo. All rights reserved.
+
+"""Typed messages exchanged with the selected-Python kernel bridge."""
+
+from __future__ import annotations
+
+import struct
+from typing import TYPE_CHECKING, Literal
+
+import marimo._ipc as ipc
+import msgspec
+
+# msgspec resolves these postponed annotations when it constructs decoders.
+from marimo._ipc.types import ConnectionInfo  # noqa: TC002
+from marimo._runtime.commands import CommandMessage  # noqa: TC002
+
+if TYPE_CHECKING:
+    from typing_extensions import TypeForm
+
+VERSION = 1
+_HEADER = struct.Struct(">I")
+HEADER_SIZE = _HEADER.size
+
+
+class Ready(msgspec.Struct, tag="ready", tag_field="type", rename="camel"):
+    """The kernel bridge is ready."""
+
+    version: Literal[1] = VERSION
+
+
+class Operation(msgspec.Struct, tag="operation", tag_field="type", rename="camel"):
+    """An opaque marimo kernel operation."""
+
+    message: msgspec.Raw
+    version: Literal[1] = VERSION
+
+
+class Error(msgspec.Struct, tag="error", tag_field="type", rename="camel"):
+    """The kernel bridge failed."""
+
+    message: str
+    version: Literal[1] = VERSION
+
+
+class Log(msgspec.Struct, tag="log", tag_field="type", rename="camel"):
+    """A kernel log line."""
+
+    message: str
+    version: Literal[1] = VERSION
+
+
+type FromBridge = Ready | Operation | Error | Log
+
+
+class KernelLaunchArgs(ipc.KernelArgs):
+    """Kernel arguments before the selected Python binds its IPC sockets.
+
+    TODO: Replace this compatibility shim when marimo._ipc separates portable
+    kernel arguments from the connection information required to launch them.
+    """
+
+    connection_info: ConnectionInfo | None = None
+
+
+class Start(msgspec.Struct, tag="start", tag_field="type", rename="camel"):
+    """Start a kernel."""
+
+    working_directory: str
+    kernel_args: KernelLaunchArgs
+    version: Literal[1] = VERSION
+
+
+class Control(msgspec.Struct, tag="control", tag_field="type", rename="camel"):
+    """Send a marimo command."""
+
+    request: CommandMessage
+    version: Literal[1] = VERSION
+
+
+class Input(msgspec.Struct, tag="input", tag_field="type", rename="camel"):
+    """Respond to a kernel input request."""
+
+    text: str
+    version: Literal[1] = VERSION
+
+
+class Interrupt(msgspec.Struct, tag="interrupt", tag_field="type", rename="camel"):
+    """Interrupt the kernel."""
+
+    version: Literal[1] = VERSION
+
+
+class Close(msgspec.Struct, tag="close", tag_field="type", rename="camel"):
+    """Close the kernel."""
+
+    version: Literal[1] = VERSION
+
+
+type ToBridge = Start | Control | Input | Interrupt | Close
+
+
+def encode(message: FromBridge | ToBridge) -> bytes:
+    """Encode one length-prefixed protocol message."""
+    payload = msgspec.json.encode(message)
+    return _HEADER.pack(len(payload)) + payload
+
+
+def read_header(header: bytes | bytearray) -> int:
+    """Decode a complete frame header into its payload length."""
+    if len(header) != _HEADER.size:
+        message = "Incomplete kernel frame header"
+        raise EOFError(message)
+    return _HEADER.unpack(header)[0]
+
+
+class Decoder[Message]:
+    """Decode length-prefixed messages across arbitrary byte chunks."""
+
+    def __init__(self, message_type: TypeForm[Message]) -> None:
+        self._buffer = bytearray()
+        self._decoder = msgspec.json.Decoder(message_type)
+
+    def feed(self, chunk: bytes) -> list[Message]:
+        """Decode every complete message in a chunk."""
+        self._buffer.extend(chunk)
+        messages: list[Message] = []
+        while len(self._buffer) >= _HEADER.size:
+            length = read_header(self._buffer[: _HEADER.size])
+            frame_length = _HEADER.size + length
+            if len(self._buffer) < frame_length:
+                break
+            payload = bytes(self._buffer[_HEADER.size : frame_length])
+            del self._buffer[:frame_length]
+            messages.append(self._decoder.decode(payload))
+        return messages

--- a/src/marimo_lsp/wasm/protocol.py
+++ b/src/marimo_lsp/wasm/protocol.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
 VERSION = 1
 _HEADER = struct.Struct(">I")
 HEADER_SIZE = _HEADER.size
+MAX_FRAME_SIZE = 64 * 1024 * 1024
 
 
 class Ready(msgspec.Struct, tag="ready", tag_field="type", rename="camel"):
@@ -102,6 +103,9 @@ type ToBridge = Start | Control | Input | Interrupt | Close
 def encode(message: FromBridge | ToBridge) -> bytes:
     """Encode one length-prefixed protocol message."""
     payload = msgspec.json.encode(message)
+    if len(payload) > MAX_FRAME_SIZE:
+        msg = f"Kernel frame exceeds {MAX_FRAME_SIZE} bytes"
+        raise ValueError(msg)
     return _HEADER.pack(len(payload)) + payload
 
 
@@ -126,6 +130,10 @@ class Decoder[Message]:
         messages: list[Message] = []
         while len(self._buffer) >= _HEADER.size:
             length = read_header(self._buffer[: _HEADER.size])
+            if length > MAX_FRAME_SIZE:
+                self._buffer.clear()
+                msg = f"Kernel frame exceeds {MAX_FRAME_SIZE} bytes"
+                raise ValueError(msg)
             frame_length = _HEADER.size + length
             if len(self._buffer) < frame_length:
                 break

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -188,6 +188,33 @@ def test_session_status_tracks_running_and_completed_operations() -> None:
     assert session._on_change.call_count == 2
 
 
+def test_terminal_kernel_error_removes_live_session() -> None:
+    server = Mock()
+    sessions = Sessions(server, kernels=Mock())
+    session = Mock(spec=Session)
+    sessions._sessions["file:///test.py"] = session
+    sessions._notify_changed = Mock()
+
+    sessions._kernel_failed(session, "bridge exited")
+
+    assert sessions.get("file:///test.py") is None
+    session.close.assert_called_once_with()
+    sessions._notify_changed.assert_called_once_with()
+
+
+def test_terminal_kernel_operation_invokes_failure_callback() -> None:
+    session, _queue_manager = _make_session()
+    session._closed = False
+    session._operation_sink = Mock()
+    session._on_kernel_failure = Mock()
+    message = KernelMessage(b'{"op": "kernel-startup-error", "error": "bridge exited"}')
+
+    session.accept_kernel_message(message)
+
+    session._on_kernel_failure.assert_called_once_with(session, "bridge exited")
+    session._operation_sink.notify.assert_called_once_with(message)
+
+
 def test_sessions_changed_notification_contains_public_snapshot() -> None:
     server = Mock()
     sessions = Sessions(server, kernels=Mock())

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -464,6 +464,38 @@ async def test_startup_message_handoff_preserves_order(
 
 
 @pytest.mark.asyncio
+async def test_terminal_error_during_startup_handoff_aborts_session() -> None:
+    error = KernelMessage(b'{"op": "kernel-startup-error", "error": "bridge exited"}')
+    kernel = Mock()
+
+    async def launch(**kwargs: object) -> object:
+        receive = cast("Callable[[KernelMessage], None]", kwargs["receive"])
+        receive(error)
+        await asyncio.sleep(0)
+        return kernel
+
+    kernels = Mock()
+    kernels.launch = AsyncMock(side_effect=launch)
+    sessions = Sessions(Mock(), kernels=kernels)
+    previous = Mock(spec=Session)
+    previous.app_file_manager = Mock()
+    previous.config_manager = Mock()
+    previous.config_manager.get_config.return_value = DEFAULT_CONFIG
+    previous.session_view = Mock()
+    previous.started_at = 42
+
+    with pytest.raises(KernelOpenError, match="bridge exited"):
+        await sessions._create(
+            "file:///test.py",
+            "/usr/bin/python",
+            "/workspace",
+            previous=previous,
+        )
+
+    kernel.close.assert_called_once_with()
+
+
+@pytest.mark.asyncio
 async def test_restart_replaces_kernel_without_reloading_closed_notebook() -> None:
     sessions = Sessions(Mock(), kernels=Mock())
     current = Mock(spec=Session)

--- a/tests/test_wasm.py
+++ b/tests/test_wasm.py
@@ -1,0 +1,75 @@
+# Copyright 2026 Marimo. All rights reserved.
+
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import msgspec
+from inline_snapshot import snapshot
+
+from marimo_lsp.wasm import create_bridge
+
+
+def test_wasm_server_handles_initialize_message() -> None:
+    messages: list[object] = []
+    server = create_bridge(
+        lambda message: messages.append(msgspec.json.decode(message)),
+        Mock(),
+    )
+
+    server.handle_message(
+        msgspec.json.encode(
+            {
+                "id": 1,
+                "method": "initialize",
+                "jsonrpc": "2.0",
+                "params": {
+                    "processId": None,
+                    "rootUri": None,
+                    "capabilities": {},
+                },
+            }
+        ).decode()
+    )
+
+    assert messages == snapshot(
+        [
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": {
+                    "capabilities": {
+                        "positionEncoding": "utf-16",
+                        "textDocumentSync": {
+                            "openClose": True,
+                            "change": 2,
+                            "save": False,
+                        },
+                        "completionProvider": {
+                            "triggerCharacters": ["@"],
+                            "resolveProvider": False,
+                        },
+                        "codeActionProvider": {
+                            "codeActionKinds": ["refactor.rewrite"],
+                            "resolveProvider": False,
+                        },
+                        "executeCommandProvider": {
+                            "commands": ["marimo.api", "marimo.convert"]
+                        },
+                        "diagnosticProvider": {
+                            "interFileDependencies": False,
+                            "workspaceDiagnostics": False,
+                        },
+                        "workspace": {
+                            "workspaceFolders": {
+                                "supported": True,
+                                "changeNotifications": True,
+                            },
+                            "fileOperations": {},
+                        },
+                    },
+                    "serverInfo": {"name": "marimo-lsp", "version": "0.1.0"},
+                },
+            }
+        ]
+    )

--- a/tests/test_wasm.py
+++ b/tests/test_wasm.py
@@ -75,6 +75,7 @@ async def test_wasm_server_handles_initialize_message() -> None:
             }
         ]
     )
+    server.close()
 
 
 @pytest.mark.asyncio
@@ -107,3 +108,15 @@ async def test_wasm_server_drives_async_api_handler() -> None:
     assert responses == snapshot(
         [{"jsonrpc": "2.0", "id": 1, "result": {"sessions": []}}]
     )
+    server.close()
+
+
+def test_wasm_server_close_releases_tracked_kernels() -> None:
+    server = create_bridge(Mock(), Mock())
+    kernel = Mock()
+    server._kernels._kernels["kernel"] = kernel
+
+    server.close()
+    server.close()
+
+    kernel.close.assert_called_once_with()

--- a/tests/test_wasm.py
+++ b/tests/test_wasm.py
@@ -5,19 +5,21 @@ from __future__ import annotations
 from unittest.mock import Mock
 
 import msgspec
+import pytest
 from inline_snapshot import snapshot
 
 from marimo_lsp.wasm import create_bridge
 
 
-def test_wasm_server_handles_initialize_message() -> None:
+@pytest.mark.asyncio
+async def test_wasm_server_handles_initialize_message() -> None:
     messages: list[object] = []
     server = create_bridge(
         lambda message: messages.append(msgspec.json.decode(message)),
         Mock(),
     )
 
-    server.handle_message(
+    await server.handle_message(
         msgspec.json.encode(
             {
                 "id": 1,
@@ -72,4 +74,36 @@ def test_wasm_server_handles_initialize_message() -> None:
                 },
             }
         ]
+    )
+
+
+@pytest.mark.asyncio
+async def test_wasm_server_drives_async_api_handler() -> None:
+    messages: list[object] = []
+    server = create_bridge(
+        lambda message: messages.append(msgspec.json.decode(message)),
+        Mock(),
+    )
+
+    await server.handle_message(
+        msgspec.json.encode(
+            {
+                "id": 1,
+                "method": "workspace/executeCommand",
+                "jsonrpc": "2.0",
+                "params": {
+                    "command": "marimo.api",
+                    "arguments": [{"method": "list-sessions", "params": {}}],
+                },
+            }
+        ).decode()
+    )
+
+    responses = [
+        message
+        for message in messages
+        if isinstance(message, dict) and message.get("id") == 1
+    ]
+    assert responses == snapshot(
+        [{"jsonrpc": "2.0", "id": 1, "result": {"sessions": []}}]
     )

--- a/tests/test_wasm_bridge.py
+++ b/tests/test_wasm_bridge.py
@@ -4,14 +4,15 @@ from __future__ import annotations
 
 import importlib.util
 import sys
+import threading
 from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest.mock import Mock
 
+import pytest
+
 if TYPE_CHECKING:
     from types import ModuleType
-
-    import pytest
 
 
 def _load_bridge_module(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
@@ -42,3 +43,19 @@ def test_windows_interrupt_uses_positional_queue_value(
     bridge.interrupt()
 
     interrupt_queue.put_nowait.assert_called_once_with(True)  # noqa: FBT003
+
+
+def test_kernel_readiness_has_a_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    bridge_module = _load_bridge_module(monkeypatch)
+    bridge = bridge_module._Bridge()
+    release_reader = threading.Event()
+    bridge._process = Mock()
+    bridge._process.stdout.readline.side_effect = lambda: (
+        release_reader.wait(),
+        b"KERNEL_READY\n",
+    )[1]
+
+    with pytest.raises(TimeoutError, match="did not become ready"):
+        bridge._wait_for_kernel_ready(timeout=0.01)
+
+    release_reader.set()

--- a/tests/test_wasm_bridge.py
+++ b/tests/test_wasm_bridge.py
@@ -1,0 +1,44 @@
+# Copyright 2026 Marimo. All rights reserved.
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import Mock
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+    import pytest
+
+
+def _load_bridge_module(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
+    resource_directory = Path(__file__).parents[1] / "extension" / "resources" / "wasm"
+    monkeypatch.syspath_prepend(str(resource_directory))
+    spec = importlib.util.spec_from_file_location(
+        "marimo_lsp_test_wasm_bridge",
+        resource_directory / "kernel.py",
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_windows_interrupt_uses_positional_queue_value(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bridge_module = _load_bridge_module(monkeypatch)
+    bridge = bridge_module._Bridge()
+    bridge._process = Mock(pid=42)
+    bridge._process.poll.return_value = None
+    bridge._queues = Mock()
+    interrupt_queue = bridge._queues.win32_interrupt_queue
+    monkeypatch.setattr(sys, "platform", "win32")
+
+    bridge.interrupt()
+
+    interrupt_queue.put_nowait.assert_called_once_with(True)  # noqa: FBT003

--- a/tests/test_wasm_bridge.py
+++ b/tests/test_wasm_bridge.py
@@ -6,6 +6,7 @@ import importlib.util
 import sys
 import threading
 from pathlib import Path
+from types import SimpleNamespace
 from typing import TYPE_CHECKING
 from unittest.mock import Mock
 
@@ -59,3 +60,19 @@ def test_kernel_readiness_has_a_timeout(monkeypatch: pytest.MonkeyPatch) -> None
         bridge._wait_for_kernel_ready(timeout=0.01)
 
     release_reader.set()
+
+
+def test_bridge_rejects_oversized_frame_before_reading_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bridge_module = _load_bridge_module(monkeypatch)
+    stream = Mock()
+    stream.read.return_value = (bridge_module.MAX_FRAME_SIZE + 1).to_bytes(
+        4, byteorder="big"
+    )
+    monkeypatch.setattr(bridge_module.sys, "stdin", SimpleNamespace(buffer=stream))
+
+    with pytest.raises(ValueError, match="frame exceeds"):
+        bridge_module._read_frame()
+
+    stream.read.assert_called_once_with(bridge_module.HEADER_SIZE)

--- a/tests/test_wasm_kernel.py
+++ b/tests/test_wasm_kernel.py
@@ -1,0 +1,169 @@
+# Copyright 2026 Marimo. All rights reserved.
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, cast
+from unittest.mock import Mock
+
+import msgspec
+import pytest
+from inline_snapshot import snapshot
+from marimo._config.config import DEFAULT_CONFIG
+from marimo._messaging.types import KernelMessage
+from marimo._runtime.commands import ExecuteCellsCommand
+
+from marimo_lsp.kernels import KernelOpenError
+from marimo_lsp.wasm.kernels import WasmKernels
+from marimo_lsp.wasm.protocol import (
+    Decoder,
+    Error,
+    Operation,
+    Ready,
+    ToBridge,
+    encode,
+)
+
+if TYPE_CHECKING:
+    from marimo._config.manager import MarimoConfigManager
+
+    from marimo_lsp.app_file_manager import LspAppFileManager
+
+
+class _Callbacks:
+    def __init__(self) -> None:
+        self.spawns: list[tuple[str, str, str]] = []
+        self.writes: list[tuple[str, bytes]] = []
+        self.closes: list[str] = []
+
+    def spawn(
+        self,
+        process_id: str,
+        executable: str,
+        working_directory: str,
+    ) -> None:
+        self.spawns.append((process_id, executable, working_directory))
+
+    def write(self, process_id: str, chunk: bytes) -> None:
+        self.writes.append((process_id, chunk))
+
+    def close(self, process_id: str) -> None:
+        self.closes.append(process_id)
+
+
+async def _begin_launch():
+    callbacks = _Callbacks()
+    kernels = WasmKernels(callbacks)
+    app_file_manager = SimpleNamespace(
+        path="/workspace/notebook.py",
+        app=SimpleNamespace(
+            config={},
+            cell_manager=SimpleNamespace(config_map=dict),
+        ),
+    )
+    config_manager = Mock()
+    config_manager.get_config.return_value = DEFAULT_CONFIG
+    messages: list[KernelMessage] = []
+    launch = asyncio.create_task(
+        kernels.launch(
+            executable="/python",
+            working_directory="/workspace",
+            app_file_manager=cast("LspAppFileManager", app_file_manager),
+            config_manager=cast("MarimoConfigManager", config_manager),
+            receive=messages.append,
+        )
+    )
+    await asyncio.sleep(0)
+    return callbacks, kernels, launch, messages
+
+
+async def _launch_kernel():
+    callbacks, kernels, launch, messages = await _begin_launch()
+    process_id = callbacks.spawns[0][0]
+    kernels.accept(process_id, encode(Ready()))
+    kernel = await launch
+    return callbacks, kernels, kernel, messages
+
+
+@pytest.mark.asyncio
+async def test_wasm_launch_fails_before_publishing_unready_kernel() -> None:
+    callbacks, kernels, launch, _messages = await _begin_launch()
+    process_id = callbacks.spawns[0][0]
+
+    kernels.accept(process_id, encode(Error(message="failed to start")))
+
+    with pytest.raises(KernelOpenError, match="failed to start"):
+        await launch
+    assert callbacks.closes == snapshot([process_id])
+
+
+@pytest.mark.asyncio
+async def test_wasm_kernel_forwards_lifecycle_and_messages() -> None:
+    callbacks, kernels, kernel, messages = await _launch_kernel()
+    process_id = callbacks.spawns[0][0]
+
+    kernel.send(ExecuteCellsCommand(cell_ids=[], codes=[]))
+    kernel.input("answer")
+    kernel.interrupt()
+    operation = encode(Operation(message=msgspec.Raw(b'{"op":"ready"}')))
+    kernels.accept(process_id, operation[:3])
+    kernels.accept(process_id, operation[3:])
+    kernel.close()
+
+    decoder = Decoder(ToBridge)
+    wire_messages = [
+        message for _, chunk in callbacks.writes for message in decoder.feed(chunk)
+    ]
+    wire = [
+        msgspec.json.decode(msgspec.json.encode(message)) for message in wire_messages
+    ]
+    kernel_args = wire[0]["kernelArgs"]
+    assert {
+        "spawn": callbacks.spawns,
+        "start": {
+            "type": wire[0]["type"],
+            "workingDirectory": wire[0]["workingDirectory"],
+            "filename": kernel_args["app_metadata"]["filename"],
+            "theme": kernel_args["user_config"]["display"]["theme"],
+        },
+        "request": {
+            "type": wire[1]["type"],
+            "requestType": wire[1]["request"]["type"],
+        },
+        "input": wire[2],
+        "interrupt": wire[3],
+        "close": wire[4],
+        "closes": callbacks.closes,
+        "operations": messages,
+    } == snapshot(
+        {
+            "spawn": [(process_id, "/python", "/workspace")],
+            "start": {
+                "type": "start",
+                "workingDirectory": "/workspace",
+                "filename": "/workspace/notebook.py",
+                "theme": "light",
+            },
+            "request": {"type": "control", "requestType": "execute-cells"},
+            "input": {"type": "input", "text": "answer", "version": 1},
+            "interrupt": {"type": "interrupt", "version": 1},
+            "close": {"type": "close", "version": 1},
+            "closes": [process_id],
+            "operations": [KernelMessage(b'{"op":"ready"}')],
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_closed_wasm_kernel_drops_late_messages() -> None:
+    callbacks, kernels, kernel, messages = await _launch_kernel()
+    process_id = callbacks.spawns[0][0]
+
+    kernel.close()
+    kernels.accept(
+        process_id,
+        encode(Operation(message=msgspec.Raw(b'{"op":"late"}'))),
+    )
+
+    assert messages == snapshot([])

--- a/tests/test_wasm_kernel.py
+++ b/tests/test_wasm_kernel.py
@@ -99,6 +99,18 @@ async def test_wasm_launch_fails_before_publishing_unready_kernel() -> None:
 
 
 @pytest.mark.asyncio
+async def test_cancelled_wasm_launch_releases_bridge() -> None:
+    callbacks, _kernels, launch, _messages = await _begin_launch()
+    process_id = callbacks.spawns[0][0]
+
+    launch.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await launch
+    assert callbacks.closes == snapshot([process_id])
+
+
+@pytest.mark.asyncio
 async def test_wasm_kernel_forwards_lifecycle_and_messages() -> None:
     callbacks, kernels, kernel, messages = await _launch_kernel()
     process_id = callbacks.spawns[0][0]
@@ -166,4 +178,38 @@ async def test_closed_wasm_kernel_drops_late_messages() -> None:
         encode(Operation(message=msgspec.Raw(b'{"op":"late"}'))),
     )
 
+    assert messages == snapshot([])
+
+
+@pytest.mark.asyncio
+async def test_ready_wasm_kernel_failure_releases_bridge() -> None:
+    callbacks, kernels, _kernel, messages = await _launch_kernel()
+    process_id = callbacks.spawns[0][0]
+
+    kernels.accept(process_id, encode(Error(message="bridge failed")))
+    kernels.accept(
+        process_id,
+        encode(Operation(message=msgspec.Raw(b'{"op":"late"}'))),
+    )
+
+    assert callbacks.closes == snapshot([process_id])
+    assert messages == snapshot(
+        [KernelMessage(b'{"op": "kernel-startup-error", "error": "bridge failed"}')]
+    )
+
+
+@pytest.mark.asyncio
+async def test_failed_close_write_still_releases_bridge() -> None:
+    callbacks, kernels, kernel, messages = await _launch_kernel()
+    process_id = callbacks.spawns[0][0]
+    callbacks.write = Mock(side_effect=RuntimeError("write failed"))
+
+    with pytest.raises(RuntimeError, match="write failed"):
+        kernel.close()
+    kernels.accept(
+        process_id,
+        encode(Operation(message=msgspec.Raw(b'{"op":"late"}'))),
+    )
+
+    assert callbacks.closes == snapshot([process_id])
     assert messages == snapshot([])

--- a/tests/test_wasm_kernel.py
+++ b/tests/test_wasm_kernel.py
@@ -17,8 +17,10 @@ from marimo._runtime.commands import ExecuteCellsCommand
 from marimo_lsp.kernels import KernelOpenError
 from marimo_lsp.wasm.kernels import WasmKernels
 from marimo_lsp.wasm.protocol import (
+    MAX_FRAME_SIZE,
     Decoder,
     Error,
+    FromBridge,
     Operation,
     Ready,
     ToBridge,
@@ -213,3 +215,13 @@ async def test_failed_close_write_still_releases_bridge() -> None:
 
     assert callbacks.closes == snapshot([process_id])
     assert messages == snapshot([])
+
+
+def test_decoder_rejects_and_discards_oversized_frame() -> None:
+    decoder = Decoder(FromBridge)
+    oversized_header = (MAX_FRAME_SIZE + 1).to_bytes(4, byteorder="big")
+
+    with pytest.raises(ValueError, match="frame exceeds"):
+        decoder.feed(oversized_header)
+
+    assert decoder.feed(encode(Ready())) == [Ready()]


### PR DESCRIPTION
The language server can run inside Pyodide, but notebook kernels still need the selected native Python environment and marimo IPC. Keep those responsibilities separate: Pyodide owns language-server and session state, while a small selected-Python bridge owns subprocess launch and ZeroMQ.

The WASM side asks JavaScript for only opaque process operations:

```python
class ProcessCallbacks(Protocol):
    def spawn(self, process_id, executable, working_directory) -> None: ...
    def write(self, process_id, chunk: bytes) -> None: ...
    def close(self, process_id) -> None: ...
```

Messages crossing that process boundary are length-prefixed `msgspec` structs. Control requests retain marimo's typed `CommandMessage`, while kernel operations use `msgspec.Raw` so they are not decoded and encoded again:

```python
class Control(msgspec.Struct, tag="control", tag_field="type"):
    request: CommandMessage

class Operation(msgspec.Struct, tag="operation", tag_field="type"):
    message: msgspec.Raw
```

`KernelLaunchArgs` inherits `marimo._ipc.KernelArgs` instead of copying its schema, making only `connection_info` optional until the bridge binds its sockets. Code generation places the same protocol beside the bridge script, and the WASM entrypoint drives pygls one complete JSON-RPC message at a time.