### PR TITLE
Fix the WASM bundle build on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,8 +158,9 @@ jobs:
         run: pnpm test --coverage
         working-directory: marimo-lsp/extension
 
+      # Runs on every matrix OS: the release workflow builds this bundle on
+      # Windows too, and Windows-only breakage otherwise first surfaces there.
       - name: Build and test the WASM language server
-        if: runner.os == 'Linux'
         env:
           TURBO_TOKEN: ${{ steps.secrets.outputs.TURBO_TOKEN }}
         run: pnpm verify:wasm-lsp

--- a/extension/scripts/build-wasm-lsp.mjs
+++ b/extension/scripts/build-wasm-lsp.mjs
@@ -80,9 +80,16 @@ try {
 
   const micropip = pyodide.pyimport("micropip");
   try {
-    await micropip.install(
-      NodeUrl.pathToFileURL(NodePath.join(buildDir, wheel)).href,
+    // micropip opens file: URLs on the host filesystem as raw URL paths,
+    // which breaks on Windows: file:///C:/... is read as /C:/... (resolved
+    // against the current drive) and percent-escapes (e.g. %7E for the ~ in
+    // 8.3 temp paths) are never decoded. Stage the wheel inside the
+    // Emscripten FS instead.
+    pyodide.FS.writeFile(
+      `/${wheel}`,
+      NodeFs.readFileSync(NodePath.join(buildDir, wheel)),
     );
+    await micropip.install(`emfs:/${wheel}`);
   } finally {
     micropip.destroy();
   }

--- a/extension/scripts/run-turbo.mjs
+++ b/extension/scripts/run-turbo.mjs
@@ -134,6 +134,10 @@ NodeChildProcess.execFileSync("pnpm", ["exec", "turbo", "run", ...tasks], {
   env: {
     ...process.env,
     BUILD_NODE_VERSION: process.version,
+    // Keys build:wasm-lsp:bundle per OS: its output is platform-independent,
+    // but a cross-platform remote-cache hit would skip running the build
+    // script on the one platform (Windows) where its host quirks show up.
+    MARIMO_LSP_BUILD_PLATFORM: process.platform,
     ...(frontendSourceHash === undefined
       ? {}
       : { MARIMO_FRONTEND_SOURCE_HASH: frontendSourceHash }),

--- a/extension/turbo.json
+++ b/extension/turbo.json
@@ -45,6 +45,7 @@
       ],
       "env": [
         "BUILD_NODE_VERSION",
+        "MARIMO_LSP_BUILD_PLATFORM",
         "MARIMO_LSP_UV_VERSION",
         "MARIMO_LSP_WASM_SOURCE_HASH"
       ],


### PR DESCRIPTION
micropip opens file: URLs as raw URL paths on the host filesystem, so the wheel path came out as D:\C:\Users\RUNNER%7E1\... on the release runners. Install through the Emscripten FS instead, and run verify:wasm-lsp on Windows CI. We key per-OS in Turbo so a Linux remote-cache hit cannot skip it.