### PR TITLE
Give the WASM kernel valid standard handles on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,15 +198,18 @@ jobs:
           uv run ruff check
 
   python-test:
-    name: Python / Test
-    runs-on: ubuntu-latest
+    name: Python / Test / ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
       - run: uv run pytest --cov --cov-report=term --cov-report=xml:coverage.xml --cov-report=json:coverage.json
 
       - name: Upload Python coverage
-        if: always()
+        if: always() && matrix.os == 'ubuntu-latest'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: python-coverage

--- a/extension/resources/wasm/kernel.py
+++ b/extension/resources/wasm/kernel.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import atexit
 import contextlib
+import os
 import sys
 import threading
 from pathlib import Path
@@ -43,6 +44,42 @@ if TYPE_CHECKING:
 
 _write_lock = threading.Lock()
 _decoder = msgspec.json.Decoder(ToBridge)
+
+
+def _bind_std_handles_to_nul() -> None:
+    """Point this process's Win32 standard handles at the NUL device.
+
+    ``multiprocessing`` spawns children on Windows with ``bInheritHandles=FALSE``
+    and no ``STARTUPINFO``, so the kernel process inherits this bridge's
+    standard handle *values* without the handles themselves. Those dangling
+    numbers end up aliasing whatever unrelated objects reuse them inside the
+    kernel — multiprocessing pipes among them. ``subprocess`` forwards
+    ``GetStdHandle(...)`` results to every child it launches, so a notebook
+    cell's ``subprocess.run(...)`` hands its child an aliased pipe as stdin and
+    the child hangs at startup behind that pipe's pending reads until the next
+    control message happens to complete them (marimo-lsp#734). Rebinding the
+    slots to NUL gives cell subprocesses real, inert handles; streams a cell
+    doesn't redirect land in NUL, matching a windowless host.
+    """
+    import ctypes  # noqa: PLC0415 - Windows-only, in the hook that needs it.
+    import msvcrt  # noqa: PLC0415
+
+    kernel32 = ctypes.windll.kernel32
+    for slot, flags in (
+        (-10, os.O_RDONLY),  # STD_INPUT_HANDLE
+        (-11, os.O_WRONLY),  # STD_OUTPUT_HANDLE
+        (-12, os.O_WRONLY),  # STD_ERROR_HANDLE
+    ):
+        # Deliberately left open for the life of the process.
+        fd = os.open(os.devnull, flags)
+        if not kernel32.SetStdHandle(slot, msvcrt.get_osfhandle(fd)):
+            raise ctypes.WinError()
+
+
+# multiprocessing re-imports this script in every spawned child before running
+# its target, which is the only hook we get into the kernel process itself.
+if sys.platform == "win32" and __name__ == "__mp_main__":
+    _bind_std_handles_to_nul()
 
 
 class _StaticConfigManager(MarimoConfigReader):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import TYPE_CHECKING, cast
 from unittest.mock import MagicMock, patch
 
@@ -336,13 +337,16 @@ async def test_update_configuration_returns_saved_config() -> None:
 
 
 @pytest.mark.asyncio
-async def test_update_configuration_returns_effective_config_without_session() -> None:
+async def test_update_configuration_returns_effective_config_without_session(
+    tmp_path: Path,
+) -> None:
     sessions = MagicMock()
     sessions.get.return_value = None
     manager = MagicMock()
     manager.save_config.return_value = MagicMock(name="saved_user_config")
     manager.get_config.return_value = DEFAULT_CONFIG
     partial_config: dict[str, object] = {"runtime": {"on_cell_change": "lazy"}}
+    notebook_path = tmp_path / "notebook.py"
 
     with patch(
         "marimo_lsp.api.get_default_config_manager", return_value=manager
@@ -350,23 +354,25 @@ async def test_update_configuration_returns_effective_config_without_session() -
         result = await update_configuration(
             _context(sessions),
             NotebookCommand(
-                notebook_uri="file:///notebook.py",
+                notebook_uri=notebook_path.as_uri(),
                 inner=UpdateConfigurationRequest(config=partial_config),
             ),
         )
 
-    get_manager.assert_called_once_with(current_path="/notebook.py")
+    get_manager.assert_called_once()
+    assert Path(get_manager.call_args.kwargs["current_path"]) == notebook_path
     manager.save_config.assert_called_once_with(partial_config)
     manager.get_config.assert_called_once_with()
     assert result == DEFAULT_CONFIG
 
 
 @pytest.mark.asyncio
-async def test_get_configuration_loads_without_session() -> None:
+async def test_get_configuration_loads_without_session(tmp_path: Path) -> None:
     sessions = MagicMock()
     sessions.get.return_value = None
     manager = MagicMock()
     manager.get_config.return_value = DEFAULT_CONFIG
+    notebook_path = tmp_path / "notebook.py"
 
     with patch(
         "marimo_lsp.api.get_default_config_manager", return_value=manager
@@ -374,12 +380,13 @@ async def test_get_configuration_loads_without_session() -> None:
         result = await get_configuration(
             _context(sessions),
             NotebookCommand(
-                notebook_uri="file:///notebook.py",
+                notebook_uri=notebook_path.as_uri(),
                 inner=GetConfigurationRequest(),
             ),
         )
 
-    get_manager.assert_called_once_with(current_path="/notebook.py")
+    get_manager.assert_called_once()
+    assert Path(get_manager.call_args.kwargs["current_path"]) == notebook_path
     manager.get_config.assert_called_once_with()
     assert result.config == DEFAULT_CONFIG
 

--- a/tests/test_process_cleanup.py
+++ b/tests/test_process_cleanup.py
@@ -7,7 +7,6 @@ Verifies the kernel `Process` terminates subprocesses (including force-kill).
 
 from __future__ import annotations
 
-import os
 import subprocess
 import sys
 import time
@@ -16,16 +15,6 @@ import typing
 import pytest
 
 from marimo_lsp.kernels.manager import Process
-
-
-def process_exists(pid: int) -> bool:
-    """Check if a process with the given PID exists."""
-    try:
-        os.kill(pid, 0)
-    except OSError:
-        return False
-
-    return True
 
 
 @pytest.fixture
@@ -80,16 +69,13 @@ def test_popen_terminate_graceful(
 ) -> None:
     """Test that terminate() gracefully stops a process."""
     wrapper = Process(long_running_process)
-    pid = wrapper.pid
 
-    assert pid is not None
+    assert wrapper.pid is not None
     assert wrapper.is_alive()
-    assert process_exists(pid)
 
     wrapper.terminate()
 
     assert not wrapper.is_alive()
-    assert not process_exists(pid)
 
 
 def test_popen_terminate_already_dead() -> None:
@@ -119,11 +105,9 @@ def test_popen_terminate_force_kill(
     wrapper = Process(stubborn_process)
     wrapper.TERMINATE_TIMEOUT = 0.5  # Shorter timeout for testing
 
-    pid = wrapper.pid
-    assert pid is not None
+    assert wrapper.pid is not None
     assert wrapper.is_alive()
 
     wrapper.terminate()
 
     assert not wrapper.is_alive()
-    assert not process_exists(pid)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -70,26 +70,36 @@ def replace_generated_with(src: str) -> str:
     )
 
 
-@pytest_lsp.fixture(
-    config=ClientServerConfig(server_command=["marimo-lsp"]), scope="module"
-)
-async def lsp_process(lsp_client: LanguageClient):  # noqa: ANN201
-    """Start one initialized LSP process for this module."""
-    response = await lsp_client.initialize_session(
-        lsp.InitializeParams(
-            root_uri="file:///test/workspace",
-            capabilities=lsp.ClientCapabilities(
-                notebook_document=lsp.NotebookDocumentClientCapabilities(
-                    synchronization=lsp.NotebookDocumentSyncClientCapabilities()
-                )
-            ),
+if sys.platform == "win32":
+
+    @pytest.fixture(scope="module")
+    def lsp_process() -> None:
+        pytest.skip(
+            "pytest-lsp cannot start subprocesses with marimo's Windows selector event loop"
         )
+
+else:
+
+    @pytest_lsp.fixture(
+        config=ClientServerConfig(server_command=["marimo-lsp"]), scope="module"
     )
-    assert response is not None
+    async def lsp_process(lsp_client: LanguageClient):  # noqa: ANN201
+        """Start one initialized LSP process for this module."""
+        response = await lsp_client.initialize_session(
+            lsp.InitializeParams(
+                root_uri="file:///test/workspace",
+                capabilities=lsp.ClientCapabilities(
+                    notebook_document=lsp.NotebookDocumentClientCapabilities(
+                        synchronization=lsp.NotebookDocumentSyncClientCapabilities()
+                    )
+                ),
+            )
+        )
+        assert response is not None
 
-    yield lsp_client
+        yield lsp_client
 
-    await lsp_client.shutdown_session()
+        await lsp_client.shutdown_session()
 
 
 @pytest_asyncio.fixture(loop_scope="module")

--- a/tests/test_wasm_bridge.py
+++ b/tests/test_wasm_bridge.py
@@ -9,6 +9,7 @@ import logging
 import queue
 import subprocess
 import sys
+import tempfile
 import threading
 import time
 from pathlib import Path
@@ -120,12 +121,13 @@ class _BridgeProcess:
     """Drive the real kernel bridge over framed stdio, as the extension does."""
 
     def __init__(self, working_directory: Path) -> None:
+        self._stderr = tempfile.TemporaryFile()  # noqa: SIM115 - closed in close().
         self.child = subprocess.Popen(  # noqa: S603
             [sys.executable, str(BRIDGE_SCRIPT)],
             cwd=str(working_directory),
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            stderr=self._stderr,
         )
         assert self.child.stdin is not None
         assert self.child.stdout is not None
@@ -147,6 +149,13 @@ class _BridgeProcess:
             for message in decoder.feed(chunk):
                 self.frames.put(message)
 
+    def _failure_details(self, received: list[FromBridge]) -> str:
+        self._stderr.seek(0)
+        stderr = self._stderr.read().decode(errors="replace")
+        if stderr:
+            return f"received: {received}; bridge stderr:\n{stderr}"
+        return f"received: {received}; bridge stderr was empty"
+
     def send(self, message: Start | Control) -> None:
         assert self.child.stdin is not None
         self.child.stdin.write(encode(message))
@@ -164,14 +173,15 @@ class _BridgeProcess:
             remaining = deadline - time.monotonic()
             if remaining <= 0:
                 pytest.fail(
-                    f"No matching frame within {timeout}s; received: {received}"
+                    f"No matching frame within {timeout}s; "
+                    f"{self._failure_details(received)}"
                 )
             try:
                 message = self.frames.get(timeout=remaining)
             except queue.Empty:
                 continue
             if message is None:
-                pytest.fail(f"Bridge closed stdout; received: {received}")
+                pytest.fail(f"Bridge closed stdout; {self._failure_details(received)}")
             received.append(message)
             if predicate(message):
                 return received
@@ -184,6 +194,7 @@ class _BridgeProcess:
         except subprocess.TimeoutExpired:
             self.child.kill()
             self.child.wait()
+        self._stderr.close()
 
 
 def _start_frame(working_directory: Path) -> Start:

--- a/tests/test_wasm_bridge.py
+++ b/tests/test_wasm_bridge.py
@@ -3,15 +3,43 @@
 from __future__ import annotations
 
 import importlib.util
+import io
+import json
+import logging
+import queue
+import subprocess
+import sys
+import threading
+import time
 from pathlib import Path
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
 from unittest.mock import ANY, Mock
 
 import pytest
+from marimo._ast.app_config import _AppConfig
+from marimo._config.config import DEFAULT_CONFIG
+from marimo._runtime.commands import AppMetadata, ExecuteCellsCommand
+from marimo._types.ids import CellId_t
+
+from marimo_lsp.wasm.protocol import (
+    Control,
+    Decoder,
+    FromBridge,
+    KernelLaunchArgs,
+    Operation,
+    Ready,
+    Start,
+    encode,
+)
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from types import ModuleType
+
+BRIDGE_SCRIPT = (
+    Path(__file__).parents[1] / "extension" / "resources" / "wasm" / "kernel.py"
+)
 
 
 def _load_bridge_module(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
@@ -86,6 +114,162 @@ def test_bridge_uses_normal_edit_mode_multiprocessing_manager(
     assert config_manager.get_config() is args.user_config
     manager.start_kernel.assert_called_once_with()
     write_frame.assert_any_call(bridge_module.Ready())
+
+
+class _BridgeProcess:
+    """Drive the real kernel bridge over framed stdio, as the extension does."""
+
+    def __init__(self, working_directory: Path) -> None:
+        self.child = subprocess.Popen(  # noqa: S603
+            [sys.executable, str(BRIDGE_SCRIPT)],
+            cwd=str(working_directory),
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        assert self.child.stdin is not None
+        assert self.child.stdout is not None
+        self.frames: queue.Queue[FromBridge | None] = queue.Queue()
+        threading.Thread(target=self._read_frames, daemon=True).start()
+
+    def _read_frames(self) -> None:
+        stdout = self.child.stdout
+        # Popen with binary stdout=PIPE hands back a BufferedReader, whose
+        # read1 returns whatever bytes are available instead of blocking for
+        # a full buffer.
+        assert isinstance(stdout, io.BufferedReader)
+        decoder = Decoder(FromBridge)
+        while True:
+            chunk = stdout.read1(65536)
+            if not chunk:
+                self.frames.put(None)
+                return
+            for message in decoder.feed(chunk):
+                self.frames.put(message)
+
+    def send(self, message: Start | Control) -> None:
+        assert self.child.stdin is not None
+        self.child.stdin.write(encode(message))
+        self.child.stdin.flush()
+
+    def wait_for(
+        self,
+        predicate: Callable[[FromBridge], bool],
+        timeout: float,
+    ) -> list[FromBridge]:
+        """Collect frames until one matches; fail with what arrived so far."""
+        received: list[FromBridge] = []
+        deadline = time.monotonic() + timeout
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                pytest.fail(
+                    f"No matching frame within {timeout}s; received: {received}"
+                )
+            try:
+                message = self.frames.get(timeout=remaining)
+            except queue.Empty:
+                continue
+            if message is None:
+                pytest.fail(f"Bridge closed stdout; received: {received}")
+            received.append(message)
+            if predicate(message):
+                return received
+
+    def close(self) -> None:
+        if self.child.stdin is not None and not self.child.stdin.closed:
+            self.child.stdin.close()
+        try:
+            self.child.wait(timeout=15)
+        except subprocess.TimeoutExpired:
+            self.child.kill()
+            self.child.wait()
+
+
+def _start_frame(working_directory: Path) -> Start:
+    return Start(
+        working_directory=str(working_directory),
+        kernel_args=KernelLaunchArgs(
+            configs={},
+            app_metadata=AppMetadata(
+                query_params={},
+                filename=str(working_directory / "notebook.py"),
+                cli_args={},
+                argv=None,
+                app_config=_AppConfig(),
+            ),
+            user_config=DEFAULT_CONFIG,
+            log_level=logging.WARNING,
+            profile_path=None,
+        ),
+    )
+
+
+def _operation(message: FromBridge) -> dict[str, object] | None:
+    if not isinstance(message, Operation):
+        return None
+    decoded = json.loads(bytes(message.message))
+    assert isinstance(decoded, dict)
+    return decoded
+
+
+def _is_completed_run(message: FromBridge) -> bool:
+    operation = _operation(message)
+    return operation is not None and operation.get("op") == "completed-run"
+
+
+def _console_text(received: list[FromBridge]) -> str:
+    """Concatenate the console output carried by cell-op operations."""
+    chunks: list[str] = []
+    for message in received:
+        operation = _operation(message)
+        if operation is None:
+            continue
+        console = operation.get("console")
+        if not isinstance(console, dict):
+            continue
+        data = console.get("data")
+        if isinstance(data, str):
+            chunks.append(data)
+    return "".join(chunks)
+
+
+def test_cell_running_subprocess_completes_without_further_messages(
+    tmp_path: Path,
+) -> None:
+    """After one execute request and no other messages, completed-run arrives.
+
+    Regression test for marimo-lsp#734: on Windows the kernel process handed
+    cell subprocesses dangling standard handles, so a cell calling
+    ``subprocess.run(...)`` stalled until the *next* control message happened
+    to arrive (the reporter's workaround was running ``print(123)`` in another
+    cell). The client here goes silent after the execute request, so the run
+    can only complete if cell subprocesses no longer depend on that stimulus.
+    """
+    bridge = _BridgeProcess(tmp_path)
+    try:
+        bridge.send(_start_frame(tmp_path))
+        bridge.wait_for(lambda m: isinstance(m, Ready), timeout=90)
+
+        code = (
+            "import subprocess, sys\n"
+            "completed = subprocess.run(\n"
+            "    [sys.executable, '-c', 'print(\"sub-ok\")'],\n"
+            "    capture_output=True,\n"
+            "    check=True,\n"
+            ")\n"
+            "print('cell finished', completed.stdout.decode().strip())"
+        )
+        bridge.send(
+            Control(
+                request=ExecuteCellsCommand(cell_ids=[CellId_t("c1")], codes=[code])
+            )
+        )
+        received = bridge.wait_for(_is_completed_run, timeout=60)
+
+        assert "cell finished sub-ok" in _console_text(received)
+    finally:
+        bridge.close()
 
 
 def test_bridge_rejects_oversized_frame_before_reading_payload(


### PR DESCRIPTION
A cell calling `subprocess.run(...)` under the WASM language server stalled on Windows until the next control message arrived.

multiprocessing spawns the kernel with no handle inheritance and no startup handles.

```py
hp, ht, pid, tid = _winapi.CreateProcess(
    python_exe, cmd,
    None, None, False, ...)  # bInheritHandles=FALSE
```

Lack of interitance leaves the kernel's standard handle slots holding dangling values that alias unrelated kernel objects. `subprocess` forwards them to every cell subprocess, which then hangs at startup behind an aliased pipe's pending reads. 

These changes rebind the slots to `NUL` handles the kernel owns. `NUL` does not block and discard writes. The rebinding runs in the child re-import of this script, before marimo starts.

Closes #734.