### PR TITLE
Replace WASM kernel ZeroMQ with multiprocessing

### DIFF
--- a/extension/resources/wasm/kernel.py
+++ b/extension/resources/wasm/kernel.py
@@ -2,27 +2,24 @@
 
 """Run a marimo kernel behind the WASM language server's stdio protocol.
 
-This script runs in the notebook's selected Python. It owns marimo IPC and
-ZeroMQ; Node only brokers its opaque stdin and stdout bytes.
+This script runs in the notebook's selected Python. It adapts Node's opaque
+stdin and stdout bytes to marimo's normal edit-mode kernel manager.
 """
 
 from __future__ import annotations
 
 import atexit
 import contextlib
-import os
-import queue
-import signal
-import subprocess
 import sys
 import threading
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-import marimo._ipc as ipc
 import msgspec
-from marimo._runtime.commands import StopKernelCommand
-from marimo._session.managers import IPCQueueManagerImpl
+from marimo._config.manager import MarimoConfigReader
+from marimo._session.managers.kernel import KernelManagerImpl
+from marimo._session.managers.queue import QueueManagerImpl
+from marimo._session.model import SessionMode
 from protocol import (
     HEADER_SIZE,
     MAX_FRAME_SIZE,
@@ -32,7 +29,6 @@ from protocol import (
     FromBridge,
     Input,
     Interrupt,
-    Log,
     Operation,
     Ready,
     Start,
@@ -42,11 +38,22 @@ from protocol import (
 )
 
 if TYPE_CHECKING:
+    from marimo._config.config import MarimoConfig
     from marimo._messaging.types import KernelMessage
 
 _write_lock = threading.Lock()
 _decoder = msgspec.json.Decoder(ToBridge)
-KERNEL_READY_TIMEOUT = 10.0
+
+
+class _StaticConfigManager(MarimoConfigReader):
+    """Expose the launch-time user config through marimo's manager API."""
+
+    def __init__(self, config: MarimoConfig) -> None:
+        self._user_config = config
+
+    def get_config(self, *, hide_secrets: bool = True) -> MarimoConfig:
+        del hide_secrets
+        return self._user_config
 
 
 def _read_frame() -> ToBridge | None:
@@ -72,98 +79,52 @@ def _write_frame(message: FromBridge) -> None:
 
 
 class _Bridge:
-    """Own one native kernel and its marimo IPC queues."""
+    """Own marimo's edit-mode kernel manager and its stdio adapter."""
 
     def __init__(self) -> None:
-        self._queues: IPCQueueManagerImpl | None = None
-        self._ipc_queues: ipc.QueueManager | None = None
-        self._process: subprocess.Popen[bytes] | None = None
+        self._queues: QueueManagerImpl | None = None
+        self._manager: KernelManagerImpl | None = None
+        self._operation_thread: threading.Thread | None = None
         self._closed = False
 
     def start(self, message: Start) -> None:
-        """Create queues and start the kernel subprocess."""
+        """Start a regular marimo edit-mode kernel subprocess."""
         working_directory = message.working_directory
         path = Path(working_directory)
         if not path.is_absolute() or not path.is_dir():
             msg = f"Invalid kernel working directory: {working_directory}"
             raise ValueError(msg)
 
-        ipc_queues, connection_info = ipc.QueueManager.create()
-        self._ipc_queues = ipc_queues
-        self._queues = IPCQueueManagerImpl.from_ipc(ipc_queues)
-
-        kernel_args = msgspec.structs.replace(
-            message.kernel_args,
-            connection_info=connection_info,
-            parent_pid=os.getpid(),
+        args = message.kernel_args
+        self._queues = QueueManagerImpl(use_multiprocessing=True)
+        self._manager = KernelManagerImpl(
+            queue_manager=self._queues,
+            mode=SessionMode.EDIT,
+            configs=args.configs,
+            app_metadata=args.app_metadata,
+            config_manager=_StaticConfigManager(args.user_config),
+            virtual_file_storage=None,
+            redirect_console_to_browser=args.redirect_console_to_browser,
         )
-
-        self._process = subprocess.Popen(
-            [sys.executable, "-m", "marimo._ipc.launch_kernel"],
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            cwd=working_directory,
+        self._manager.start_kernel()
+        self._operation_thread = threading.Thread(
+            target=self._forward_operations,
+            name="kernel-operation-forwarder",
+            daemon=True,
         )
-        assert self._process.stdin is not None
-        assert self._process.stdout is not None
-        self._process.stdin.write(kernel_args.encode_json())
-        self._process.stdin.flush()
-        self._process.stdin.close()
-
-        # Drain stderr before waiting for readiness so a noisy child cannot
-        # fill its pipe and deadlock startup.
-        threading.Thread(target=self._forward_stderr, daemon=True).start()
-        ready = self._wait_for_kernel_ready()
-        if ready != "KERNEL_READY":
-            msg = f"Expected KERNEL_READY, received {ready!r}"
-            raise RuntimeError(msg)
-
-        threading.Thread(target=self._forward_operations, daemon=True).start()
+        self._operation_thread.start()
         _write_frame(Ready())
 
-    def _wait_for_kernel_ready(
-        self,
-        timeout: float = KERNEL_READY_TIMEOUT,
-    ) -> str:
-        """Read the readiness line without allowing startup to hang forever."""
-        assert self._process is not None
-        assert self._process.stdout is not None
-        result: queue.Queue[str | Exception] = queue.Queue(maxsize=1)
-
-        def read_ready() -> None:
-            try:
-                ready = self._process.stdout.readline().decode(errors="replace").strip()
-                result.put(ready)
-            except Exception as error:  # noqa: BLE001
-                result.put(error)
-
-        threading.Thread(target=read_ready, daemon=True).start()
-        try:
-            ready = result.get(timeout=timeout)
-        except queue.Empty as error:
-            msg = f"Kernel did not become ready within {timeout:g} seconds"
-            raise TimeoutError(msg) from error
-        if isinstance(ready, Exception):
-            raise ready
-        return ready
-
     def _forward_operations(self) -> None:
-        assert self._queues is not None
-        stream = self._queues.stream_queue
-        if stream is None:
-            return
-        while not self._closed:
-            message: KernelMessage | None = stream.get()
-            if message is None:
-                return
-            _write_frame(Operation(message=msgspec.Raw(message)))
-
-    def _forward_stderr(self) -> None:
-        if self._process is None or self._process.stderr is None:
-            return
-        for line in self._process.stderr:
-            _write_frame(Log(message=line.decode(errors="replace").rstrip()))
+        assert self._manager is not None
+        connection = self._manager.kernel_connection
+        try:
+            while True:
+                message: KernelMessage = connection.recv()
+                _write_frame(Operation(message=msgspec.Raw(message)))
+        except (EOFError, OSError):
+            if not self._closed:
+                _write_frame(Error(message="Kernel connection closed unexpectedly"))
 
     def handle(self, message: ToBridge) -> bool:
         """Apply one command and return whether to keep reading."""
@@ -184,35 +145,21 @@ class _Bridge:
         return True
 
     def interrupt(self) -> None:
-        """Interrupt the running kernel."""
-        if self._process is None or self._process.poll() is not None:
+        """Interrupt the kernel subprocess."""
+        if self._closed or self._manager is None:
             return
-        assert self._queues is not None
-        interrupt_queue = self._queues.win32_interrupt_queue
-        if sys.platform == "win32" and interrupt_queue is not None:
-            interrupt_queue.put_nowait(True)  # noqa: FBT003
-        else:
-            os.kill(self._process.pid, signal.SIGINT)
+        self._manager.interrupt_kernel()
 
     def close(self) -> None:
-        """Stop the kernel and release its queues."""
+        """Stop the kernel exactly once."""
         if self._closed:
             return
         self._closed = True
-        if self._queues is not None:
+        if self._manager is not None:
             with contextlib.suppress(Exception):
-                self._queues.put_control_request(StopKernelCommand())
-        if self._process is not None and self._process.poll() is None:
-            try:
-                self._process.wait(timeout=2)
-            except subprocess.TimeoutExpired:
-                self._process.terminate()
-                try:
-                    self._process.wait(timeout=2)
-                except subprocess.TimeoutExpired:
-                    self._process.kill()
-        if self._ipc_queues is not None:
-            self._ipc_queues.close_queues()
+                self._manager.close_kernel()
+        if self._operation_thread is not None:
+            self._operation_thread.join(timeout=1)
 
 
 def _read_start_frame() -> Start:

--- a/extension/scripts/test-wasm-lsp.mjs
+++ b/extension/scripts/test-wasm-lsp.mjs
@@ -1,6 +1,8 @@
 // @ts-check
 import * as NodeAssert from "node:assert/strict";
 import * as NodeChildProcess from "node:child_process";
+import * as NodeFs from "node:fs";
+import * as NodeOs from "node:os";
 import * as NodePath from "node:path";
 import * as NodeUrl from "node:url";
 
@@ -98,9 +100,27 @@ send({
 const initializeMessage = await initialized;
 send({ jsonrpc: "2.0", method: "initialized", params: {} });
 
-const notebookUri = "file:///tmp/marimo-wasm-smoke.py";
-const cellUri =
-  "vscode-notebook-cell:///tmp/marimo-wasm-smoke.py#W0sZmlsZQ%3D%3D";
+const notebookPath = NodePath.join(
+  NodeOs.tmpdir(),
+  `marimo-wasm-smoke-${process.pid}.py`,
+);
+NodeFs.writeFileSync(notebookPath, "", { flag: "wx" });
+process.on("exit", () => NodeFs.rmSync(notebookPath, { force: true }));
+const notebookUri = NodeUrl.pathToFileURL(notebookPath).href;
+const notebookCellUri = notebookUri.replace(/^file:/, "vscode-notebook-cell:");
+const sliderCellUri = `${notebookCellUri}#W0sZmlsZQ%3D%3D`;
+const valueCellUri = `${notebookCellUri}#W1sZmlsZQ%3D%3D`;
+const sliderCode = [
+  "import marimo as mo",
+  "slider = mo.ui.slider(0, 100)",
+  "slider",
+].join("\n");
+const valueCode = [
+  "import time",
+  "time.sleep(0.01)",
+  "value = slider.value",
+  'print(f"slider-value:{value}")',
+].join("\n");
 send({
   jsonrpc: "2.0",
   method: "notebookDocument/didOpen",
@@ -109,10 +129,24 @@ send({
       uri: notebookUri,
       notebookType: "marimo-notebook",
       version: 1,
-      cells: [{ kind: 2, document: cellUri }],
+      cells: [
+        { kind: 2, document: sliderCellUri },
+        { kind: 2, document: valueCellUri },
+      ],
     },
     cellTextDocuments: [
-      { uri: cellUri, languageId: "python", version: 1, text: "x = 1" },
+      {
+        uri: sliderCellUri,
+        languageId: "python",
+        version: 1,
+        text: sliderCode,
+      },
+      {
+        uri: valueCellUri,
+        languageId: "python",
+        version: 1,
+        text: valueCode,
+      },
     ],
   },
 });
@@ -131,7 +165,10 @@ send({
           notebookUri,
           executable: kernelPython,
           workingDirectory: repositoryDir,
-          inner: { cellIds: ["cell"], codes: ["x = 1"] },
+          inner: {
+            cellIds: ["slider-cell", "value-cell"],
+            codes: [sliderCode, valueCode],
+          },
         },
       },
     ],
@@ -139,9 +176,91 @@ send({
 });
 await executed;
 await waitForOutput(/"op":"completed-run"/);
+await waitForOutput(/slider-value:0/);
 
-const shutdown = response(3);
-send({ jsonrpc: "2.0", id: 3, method: "shutdown", params: null });
+const initialOutput = Buffer.concat(stdout).toString("utf8");
+const sliderId = initialOutput.match(/object-id='([^']+)'/)?.[1];
+NodeAssert.ok(
+  sliderId,
+  `Could not find slider ID in output:\n${initialOutput}`,
+);
+
+/** @type {Promise<unknown>[]} */
+const updates = [];
+for (let value = 1; value <= 100; value++) {
+  const id = value + 10;
+  updates.push(response(id));
+  send({
+    jsonrpc: "2.0",
+    id,
+    method: "workspace/executeCommand",
+    params: {
+      command: "marimo.api",
+      arguments: [
+        {
+          method: "update-ui-element",
+          params: {
+            notebookUri,
+            inner: { objectIds: [sliderId], values: [value] },
+          },
+        },
+      ],
+    },
+  });
+}
+await Promise.all(updates);
+await waitForOutput(/slider-value:100/);
+
+const longRun = response(300);
+send({
+  jsonrpc: "2.0",
+  id: 300,
+  method: "workspace/executeCommand",
+  params: {
+    command: "marimo.api",
+    arguments: [
+      {
+        method: "execute-cells",
+        params: {
+          notebookUri,
+          executable: kernelPython,
+          workingDirectory: repositoryDir,
+          inner: {
+            cellIds: ["value-cell"],
+            codes: [
+              'print("interrupt-started", flush=True)\n' +
+                "time.sleep(60)\n" +
+                "value = slider.value",
+            ],
+          },
+        },
+      },
+    ],
+  },
+});
+await longRun;
+await waitForOutput(/interrupt-started/);
+
+const interrupted = response(301);
+send({
+  jsonrpc: "2.0",
+  id: 301,
+  method: "workspace/executeCommand",
+  params: {
+    command: "marimo.api",
+    arguments: [
+      {
+        method: "interrupt",
+        params: { notebookUri, inner: {} },
+      },
+    ],
+  },
+});
+await interrupted;
+await waitForOutput(/"op":"interrupted"/);
+
+const shutdown = response(200);
+send({ jsonrpc: "2.0", id: 200, method: "shutdown", params: null });
 await shutdown;
 send({ jsonrpc: "2.0", method: "exit", params: null });
 child.stdin.end();
@@ -167,8 +286,7 @@ NodeAssert.equal(exitCode, 0, errors);
 NodeAssert.equal(initializeMessage.result.serverInfo.name, "marimo-lsp");
 NodeAssert.match(output, /"method":"marimo\/operation"/);
 NodeAssert.match(output, /"op":"completed-run"/);
-NodeAssert.match(
-  output,
-  /"op":"variable-values","variables":\[\{"name":"x","value":"1"/,
-);
-console.log("WASM language-server smoke test passed");
+NodeAssert.match(output, /slider-value:100/);
+NodeAssert.match(output, /"op":"interrupted"/);
+NodeAssert.doesNotMatch(output, /"channel":"marimo-error"/);
+console.log("WASM language-server UI update and interrupt test passed");

--- a/tests/test_wasm_bridge.py
+++ b/tests/test_wasm_bridge.py
@@ -3,12 +3,10 @@
 from __future__ import annotations
 
 import importlib.util
-import sys
-import threading
 from pathlib import Path
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
-from unittest.mock import Mock
+from unittest.mock import ANY, Mock
 
 import pytest
 
@@ -30,36 +28,64 @@ def _load_bridge_module(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
     return module
 
 
-def test_windows_interrupt_uses_positional_queue_value(
+def test_interrupt_delegates_to_marimo_kernel_manager(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     bridge_module = _load_bridge_module(monkeypatch)
     bridge = bridge_module._Bridge()
-    bridge._process = Mock(pid=42)
-    bridge._process.poll.return_value = None
-    bridge._queues = Mock()
-    interrupt_queue = bridge._queues.win32_interrupt_queue
-    monkeypatch.setattr(sys, "platform", "win32")
+    bridge._manager = Mock()
 
     bridge.interrupt()
 
-    interrupt_queue.put_nowait.assert_called_once_with(True)  # noqa: FBT003
+    bridge._manager.interrupt_kernel.assert_called_once_with()
 
 
-def test_kernel_readiness_has_a_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_bridge_uses_normal_edit_mode_multiprocessing_manager(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
     bridge_module = _load_bridge_module(monkeypatch)
+    queues = Mock()
+    manager = Mock()
+    manager.kernel_connection.recv.side_effect = EOFError
+    queue_manager = Mock(return_value=queues)
+    kernel_manager = Mock(return_value=manager)
+    write_frame = Mock()
+    monkeypatch.setattr(bridge_module, "QueueManagerImpl", queue_manager)
+    monkeypatch.setattr(bridge_module, "KernelManagerImpl", kernel_manager)
+    monkeypatch.setattr(bridge_module, "_write_frame", write_frame)
     bridge = bridge_module._Bridge()
-    release_reader = threading.Event()
-    bridge._process = Mock()
-    bridge._process.stdout.readline.side_effect = lambda: (
-        release_reader.wait(),
-        b"KERNEL_READY\n",
-    )[1]
+    args = SimpleNamespace(
+        configs={},
+        app_metadata=Mock(),
+        user_config=Mock(),
+        redirect_console_to_browser=True,
+    )
 
-    with pytest.raises(TimeoutError, match="did not become ready"):
-        bridge._wait_for_kernel_ready(timeout=0.01)
+    bridge.start(
+        SimpleNamespace(
+            working_directory=str(tmp_path),
+            kernel_args=args,
+        )
+    )
+    assert bridge._operation_thread is not None
+    bridge._operation_thread.join(timeout=1)
 
-    release_reader.set()
+    queue_manager.assert_called_once_with(use_multiprocessing=True)
+    kernel_manager.assert_called_once_with(
+        queue_manager=queues,
+        mode=bridge_module.SessionMode.EDIT,
+        configs={},
+        app_metadata=args.app_metadata,
+        config_manager=ANY,
+        virtual_file_storage=None,
+        redirect_console_to_browser=True,
+    )
+    config_manager = kernel_manager.call_args.kwargs["config_manager"]
+    assert isinstance(config_manager, bridge_module._StaticConfigManager)
+    assert config_manager.get_config() is args.user_config
+    manager.start_kernel.assert_called_once_with()
+    write_frame.assert_any_call(bridge_module.Ready())
 
 
 def test_bridge_rejects_oversized_frame_before_reading_payload(


### PR DESCRIPTION
The WASM language server needs Node to launch the selected Python, but the selected-Python bridge already owns exactly one kernel. Launching that kernel through `marimo._ipc` keeps the useful child-process boundary while adding a redundant ZeroMQ transport and readiness handshake.

Use marimo’s standard edit-mode topology inside the bridge instead:

```text
Pyodide → Node → bridge → multiprocessing queues / Connection → kernel
```

The process count stays unchanged. Multiprocessing queues carry control, UI, completion, and input messages; the standard kernel connection carries operations. Keeping the kernel as a child process preserves failure isolation and reliable `SIGINT`, while marimo’s dedicated UI queue retains last-write-wins batching for rapid element updates.

The end-to-end WASM test now drives a slider through 100 immediate updates and verifies the final value, then starts a 60-second cell, interrupts it, and observes marimo’s `interrupted` operation.