### PR TITLE
Preserve uv dependency placement on install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ extension/.vscode-test/
 .claude/*
 !.claude/skills/
 .claude/settings.local.json
+.pnpm-store
 
 # Vendored reference source (populated by `just vendor-effect`)
 repos/

--- a/extension/package.json
+++ b/extension/package.json
@@ -39,6 +39,7 @@
     "@oxlint/plugins": "^1.77.0",
     "@sentry/node": "^9.47.1",
     "@std/semver": "jsr:^1.0.8",
+    "@std/toml": "jsr:^1.0.11",
     "@tailwindcss/vite": "^4.3.3",
     "@types/mocha": "^10.0.10",
     "@types/node": "^24.13.3",

--- a/extension/pnpm-lock.yaml
+++ b/extension/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
       '@std/semver':
         specifier: jsr:^1.0.8
         version: '@jsr/std__semver@1.0.8'
+      '@std/toml':
+        specifier: jsr:^1.0.11
+        version: '@jsr/std__toml@1.0.11'
       '@tailwindcss/vite':
         specifier: ^4.3.3
         version: 4.3.3(@voidzero-dev/vite-plus-core@0.2.7(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(typescript@6.0.3))
@@ -470,8 +473,14 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@jsr/std__collections@1.3.0':
+    resolution: {integrity: sha512-oJ5V5ZvsWyO5VLdGk3TaRHaVibfVKHvDC8KJdgmxIucHN2QzAXlMt36ApyTUBncfrhXdN/5Q3yMNvloAKym8RA==, tarball: https://npm.jsr.io/~/11/@jsr/std__collections/1.3.0.tgz}
+
   '@jsr/std__semver@1.0.8':
     resolution: {integrity: sha512-YhkykPU2Majz66e+rQbP0okYc7kKv+U32aguLPCXZZAL+vEVmBA+khHjPHhLBpWR073gzU3WHqGRgB7a/aXCjg==, tarball: https://npm.jsr.io/~/11/@jsr/std__semver/1.0.8.tgz}
+
+  '@jsr/std__toml@1.0.11':
+    resolution: {integrity: sha512-+LZAizoPAPwMDmRZr86/xPrbO8E0Oq0BJ70mr1fNMobJ/6X6v15Jk16ZClFGukWgzBMd8ggiMWnzp24+N3VNZg==, tarball: https://npm.jsr.io/~/11/@jsr/std__toml/1.0.11.tgz}
 
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4':
     resolution: {integrity: sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ==}
@@ -3185,7 +3194,13 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@jsr/std__collections@1.3.0': {}
+
   '@jsr/std__semver@1.0.8': {}
+
+  '@jsr/std__toml@1.0.11':
+    dependencies:
+      '@jsr/std__collections': 1.3.0
 
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4':
     optional: true

--- a/extension/src/__mocks__/TestVsCode.ts
+++ b/extension/src/__mocks__/TestVsCode.ts
@@ -1722,9 +1722,9 @@ export class TestVsCode extends Data.TaggedClass("TestVsCode")<{
           showErrorMessage:
             options.window?.showErrorMessage ??
             (() => Effect.succeed(Option.none())),
-          showQuickPick() {
-            return Effect.succeed(Option.none());
-          },
+          showQuickPick:
+            options.window?.showQuickPick ??
+            (() => Effect.succeed(Option.none())),
           showQuickPickItems() {
             return Effect.succeed(Option.none());
           },

--- a/extension/src/kernel/__tests__/operations.test.ts
+++ b/extension/src/kernel/__tests__/operations.test.ts
@@ -1,7 +1,10 @@
-import { expect, it } from "@effect/vitest";
-import { Effect, Layer, Option, Ref } from "effect";
+import * as NodeFs from "node:fs";
+import * as NodeOs from "node:os";
+import * as NodePath from "node:path";
 
-import { TestPythonExtension } from "../../__mocks__/TestPythonExtension.ts";
+import { expect, it } from "@effect/vitest";
+import { Effect, Layer, Option, Ref, Stream } from "effect";
+
 import { TestVsCode } from "../../__mocks__/TestVsCode.ts";
 import { Config } from "../../config/Config.ts";
 import { PythonEnvInvalidation } from "../../python/PythonEnvInvalidation.ts";
@@ -29,13 +32,19 @@ const controller: NotebookController = {
 
 const withTestCtx = Effect.fn(function* (options: {
   disableUvIntegration: boolean;
+  installAll?: boolean;
 }) {
   const prompts = yield* Ref.make(0);
+  const invalidations = yield* Ref.make(0);
   const vscode = yield* TestVsCode.make({
     window: {
-      showInformationMessage: <T extends string>() =>
+      showInformationMessage: (_message, messageOptions = {}) =>
         Ref.update(prompts, (count) => count + 1).pipe(
-          Effect.as(Option.none<T>()),
+          Effect.as(
+            options.installAll
+              ? Option.fromNullable(messageOptions.items?.[0])
+              : Option.none(),
+          ),
         ),
     },
     workspace: {
@@ -62,11 +71,16 @@ const withTestCtx = Effect.fn(function* (options: {
   const layer = Layer.mergeAll(
     vscode.layer,
     Config.Default.pipe(Layer.provide(vscode.layer)),
-    PythonEnvInvalidation.Default.pipe(
-      Layer.provide(TestPythonExtension.Default),
+    Layer.succeed(
+      PythonEnvInvalidation,
+      PythonEnvInvalidation.make({
+        invalidate: () =>
+          Ref.update(invalidations, (count) => count + 1).pipe(Effect.as(true)),
+        changes: () => Stream.empty,
+      }),
     ),
-    // These tests never reach the install path; any Uv method call is a
-    // defect. Layer.mock still requires the non-method properties.
+    // Cancellation happens before invoking uv; any Uv method call is a defect.
+    // Layer.mock still requires the non-method properties.
     Layer.mock(Uv, {
       _tag: "Uv",
       bin: Effect.succeed(
@@ -78,7 +92,7 @@ const withTestCtx = Effect.fn(function* (options: {
       channel: { name: "test", show: () => undefined },
     }),
   );
-  return { layer, notebook, prompts };
+  return { layer, notebook, prompts, invalidations };
 });
 
 it.scoped("prompts to install missing packages when uv is enabled", () =>
@@ -99,4 +113,38 @@ it.scoped("skips the install prompt when uv integration is disabled", () =>
     );
     expect(yield* Ref.get(ctx.prompts)).toBe(0);
   }),
+);
+
+it.scoped(
+  "does not invalidate the environment when placement is cancelled",
+  () =>
+    Effect.gen(function* () {
+      using project = NodeFs.mkdtempDisposableSync(
+        NodePath.join(NodeOs.tmpdir(), "marimo-operations-"),
+      );
+      const venv = NodePath.join(project.path, ".venv");
+      NodeFs.mkdirSync(NodePath.join(venv, "bin"), { recursive: true });
+      NodeFs.writeFileSync(NodePath.join(venv, "pyvenv.cfg"), "");
+      NodeFs.writeFileSync(
+        NodePath.join(project.path, "pyproject.toml"),
+        `
+[project]
+dependencies = ["polars"]
+
+[dependency-groups]
+dev = ["polars"]
+`,
+      );
+
+      const ctx = yield* withTestCtx({
+        disableUvIntegration: false,
+        installAll: true,
+      });
+      yield* handleMissingPackageAlert(alert, ctx.notebook, {
+        ...controller,
+        executable: NodePath.join(venv, "bin", "python"),
+      }).pipe(Effect.provide(ctx.layer));
+
+      expect(yield* Ref.get(ctx.invalidations)).toBe(0);
+    }),
 );

--- a/extension/src/kernel/operations.ts
+++ b/extension/src/kernel/operations.ts
@@ -79,13 +79,14 @@ export const handleMissingPackageAlert = Effect.fn("handleMissingPackageAlert")(
         Effect.annotateLogs("packages", operation.packages),
       );
 
-      if ("venvPath" in options) {
-        yield* installPackages(operation.packages, options);
-      } else {
-        yield* installPackages(operation.packages, options);
-      }
+      const outcome =
+        "venvPath" in options
+          ? yield* installPackages(operation.packages, options)
+          : yield* installPackages(operation.packages, options);
 
-      yield* envInvalidation.invalidate("package-install");
+      if (outcome === "installed") {
+        yield* envInvalidation.invalidate("package-install");
+      }
       return;
     }
 
@@ -105,13 +106,14 @@ export const handleMissingPackageAlert = Effect.fn("handleMissingPackageAlert")(
         Effect.annotateLogs("packages", newPackages),
       );
 
-      if ("venvPath" in options) {
-        yield* installPackages(newPackages, options);
-      } else {
-        yield* installPackages(newPackages, options);
-      }
+      const outcome =
+        "venvPath" in options
+          ? yield* installPackages(newPackages, options)
+          : yield* installPackages(newPackages, options);
 
-      yield* envInvalidation.invalidate("package-install");
+      if (outcome === "installed") {
+        yield* envInvalidation.invalidate("package-install");
+      }
     }
   },
 );

--- a/extension/src/lib/__tests__/installPackages.test.ts
+++ b/extension/src/lib/__tests__/installPackages.test.ts
@@ -1,0 +1,145 @@
+import * as NodeFs from "node:fs";
+import * as NodeOs from "node:os";
+import * as NodePath from "node:path";
+
+import { expect, it } from "@effect/vitest";
+import { Effect, Option } from "effect";
+
+import { TestVsCode } from "../../__mocks__/TestVsCode.ts";
+import { resolveProjectInstallRequests } from "../installPackages.ts";
+
+function makeProject(content: string) {
+  const tmp = NodeFs.mkdtempDisposableSync(
+    NodePath.join(NodeOs.tmpdir(), "marimo-install-packages-"),
+  );
+  NodeFs.writeFileSync(NodePath.join(tmp.path, "pyproject.toml"), content);
+  return tmp;
+}
+
+it.effect(
+  "uses the package's unique existing dependency group",
+  Effect.fn(function* () {
+    using project = makeProject(`
+[project]
+dependencies = []
+
+[dependency-groups]
+notebooks = ["marimo>=0.10"]
+`);
+    const vscode = yield* TestVsCode.make();
+
+    const requests = yield* resolveProjectInstallRequests(
+      ["marimo>=0.20"],
+      project.path,
+    ).pipe(Effect.provide(vscode.layer));
+
+    expect(requests).toEqual([
+      {
+        packages: ["marimo>=0.20"],
+        target: { kind: "group", name: "notebooks" },
+      },
+    ]);
+  }),
+);
+
+it.effect(
+  "asks which existing declaration to update when placement is ambiguous",
+  Effect.fn(function* () {
+    using project = makeProject(`
+[project]
+dependencies = ["marimo>=0.10"]
+
+[dependency-groups]
+dev = ["marimo>=0.10"]
+`);
+    const vscode = yield* TestVsCode.make({
+      window: {
+        showQuickPick: (items) =>
+          Effect.succeed(Option.some(items[1] ?? items[0])),
+      },
+    });
+
+    const requests = yield* resolveProjectInstallRequests(
+      ["marimo>=0.20"],
+      project.path,
+    ).pipe(Effect.provide(vscode.layer));
+
+    expect(requests).toEqual([
+      {
+        packages: ["marimo>=0.20"],
+        target: { kind: "group", name: "dev" },
+      },
+    ]);
+  }),
+);
+
+it.effect(
+  "cancels installation when ambiguous placement is dismissed",
+  Effect.fn(function* () {
+    using project = makeProject(`
+[project]
+dependencies = ["marimo>=0.10"]
+
+[dependency-groups]
+dev = ["marimo>=0.10"]
+`);
+    const vscode = yield* TestVsCode.make();
+
+    const requests = yield* resolveProjectInstallRequests(
+      ["marimo>=0.20"],
+      project.path,
+    ).pipe(Effect.provide(vscode.layer));
+
+    expect(requests).toBeNull();
+  }),
+);
+
+it.effect(
+  "falls back to project dependencies when TOML inspection fails",
+  Effect.fn(function* () {
+    using project = makeProject("[project\ndependencies = []");
+    const vscode = yield* TestVsCode.make();
+
+    const requests = yield* resolveProjectInstallRequests(
+      ["marimo>=0.20"],
+      project.path,
+    ).pipe(Effect.provide(vscode.layer));
+
+    expect(requests).toEqual([
+      {
+        packages: ["marimo>=0.20"],
+        target: { kind: "production" },
+      },
+    ]);
+  }),
+);
+
+it.effect(
+  "batches packages that share a target and separates different targets",
+  Effect.fn(function* () {
+    using project = makeProject(`
+[project]
+dependencies = ["httpx"]
+
+[dependency-groups]
+dev = ["marimo", "pytest"]
+`);
+    const vscode = yield* TestVsCode.make();
+
+    const requests = yield* resolveProjectInstallRequests(
+      ["marimo>=0.20", "pytest", "httpx"],
+      project.path,
+    ).pipe(Effect.provide(vscode.layer));
+
+    expect(requests).toEqual([
+      {
+        packages: ["marimo>=0.20", "pytest"],
+        target: { kind: "group", name: "dev" },
+      },
+      {
+        packages: ["httpx"],
+        target: { kind: "production" },
+      },
+    ]);
+  }),
+);

--- a/extension/src/lib/__tests__/installPackages.test.ts
+++ b/extension/src/lib/__tests__/installPackages.test.ts
@@ -3,7 +3,7 @@ import * as NodeOs from "node:os";
 import * as NodePath from "node:path";
 
 import { expect, it } from "@effect/vitest";
-import { Effect, Option } from "effect";
+import { Effect } from "effect";
 
 import { TestVsCode } from "../../__mocks__/TestVsCode.ts";
 import { resolveProjectInstallRequests } from "../installPackages.ts";
@@ -43,7 +43,7 @@ notebooks = ["marimo>=0.10"]
 );
 
 it.effect(
-  "asks which existing declaration to update when placement is ambiguous",
+  "refuses to update only one of multiple declarations",
   Effect.fn(function* () {
     using project = makeProject(`
 [project]
@@ -52,36 +52,29 @@ dependencies = ["marimo>=0.10"]
 [dependency-groups]
 dev = ["marimo>=0.10"]
 `);
-    const vscode = yield* TestVsCode.make({
-      window: {
-        showQuickPick: (items) =>
-          Effect.succeed(Option.some(items[1] ?? items[0])),
-      },
-    });
+    const vscode = yield* TestVsCode.make();
 
     const requests = yield* resolveProjectInstallRequests(
       ["marimo>=0.20"],
       project.path,
     ).pipe(Effect.provide(vscode.layer));
 
-    expect(requests).toEqual([
-      {
-        packages: ["marimo>=0.20"],
-        target: { kind: "group", name: "dev" },
-      },
-    ]);
+    expect(requests).toBeNull();
   }),
 );
 
 it.effect(
-  "cancels installation when ambiguous placement is dismissed",
+  "cancels when standard and legacy dev declarations conflict",
   Effect.fn(function* () {
     using project = makeProject(`
 [project]
-dependencies = ["marimo>=0.10"]
+dependencies = []
 
 [dependency-groups]
-dev = ["marimo>=0.10"]
+dev = ["marimo<0.20"]
+
+[tool.uv]
+dev-dependencies = ["marimo<0.20"]
 `);
     const vscode = yield* TestVsCode.make();
 

--- a/extension/src/lib/__tests__/installPackages.test.ts
+++ b/extension/src/lib/__tests__/installPackages.test.ts
@@ -36,7 +36,7 @@ notebooks = ["marimo>=0.10"]
     expect(requests).toEqual([
       {
         packages: ["marimo>=0.20"],
-        target: { kind: "group", name: "notebooks" },
+        target: { _tag: "Group", name: "notebooks" },
       },
     ]);
   }),
@@ -101,7 +101,7 @@ it.effect(
     expect(requests).toEqual([
       {
         packages: ["marimo>=0.20"],
-        target: { kind: "production" },
+        target: { _tag: "Production" },
       },
     ]);
   }),
@@ -127,11 +127,11 @@ dev = ["marimo", "pytest"]
     expect(requests).toEqual([
       {
         packages: ["marimo>=0.20", "pytest"],
-        target: { kind: "group", name: "dev" },
+        target: { _tag: "Group", name: "dev" },
       },
       {
         packages: ["httpx"],
-        target: { kind: "production" },
+        target: { _tag: "Production" },
       },
     ]);
   }),

--- a/extension/src/lib/installPackages.ts
+++ b/extension/src/lib/installPackages.ts
@@ -5,8 +5,8 @@ import { Cause, Data, Effect, Option } from "effect";
 import { assert, unreachable } from "../assert.ts";
 import { VsCode } from "../platform/VsCode.ts";
 import {
-  findProjectDependencyTargets,
   formatProjectDependencyTarget,
+  inspectProjectDependencies,
   type ProjectDependencyTarget,
 } from "../python/ProjectDependencyTarget.ts";
 import { Uv, UvUnknownError } from "../python/Uv.ts";
@@ -17,24 +17,24 @@ export function installPackages(
   options: {
     venvPath: string;
   },
-): Effect.Effect<void, never, Uv | VsCode>;
+): Effect.Effect<InstallPackagesOutcome, never, Uv | VsCode>;
 export function installPackages(
   packages: ReadonlyArray<string>,
   options: {
     script: MarimoNotebookDocument;
   },
-): Effect.Effect<void, never, Uv | VsCode>;
+): Effect.Effect<InstallPackagesOutcome, never, Uv | VsCode>;
 export function installPackages(
   packages: ReadonlyArray<string>,
   options: {
     script?: MarimoNotebookDocument;
     venvPath?: string;
   },
-): Effect.Effect<void, never, Uv | VsCode> {
+): Effect.Effect<InstallPackagesOutcome, never, Uv | VsCode> {
   return Effect.gen(function* () {
     const uv = yield* Uv;
     const code = yield* VsCode;
-    yield* code.window.withProgress(
+    return yield* code.window.withProgress(
       {
         location: code.ProgressLocation.Notification,
         title: `Installing ${packages.length > 1 ? "packages" : "package"}`,
@@ -52,7 +52,7 @@ export function installPackages(
               packages,
               venvPath,
             ).pipe(Effect.provideService(VsCode, code));
-            if (requests == null) return;
+            if (requests == null) return "cancelled" as const;
 
             for (const request of requests) {
               yield* uv
@@ -96,6 +96,7 @@ export function installPackages(
           progress.report({
             message: `Successfully installed ${packages.join(", ")}`,
           });
+          return "installed" as const;
         }).pipe(
           Effect.catchAllCause(
             Effect.fn(function* (cause) {
@@ -112,12 +113,15 @@ export function installPackages(
               yield* code.window.showErrorMessage(
                 `Failed to install ${packages.join(", ")}.${suffix}`,
               );
+              return "failed" as const;
             }),
           ),
         ),
     );
   });
 }
+
+export type InstallPackagesOutcome = "installed" | "cancelled" | "failed";
 
 export type ProjectInstallRequest = {
   readonly packages: ReadonlyArray<string>;
@@ -136,38 +140,45 @@ export const resolveProjectInstallRequests = Effect.fn(
   const code = yield* VsCode;
   const requests: ProjectInstallRequest[] = [];
 
+  const inspection = yield* Effect.try({
+    try: () => inspectProjectDependencies(directory),
+    catch: (cause) => new ProjectInspectionError({ cause }),
+  }).pipe(
+    Effect.tapError((cause) =>
+      Effect.logWarning(
+        "Failed to inspect pyproject.toml; using project dependencies",
+      ).pipe(Effect.annotateLogs({ cause })),
+    ),
+    Effect.option,
+  );
+
   for (const pkg of packages) {
-    const targets = yield* Effect.try({
-      try: () => findProjectDependencyTargets(directory, pkg),
-      catch: (cause) => new ProjectInspectionError({ cause }),
-    }).pipe(
-      Effect.tapError((cause) =>
-        Effect.logWarning(
-          "Failed to inspect pyproject.toml; using project dependencies",
-        ).pipe(Effect.annotateLogs({ cause, package: pkg })),
-      ),
-      Effect.orElseSucceed(() => []),
-    );
+    const targets = Option.match(inspection, {
+      onNone: () => [],
+      onSome: (index) => index.findTargets(pkg),
+    });
+
+    const hasDuplicateDevDeclaration =
+      Option.isSome(inspection) &&
+      inspection.value.hasDuplicateDevDeclaration(pkg);
+    if (hasDuplicateDevDeclaration || targets.length > 1) {
+      const locations = targets.map(formatProjectDependencyTarget).join(", ");
+      const legacyLocation = hasDuplicateDevDeclaration
+        ? `${locations.length > 0 ? ", " : ""}Legacy uv dev dependencies`
+        : "";
+      yield* code.window.showErrorMessage(
+        `${pkg} is declared in multiple locations (${locations}${legacyLocation}). uv cannot safely update only one declaration because the remaining constraint may prevent resolution. Consolidate or update the declarations in pyproject.toml manually.`,
+      );
+      return null;
+    }
 
     let target: ProjectDependencyTarget;
     if (targets.length === 0) {
       target = { kind: "production" };
-    } else if (targets.length === 1) {
+    } else {
       const [onlyTarget] = targets;
       assert(onlyTarget, "Expected one project dependency target");
       target = onlyTarget;
-    } else {
-      const labels = targets.map(formatProjectDependencyTarget);
-      const selection = yield* code.window.showQuickPick(labels, {
-        placeHolder: `${pkg} is declared in multiple locations. Choose where to update it.`,
-      });
-      if (Option.isNone(selection)) return null;
-      const selectedTarget = targets.find(
-        (candidate) =>
-          formatProjectDependencyTarget(candidate) === selection.value,
-      );
-      assert(selectedTarget, "Expected selected project dependency target");
-      target = selectedTarget;
     }
 
     const existing = requests.find((request) =>

--- a/extension/src/lib/installPackages.ts
+++ b/extension/src/lib/installPackages.ts
@@ -1,9 +1,14 @@
 import * as NodeFs from "node:fs";
 
-import { Cause, Effect } from "effect";
+import { Cause, Data, Effect, Option } from "effect";
 
-import { assert } from "../assert.ts";
+import { assert, unreachable } from "../assert.ts";
 import { VsCode } from "../platform/VsCode.ts";
+import {
+  findProjectDependencyTargets,
+  formatProjectDependencyTarget,
+  type ProjectDependencyTarget,
+} from "../python/ProjectDependencyTarget.ts";
 import { Uv, UvUnknownError } from "../python/Uv.ts";
 import type { MarimoNotebookDocument } from "../schemas/MarimoNotebookDocument.ts";
 
@@ -43,17 +48,33 @@ export function installPackages(
 
           if (options.venvPath) {
             const venvPath = options.venvPath;
-            yield* uv.addProject({ directory: venvPath, packages }).pipe(
-              Effect.catchTag(
-                "UvMissingPyProjectError",
-                Effect.fn(function* () {
-                  yield* Effect.logWarning(
-                    "Failed to `uv add`, attempting `uv pip install`.",
-                  );
-                  yield* uv.pipInstall(packages, { venv: venvPath });
-                }),
-              ),
-            );
+            const requests = yield* resolveProjectInstallRequests(
+              packages,
+              venvPath,
+            ).pipe(Effect.provideService(VsCode, code));
+            if (requests == null) return;
+
+            for (const request of requests) {
+              yield* uv
+                .addProject({
+                  directory: venvPath,
+                  packages: request.packages,
+                  target: request.target,
+                })
+                .pipe(
+                  Effect.catchTag(
+                    "UvMissingPyProjectError",
+                    Effect.fn(function* () {
+                      yield* Effect.logWarning(
+                        "Failed to `uv add`, attempting `uv pip install`.",
+                      );
+                      yield* uv.pipInstall(request.packages, {
+                        venv: venvPath,
+                      });
+                    }),
+                  ),
+                );
+            }
           } else {
             const notebook = options.script;
             assert(notebook, "Expected notebook");
@@ -96,6 +117,89 @@ export function installPackages(
         ),
     );
   });
+}
+
+export type ProjectInstallRequest = {
+  readonly packages: ReadonlyArray<string>;
+  readonly target: ProjectDependencyTarget;
+};
+
+class ProjectInspectionError extends Data.TaggedError(
+  "ProjectInspectionError",
+)<{
+  readonly cause: unknown;
+}> {}
+
+export const resolveProjectInstallRequests = Effect.fn(
+  "resolveProjectInstallRequests",
+)(function* (packages: ReadonlyArray<string>, directory: string) {
+  const code = yield* VsCode;
+  const requests: ProjectInstallRequest[] = [];
+
+  for (const pkg of packages) {
+    const targets = yield* Effect.try({
+      try: () => findProjectDependencyTargets(directory, pkg),
+      catch: (cause) => new ProjectInspectionError({ cause }),
+    }).pipe(
+      Effect.tapError((cause) =>
+        Effect.logWarning(
+          "Failed to inspect pyproject.toml; using project dependencies",
+        ).pipe(Effect.annotateLogs({ cause, package: pkg })),
+      ),
+      Effect.orElseSucceed(() => []),
+    );
+
+    let target: ProjectDependencyTarget;
+    if (targets.length === 0) {
+      target = { kind: "production" };
+    } else if (targets.length === 1) {
+      const [onlyTarget] = targets;
+      assert(onlyTarget, "Expected one project dependency target");
+      target = onlyTarget;
+    } else {
+      const labels = targets.map(formatProjectDependencyTarget);
+      const selection = yield* code.window.showQuickPick(labels, {
+        placeHolder: `${pkg} is declared in multiple locations. Choose where to update it.`,
+      });
+      if (Option.isNone(selection)) return null;
+      const selectedTarget = targets.find(
+        (candidate) =>
+          formatProjectDependencyTarget(candidate) === selection.value,
+      );
+      assert(selectedTarget, "Expected selected project dependency target");
+      target = selectedTarget;
+    }
+
+    const existing = requests.find((request) =>
+      dependencyTargetsEqual(request.target, target),
+    );
+    if (existing == null) {
+      requests.push({ packages: [pkg], target });
+    } else {
+      requests[requests.indexOf(existing)] = {
+        ...existing,
+        packages: [...existing.packages, pkg],
+      };
+    }
+  }
+
+  return requests;
+});
+
+function dependencyTargetsEqual(
+  left: ProjectDependencyTarget,
+  right: ProjectDependencyTarget,
+): boolean {
+  if (left.kind !== right.kind) return false;
+  switch (left.kind) {
+    case "production":
+      return true;
+    case "group":
+      return right.kind === "group" && left.name === right.name;
+    case "optional":
+      return right.kind === "optional" && left.name === right.name;
+  }
+  return unreachable(left);
 }
 
 export const uvAddScriptSafe = Effect.fn("uvAddScriptSafe")(function* (

--- a/extension/src/lib/installPackages.ts
+++ b/extension/src/lib/installPackages.ts
@@ -2,12 +2,12 @@ import * as NodeFs from "node:fs";
 
 import { Cause, Data, Effect, Option } from "effect";
 
-import { assert, unreachable } from "../assert.ts";
+import { assert } from "../assert.ts";
 import { VsCode } from "../platform/VsCode.ts";
 import {
   formatProjectDependencyTarget,
   inspectProjectDependencies,
-  type ProjectDependencyTarget,
+  ProjectDependencyTarget,
 } from "../python/ProjectDependencyTarget.ts";
 import { Uv, UvUnknownError } from "../python/Uv.ts";
 import type { MarimoNotebookDocument } from "../schemas/MarimoNotebookDocument.ts";
@@ -174,7 +174,7 @@ export const resolveProjectInstallRequests = Effect.fn(
 
     let target: ProjectDependencyTarget;
     if (targets.length === 0) {
-      target = { kind: "production" };
+      target = ProjectDependencyTarget.Production();
     } else {
       const [onlyTarget] = targets;
       assert(onlyTarget, "Expected one project dependency target");
@@ -201,16 +201,14 @@ function dependencyTargetsEqual(
   left: ProjectDependencyTarget,
   right: ProjectDependencyTarget,
 ): boolean {
-  if (left.kind !== right.kind) return false;
-  switch (left.kind) {
-    case "production":
-      return true;
-    case "group":
-      return right.kind === "group" && left.name === right.name;
-    case "optional":
-      return right.kind === "optional" && left.name === right.name;
+  if (left._tag !== right._tag) {
+    return false;
   }
-  return unreachable(left);
+  return ProjectDependencyTarget.$match(left, {
+    Production: () => true,
+    Group: ({ name }) => right._tag === "Group" && name == right.name,
+    Optional: ({ name }) => right._tag === "Optional" && name == right.name,
+  });
 }
 
 export const uvAddScriptSafe = Effect.fn("uvAddScriptSafe")(function* (

--- a/extension/src/python/ProjectDependencyTarget.ts
+++ b/extension/src/python/ProjectDependencyTarget.ts
@@ -10,6 +10,13 @@ export type ProjectDependencyTarget =
   | { readonly kind: "group"; readonly name: string }
   | { readonly kind: "optional"; readonly name: string };
 
+export type ProjectDependencyInspection = {
+  readonly findTargets: (
+    requirement: string,
+  ) => ReadonlyArray<ProjectDependencyTarget>;
+  readonly hasDuplicateDevDeclaration: (requirement: string) => boolean;
+};
+
 const PRODUCTION_TARGET = { kind: "production" } as const;
 
 /**
@@ -23,49 +30,73 @@ export function findProjectDependencyTargets(
   directory: string,
   requirement: string,
 ): ReadonlyArray<ProjectDependencyTarget> {
-  const pyproject = findPyProject(directory);
-  if (pyproject == null) return [];
+  return inspectProjectDependencies(directory).findTargets(requirement);
+}
 
-  const packageName = parseRequirementName(requirement);
-  if (packageName == null) return [];
+/** Read and index the nearest pyproject once for a package-install batch. */
+export function inspectProjectDependencies(
+  directory: string,
+): ProjectDependencyInspection {
+  const pyproject = findPyProject(directory);
+  if (pyproject == null) {
+    return {
+      findTargets: () => [],
+      hasDuplicateDevDeclaration: () => false,
+    };
+  }
 
   const document = parse(NodeFs.readFileSync(pyproject, "utf8"));
-  const targets: ProjectDependencyTarget[] = [];
   const project = asTable(document.project);
-
-  if (containsPackage(project?.dependencies, packageName)) {
-    targets.push(PRODUCTION_TARGET);
-  }
-
-  for (const [name, dependencies] of Object.entries(
-    asTable(project?.["optional-dependencies"]) ?? {},
-  )) {
-    if (containsPackage(dependencies, packageName)) {
-      targets.push({ kind: "optional", name });
-    }
-  }
-
-  for (const [name, dependencies] of Object.entries(
-    asTable(document["dependency-groups"]) ?? {},
-  )) {
-    if (containsPackage(dependencies, packageName)) {
-      targets.push({ kind: "group", name });
-    }
-  }
-
-  // uv preserves this legacy field when `--dev` is used. Treat it as the dev
-  // group, while avoiding a duplicate if both old and new fields are present.
   const legacyDevDependencies = asTable(asTable(document.tool)?.uv)?.[
     "dev-dependencies"
   ];
-  if (
-    containsPackage(legacyDevDependencies, packageName) &&
-    !targets.some((target) => target.kind === "group" && target.name === "dev")
-  ) {
-    targets.push({ kind: "group", name: "dev" });
-  }
+  const dependencyGroups = asTable(document["dependency-groups"]) ?? {};
+  const standardDevDependencies = dependencyGroups.dev;
 
-  return targets;
+  return {
+    findTargets(requirement) {
+      const packageName = parseRequirementName(requirement);
+      if (packageName == null) return [];
+
+      const targets: ProjectDependencyTarget[] = [];
+      if (containsPackage(project?.dependencies, packageName)) {
+        targets.push(PRODUCTION_TARGET);
+      }
+
+      for (const [name, dependencies] of Object.entries(
+        asTable(project?.["optional-dependencies"]) ?? {},
+      )) {
+        if (containsPackage(dependencies, packageName)) {
+          targets.push({ kind: "optional", name });
+        }
+      }
+
+      for (const [name, dependencies] of Object.entries(dependencyGroups)) {
+        if (containsPackage(dependencies, packageName)) {
+          targets.push({ kind: "group", name });
+        }
+      }
+
+      // uv preserves this legacy field when `--dev` is used. Treat it as the
+      // dev group when there is no matching standard declaration.
+      if (
+        containsPackage(legacyDevDependencies, packageName) &&
+        !containsPackage(standardDevDependencies, packageName)
+      ) {
+        targets.push({ kind: "group", name: "dev" });
+      }
+
+      return targets;
+    },
+    hasDuplicateDevDeclaration(requirement) {
+      const packageName = parseRequirementName(requirement);
+      return (
+        packageName != null &&
+        containsPackage(standardDevDependencies, packageName) &&
+        containsPackage(legacyDevDependencies, packageName)
+      );
+    },
+  };
 }
 
 export function formatProjectDependencyTarget(

--- a/extension/src/python/ProjectDependencyTarget.ts
+++ b/extension/src/python/ProjectDependencyTarget.ts
@@ -2,13 +2,16 @@ import * as NodeFs from "node:fs";
 import * as NodePath from "node:path";
 
 import { parse } from "@std/toml";
+import { Data } from "effect";
 
-import { unreachable } from "../assert.ts";
+export type ProjectDependencyTarget = Data.TaggedEnum<{
+  Production: {};
+  Group: { readonly name: string };
+  Optional: { readonly name: string };
+}>;
 
-export type ProjectDependencyTarget =
-  | { readonly kind: "production" }
-  | { readonly kind: "group"; readonly name: string }
-  | { readonly kind: "optional"; readonly name: string };
+export const ProjectDependencyTarget =
+  Data.taggedEnum<ProjectDependencyTarget>();
 
 export type ProjectDependencyInspection = {
   readonly findTargets: (
@@ -16,8 +19,6 @@ export type ProjectDependencyInspection = {
   ) => ReadonlyArray<ProjectDependencyTarget>;
   readonly hasDuplicateDevDeclaration: (requirement: string) => boolean;
 };
-
-const PRODUCTION_TARGET = { kind: "production" } as const;
 
 /**
  * Find every pyproject location in which a package is declared directly.
@@ -60,20 +61,20 @@ export function inspectProjectDependencies(
 
       const targets: ProjectDependencyTarget[] = [];
       if (containsPackage(project?.dependencies, packageName)) {
-        targets.push(PRODUCTION_TARGET);
+        targets.push(ProjectDependencyTarget.Production());
       }
 
       for (const [name, dependencies] of Object.entries(
         asTable(project?.["optional-dependencies"]) ?? {},
       )) {
         if (containsPackage(dependencies, packageName)) {
-          targets.push({ kind: "optional", name });
+          targets.push(ProjectDependencyTarget.Optional({ name }));
         }
       }
 
       for (const [name, dependencies] of Object.entries(dependencyGroups)) {
         if (containsPackage(dependencies, packageName)) {
-          targets.push({ kind: "group", name });
+          targets.push(ProjectDependencyTarget.Group({ name }));
         }
       }
 
@@ -83,7 +84,7 @@ export function inspectProjectDependencies(
         containsPackage(legacyDevDependencies, packageName) &&
         !containsPackage(standardDevDependencies, packageName)
       ) {
-        targets.push({ kind: "group", name: "dev" });
+        targets.push(ProjectDependencyTarget.Group({ name: "dev" }));
       }
 
       return targets;
@@ -102,15 +103,11 @@ export function inspectProjectDependencies(
 export function formatProjectDependencyTarget(
   target: ProjectDependencyTarget,
 ): string {
-  switch (target.kind) {
-    case "production":
-      return "Project dependencies";
-    case "group":
-      return `Dependency group: ${target.name}`;
-    case "optional":
-      return `Optional dependency: ${target.name}`;
-  }
-  return unreachable(target);
+  return ProjectDependencyTarget.$match(target, {
+    Production: () => "Project dependencies",
+    Group: ({ name }) => `Dependency group: ${name}`,
+    Optional: ({ name }) => `Optional dependency: ${name}`,
+  });
 }
 
 function findPyProject(directory: string): string | null {

--- a/extension/src/python/ProjectDependencyTarget.ts
+++ b/extension/src/python/ProjectDependencyTarget.ts
@@ -1,0 +1,122 @@
+import * as NodeFs from "node:fs";
+import * as NodePath from "node:path";
+
+import { parse } from "@std/toml";
+
+import { unreachable } from "../assert.ts";
+
+export type ProjectDependencyTarget =
+  | { readonly kind: "production" }
+  | { readonly kind: "group"; readonly name: string }
+  | { readonly kind: "optional"; readonly name: string };
+
+const PRODUCTION_TARGET = { kind: "production" } as const;
+
+/**
+ * Find every pyproject location in which a package is declared directly.
+ *
+ * uv only updates the dependency field selected by `--group` / `--optional`;
+ * an unqualified `uv add` always targets `project.dependencies`. Inspecting the
+ * existing declarations lets us preserve the user's chosen location.
+ */
+export function findProjectDependencyTargets(
+  directory: string,
+  requirement: string,
+): ReadonlyArray<ProjectDependencyTarget> {
+  const pyproject = findPyProject(directory);
+  if (pyproject == null) return [];
+
+  const packageName = parseRequirementName(requirement);
+  if (packageName == null) return [];
+
+  const document = parse(NodeFs.readFileSync(pyproject, "utf8"));
+  const targets: ProjectDependencyTarget[] = [];
+  const project = asTable(document.project);
+
+  if (containsPackage(project?.dependencies, packageName)) {
+    targets.push(PRODUCTION_TARGET);
+  }
+
+  for (const [name, dependencies] of Object.entries(
+    asTable(project?.["optional-dependencies"]) ?? {},
+  )) {
+    if (containsPackage(dependencies, packageName)) {
+      targets.push({ kind: "optional", name });
+    }
+  }
+
+  for (const [name, dependencies] of Object.entries(
+    asTable(document["dependency-groups"]) ?? {},
+  )) {
+    if (containsPackage(dependencies, packageName)) {
+      targets.push({ kind: "group", name });
+    }
+  }
+
+  // uv preserves this legacy field when `--dev` is used. Treat it as the dev
+  // group, while avoiding a duplicate if both old and new fields are present.
+  const legacyDevDependencies = asTable(asTable(document.tool)?.uv)?.[
+    "dev-dependencies"
+  ];
+  if (
+    containsPackage(legacyDevDependencies, packageName) &&
+    !targets.some((target) => target.kind === "group" && target.name === "dev")
+  ) {
+    targets.push({ kind: "group", name: "dev" });
+  }
+
+  return targets;
+}
+
+export function formatProjectDependencyTarget(
+  target: ProjectDependencyTarget,
+): string {
+  switch (target.kind) {
+    case "production":
+      return "Project dependencies";
+    case "group":
+      return `Dependency group: ${target.name}`;
+    case "optional":
+      return `Optional dependency: ${target.name}`;
+  }
+  return unreachable(target);
+}
+
+function findPyProject(directory: string): string | null {
+  let current = NodePath.resolve(directory);
+  while (true) {
+    const candidate = NodePath.join(current, "pyproject.toml");
+    if (NodeFs.existsSync(candidate)) return candidate;
+
+    const parent = NodePath.dirname(current);
+    if (parent === current) return null;
+    current = parent;
+  }
+}
+
+function containsPackage(value: unknown, packageName: string): boolean {
+  return (
+    Array.isArray(value) &&
+    value.some(
+      (requirement) =>
+        typeof requirement === "string" &&
+        parseRequirementName(requirement) === packageName,
+    )
+  );
+}
+
+/** Normalize a PEP 508 distribution name according to the packaging spec. */
+function parseRequirementName(requirement: string): string | null {
+  const match = /^\s*([A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?)/.exec(
+    requirement,
+  );
+  return match?.[1]?.toLowerCase().replaceAll(/[._-]+/g, "-") ?? null;
+}
+
+function asTable(value: unknown): Record<string, unknown> | null {
+  return isTable(value) ? value : null;
+}
+
+function isTable(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value != null && !Array.isArray(value);
+}

--- a/extension/src/python/Uv.ts
+++ b/extension/src/python/Uv.ts
@@ -324,11 +324,11 @@ export class Uv extends Effect.Service<Uv>()("Uv", {
         target?: ProjectDependencyTarget;
       }) {
         const args = ["add"];
-        switch (options.target?.kind) {
-          case "group":
+        switch (options.target?._tag) {
+          case "Group":
             args.push("--group", options.target.name);
             break;
-          case "optional":
+          case "Optional":
             args.push("--optional", options.target.name);
             break;
         }

--- a/extension/src/python/Uv.ts
+++ b/extension/src/python/Uv.ts
@@ -22,6 +22,7 @@ import { assert } from "../assert.ts";
 import { Config } from "../config/Config.ts";
 import { VsCode } from "../platform/VsCode.ts";
 import { Telemetry } from "../telemetry/Telemetry.ts";
+import type { ProjectDependencyTarget } from "./ProjectDependencyTarget.ts";
 
 export const UvBin = Data.taggedEnum<UvBin>();
 export type UvBin = Data.TaggedEnum<{
@@ -320,13 +321,18 @@ export class Uv extends Effect.Service<Uv>()("Uv", {
       addProject(options: {
         directory: string;
         packages: ReadonlyArray<string>;
+        target?: ProjectDependencyTarget;
       }) {
-        const args = [
-          "add",
-          ...options.packages,
-          "--directory",
-          options.directory,
-        ];
+        const args = ["add"];
+        switch (options.target?.kind) {
+          case "group":
+            args.push("--group", options.target.name);
+            break;
+          case "optional":
+            args.push("--optional", options.target.name);
+            break;
+        }
+        args.push(...options.packages, "--directory", options.directory);
         return uv({ args }).pipe(
           Effect.catchTag(
             "UvUnknownError",

--- a/extension/src/python/__tests__/ProjectDependencyTarget.test.ts
+++ b/extension/src/python/__tests__/ProjectDependencyTarget.test.ts
@@ -4,7 +4,10 @@ import * as NodePath from "node:path";
 
 import { describe, expect, it } from "vite-plus/test";
 
-import { findProjectDependencyTargets } from "../ProjectDependencyTarget.ts";
+import {
+  findProjectDependencyTargets,
+  inspectProjectDependencies,
+} from "../ProjectDependencyTarget.ts";
 
 function withProject(content: string, test: (directory: string) => void) {
   using tmp = NodeFs.mkdtempDisposableSync(
@@ -90,6 +93,53 @@ dev-dependencies = ["marimo>=0.10"]
 `,
       (directory) => {
         expect(findProjectDependencyTargets(directory, "marimo")).toEqual([
+          { kind: "group", name: "dev" },
+        ]);
+      },
+    );
+  });
+
+  it("reports matching legacy and standard dev declarations", () => {
+    withProject(
+      `
+[project]
+dependencies = []
+
+[dependency-groups]
+dev = ["marimo>=0.10"]
+
+[tool.uv]
+dev-dependencies = ["marimo>=0.10"]
+`,
+      (directory) => {
+        const inspection = inspectProjectDependencies(directory);
+        expect(inspection.hasDuplicateDevDeclaration("marimo>=0.20")).toBe(
+          true,
+        );
+      },
+    );
+  });
+
+  it("uses a single project snapshot for multiple package lookups", () => {
+    withProject(
+      `
+[project]
+dependencies = ["httpx"]
+
+[dependency-groups]
+dev = ["marimo"]
+`,
+      (directory) => {
+        const inspection = inspectProjectDependencies(directory);
+        NodeFs.writeFileSync(
+          NodePath.join(directory, "pyproject.toml"),
+          "[invalid",
+        );
+
+        expect(inspection.findTargets("httpx")).toEqual([
+          { kind: "production" },
+        ]);
+        expect(inspection.findTargets("marimo")).toEqual([
           { kind: "group", name: "dev" },
         ]);
       },

--- a/extension/src/python/__tests__/ProjectDependencyTarget.test.ts
+++ b/extension/src/python/__tests__/ProjectDependencyTarget.test.ts
@@ -34,10 +34,10 @@ docs = ["marimo>=0.13"]
       (directory) => {
         expect(findProjectDependencyTargets(directory, "marimo>=0.20")).toEqual(
           [
-            { kind: "production" },
-            { kind: "optional", name: "notebooks" },
-            { kind: "group", name: "dev" },
-            { kind: "group", name: "docs" },
+            { _tag: "Production" },
+            { _tag: "Optional", name: "notebooks" },
+            { _tag: "Group", name: "dev" },
+            { _tag: "Group", name: "docs" },
           ],
         );
       },
@@ -56,7 +56,7 @@ notebooks = ["marimo>=0.10"]
 `,
       (directory) => {
         expect(findProjectDependencyTargets(directory, "marimo")).toEqual([
-          { kind: "group", name: "notebooks" },
+          { _tag: "Group", name: "notebooks" },
         ]);
       },
     );
@@ -73,7 +73,7 @@ dev-dependencies = ["marimo>=0.10"]
 `,
       (directory) => {
         expect(findProjectDependencyTargets(directory, "marimo")).toEqual([
-          { kind: "group", name: "dev" },
+          { _tag: "Group", name: "dev" },
         ]);
       },
     );
@@ -93,7 +93,7 @@ dev-dependencies = ["marimo>=0.10"]
 `,
       (directory) => {
         expect(findProjectDependencyTargets(directory, "marimo")).toEqual([
-          { kind: "group", name: "dev" },
+          { _tag: "Group", name: "dev" },
         ]);
       },
     );
@@ -137,10 +137,10 @@ dev = ["marimo"]
         );
 
         expect(inspection.findTargets("httpx")).toEqual([
-          { kind: "production" },
+          { _tag: "Production" },
         ]);
         expect(inspection.findTargets("marimo")).toEqual([
-          { kind: "group", name: "dev" },
+          { _tag: "Group", name: "dev" },
         ]);
       },
     );
@@ -158,7 +158,7 @@ dev = ["My.Package_Name>=1"]
       (directory) => {
         expect(
           findProjectDependencyTargets(directory, "my-package-name>=2"),
-        ).toEqual([{ kind: "group", name: "dev" }]);
+        ).toEqual([{ _tag: "Group", name: "dev" }]);
       },
     );
   });
@@ -176,7 +176,7 @@ test = ["marimo"]
         const venv = NodePath.join(directory, ".venv", "nested");
         NodeFs.mkdirSync(venv, { recursive: true });
         expect(findProjectDependencyTargets(venv, "marimo")).toEqual([
-          { kind: "group", name: "test" },
+          { _tag: "Group", name: "test" },
         ]);
       },
     );

--- a/extension/src/python/__tests__/ProjectDependencyTarget.test.ts
+++ b/extension/src/python/__tests__/ProjectDependencyTarget.test.ts
@@ -1,0 +1,147 @@
+import * as NodeFs from "node:fs";
+import * as NodeOs from "node:os";
+import * as NodePath from "node:path";
+
+import { describe, expect, it } from "vite-plus/test";
+
+import { findProjectDependencyTargets } from "../ProjectDependencyTarget.ts";
+
+function withProject(content: string, test: (directory: string) => void) {
+  using tmp = NodeFs.mkdtempDisposableSync(
+    NodePath.join(NodeOs.tmpdir(), "marimo-project-target-"),
+  );
+  NodeFs.writeFileSync(NodePath.join(tmp.path, "pyproject.toml"), content);
+  test(tmp.path);
+}
+
+describe("findProjectDependencyTargets", () => {
+  it("finds production, optional, and arbitrary dependency groups", () => {
+    withProject(
+      `
+[project]
+dependencies = ["marimo[sql]>=0.10"]
+
+[project.optional-dependencies]
+notebooks = ["marimo>=0.11"]
+
+[dependency-groups]
+dev = ["marimo>=0.12"]
+docs = ["marimo>=0.13"]
+`,
+      (directory) => {
+        expect(findProjectDependencyTargets(directory, "marimo>=0.20")).toEqual(
+          [
+            { kind: "production" },
+            { kind: "optional", name: "notebooks" },
+            { kind: "group", name: "dev" },
+            { kind: "group", name: "docs" },
+          ],
+        );
+      },
+    );
+  });
+
+  it("finds a direct dependency in a nested group, not its includer", () => {
+    withProject(
+      `
+[project]
+dependencies = []
+
+[dependency-groups]
+dev = [{ include-group = "notebooks" }]
+notebooks = ["marimo>=0.10"]
+`,
+      (directory) => {
+        expect(findProjectDependencyTargets(directory, "marimo")).toEqual([
+          { kind: "group", name: "notebooks" },
+        ]);
+      },
+    );
+  });
+
+  it("maps legacy uv dev dependencies to the dev group", () => {
+    withProject(
+      `
+[project]
+dependencies = []
+
+[tool.uv]
+dev-dependencies = ["marimo>=0.10"]
+`,
+      (directory) => {
+        expect(findProjectDependencyTargets(directory, "marimo")).toEqual([
+          { kind: "group", name: "dev" },
+        ]);
+      },
+    );
+  });
+
+  it("does not duplicate dev when legacy and standard declarations coexist", () => {
+    withProject(
+      `
+[project]
+dependencies = []
+
+[dependency-groups]
+dev = ["marimo>=0.10"]
+
+[tool.uv]
+dev-dependencies = ["marimo>=0.10"]
+`,
+      (directory) => {
+        expect(findProjectDependencyTargets(directory, "marimo")).toEqual([
+          { kind: "group", name: "dev" },
+        ]);
+      },
+    );
+  });
+
+  it("normalizes distribution names", () => {
+    withProject(
+      `
+[project]
+dependencies = []
+
+[dependency-groups]
+dev = ["My.Package_Name>=1"]
+`,
+      (directory) => {
+        expect(
+          findProjectDependencyTargets(directory, "my-package-name>=2"),
+        ).toEqual([{ kind: "group", name: "dev" }]);
+      },
+    );
+  });
+
+  it("searches parent directories from the virtual environment", () => {
+    withProject(
+      `
+[project]
+dependencies = []
+
+[dependency-groups]
+test = ["marimo"]
+`,
+      (directory) => {
+        const venv = NodePath.join(directory, ".venv", "nested");
+        NodeFs.mkdirSync(venv, { recursive: true });
+        expect(findProjectDependencyTargets(venv, "marimo")).toEqual([
+          { kind: "group", name: "test" },
+        ]);
+      },
+    );
+  });
+
+  it("returns no targets without a pyproject or direct declaration", () => {
+    using tmp = NodeFs.mkdtempDisposableSync(
+      NodePath.join(NodeOs.tmpdir(), "marimo-project-target-"),
+    );
+    expect(findProjectDependencyTargets(tmp.path, "marimo")).toEqual([]);
+  });
+
+  it("rejects malformed TOML", () => {
+    withProject("[project\ndependencies = []", (directory) => {
+      expect(() => findProjectDependencyTargets(directory, "marimo")).toThrow();
+    });
+  });
+});

--- a/extension/src/python/__tests__/Uv.test.ts
+++ b/extension/src/python/__tests__/Uv.test.ts
@@ -10,6 +10,7 @@ import { Effect, Either, Layer, Option } from "effect";
 import { TestTelemetryLive } from "../../__mocks__/TestTelemetry.ts";
 import { TestVsCode } from "../../__mocks__/TestVsCode.ts";
 import { Uv } from "../../python/Uv.ts";
+import { ProjectDependencyTarget } from "../ProjectDependencyTarget.ts";
 
 const python = "3.13";
 const timeout = 30_000;
@@ -80,7 +81,7 @@ describe("Uv", () => {
         yield* uv.addProject({
           directory: tmpdir.path,
           packages: ["httpx"],
-          target: { kind: "group", name: "notebooks" },
+          target: ProjectDependencyTarget.Group({ name: "notebooks" }),
         });
 
         const pyproject = NodeFs.readFileSync(
@@ -106,7 +107,7 @@ describe("Uv", () => {
         yield* uv.addProject({
           directory: tmpdir.path,
           packages: ["typing-extensions"],
-          target: { kind: "optional", name: "notebooks" },
+          target: ProjectDependencyTarget.Optional({ name: "notebooks" }),
         });
 
         const pyproject = NodeFs.readFileSync(

--- a/extension/src/python/__tests__/Uv.test.ts
+++ b/extension/src/python/__tests__/Uv.test.ts
@@ -71,6 +71,58 @@ describe("Uv", () => {
 
   it.layer(Layer.fresh(UvLive))((it) => {
     it.scoped(
+      "should preserve custom dependency-group placement with `uv add`",
+      Effect.fn(function* () {
+        const uv = yield* Uv;
+        const tmpdir = yield* TmpDir;
+        yield* uv.init(tmpdir.path, { python });
+
+        yield* uv.addProject({
+          directory: tmpdir.path,
+          packages: ["httpx"],
+          target: { kind: "group", name: "notebooks" },
+        });
+
+        const pyproject = NodeFs.readFileSync(
+          NodePath.join(tmpdir.path, "pyproject.toml"),
+          "utf8",
+        );
+        expect(pyproject).toContain("[dependency-groups]");
+        expect(pyproject).toMatch(/notebooks = \[\s*"httpx/);
+        expect(pyproject).not.toMatch(/dependencies = \[\s*"httpx/);
+      }),
+      { timeout },
+    );
+  });
+
+  it.layer(Layer.fresh(UvLive))((it) => {
+    it.scoped(
+      "should preserve optional-dependency placement with `uv add`",
+      Effect.fn(function* () {
+        const uv = yield* Uv;
+        const tmpdir = yield* TmpDir;
+        yield* uv.init(tmpdir.path, { python });
+
+        yield* uv.addProject({
+          directory: tmpdir.path,
+          packages: ["typing-extensions"],
+          target: { kind: "optional", name: "notebooks" },
+        });
+
+        const pyproject = NodeFs.readFileSync(
+          NodePath.join(tmpdir.path, "pyproject.toml"),
+          "utf8",
+        );
+        expect(pyproject).toContain("[project.optional-dependencies]");
+        expect(pyproject).toMatch(/notebooks = \[\s*"typing-extensions/);
+        expect(pyproject).not.toMatch(/dependencies = \[\s*"typing-extensions/);
+      }),
+      { timeout },
+    );
+  });
+
+  it.layer(Layer.fresh(UvLive))((it) => {
+    it.scoped(
       "should `uv pip install` into venv",
       Effect.fn(function* () {
         const uv = yield* Uv;


### PR DESCRIPTION
Plain `uv add` targets `project.dependencies` even when the package is already declared in a development group or optional extra. Inspect the existing declaration and pass uv's matching selector, prompting only when multiple declarations make the user's intent ambiguous.

Closes #548 