### PR TITLE
Cache extension and WASM builds with Turbo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,8 @@ jobs:
 
       - name: Build and test the WASM language server
         if: runner.os == 'Linux'
+        env:
+          TURBO_TOKEN: ${{ steps.secrets.outputs.TURBO_TOKEN }}
         run: pnpm verify:wasm-lsp
         working-directory: marimo-lsp/extension
 

--- a/extension/package.json
+++ b/extension/package.json
@@ -14,7 +14,7 @@
     "prepare": "effect-tsgo patch --no-typescript --oxlint",
     "patch-tsc": "effect-language-service patch",
     "typecheck-ci": "tsc",
-    "build": "turbo build:renderer && turbo build:extension",
+    "build": "node scripts/run-turbo.mjs build:renderer build:extension",
     "build:extension": "esbuild --format=cjs --define:import.meta.env.DEV=false --platform=node --minify --external:vscode --external:../bundled/wasm/pyodide.js --bundle --sourcemap src/extension.ts src/wasmServer.ts --outdir=dist",
     "build:renderer": "vp build",
     "check": "vp check && node ./scripts/check-css-variables.mjs",
@@ -23,9 +23,10 @@
     "pretest:extension": "pnpm run build:extension",
     "test:extension": "vscode-test",
     "embed-sdist": "node scripts/embed-sdist.mjs",
-    "build:wasm-lsp": "node scripts/build-wasm-lsp.mjs",
+    "build:wasm-lsp": "node scripts/run-turbo.mjs build:wasm-lsp:bundle",
+    "build:wasm-lsp:bundle": "node scripts/build-wasm-lsp.mjs",
     "test:wasm-lsp": "node scripts/test-wasm-lsp.mjs",
-    "verify:wasm-lsp": "pnpm build:wasm-lsp && pnpm build:extension && pnpm test:wasm-lsp"
+    "verify:wasm-lsp": "node scripts/run-turbo.mjs build:wasm-lsp:bundle build:extension && pnpm test:wasm-lsp"
   },
   "devDependencies": {
     "@effect/platform": "^0.92.1",

--- a/extension/scripts/build-wasm-lsp.mjs
+++ b/extension/scripts/build-wasm-lsp.mjs
@@ -43,6 +43,7 @@ try {
   buildDir = NodeFs.mkdtempSync(
     NodePath.join(NodeOs.tmpdir(), "marimo-lsp-wasm-"),
   );
+  NodeFs.rmSync(outputDir, { recursive: true, force: true });
   NodeFs.mkdirSync(outputDir, { recursive: true });
   for (const filename of runtimeFiles) {
     NodeFs.copyFileSync(

--- a/extension/scripts/run-turbo.mjs
+++ b/extension/scripts/run-turbo.mjs
@@ -26,25 +26,50 @@ function hashFile(hash, root, path) {
   hash.update("\0");
 }
 
+/** @param {string} repository @param {string[]} args */
+async function gitOutput(repository, args) {
+  const child = NodeChildProcess.spawn("git", args, {
+    cwd: repository,
+    stdio: ["ignore", "pipe", "inherit"],
+  });
+  const completed = new Promise((resolve, reject) => {
+    child.once("error", reject);
+    child.once("close", resolve);
+  });
+  const chunks = [];
+  for await (const chunk of child.stdout) chunks.push(chunk);
+  const code = await completed;
+  if (code !== 0) throw new Error(`git ${args[0]} exited with code ${code}`);
+  return Buffer.concat(chunks);
+}
+
 /** @param {string} repository @param {string[]} paths */
-function gitSourceHash(repository, paths) {
+async function gitSourceHash(repository, paths) {
   const hash = NodeCrypto.createHash("sha256");
-  for (const args of [
-    ["rev-parse", ...paths.map((path) => `HEAD:${path}`)],
-    ["diff", "--no-ext-diff", "--binary", "HEAD", "--", ...paths],
-  ]) {
-    hash.update(
-      NodeChildProcess.execFileSync("git", args, { cwd: repository }),
-    );
+  const outputs = await Promise.all(
+    [
+      ["rev-parse", ...paths.map((path) => `HEAD:${path}`)],
+      ["diff", "--no-ext-diff", "--binary", "HEAD", "--", ...paths],
+    ].map((args) => gitOutput(repository, args)),
+  );
+  for (const output of outputs) {
+    hash.update(output);
     hash.update("\0");
   }
 
-  const untracked = NodeChildProcess.execFileSync(
-    "git",
-    ["ls-files", "--others", "--exclude-standard", "-z", "--", ...paths],
-    { cwd: repository, encoding: "utf8" },
-  );
-  for (const relativePath of untracked.split("\0").filter(Boolean).sort()) {
+  const untracked = await gitOutput(repository, [
+    "ls-files",
+    "--others",
+    "--exclude-standard",
+    "-z",
+    "--",
+    ...paths,
+  ]);
+  for (const relativePath of untracked
+    .toString("utf8")
+    .split("\0")
+    .filter(Boolean)
+    .sort()) {
     hashFile(hash, repository, NodePath.join(repository, relativePath));
   }
   return hash.digest("hex");
@@ -72,6 +97,25 @@ const rendererRequested = tasks.includes("build:renderer");
 const frontendRequested = tasks.some((task) =>
   ["build:extension", "build:renderer"].includes(task),
 );
+const [frontendSourceHash, wasmSourceHash] = await Promise.all([
+  frontendRequested
+    ? gitSourceHash(marimoDir, [
+        "frontend",
+        "package.json",
+        "packages",
+        "patches",
+        "pnpm-lock.yaml",
+        "pnpm-workspace.yaml",
+      ])
+    : undefined,
+  wasmRequested
+    ? gitSourceHash(repositoryDir, [
+        "pyproject.toml",
+        "README.md",
+        "src/marimo_lsp",
+      ])
+    : undefined,
+]);
 
 if (rendererRequested) {
   removeFiles(NodePath.join(extensionDir, "dist"), (path) =>
@@ -93,14 +137,9 @@ NodeChildProcess.execFileSync(
     env: {
       ...process.env,
       BUILD_NODE_VERSION: process.version,
-      ...(frontendRequested
-        ? {
-            MARIMO_FRONTEND_SOURCE_HASH: gitSourceHash(marimoDir, [
-              "frontend",
-              "packages",
-            ]),
-          }
-        : {}),
+      ...(frontendSourceHash === undefined
+        ? {}
+        : { MARIMO_FRONTEND_SOURCE_HASH: frontendSourceHash }),
       MARIMO_LSP_UV_VERSION: wasmRequested
         ? NodeChildProcess.execFileSync("uv", ["--version"], {
             encoding: "utf8",
@@ -109,15 +148,9 @@ NodeChildProcess.execFileSync(
             .split(" ", 2)
             .join(" ")
         : "",
-      ...(wasmRequested
-        ? {
-            MARIMO_LSP_WASM_SOURCE_HASH: gitSourceHash(repositoryDir, [
-              "pyproject.toml",
-              "README.md",
-              "src/marimo_lsp",
-            ]),
-          }
-        : {}),
+      ...(wasmSourceHash === undefined
+        ? {}
+        : { MARIMO_LSP_WASM_SOURCE_HASH: wasmSourceHash }),
     },
     stdio: "inherit",
   },

--- a/extension/scripts/run-turbo.mjs
+++ b/extension/scripts/run-turbo.mjs
@@ -1,0 +1,124 @@
+// @ts-check
+/**
+ * Run Turbo with hashes for build inputs that live outside extension/.
+ *
+ * extension/ is the pnpm/Turbo root, while the Python package and the linked
+ * marimo frontend checkout are its siblings. Turbo intentionally cannot glob
+ * outside its root, so pass deterministic digests as task env inputs.
+ */
+import * as NodeChildProcess from "node:child_process";
+import * as NodeCrypto from "node:crypto";
+import * as NodeFs from "node:fs";
+import * as NodePath from "node:path";
+import * as NodeUrl from "node:url";
+
+const extensionDir = NodePath.dirname(
+  NodeUrl.fileURLToPath(new URL("../package.json", import.meta.url)),
+);
+const repositoryDir = NodePath.dirname(extensionDir);
+const marimoDir = NodePath.resolve(extensionDir, "..", "..", "marimo");
+
+/** @param {NodeCrypto.Hash} hash @param {string} root @param {string} path */
+function hashFile(hash, root, path) {
+  hash.update(NodePath.relative(root, path));
+  hash.update("\0");
+  hash.update(NodeFs.readFileSync(path));
+  hash.update("\0");
+}
+
+/** @param {string} repository @param {string[]} paths */
+function gitSourceHash(repository, paths) {
+  const hash = NodeCrypto.createHash("sha256");
+  for (const args of [
+    ["rev-parse", ...paths.map((path) => `HEAD:${path}`)],
+    ["diff", "--no-ext-diff", "--binary", "HEAD", "--", ...paths],
+  ]) {
+    hash.update(
+      NodeChildProcess.execFileSync("git", args, { cwd: repository }),
+    );
+    hash.update("\0");
+  }
+
+  const untracked = NodeChildProcess.execFileSync(
+    "git",
+    ["ls-files", "--others", "--exclude-standard", "-z", "--", ...paths],
+    { cwd: repository, encoding: "utf8" },
+  );
+  for (const relativePath of untracked.split("\0").filter(Boolean).sort()) {
+    hashFile(hash, repository, NodePath.join(repository, relativePath));
+  }
+  return hash.digest("hex");
+}
+
+/** @param {string} directory @param {(path: string) => boolean} matches */
+function removeFiles(directory, matches) {
+  if (!NodeFs.existsSync(directory)) return;
+  for (const entry of NodeFs.readdirSync(directory, { withFileTypes: true })) {
+    const path = NodePath.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      removeFiles(path, matches);
+    } else if (matches(path)) {
+      NodeFs.rmSync(path);
+    }
+  }
+}
+
+const tasks = process.argv.slice(2);
+if (tasks.length === 0) {
+  throw new Error("Pass at least one Turbo task to run");
+}
+const wasmRequested = tasks.includes("build:wasm-lsp:bundle");
+const rendererRequested = tasks.includes("build:renderer");
+const frontendRequested = tasks.some((task) =>
+  ["build:extension", "build:renderer"].includes(task),
+);
+
+if (rendererRequested) {
+  removeFiles(NodePath.join(extensionDir, "dist"), (path) =>
+    /\.mjs(?:\.map)?$/.test(path),
+  );
+}
+if (wasmRequested) {
+  NodeFs.rmSync(NodePath.join(extensionDir, "bundled", "wasm"), {
+    recursive: true,
+    force: true,
+  });
+}
+
+NodeChildProcess.execFileSync(
+  process.platform === "win32" ? "pnpm.cmd" : "pnpm",
+  ["exec", "turbo", "run", ...tasks],
+  {
+    cwd: extensionDir,
+    env: {
+      ...process.env,
+      BUILD_NODE_VERSION: process.version,
+      ...(frontendRequested
+        ? {
+            MARIMO_FRONTEND_SOURCE_HASH: gitSourceHash(marimoDir, [
+              "frontend",
+              "packages",
+            ]),
+          }
+        : {}),
+      MARIMO_LSP_UV_VERSION: wasmRequested
+        ? NodeChildProcess.execFileSync("uv", ["--version"], {
+            encoding: "utf8",
+          })
+            .trim()
+            .split(" ", 2)
+            .join(" ")
+        : "",
+      ...(wasmRequested
+        ? {
+            MARIMO_LSP_WASM_SOURCE_HASH: gitSourceHash(repositoryDir, [
+              "pyproject.toml",
+              "README.md",
+              "src/marimo_lsp",
+            ]),
+          }
+        : {}),
+    },
+    stdio: "inherit",
+  },
+);

--- a/extension/turbo.json
+++ b/extension/turbo.json
@@ -7,6 +7,8 @@
         "src/renderer/**",
         "!src/renderer/**/__tests__/**",
         "!src/renderer/**/*.test.*",
+        "src/assert.ts",
+        "src/types.ts",
         "scripts/run-turbo.mjs",
         "scripts/vite-plugin-virtual-stylesheet.mts",
         "vite.config.mts",

--- a/extension/turbo.json
+++ b/extension/turbo.json
@@ -2,19 +2,59 @@
   "$schema": "https://turbo.build/schema.json",
   "tasks": {
     "build:renderer": {
-      "outputs": ["dist/renderer.mjs", "dist/renderer.mjs.map"],
-      "inputs": ["src/renderer/**", "vite.config.ts", "package.json"],
-      "env": ["NODE_ENV", "MODE"]
+      "outputs": ["dist/**/*.mjs", "dist/**/*.mjs.map"],
+      "inputs": [
+        "src/renderer/**",
+        "!src/renderer/**/__tests__/**",
+        "!src/renderer/**/*.test.*",
+        "scripts/run-turbo.mjs",
+        "scripts/vite-plugin-virtual-stylesheet.mts",
+        "vite.config.mts",
+        "package.json"
+      ],
+      "env": ["NODE_ENV", "BUILD_NODE_VERSION", "MARIMO_FRONTEND_SOURCE_HASH"],
+      "outputLogs": "new-only"
     },
     "build:extension": {
-      "outputs": ["dist/extension.js", "dist/extension.js.map"],
-      "inputs": ["src/**/*.ts", "!src/renderer/**", "package.json"],
-      "env": ["NODE_ENV", "MODE"]
+      "outputs": [
+        "dist/extension.js",
+        "dist/extension.js.map",
+        "dist/wasmServer.js",
+        "dist/wasmServer.js.map"
+      ],
+      "inputs": [
+        "src/**/*.ts",
+        "!src/renderer/**",
+        "!src/**/__mocks__/**",
+        "!src/**/__tests__/**",
+        "!src/**/*.test.*",
+        "builtin-command-catalog.json",
+        "package.json"
+      ],
+      "env": ["BUILD_NODE_VERSION", "MARIMO_FRONTEND_SOURCE_HASH"],
+      "outputLogs": "new-only"
+    },
+    "build:wasm-lsp:bundle": {
+      "outputs": ["bundled/wasm/**"],
+      "inputs": [
+        "scripts/build-wasm-lsp.mjs",
+        "scripts/run-turbo.mjs",
+        "package.json"
+      ],
+      "env": [
+        "BUILD_NODE_VERSION",
+        "MARIMO_LSP_UV_VERSION",
+        "MARIMO_LSP_WASM_SOURCE_HASH"
+      ],
+      "outputLogs": "new-only"
     },
     "check": {},
-    "fix": {},
+    "fix": {
+      "cache": false
+    },
     "test:extension": {
-      "dependsOn": ["build:extension"]
+      "dependsOn": ["build:extension"],
+      "cache": false
     }
   }
 }

--- a/extension/vite.config.mts
+++ b/extension/vite.config.mts
@@ -7,6 +7,9 @@ import stylesheet from "./scripts/vite-plugin-virtual-stylesheet.mts";
 
 export default vite.defineConfig({
   build: {
+    // The extension bundle shares dist/ and is built independently by Turbo.
+    // Output cleanup happens once in scripts/run-turbo.mjs before cache restore.
+    emptyOutDir: false,
     // Shipped in: Electron 37.7, VSCode 1.106
     target: "chrome138",
     minify: process.env.NODE_ENV === "production",


### PR DESCRIPTION
The extension build consumes Python sources from this repository and frontend sources from a sibling marimo checkout, both outside the Turbo extension root. Hash those sources into the task environment so local and remote cache entries follow the actual build inputs.

Cached restoration does not remove obsolete Vite chunks or WASM artifacts. Clean those output families before Turbo runs so a cache hit reproduces the declared artifact set instead of mixing it with files from an earlier build.