### PR TITLE
Broker opaque kernel bytes

### DIFF
--- a/extension/scripts/test-wasm-lsp.mjs
+++ b/extension/scripts/test-wasm-lsp.mjs
@@ -10,13 +10,25 @@ const TIMEOUT_MS = 20_000;
 const extensionDir = NodePath.dirname(
   NodeUrl.fileURLToPath(new URL("../package.json", import.meta.url)),
 );
+const repositoryDir = NodePath.dirname(extensionDir);
+const kernelPython = NodeChildProcess.execFileSync(
+  "uv",
+  ["run", "python", "-c", "import sys; print(sys.executable)"],
+  {
+    cwd: repositoryDir,
+    encoding: "utf8",
+  },
+).trim();
 const child = NodeChildProcess.spawn(
   process.execPath,
   [NodePath.join(extensionDir, "dist", "wasmServer.js")],
   { stdio: ["pipe", "pipe", "pipe"] },
 );
 /** @type {Buffer[]} */
+const stdout = [];
+/** @type {Buffer[]} */
 const stderr = [];
+child.stdout.on("data", (chunk) => stdout.push(chunk));
 child.stderr.on("data", (chunk) => stderr.push(chunk));
 
 const reader = new StreamMessageReader(child.stdout);
@@ -55,6 +67,27 @@ function send(message) {
   child.stdin.write(body);
 }
 
+/** @param {RegExp} pattern */
+function waitForOutput(pattern) {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(
+        new Error(
+          `Timed out waiting for ${pattern}\n${Buffer.concat(stdout).toString("utf8")}\n${Buffer.concat(stderr).toString("utf8")}`,
+        ),
+      );
+    }, 20_000);
+    const inspect = () => {
+      if (!pattern.test(Buffer.concat(stdout).toString("utf8"))) return;
+      clearTimeout(timeout);
+      child.stdout.off("data", inspect);
+      resolve(undefined);
+    };
+    child.stdout.on("data", inspect);
+    inspect();
+  });
+}
+
 const initialized = response(1);
 send({
   jsonrpc: "2.0",
@@ -65,17 +98,47 @@ send({
 const initializeMessage = await initialized;
 send({ jsonrpc: "2.0", method: "initialized", params: {} });
 
-const listed = response(2);
+const notebookUri = "file:///tmp/marimo-wasm-smoke.py";
+const cellUri =
+  "vscode-notebook-cell:///tmp/marimo-wasm-smoke.py#W0sZmlsZQ%3D%3D";
+send({
+  jsonrpc: "2.0",
+  method: "notebookDocument/didOpen",
+  params: {
+    notebookDocument: {
+      uri: notebookUri,
+      notebookType: "marimo-notebook",
+      version: 1,
+      cells: [{ kind: 2, document: cellUri }],
+    },
+    cellTextDocuments: [
+      { uri: cellUri, languageId: "python", version: 1, text: "x = 1" },
+    ],
+  },
+});
+
+const executed = response(2);
 send({
   jsonrpc: "2.0",
   id: 2,
   method: "workspace/executeCommand",
   params: {
     command: "marimo.api",
-    arguments: [{ method: "list-sessions", params: {} }],
+    arguments: [
+      {
+        method: "execute-cells",
+        params: {
+          notebookUri,
+          executable: kernelPython,
+          workingDirectory: repositoryDir,
+          inner: { cellIds: ["cell"], codes: ["x = 1"] },
+        },
+      },
+    ],
   },
 });
-const listMessage = await listed;
+await executed;
+await waitForOutput(/"op":"completed-run"/);
 
 const shutdown = response(3);
 send({ jsonrpc: "2.0", id: 3, method: "shutdown", params: null });
@@ -99,7 +162,13 @@ const exitCode = await new Promise((resolve, reject) => {
   });
 });
 const errors = Buffer.concat(stderr).toString("utf8");
+const output = Buffer.concat(stdout).toString("utf8");
 NodeAssert.equal(exitCode, 0, errors);
 NodeAssert.equal(initializeMessage.result.serverInfo.name, "marimo-lsp");
-NodeAssert.deepEqual(listMessage.result, { sessions: [] });
+NodeAssert.match(output, /"method":"marimo\/operation"/);
+NodeAssert.match(output, /"op":"completed-run"/);
+NodeAssert.match(
+  output,
+  /"op":"variable-values","variables":\[\{"name":"x","value":"1"/,
+);
 console.log("WASM language-server smoke test passed");

--- a/extension/src/wasm/Processes.ts
+++ b/extension/src/wasm/Processes.ts
@@ -1,0 +1,92 @@
+import * as NodeChildProcess from "node:child_process";
+import * as NodePath from "node:path";
+import type { Writable } from "node:stream";
+
+interface ProcessState {
+  readonly child: NodeChildProcess.ChildProcess;
+  readonly input: Writable;
+  expectedClose: boolean;
+  exited: boolean;
+}
+
+interface ProcessCallbacks {
+  readonly stdout: (processId: string, chunk: Uint8Array) => void;
+  readonly exited: (
+    processId: string,
+    code: number | null,
+    signal: NodeJS.Signals | null,
+  ) => void;
+}
+
+/** Brokers opaque bytes between Pyodide and selected-Python processes. */
+export class Processes {
+  readonly #processes = new Map<string, ProcessState>();
+  readonly #callbacks: ProcessCallbacks;
+
+  constructor(callbacks: ProcessCallbacks) {
+    this.#callbacks = callbacks;
+  }
+
+  spawn(processId: string, executable: string, workingDirectory: string): void {
+    const script = NodePath.join(
+      __dirname,
+      "..",
+      "resources",
+      "wasm",
+      "kernel.py",
+    );
+    const child = NodeChildProcess.spawn(executable, [script], {
+      cwd: workingDirectory,
+      // Keep smoke tests from writing bytecode into packaged resources.
+      env: { ...process.env, PYTHONDONTWRITEBYTECODE: "1" },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    if (child.stdin === null || child.stdout === null) {
+      child.kill();
+      throw new Error("Kernel process did not expose stdio pipes");
+    }
+
+    const state: ProcessState = {
+      child,
+      input: child.stdin,
+      expectedClose: false,
+      exited: false,
+    };
+    this.#processes.set(processId, state);
+    child.stdout.on("data", (chunk: Buffer) => {
+      this.#callbacks.stdout(
+        processId,
+        new Uint8Array(chunk.buffer, chunk.byteOffset, chunk.byteLength),
+      );
+    });
+    child.stderr?.on("data", (chunk: Buffer) => process.stderr.write(chunk));
+    const exited = (code: number | null, signal: NodeJS.Signals | null) => {
+      if (state.exited) return;
+      state.exited = true;
+      this.#processes.delete(processId);
+      if (!state.expectedClose) this.#callbacks.exited(processId, code, signal);
+    };
+    child.once("error", (error) => {
+      process.stderr.write(`${error.message}\n`);
+      exited(null, null);
+    });
+    child.once("exit", exited);
+  }
+
+  write(processId: string, chunk: Uint8Array): void {
+    const state = this.#processes.get(processId);
+    if (state === undefined) throw new Error(`No process with id ${processId}`);
+    state.input.write(chunk);
+  }
+
+  close(processId: string): void {
+    const state = this.#processes.get(processId);
+    if (state === undefined) return;
+    state.expectedClose = true;
+    state.input.end();
+  }
+
+  closeAll(): void {
+    for (const processId of this.#processes.keys()) this.close(processId);
+  }
+}

--- a/extension/src/wasm/Processes.ts
+++ b/extension/src/wasm/Processes.ts
@@ -1,9 +1,23 @@
 import * as NodeChildProcess from "node:child_process";
+import type { EventEmitter } from "node:events";
 import * as NodePath from "node:path";
-import type { Writable } from "node:stream";
+import type { Readable, Writable } from "node:stream";
+
+interface SpawnedProcess extends EventEmitter {
+  readonly stdin: Writable | null;
+  readonly stdout: Readable | null;
+  readonly stderr: Readable | null;
+  kill(): boolean;
+}
+
+type SpawnProcess = (
+  executable: string,
+  args: string[],
+  options: NodeChildProcess.SpawnOptions,
+) => SpawnedProcess;
 
 interface ProcessState {
-  readonly child: NodeChildProcess.ChildProcess;
+  readonly child: SpawnedProcess;
   readonly input: Writable;
   expectedClose: boolean;
   exited: boolean;
@@ -22,9 +36,15 @@ interface ProcessCallbacks {
 export class Processes {
   readonly #processes = new Map<string, ProcessState>();
   readonly #callbacks: ProcessCallbacks;
+  readonly #spawn: SpawnProcess;
 
-  constructor(callbacks: ProcessCallbacks) {
+  constructor(
+    callbacks: ProcessCallbacks,
+    spawn: SpawnProcess = (executable, args, options) =>
+      NodeChildProcess.spawn(executable, args, options),
+  ) {
     this.#callbacks = callbacks;
+    this.#spawn = spawn;
   }
 
   spawn(processId: string, executable: string, workingDirectory: string): void {
@@ -35,7 +55,7 @@ export class Processes {
       "wasm",
       "kernel.py",
     );
-    const child = NodeChildProcess.spawn(executable, [script], {
+    const child = this.#spawn(executable, [script], {
       cwd: workingDirectory,
       // Keep smoke tests from writing bytecode into packaged resources.
       env: { ...process.env, PYTHONDONTWRITEBYTECODE: "1" },
@@ -68,9 +88,10 @@ export class Processes {
     };
     child.once("error", (error) => {
       process.stderr.write(`${error.message}\n`);
-      exited(null, null);
     });
-    child.once("exit", exited);
+    // `exit` can precede the final stdout data. `close` is emitted only after
+    // the process has exited and its stdio streams have closed.
+    child.once("close", exited);
   }
 
   write(processId: string, chunk: Uint8Array): void {

--- a/extension/src/wasm/Processes.ts
+++ b/extension/src/wasm/Processes.ts
@@ -81,7 +81,7 @@ export class Processes {
 
   close(processId: string): void {
     const state = this.#processes.get(processId);
-    if (state === undefined) return;
+    if (state === undefined || state.expectedClose) return;
     state.expectedClose = true;
     state.input.end();
   }

--- a/extension/src/wasm/WasmBridgeRuntime.ts
+++ b/extension/src/wasm/WasmBridgeRuntime.ts
@@ -1,0 +1,124 @@
+import { Processes } from "./Processes.ts";
+
+interface WasmBridge {
+  readonly handle_message: (messageJson: string) => Promise<void>;
+  readonly handle_kernel_bytes: (processId: string, chunk: Uint8Array) => void;
+  readonly handle_kernel_exit: (
+    processId: string,
+    code: number | null,
+    signal: string | null,
+  ) => void;
+  readonly close: () => void;
+  readonly destroy: () => void;
+}
+
+interface BytesProxy {
+  readonly toJs: () => unknown;
+  readonly destroy: () => void;
+}
+
+export interface WasmModule {
+  readonly create_bridge: (
+    writeMessage: (messageJson: string) => void,
+    processes: object,
+  ) => WasmBridge;
+  readonly destroy: () => void;
+}
+
+type RuntimeState =
+  | { readonly status: "starting" }
+  | { readonly status: "running"; readonly bridge: WasmBridge }
+  | { readonly status: "closing" }
+  | { readonly status: "closed" };
+
+function takeBytes(value: Uint8Array | BytesProxy): Uint8Array {
+  if (value instanceof Uint8Array) return value;
+  const converted = value.toJs();
+  value.destroy();
+  if (!(converted instanceof Uint8Array)) {
+    throw new TypeError("Python bytes did not convert to Uint8Array");
+  }
+  return converted;
+}
+
+/** Owns the Pyodide bridge and its selected-Python process lifecycle. */
+export class WasmBridgeRuntime {
+  readonly #module: WasmModule;
+  readonly #processes: Processes;
+  #state: RuntimeState = { status: "starting" };
+
+  constructor(
+    wasmModule: WasmModule,
+    writeMessage: (messageJson: string) => void,
+  ) {
+    this.#module = wasmModule;
+    this.#processes = new Processes({
+      stdout: (processId, chunk) => {
+        const state = this.#state;
+        if (state.status === "running") {
+          state.bridge.handle_kernel_bytes(processId, chunk);
+        }
+      },
+      exited: (processId, code, signal) => {
+        const state = this.#state;
+        if (state.status === "running") {
+          state.bridge.handle_kernel_exit(processId, code, signal);
+        }
+      },
+    });
+    const processCallbacks = {
+      spawn: (
+        processId: string,
+        executable: string,
+        workingDirectory: string,
+      ) => this.#processes.spawn(processId, executable, workingDirectory),
+      write: (processId: string, chunk: Uint8Array | BytesProxy) => {
+        this.#processes.write(processId, takeBytes(chunk));
+      },
+      close: (processId: string) => this.#processes.close(processId),
+    };
+
+    try {
+      const bridge = wasmModule.create_bridge(writeMessage, processCallbacks);
+      this.#state = { status: "running", bridge };
+    } catch (error) {
+      this.#processes.closeAll();
+      this.#module.destroy();
+      this.#state = { status: "closed" };
+      throw error;
+    }
+  }
+
+  handleMessage(messageJson: string): Promise<void> {
+    const state = this.#state;
+    if (state.status !== "running") {
+      return Promise.reject(
+        new Error(`Cannot handle a message while bridge is ${state.status}`),
+      );
+    }
+    return state.bridge.handle_message(messageJson);
+  }
+
+  close(): void {
+    const state = this.#state;
+    if (state.status !== "running") return;
+    this.#state = { status: "closing" };
+    try {
+      // The Python bridge writes each kernel's final Close frame before it
+      // asks Processes to end that kernel's stdin.
+      state.bridge.close();
+    } finally {
+      try {
+        // Also release any process that was not tracked by the Python bridge.
+        this.#processes.closeAll();
+      } finally {
+        try {
+          state.bridge.destroy();
+        } finally {
+          this.#module.destroy();
+          this.#state = { status: "closed" };
+        }
+      }
+    }
+  }
+}

--- a/extension/src/wasm/__tests__/Processes.test.ts
+++ b/extension/src/wasm/__tests__/Processes.test.ts
@@ -1,3 +1,6 @@
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+
 import { expect, it } from "@effect/vitest";
 import { vi } from "vite-plus/test";
 
@@ -16,9 +19,38 @@ it("reports a selected-Python spawn failure", async () => {
 
   processes.spawn("kernel", "/definitely-not-a-marimo-python", process.cwd());
 
-  await expect(exited.promise).resolves.toEqual({ code: null, signal: null });
+  const result = await exited.promise;
+  expect(result.code).not.toBe(0);
+  expect(result.signal).toBeNull();
   expect(() => processes.write("kernel", new Uint8Array())).toThrow(
     "No process with id kernel",
   );
   stderr.mockRestore();
+});
+
+it("drains stdout before reporting process exit", () => {
+  const child = Object.assign(new EventEmitter(), {
+    stdin: new PassThrough(),
+    stdout: new PassThrough(),
+    stderr: new PassThrough(),
+    kill: vi.fn(() => true),
+  });
+  const spawn = vi.fn(() => child);
+  const events: string[] = [];
+  const processes = new Processes(
+    {
+      stdout: (_processId, chunk) => events.push(Buffer.from(chunk).toString()),
+      exited: () => events.push("exited"),
+    },
+    spawn,
+  );
+
+  processes.spawn("kernel", "/python", "/workspace");
+  child.emit("exit", 0, null);
+  child.stdout.write("final output");
+
+  expect(events).toEqual(["final output"]);
+
+  child.emit("close", 0, null);
+  expect(events).toEqual(["final output", "exited"]);
 });

--- a/extension/src/wasm/__tests__/Processes.test.ts
+++ b/extension/src/wasm/__tests__/Processes.test.ts
@@ -1,0 +1,24 @@
+import { expect, it } from "@effect/vitest";
+import { vi } from "vite-plus/test";
+
+import { Processes } from "../Processes.ts";
+
+it("reports a selected-Python spawn failure", async () => {
+  const stderr = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+  const exited = Promise.withResolvers<{
+    code: number | null;
+    signal: NodeJS.Signals | null;
+  }>();
+  const processes = new Processes({
+    stdout: () => {},
+    exited: (_processId, code, signal) => exited.resolve({ code, signal }),
+  });
+
+  processes.spawn("kernel", "/definitely-not-a-marimo-python", process.cwd());
+
+  await expect(exited.promise).resolves.toEqual({ code: null, signal: null });
+  expect(() => processes.write("kernel", new Uint8Array())).toThrow(
+    "No process with id kernel",
+  );
+  stderr.mockRestore();
+});

--- a/extension/src/wasmServer.ts
+++ b/extension/src/wasmServer.ts
@@ -5,14 +5,37 @@ import * as NodePath from "node:path";
 import type { loadPyodide as LoadPyodide } from "pyodide";
 import { StreamMessageReader, StreamMessageWriter } from "vscode-jsonrpc/node";
 
+import { Processes } from "./wasm/Processes.ts";
+
 interface PyodideModule {
   readonly loadPyodide: typeof LoadPyodide;
 }
 
 interface WasmBridge {
   readonly handle_message: (messageJson: string) => Promise<void>;
+  readonly handle_kernel_bytes: (processId: string, chunk: Uint8Array) => void;
+  readonly handle_kernel_exit: (
+    processId: string,
+    code: number | null,
+    signal: string | null,
+  ) => void;
   readonly close: () => void;
   readonly destroy: () => void;
+}
+
+interface BytesProxy {
+  readonly toJs: () => unknown;
+  readonly destroy: () => void;
+}
+
+function takeBytes(value: Uint8Array | BytesProxy): Uint8Array {
+  if (value instanceof Uint8Array) return value;
+  const converted = value.toJs();
+  value.destroy();
+  if (!(converted instanceof Uint8Array)) {
+    throw new TypeError("Python bytes did not convert to Uint8Array");
+  }
+  return converted;
 }
 
 interface WasmModule {
@@ -75,16 +98,23 @@ shutil.unpack_archive("/marimo-lsp-site-packages.zip", sysconfig.get_path("purel
     throw new TypeError("Bundled marimo_lsp.wasm module is invalid");
   }
   const writer = new StreamMessageWriter(process.stdout);
-  const unsupportedProcesses = {
-    spawn: () => {
-      throw new Error("Native kernels are not available in this revision");
+  let bridge: WasmBridge | undefined;
+  const processes = new Processes({
+    stdout: (processId, chunk) => bridge?.handle_kernel_bytes(processId, chunk),
+    exited: (processId, code, signal) =>
+      bridge?.handle_kernel_exit(processId, code, signal),
+  });
+  const processCallbacks = {
+    spawn: (processId: string, executable: string, workingDirectory: string) =>
+      processes.spawn(processId, executable, workingDirectory),
+    write: (processId: string, chunk: Uint8Array | BytesProxy) => {
+      processes.write(processId, takeBytes(chunk));
     },
-    write: () => {},
-    close: () => {},
+    close: (processId: string) => processes.close(processId),
   };
-  const bridge = imported.create_bridge((messageJson: string) => {
+  bridge = imported.create_bridge((messageJson: string) => {
     void writer.write(JSON.parse(messageJson));
-  }, unsupportedProcesses);
+  }, processCallbacks);
   const reader = new StreamMessageReader(process.stdin);
   let resolveExit = () => {};
   const exitRequested = new Promise<void>((resolve) => {
@@ -108,6 +138,7 @@ shutil.unpack_archive("/marimo-lsp-site-packages.zip", sysconfig.get_path("purel
     process.stdin.once("error", reject);
   });
   await Promise.race([stdinEnded, exitRequested]);
+  processes.closeAll();
   reader.dispose();
   process.stdin.pause();
   bridge.close();

--- a/extension/src/wasmServer.ts
+++ b/extension/src/wasmServer.ts
@@ -5,45 +5,13 @@ import * as NodePath from "node:path";
 import type { loadPyodide as LoadPyodide } from "pyodide";
 import { StreamMessageReader, StreamMessageWriter } from "vscode-jsonrpc/node";
 
-import { Processes } from "./wasm/Processes.ts";
+import {
+  WasmBridgeRuntime,
+  type WasmModule,
+} from "./wasm/WasmBridgeRuntime.ts";
 
 interface PyodideModule {
   readonly loadPyodide: typeof LoadPyodide;
-}
-
-interface WasmBridge {
-  readonly handle_message: (messageJson: string) => Promise<void>;
-  readonly handle_kernel_bytes: (processId: string, chunk: Uint8Array) => void;
-  readonly handle_kernel_exit: (
-    processId: string,
-    code: number | null,
-    signal: string | null,
-  ) => void;
-  readonly close: () => void;
-  readonly destroy: () => void;
-}
-
-interface BytesProxy {
-  readonly toJs: () => unknown;
-  readonly destroy: () => void;
-}
-
-function takeBytes(value: Uint8Array | BytesProxy): Uint8Array {
-  if (value instanceof Uint8Array) return value;
-  const converted = value.toJs();
-  value.destroy();
-  if (!(converted instanceof Uint8Array)) {
-    throw new TypeError("Python bytes did not convert to Uint8Array");
-  }
-  return converted;
-}
-
-interface WasmModule {
-  readonly create_bridge: (
-    writeMessage: (messageJson: string) => void,
-    processes: object,
-  ) => WasmBridge;
-  readonly destroy: () => void;
 }
 
 function isPyodideModule(value: unknown): value is PyodideModule {
@@ -98,23 +66,9 @@ shutil.unpack_archive("/marimo-lsp-site-packages.zip", sysconfig.get_path("purel
     throw new TypeError("Bundled marimo_lsp.wasm module is invalid");
   }
   const writer = new StreamMessageWriter(process.stdout);
-  let bridge: WasmBridge | undefined;
-  const processes = new Processes({
-    stdout: (processId, chunk) => bridge?.handle_kernel_bytes(processId, chunk),
-    exited: (processId, code, signal) =>
-      bridge?.handle_kernel_exit(processId, code, signal),
-  });
-  const processCallbacks = {
-    spawn: (processId: string, executable: string, workingDirectory: string) =>
-      processes.spawn(processId, executable, workingDirectory),
-    write: (processId: string, chunk: Uint8Array | BytesProxy) => {
-      processes.write(processId, takeBytes(chunk));
-    },
-    close: (processId: string) => processes.close(processId),
-  };
-  bridge = imported.create_bridge((messageJson: string) => {
+  const runtime = new WasmBridgeRuntime(imported, (messageJson: string) => {
     void writer.write(JSON.parse(messageJson));
-  }, processCallbacks);
+  });
   const reader = new StreamMessageReader(process.stdin);
   let resolveExit = () => {};
   const exitRequested = new Promise<void>((resolve) => {
@@ -125,8 +79,8 @@ shutil.unpack_archive("/marimo-lsp-site-packages.zip", sysconfig.get_path("purel
       resolveExit();
       return;
     }
-    void bridge
-      .handle_message(JSON.stringify(message))
+    void runtime
+      .handleMessage(JSON.stringify(message))
       .catch((error: unknown) => {
         console.error(error);
         process.exitCode = 1;
@@ -138,12 +92,9 @@ shutil.unpack_archive("/marimo-lsp-site-packages.zip", sysconfig.get_path("purel
     process.stdin.once("error", reject);
   });
   await Promise.race([stdinEnded, exitRequested]);
-  processes.closeAll();
   reader.dispose();
   process.stdin.pause();
-  bridge.close();
-  bridge.destroy();
-  imported.destroy();
+  runtime.close();
 }
 
 void main().catch((error: unknown) => {


### PR DESCRIPTION
The WASM language server cannot spawn the selected Python or open its ZeroMQ sockets. Node can launch that process, but teaching Node the kernel protocol would create a second implementation of marimo IPC.

Keep the Node interface limited to process ownership:

```ts
class Processes {
  spawn(processId, executable, workingDirectory): void;
  write(processId, chunk: Uint8Array): void;
  close(processId): void;
}
```

Stdout uses a `Uint8Array` view over the existing Node `Buffer`; Node does not parse or reserialize the framed messages. The selected-Python bridge decodes those bytes, owns marimo IPC and ZeroMQ, and forwards kernel operations back through the same opaque channel.

Process exits and spawn failures are reported to the WASM adapter so kernel launch rejects instead of waiting indefinitely. The smoke test executes a cell through the complete Pyodide, Node, selected-Python, and ZeroMQ path and verifies the resulting variable operation.