### PR TITLE
Own extension runtime through deactivation

### DIFF
--- a/extension/src/__tests__/extension.test.ts
+++ b/extension/src/__tests__/extension.test.ts
@@ -13,7 +13,7 @@ import disableCell from "../commands/disableCell.ts";
 import hideCellCode from "../commands/hideCellCode.ts";
 import showCellCode from "../commands/showCellCode.ts";
 import { NOTEBOOK_TYPE } from "../constants.ts";
-import { makeActivate } from "../features/Main.ts";
+import { makeExtension } from "../features/Main.ts";
 import { SANDBOX_CONTROLLER_ID } from "../ids.ts";
 import { makeTestMarimoClient } from "./__utils__/TestMarimoClient.ts";
 
@@ -28,24 +28,22 @@ const withTestCtx = Effect.fn(function* () {
     Layer.provideMerge(TestTelemetryLive),
   );
   return {
-    layer,
     vscode,
-    activate: makeActivate(layer, LogLevel.Error),
+    extension: makeExtension(layer, LogLevel.Error),
   };
 });
 
 describe("extension.activate", () => {
   it.scoped(
-    "should return a disposable",
+    "should return the public API",
     Effect.fn(function* () {
-      const { activate } = yield* withTestCtx();
+      const { extension } = yield* withTestCtx();
 
       const context = yield* getTestExtensionContext();
-      const disposable = yield* Effect.promise(() => activate(context));
+      const api = yield* Effect.promise(() => extension.activate(context));
 
-      expect(disposable).toMatchInlineSnapshot(`
+      expect(api).toMatchInlineSnapshot(`
         {
-          "dispose": [Function],
           "experimental": {
             "kernels": {
               "getKernel": [Function],
@@ -53,6 +51,7 @@ describe("extension.activate", () => {
           },
         }
       `);
+      yield* Effect.promise(() => extension.deactivate());
       // Full activation builds the entire layer graph; the default 5s
       // timeout flakes under parallel-worker load.
     }),
@@ -60,13 +59,13 @@ describe("extension.activate", () => {
   );
 
   it.scoped(
-    "should register contributions on activation",
+    "should own contributions until deactivation",
     Effect.fn(function* () {
-      const { vscode, activate } = yield* withTestCtx();
+      const { vscode, extension } = yield* withTestCtx();
 
       // activate the extension
       const context = yield* getTestExtensionContext();
-      yield* Effect.promise(() => activate(context));
+      yield* Effect.promise(() => extension.activate(context));
 
       const snapshot = yield* vscode.snapshot();
 
@@ -86,6 +85,14 @@ describe("extension.activate", () => {
 
       assert.strictEqual(pkg.contributes.notebooks.length, 1);
       assert.strictEqual(pkg.contributes.notebooks[0].type, NOTEBOOK_TYPE);
+
+      yield* Effect.promise(() => extension.deactivate());
+      expect(yield* vscode.snapshot()).toEqual({
+        views: [],
+        commands: [],
+        serializers: [],
+        controllers: [],
+      });
     }),
     20_000,
   );

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -1,7 +1,7 @@
 import { Layer, LogLevel } from "effect";
 
 import { LoggerLive } from "./features/Logger.ts";
-import { makeActivate } from "./features/Main.ts";
+import { makeExtension } from "./features/Main.ts";
 import { MarimoClient } from "./lsp/MarimoClient.ts";
 import { RuffLanguageServer } from "./lsp/RuffLanguageServer.ts";
 import { TyLanguageServer } from "./lsp/TyLanguageServer.ts";
@@ -10,7 +10,7 @@ import { VsCode } from "./platform/VsCode.ts";
 import { PythonExtension } from "./python/PythonExtension.ts";
 import { Telemetry } from "./telemetry/Telemetry.ts";
 
-export const activate = makeActivate(
+export const { activate, deactivate } = makeExtension(
   Layer.empty.pipe(
     Layer.provideMerge(TyLanguageServer.Default),
     Layer.provideMerge(RuffLanguageServer.Default),
@@ -25,8 +25,3 @@ export const activate = makeActivate(
   ),
   LogLevel.All,
 );
-
-export async function deactivate() {
-  // No-op: VSCode will call `dispose()` on the returned `Disposable`
-  // from `activate()`, which closes the scope and releases all resources.
-}

--- a/extension/src/features/Main.ts
+++ b/extension/src/features/Main.ts
@@ -1,14 +1,4 @@
-import {
-  Context,
-  Effect,
-  Exit,
-  Layer,
-  Logger,
-  type LogLevel,
-  pipe,
-  Runtime,
-  Scope,
-} from "effect";
+import { Layer, Logger, type LogLevel, ManagedRuntime } from "effect";
 import type * as vscode from "vscode";
 
 import { Config } from "../config/Config.ts";
@@ -116,7 +106,7 @@ const MainLive = Layer.empty
     Layer.provide(NotebookRuntime.Default),
   );
 
-export function makeActivate(
+export function makeExtension(
   layer: Layer.Layer<
     | MarimoClient
     | VsCode
@@ -128,35 +118,43 @@ export function makeActivate(
     ExtensionContext
   >,
   minimumLogLevel: LogLevel.LogLevel,
-): (
-  context: Pick<
-    vscode.ExtensionContext,
-    "workspaceState" | "globalState" | "extensionUri" | "globalStorageUri"
-  >,
-) => Promise<vscode.Disposable & MarimoApi> {
-  return (context) =>
-    pipe(
-      Effect.gen(function* () {
-        const runPromise = Runtime.runPromise(yield* Effect.runtime());
-        // Create a scope and build layers with it. Layer.buildWithScope completes
-        // once all layer initialization finishes (commands registered, serializer
-        // registered, notification streams set up). The LSP client will start lazily
-        // on first use. Resources are kept alive by extending their lifetime to the
-        // manually-managed scope, and are only released when we explicitly close the
-        // scope on deactivation.
-        const scope = yield* Scope.make();
-        const ctx = yield* Layer.buildWithScope(
-          Layer.provide(MainLive, layer),
-          scope,
-        );
-        const api = Context.get(ctx, Api);
-        return {
-          experimental: api.experimental,
-          dispose: () => runPromise(Scope.close(scope, Exit.void)),
-        };
-      }),
-      Effect.provideService(ExtensionContext, context),
-      Logger.withMinimumLogLevel(minimumLogLevel),
-      Effect.runPromise,
-    );
+): {
+  readonly activate: (
+    context: Pick<
+      vscode.ExtensionContext,
+      "workspaceState" | "globalState" | "extensionUri" | "globalStorageUri"
+    >,
+  ) => Promise<MarimoApi>;
+  readonly deactivate: () => Promise<void>;
+} {
+  let closeActive: (() => Promise<void>) | undefined;
+
+  return {
+    async activate(context): Promise<MarimoApi> {
+      if (closeActive !== undefined) {
+        throw new Error("Extension is already active");
+      }
+
+      const appLayer = Layer.provide(
+        Layer.provide(MainLive, layer),
+        Layer.succeed(ExtensionContext, context),
+      ).pipe(Layer.merge(Logger.minimumLogLevel(minimumLogLevel)));
+      const runtime = ManagedRuntime.make(appLayer);
+      closeActive = runtime.dispose;
+
+      try {
+        const api = await runtime.runPromise(Api);
+        return { experimental: api.experimental };
+      } catch (error) {
+        closeActive = undefined;
+        await runtime.dispose();
+        throw error;
+      }
+    },
+    async deactivate(): Promise<void> {
+      const close = closeActive;
+      closeActive = undefined;
+      await close?.();
+    },
+  };
 }


### PR DESCRIPTION
VS Code treats the value returned by `activate()` as the extension public API, so the previous disposable was never invoked and scoped language-client finalizers could be skipped during reload.

Keep `ManagedRuntime` private behind one activate/deactivate lifecycle. The live and test Layers share that interface, while `deactivate()` is the sole awaited owner of cleanup.