### PR TITLE
Bundle the WASM language server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,11 @@ jobs:
         run: pnpm test --coverage
         working-directory: marimo-lsp/extension
 
+      - name: Build and test the WASM language server
+        if: runner.os == 'Linux'
+        run: pnpm verify:wasm-lsp
+        working-directory: marimo-lsp/extension
+
       - name: Upload TypeScript coverage
         if: always() && matrix.os == 'ubuntu-latest'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/update-marimo-version.yml
+++ b/.github/workflows/update-marimo-version.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Read current pinned version
         id: current_version
         run: |
-          CURRENT_VERSION=$(sed -n 's/^  "marimo==\([0-9.]*\)",$/\1/p' pyproject.toml)
+          CURRENT_VERSION=$(sed -n 's/^  "marimo-base==\([0-9.]*\)",$/\1/p' pyproject.toml)
           echo "version=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Skip if already up to date
@@ -41,7 +41,7 @@ jobs:
       - name: Bump pyproject.toml pin
         if: steps.current_version.outputs.version != steps.get_version.outputs.version
         run: |
-          sed -i 's/^  "marimo==[0-9.]*",$/  "marimo==${{ steps.get_version.outputs.version }}",/' pyproject.toml
+          sed -i 's/^  "marimo-base==[0-9.]*",$/  "marimo-base==${{ steps.get_version.outputs.version }}",/' pyproject.toml
 
       - name: Bump .marimo-version
         if: steps.current_version.outputs.version != steps.get_version.outputs.version
@@ -50,7 +50,7 @@ jobs:
 
       - name: Refresh uv.lock
         if: steps.current_version.outputs.version != steps.get_version.outputs.version
-        run: uv lock --upgrade-package marimo
+        run: uv lock --upgrade-package marimo-base
 
       - name: Create Pull Request
         if: steps.current_version.outputs.version != steps.get_version.outputs.version
@@ -64,9 +64,9 @@ jobs:
             Automated PR to bump the pinned `marimo` version from `${{ steps.current_version.outputs.version }}` to `${{ steps.get_version.outputs.version }}`.
 
             Updates:
-            - `pyproject.toml` — exact pin of the `marimo` dependency
+            - `pyproject.toml` — exact pin of the `marimo-base` dependency
             - `.marimo-version` — sibling-checkout ref used by CI and local dev
-            - `uv.lock` — refreshed via `uv lock --upgrade-package marimo`
+            - `uv.lock` — refreshed via `uv lock --upgrade-package marimo-base`
 
             Note: `[tool.marimo-lsp] minimum-kernel-version` is **not** changed by this workflow. Bump it manually when intentionally dropping support for an older marimo release.
 

--- a/extension/package.json
+++ b/extension/package.json
@@ -24,7 +24,8 @@
     "test:extension": "vscode-test",
     "embed-sdist": "node scripts/embed-sdist.mjs",
     "build:wasm-lsp": "node scripts/build-wasm-lsp.mjs",
-    "test:wasm-lsp": "node scripts/test-wasm-lsp.mjs"
+    "test:wasm-lsp": "node scripts/test-wasm-lsp.mjs",
+    "verify:wasm-lsp": "pnpm build:wasm-lsp && pnpm build:extension && pnpm test:wasm-lsp"
   },
   "devDependencies": {
     "@effect/platform": "^0.92.1",

--- a/extension/package.json
+++ b/extension/package.json
@@ -15,14 +15,16 @@
     "patch-tsc": "effect-language-service patch",
     "typecheck-ci": "tsc",
     "build": "turbo build:renderer && turbo build:extension",
-    "build:extension": "esbuild --format=cjs --define:import.meta.env.DEV=false --platform=node --minify --external:vscode --bundle --sourcemap src/extension.ts --outdir=dist",
+    "build:extension": "esbuild --format=cjs --define:import.meta.env.DEV=false --platform=node --minify --external:vscode --external:../bundled/wasm/pyodide.js --bundle --sourcemap src/extension.ts src/wasmServer.ts --outdir=dist",
     "build:renderer": "vp build",
     "check": "vp check && node ./scripts/check-css-variables.mjs",
     "fix": "vp fmt && vp check --fix",
     "test": "vp test",
     "pretest:extension": "pnpm run build:extension",
     "test:extension": "vscode-test",
-    "embed-sdist": "node scripts/embed-sdist.mjs"
+    "embed-sdist": "node scripts/embed-sdist.mjs",
+    "build:wasm-lsp": "node scripts/build-wasm-lsp.mjs",
+    "test:wasm-lsp": "node scripts/test-wasm-lsp.mjs"
   },
   "devDependencies": {
     "@effect/platform": "^0.92.1",
@@ -56,6 +58,7 @@
     "oxlint": "1.77.0",
     "oxlint-tsgolint": "7.0.2001",
     "posthog-node": "^5.47.9",
+    "pyodide": "314.0.3",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
     "tar": "^7.5.22",

--- a/extension/pnpm-lock.yaml
+++ b/extension/pnpm-lock.yaml
@@ -105,6 +105,9 @@ importers:
       posthog-node:
         specifier: ^5.47.9
         version: 5.47.9
+      pyodide:
+        specifier: 314.0.3
+        version: 314.0.3
       react:
         specifier: ^19.2.8
         version: 19.2.8
@@ -1378,6 +1381,9 @@ packages:
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
+  '@types/emscripten@1.41.5':
+    resolution: {integrity: sha512-cMQm7pxu6BxtHyqJ7mQZ2kXWV5SLmugybFdHCBbJ5eHzOo6VhBckEgAT3//rP5FwPHNPeEiq4SmQ5ucBwsOo4Q==}
+
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
@@ -2563,6 +2569,10 @@ packages:
 
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
+
+  pyodide@314.0.3:
+    resolution: {integrity: sha512-sK40My6m8tmBUYtYH9au9rXUeh9x0wfahtHdOlGmJxZDsKBGKtP6KznyFB2+u/klbQTdDionR0uaVd176zVQzQ==}
+    engines: {node: '>=18.0.0'}
 
   randombytes@2.1.0:
     resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
@@ -3888,6 +3898,8 @@ snapshots:
 
   '@types/deep-eql@4.0.2': {}
 
+  '@types/emscripten@1.41.5': {}
+
   '@types/estree@1.0.9': {}
 
   '@types/istanbul-lib-coverage@2.0.6': {}
@@ -4945,6 +4957,14 @@ snapshots:
   process-nextick-args@2.0.1: {}
 
   pure-rand@6.1.0: {}
+
+  pyodide@314.0.3:
+    dependencies:
+      '@types/emscripten': 1.41.5
+      ws: 8.21.2
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   randombytes@2.1.0:
     dependencies:

--- a/extension/scripts/build-wasm-lsp.mjs
+++ b/extension/scripts/build-wasm-lsp.mjs
@@ -1,0 +1,120 @@
+// @ts-check
+/** Build the offline Pyodide environment bundled with the extension. */
+import * as NodeChildProcess from "node:child_process";
+import * as NodeFs from "node:fs";
+import * as NodeOs from "node:os";
+import * as NodePath from "node:path";
+import * as NodeUrl from "node:url";
+
+import { loadPyodide } from "pyodide";
+
+const extensionDir = NodePath.dirname(
+  NodeUrl.fileURLToPath(new URL("../package.json", import.meta.url)),
+);
+const repositoryDir = NodePath.dirname(extensionDir);
+const pyodideDir = NodePath.dirname(
+  NodeUrl.fileURLToPath(import.meta.resolve("pyodide")),
+);
+const outputDir = NodePath.join(extensionDir, "bundled", "wasm");
+const buildDir = NodeFs.mkdtempSync(
+  NodePath.join(NodeOs.tmpdir(), "marimo-lsp-wasm-"),
+);
+const uvCacheDir = NodePath.join(NodeOs.tmpdir(), "marimo-lsp-uv-cache");
+const pyodidePackage = JSON.parse(
+  NodeFs.readFileSync(NodePath.join(pyodideDir, "package.json"), "utf8"),
+);
+const packageBaseUrl = `https://cdn.jsdelivr.net/pyodide/v${pyodidePackage.version}/full/`;
+const runtimeFiles = [
+  "pyodide.js",
+  "pyodide.asm.mjs",
+  "pyodide.asm.wasm",
+  "pyodide-lock.json",
+  "python_stdlib.zip",
+];
+
+// TODO: Remove click after refactoring this eager import chain upstream:
+// marimo_lsp.sessions
+// └── marimo._session.managers
+//     └── marimo._session.managers.ipc
+//         └── marimo._cli.sandbox
+//             └── import click
+const pyodidePackages = ["click", "micropip", "msgspec", "pyyaml"];
+
+try {
+  NodeFs.mkdirSync(outputDir, { recursive: true });
+  for (const filename of runtimeFiles) {
+    NodeFs.copyFileSync(
+      NodePath.join(pyodideDir, filename),
+      NodePath.join(outputDir, filename),
+    );
+  }
+
+  NodeChildProcess.execFileSync(
+    "uv",
+    ["build", "--wheel", "--out-dir", buildDir],
+    {
+      cwd: repositoryDir,
+      env: { ...process.env, UV_CACHE_DIR: uvCacheDir },
+      stdio: "inherit",
+    },
+  );
+  const wheel = NodeFs.readdirSync(buildDir).find(
+    (filename) =>
+      filename.startsWith("marimo_lsp-") && filename.endsWith(".whl"),
+  );
+  if (wheel === undefined) throw new Error("uv did not produce a wheel");
+
+  const lock = JSON.parse(
+    NodeFs.readFileSync(NodePath.join(pyodideDir, "pyodide-lock.json"), "utf8"),
+  );
+  const pyodide = await loadPyodide({
+    indexURL: pyodideDir,
+    lockFileContents: lock,
+    packageBaseUrl,
+    packageCacheDir: NodePath.join(buildDir, "package-cache"),
+  });
+  await pyodide.loadPackage(pyodidePackages);
+
+  const micropip = pyodide.pyimport("micropip");
+  try {
+    await micropip.install(
+      NodeUrl.pathToFileURL(NodePath.join(buildDir, wheel)).href,
+    );
+  } finally {
+    micropip.destroy();
+  }
+
+  pyodide.runPython(`
+from pathlib import Path
+import shutil
+
+site_packages = Path("/lib/python3.14/site-packages")
+excluded = ("micropip", "jedi", "parso", "pygments", "docutils")
+for package in excluded:
+    shutil.rmtree(site_packages / package, ignore_errors=True)
+    for metadata in site_packages.glob(f"{package}-*.dist-info"):
+        shutil.rmtree(metadata)
+
+if list(site_packages.glob("marimo-*.dist-info")):
+    raise RuntimeError("The bundle must not contain the full marimo distribution")
+if not list(site_packages.glob("marimo_base-*.dist-info")):
+    raise RuntimeError("The bundle must contain marimo-base")
+
+shutil.make_archive("/marimo-lsp-site-packages", "zip", site_packages)
+`);
+  NodeFs.writeFileSync(
+    NodePath.join(outputDir, "site-packages.zip"),
+    pyodide.FS.readFile("/marimo-lsp-site-packages.zip"),
+  );
+  NodeFs.writeFileSync(
+    NodePath.join(outputDir, "manifest.json"),
+    `${JSON.stringify(
+      { pyodide: pyodide.version, pyodideNpm: pyodidePackage.version },
+      null,
+      2,
+    )}\n`,
+  );
+  console.log(`Built offline WASM language server in ${outputDir}`);
+} finally {
+  NodeFs.rmSync(buildDir, { recursive: true, force: true });
+}

--- a/extension/scripts/build-wasm-lsp.mjs
+++ b/extension/scripts/build-wasm-lsp.mjs
@@ -16,9 +16,6 @@ const pyodideDir = NodePath.dirname(
   NodeUrl.fileURLToPath(import.meta.resolve("pyodide")),
 );
 const outputDir = NodePath.join(extensionDir, "bundled", "wasm");
-const buildDir = NodeFs.mkdtempSync(
-  NodePath.join(NodeOs.tmpdir(), "marimo-lsp-wasm-"),
-);
 const uvCacheDir = NodePath.join(NodeOs.tmpdir(), "marimo-lsp-uv-cache");
 const pyodidePackage = JSON.parse(
   NodeFs.readFileSync(NodePath.join(pyodideDir, "package.json"), "utf8"),
@@ -40,7 +37,12 @@ const runtimeFiles = [
 //             └── import click
 const pyodidePackages = ["click", "micropip", "msgspec", "pyyaml"];
 
+/** @type {string | undefined} */
+let buildDir;
 try {
+  buildDir = NodeFs.mkdtempSync(
+    NodePath.join(NodeOs.tmpdir(), "marimo-lsp-wasm-"),
+  );
   NodeFs.mkdirSync(outputDir, { recursive: true });
   for (const filename of runtimeFiles) {
     NodeFs.copyFileSync(
@@ -87,8 +89,9 @@ try {
   pyodide.runPython(`
 from pathlib import Path
 import shutil
+import sysconfig
 
-site_packages = Path("/lib/python3.14/site-packages")
+site_packages = Path(sysconfig.get_path("purelib"))
 excluded = ("micropip", "jedi", "parso", "pygments", "docutils")
 for package in excluded:
     shutil.rmtree(site_packages / package, ignore_errors=True)
@@ -116,5 +119,7 @@ shutil.make_archive("/marimo-lsp-site-packages", "zip", site_packages)
   );
   console.log(`Built offline WASM language server in ${outputDir}`);
 } finally {
-  NodeFs.rmSync(buildDir, { recursive: true, force: true });
+  if (buildDir !== undefined) {
+    NodeFs.rmSync(buildDir, { recursive: true, force: true });
+  }
 }

--- a/extension/scripts/test-wasm-lsp.mjs
+++ b/extension/scripts/test-wasm-lsp.mjs
@@ -4,6 +4,9 @@ import * as NodeChildProcess from "node:child_process";
 import * as NodePath from "node:path";
 import * as NodeUrl from "node:url";
 
+import { StreamMessageReader } from "vscode-jsonrpc/node";
+
+const TIMEOUT_MS = 20_000;
 const extensionDir = NodePath.dirname(
   NodeUrl.fileURLToPath(new URL("../package.json", import.meta.url)),
 );
@@ -13,11 +16,37 @@ const child = NodeChildProcess.spawn(
   { stdio: ["pipe", "pipe", "pipe"] },
 );
 /** @type {Buffer[]} */
-const stdout = [];
-/** @type {Buffer[]} */
 const stderr = [];
-child.stdout.on("data", (chunk) => stdout.push(chunk));
 child.stderr.on("data", (chunk) => stderr.push(chunk));
+
+const reader = new StreamMessageReader(child.stdout);
+/** @type {Map<number, (message: unknown) => void>} */
+const responses = new Map();
+reader.listen((message) => {
+  if ("id" in message && typeof message.id === "number") {
+    responses.get(message.id)?.(message);
+    responses.delete(message.id);
+  }
+});
+
+/** @param {number} id */
+function response(id) {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      responses.delete(id);
+      child.kill();
+      reject(
+        new Error(
+          `Timed out waiting for response ${id}\n${Buffer.concat(stderr).toString("utf8")}`,
+        ),
+      );
+    }, TIMEOUT_MS);
+    responses.set(id, (message) => {
+      clearTimeout(timeout);
+      resolve(message);
+    });
+  });
+}
 
 /** @param {unknown} message */
 function send(message) {
@@ -26,23 +55,51 @@ function send(message) {
   child.stdin.write(body);
 }
 
+const initialized = response(1);
 send({
   jsonrpc: "2.0",
   id: 1,
   method: "initialize",
   params: { processId: process.pid, capabilities: {}, rootUri: null },
 });
+const initializeMessage = await initialized;
 send({ jsonrpc: "2.0", method: "initialized", params: {} });
-send({ jsonrpc: "2.0", id: 2, method: "shutdown", params: null });
+
+const listed = response(2);
+send({
+  jsonrpc: "2.0",
+  id: 2,
+  method: "workspace/executeCommand",
+  params: {
+    command: "marimo.api",
+    arguments: [{ method: "list-sessions", params: {} }],
+  },
+});
+const listMessage = await listed;
+
+const shutdown = response(3);
+send({ jsonrpc: "2.0", id: 3, method: "shutdown", params: null });
+await shutdown;
 send({ jsonrpc: "2.0", method: "exit", params: null });
 child.stdin.end();
 
 const exitCode = await new Promise((resolve, reject) => {
+  const timeout = setTimeout(() => {
+    child.kill();
+    reject(
+      new Error(
+        `Timed out waiting for WASM server exit\n${Buffer.concat(stderr).toString("utf8")}`,
+      ),
+    );
+  }, TIMEOUT_MS);
   child.once("error", reject);
-  child.once("exit", resolve);
+  child.once("exit", (code) => {
+    clearTimeout(timeout);
+    resolve(code);
+  });
 });
-const output = Buffer.concat(stdout).toString("utf8");
 const errors = Buffer.concat(stderr).toString("utf8");
 NodeAssert.equal(exitCode, 0, errors);
-NodeAssert.match(output, /"serverInfo":\{"name":"marimo-lsp"/);
+NodeAssert.equal(initializeMessage.result.serverInfo.name, "marimo-lsp");
+NodeAssert.deepEqual(listMessage.result, { sessions: [] });
 console.log("WASM language-server smoke test passed");

--- a/extension/scripts/test-wasm-lsp.mjs
+++ b/extension/scripts/test-wasm-lsp.mjs
@@ -1,0 +1,48 @@
+// @ts-check
+import * as NodeAssert from "node:assert/strict";
+import * as NodeChildProcess from "node:child_process";
+import * as NodePath from "node:path";
+import * as NodeUrl from "node:url";
+
+const extensionDir = NodePath.dirname(
+  NodeUrl.fileURLToPath(new URL("../package.json", import.meta.url)),
+);
+const child = NodeChildProcess.spawn(
+  process.execPath,
+  [NodePath.join(extensionDir, "dist", "wasmServer.js")],
+  { stdio: ["pipe", "pipe", "pipe"] },
+);
+/** @type {Buffer[]} */
+const stdout = [];
+/** @type {Buffer[]} */
+const stderr = [];
+child.stdout.on("data", (chunk) => stdout.push(chunk));
+child.stderr.on("data", (chunk) => stderr.push(chunk));
+
+/** @param {unknown} message */
+function send(message) {
+  const body = Buffer.from(JSON.stringify(message));
+  child.stdin.write(`Content-Length: ${body.byteLength}\r\n\r\n`);
+  child.stdin.write(body);
+}
+
+send({
+  jsonrpc: "2.0",
+  id: 1,
+  method: "initialize",
+  params: { processId: process.pid, capabilities: {}, rootUri: null },
+});
+send({ jsonrpc: "2.0", method: "initialized", params: {} });
+send({ jsonrpc: "2.0", id: 2, method: "shutdown", params: null });
+send({ jsonrpc: "2.0", method: "exit", params: null });
+child.stdin.end();
+
+const exitCode = await new Promise((resolve, reject) => {
+  child.once("error", reject);
+  child.once("exit", resolve);
+});
+const output = Buffer.concat(stdout).toString("utf8");
+const errors = Buffer.concat(stderr).toString("utf8");
+NodeAssert.equal(exitCode, 0, errors);
+NodeAssert.match(output, /"serverInfo":\{"name":"marimo-lsp"/);
+console.log("WASM language-server smoke test passed");

--- a/extension/src/wasmServer.ts
+++ b/extension/src/wasmServer.ts
@@ -1,0 +1,114 @@
+import * as NodeFs from "node:fs";
+import * as NodeModule from "node:module";
+import * as NodePath from "node:path";
+
+import type { loadPyodide as LoadPyodide } from "pyodide";
+import { StreamMessageReader, StreamMessageWriter } from "vscode-jsonrpc/node";
+
+interface PyodideModule {
+  readonly loadPyodide: typeof LoadPyodide;
+}
+
+interface WasmBridge {
+  readonly handle_message: (messageJson: string) => void;
+  readonly close: () => void;
+  readonly destroy: () => void;
+}
+
+interface WasmModule {
+  readonly create_bridge: (
+    writeMessage: (messageJson: string) => void,
+    processes: object,
+  ) => WasmBridge;
+  readonly destroy: () => void;
+}
+
+function isPyodideModule(value: unknown): value is PyodideModule {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "loadPyodide" in value &&
+    typeof value.loadPyodide === "function"
+  );
+}
+
+function isWasmModule(value: unknown): value is WasmModule {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "create_bridge" in value &&
+    typeof value.create_bridge === "function" &&
+    "destroy" in value &&
+    typeof value.destroy === "function"
+  );
+}
+
+function loadBundledPyodide(): PyodideModule {
+  const require = NodeModule.createRequire(__filename);
+  const module: unknown = require("../bundled/wasm/pyodide.js");
+  if (!isPyodideModule(module)) {
+    throw new TypeError("Bundled Pyodide module is invalid");
+  }
+  return module;
+}
+
+async function main(): Promise<void> {
+  const wasmDir = NodePath.join(__dirname, "..", "bundled", "wasm");
+  const { loadPyodide } = loadBundledPyodide();
+  const pyodide = await loadPyodide({
+    indexURL: wasmDir,
+    stdout: (line) => process.stderr.write(`${line}\n`),
+    stderr: (line) => process.stderr.write(`${line}\n`),
+  });
+  pyodide.FS.writeFile(
+    "/marimo-lsp-site-packages.zip",
+    NodeFs.readFileSync(NodePath.join(wasmDir, "site-packages.zip")),
+  );
+  pyodide.runPython(`
+import shutil
+shutil.unpack_archive("/marimo-lsp-site-packages.zip", "/lib/python3.14/site-packages")
+`);
+
+  const imported: unknown = pyodide.pyimport("marimo_lsp.wasm");
+  if (!isWasmModule(imported)) {
+    throw new TypeError("Bundled marimo_lsp.wasm module is invalid");
+  }
+  const writer = new StreamMessageWriter(process.stdout);
+  const unsupportedProcesses = {
+    spawn: () => {
+      throw new Error("Native kernels are not available in this revision");
+    },
+    write: () => {},
+    close: () => {},
+  };
+  const bridge = imported.create_bridge((messageJson: string) => {
+    void writer.write(JSON.parse(messageJson));
+  }, unsupportedProcesses);
+  const reader = new StreamMessageReader(process.stdin);
+  let resolveExit = () => {};
+  const exitRequested = new Promise<void>((resolve) => {
+    resolveExit = resolve;
+  });
+  reader.listen((message) => {
+    if ("method" in message && message.method === "exit") {
+      resolveExit();
+      return;
+    }
+    bridge.handle_message(JSON.stringify(message));
+  });
+  const stdinEnded = new Promise<void>((resolve, reject) => {
+    process.stdin.once("end", resolve);
+    process.stdin.once("error", reject);
+  });
+  await Promise.race([stdinEnded, exitRequested]);
+  reader.dispose();
+  process.stdin.pause();
+  bridge.close();
+  bridge.destroy();
+  imported.destroy();
+}
+
+void main().catch((error: unknown) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/extension/src/wasmServer.ts
+++ b/extension/src/wasmServer.ts
@@ -10,7 +10,7 @@ interface PyodideModule {
 }
 
 interface WasmBridge {
-  readonly handle_message: (messageJson: string) => void;
+  readonly handle_message: (messageJson: string) => Promise<void>;
   readonly close: () => void;
   readonly destroy: () => void;
 }
@@ -94,7 +94,13 @@ shutil.unpack_archive("/marimo-lsp-site-packages.zip", "/lib/python3.14/site-pac
       resolveExit();
       return;
     }
-    bridge.handle_message(JSON.stringify(message));
+    void bridge
+      .handle_message(JSON.stringify(message))
+      .catch((error: unknown) => {
+        console.error(error);
+        process.exitCode = 1;
+        resolveExit();
+      });
   });
   const stdinEnded = new Promise<void>((resolve, reject) => {
     process.stdin.once("end", resolve);

--- a/extension/src/wasmServer.ts
+++ b/extension/src/wasmServer.ts
@@ -66,7 +66,8 @@ async function main(): Promise<void> {
   );
   pyodide.runPython(`
 import shutil
-shutil.unpack_archive("/marimo-lsp-site-packages.zip", "/lib/python3.14/site-packages")
+import sysconfig
+shutil.unpack_archive("/marimo-lsp-site-packages.zip", sysconfig.get_path("purelib"))
 `);
 
   const imported: unknown = pyodide.pyimport("marimo_lsp.wasm");

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [{ name = "Trevor Manz", email = "trevor.j.manz@gmail.com" }]
 dependencies = [
   "jupytext==1.19.5",
   "lsprotocol==2025.0.0",
-  "marimo==0.23.16",
+  "marimo-base==0.23.16",
   "pygls==2.1.1",
   "typing-extensions>=4.15.0",
 ]
@@ -102,4 +102,4 @@ exclude_also = [
 
 [tool.uv]
 exclude-newer = "7 days"
-exclude-newer-package = { marimo = false }
+exclude-newer-package = { marimo-base = false }

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -400,11 +400,11 @@ async def test_marimo_get_package_list_venv_no_session(
     )
 
     # Endpoint is session-free; uv lists packages from the executable directly.
-    # `marimo` is a runtime dep of marimo-lsp, so it must appear when listing
+    # `marimo-base` is a runtime dep of marimo-lsp, so it must appear when listing
     # against `sys.executable`. Asserting on it catches a regression to `[]`.
     assert result is not None
     names = {p["name"] for p in result["packages"]}
-    assert "marimo" in names, f"expected marimo in package list, got {names}"
+    assert "marimo-base" in names, f"expected marimo-base in package list, got {names}"
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -7,7 +7,7 @@ exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for 
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
-marimo = false
+marimo-base = false
 
 [[package]]
 name = "anyio"
@@ -416,7 +416,7 @@ wheels = [
 ]
 
 [[package]]
-name = "marimo"
+name = "marimo-base"
 version = "0.23.16"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
@@ -440,9 +440,9 @@ dependencies = [
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
     { name = "websockets", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/83/c0/b6b7101dc9d3760c51d67714d4547047cb2c29c11f26691bed6a64d8a995/marimo-0.23.16.tar.gz", hash = "sha256:378c892f0e1bc3985bc0b5b61109078e09fc767438b95234bfec9faa45858c98", size = 38789959, upload-time = "2026-07-31T20:04:47.92Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4b/39/7d1fac9c337465e666142370d1c7fff928e9ab3eeab24ef8345bd5985884/marimo_base-0.23.16.tar.gz", hash = "sha256:5ea00af7034b9c9c92b8f2311d5226b7a8171701bf88fdc22e9f16fbc2410229", size = 1639775, upload-time = "2026-07-31T20:01:34.008Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/7a/db0583b21d1f03403fc26800cb4638f59e95a33efd333f7a4d45ac348b82/marimo-0.23.16-py3-none-any.whl", hash = "sha256:e0bba0a44b395d402072c65d686fb459bd8955c9ab8b0d6135a22f729c989373", size = 39241287, upload-time = "2026-07-31T20:04:43.678Z" },
+    { url = "https://files.pythonhosted.org/packages/81/67/3599202da0bc2f827186f4d1ac6bfcd8471884d1eeb4362ae722d32557c7/marimo_base-0.23.16-py3-none-any.whl", hash = "sha256:96c5db9e96526fc19ad2c20640d19c9de8be2b296c176e0236add6b587585928", size = 1880917, upload-time = "2026-07-31T20:01:32.45Z" },
 ]
 
 [[package]]
@@ -452,7 +452,7 @@ source = { editable = "." }
 dependencies = [
     { name = "jupytext" },
     { name = "lsprotocol" },
-    { name = "marimo" },
+    { name = "marimo-base" },
     { name = "pygls" },
     { name = "typing-extensions" },
 ]
@@ -472,7 +472,7 @@ dev = [
 requires-dist = [
     { name = "jupytext", specifier = "==1.19.5" },
     { name = "lsprotocol", specifier = "==2025.0.0" },
-    { name = "marimo", specifier = "==0.23.16" },
+    { name = "marimo-base", specifier = "==0.23.16" },
     { name = "pygls", specifier = "==2.1.1" },
     { name = "typing-extensions", specifier = ">=4.15.0" },
 ]


### PR DESCRIPTION
Loading Pyodide from npm still leaves runtime packages and the marimo-lsp wheel to be resolved at startup. That would replace the native Python provisioning problem with a network-dependent WASM provisioning step.

Use `marimo-base` for both native and Emscripten installs. It exposes the same `marimo` Python package and native IPC dependencies without shipping the frontend distribution.

Build the environment entirely at extension build time:

```text
Pyodide runtime + marimo-lsp wheel + marimo-base
    -> install under Pyodide
    -> remove kernel-only packages
    -> bundled/wasm/site-packages.zip
```

The Node entrypoint loads only these local artifacts and translates stdio JSON-RPC frames into complete messages for `marimo_lsp.wasm`. `pnpm build:wasm-lsp` assembles the environment, while `pnpm test:wasm-lsp` starts the bundled server and verifies an initialize round trip without a native language-server interpreter.