### PR TITLE
Make the WASM language server the default

### DIFF
--- a/extension/README.md
+++ b/extension/README.md
@@ -45,8 +45,8 @@ icon in the editor title bar to open it as a notebook (see image above).
 
 | Setting                                 | Type      | Default          | Description                                                                                                                                                                                         |
 | --------------------------------------- | --------- | ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `marimo.lsp.path`                       | `array`   | `[]`             | Path to a custom `marimo-lsp` executable, e.g., `["/path/to/marimo-lsp"]`. Leave empty to use the uv-based server, or enable `marimo.experimental.wasmLsp` to use the bundled WASM server.          |
-| `marimo.experimental.wasmLsp`           | `boolean` | `false`          | Experimental: run the bundled marimo language server in Pyodide instead of provisioning a Python environment.                                                                                       |
+| `marimo.lsp.server`                     | `string`  | `wasm`           | Language-server runtime: bundled `wasm`, uv-managed `python`, or `custom`. This does not change the interpreter used by notebook kernels.                                                           |
+| `marimo.lsp.path`                       | `array`   | `[]`             | Command and arguments used when `marimo.lsp.server` is `custom`, e.g., `["/path/to/marimo-lsp"]`.                                                                                                   |
 | `marimo.uv.path`                        | `string`  |                  | Path to the `uv` binary, e.g., `/Users/me/.local/bin/uv`. Leave empty to use `uv` from the system PATH.                                                                                             |
 | `marimo.ruff.path`                      | `string`  |                  | Path to a custom `ruff` binary, e.g., `/usr/local/bin/ruff`. Useful for offline environments. Leave empty to auto-discover or install via uv.                                                       |
 | `marimo.ty.path`                        | `string`  |                  | Path to a custom `ty` binary, e.g., `/usr/local/bin/ty`. Useful for offline environments. Leave empty to auto-discover or install via uv.                                                           |
@@ -55,10 +55,13 @@ icon in the editor title bar to open it as a notebook (see image above).
 | `marimo.telemetry`                      | `boolean` | `true`           | Anonymous usage data. This helps us prioritize features for the marimo VSCode extension.                                                                                                            |
 | `marimo.notebookFileRoot`               | `string`  | `${fileDirname}` | Initial working directory for locally launched kernels. Supports the notebook directory, workspace folder, home-relative, absolute, and workspace-relative paths. Requires a kernel restart.        |
 
-The experimental WASM language server loads entirely from artifacts bundled
-with the extension and does not download Python packages at runtime. Notebook
-kernels still run in the selected Python environment: opening and executing a
-notebook launches that interpreter and runs the notebook's code locally.
+By default, the WASM language server loads entirely from artifacts bundled with
+the extension and does not download Python packages at runtime. Set
+`marimo.lsp.server` to `python` to use the bundled server through a uv-managed
+CPython environment, or to `custom` with `marimo.lsp.path` to run another
+command. Notebook kernels still run in the selected Python environment: opening
+and executing a notebook launches that interpreter and runs the notebook's code
+locally.
 
 `marimo.notebookFileRoot` controls process-relative behavior such as `Path.cwd()`, file access, and subprocesses. For paths that must remain portable across VS Code, CLI execution, exports, and deployment, prefer `mo.notebook_dir()`.
 

--- a/extension/package.json
+++ b/extension/package.json
@@ -78,19 +78,36 @@
     "configuration": {
       "title": "Marimo",
       "properties": {
+        "marimo.lsp.server": {
+          "type": "string",
+          "default": "wasm",
+          "enum": [
+            "wasm",
+            "python",
+            "custom"
+          ],
+          "markdownEnumDescriptions": [
+            "Default. Run the self-contained language server using the bundled Pyodide runtime.",
+            "Run the bundled Python language server in a uv-managed CPython environment.",
+            "Run the command configured by `marimo.lsp.path`."
+          ],
+          "markdownDescription": "Select how the extension runs the marimo language server. This does not change the Python interpreter used by notebook kernels.",
+          "scope": "window"
+        },
         "marimo.lsp.path": {
           "type": "array",
           "items": {
             "type": "string"
           },
           "default": [],
-          "markdownDescription": "Path to a custom `marimo-lsp` executable, e.g., `[\"/path/to/marimo-lsp\"]`. Leave empty to use the uv-based server, or enable `marimo.experimental.wasmLsp` to use the bundled WASM server.",
-          "scope": "resource"
+          "markdownDescription": "Command and arguments used when `marimo.lsp.server` is `custom`, e.g., `[\"/path/to/marimo-lsp\"]`.",
+          "scope": "window"
         },
         "marimo.experimental.wasmLsp": {
           "type": "boolean",
-          "default": false,
-          "markdownDescription": "Experimental: run the bundled marimo language server in Pyodide instead of provisioning a Python environment.",
+          "markdownDescription": "Deprecated setting retained so existing configurations receive migration guidance. It no longer affects which language server runs.",
+          "markdownDeprecationMessage": "**Deprecated:** This setting no longer has any effect. Use `#marimo.lsp.server#` instead; select `python` to keep the previous native server.",
+          "deprecationMessage": "Deprecated: This setting no longer has any effect. Use marimo.lsp.server instead; select python to keep the previous native server.",
           "scope": "window"
         },
         "marimo.uv.path": {

--- a/extension/src/__mocks__/TestMarimoClient.ts
+++ b/extension/src/__mocks__/TestMarimoClient.ts
@@ -3,6 +3,7 @@ import * as NodeChildProcess from "node:child_process";
 import { Effect, Layer, Redacted, Stream } from "effect";
 import * as rpc from "vscode-jsonrpc/node";
 
+import { MarimoLspServer } from "../config/Config.ts";
 import { acquireDisposable } from "../lib/acquireDisposable.ts";
 import {
   findMarimoLspExecutable,
@@ -48,7 +49,7 @@ export const TestMarimoClientProcess = Layer.scoped(
         }),
     );
     return MarimoClient.make({
-      mode: "uv",
+      server: MarimoLspServer.Python(),
       channel: {
         name: "marimo-lsp",
         show() {},

--- a/extension/src/__tests__/__utils__/TestMarimoClient.ts
+++ b/extension/src/__tests__/__utils__/TestMarimoClient.ts
@@ -7,6 +7,7 @@ import {
   Stream,
 } from "effect";
 
+import { MarimoLspServer } from "../../config/Config.ts";
 import {
   type NotebookController,
   type NotebookControllerSelection,
@@ -118,7 +119,7 @@ export function makeTestNotebookRuntime(options: Options = {}) {
 
 function makeTestMarimoClientValue(options: Options) {
   return MarimoClient.make({
-    mode: "uv",
+    server: MarimoLspServer.Python(),
     channel: { name: "marimo-lsp-test", show() {} },
     restart: () => Effect.void,
     ...makeMarimoCommands({

--- a/extension/src/commands/__tests__/showNotebookMenu.test.ts
+++ b/extension/src/commands/__tests__/showNotebookMenu.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "@effect/vitest";
 import { Effect, Layer, Option, Ref, Stream } from "effect";
 
 import { TestVsCode } from "../../__mocks__/TestVsCode.ts";
+import { MarimoLspServer } from "../../config/Config.ts";
 import { MarimoConfigurationService } from "../../config/MarimoConfigurationService.ts";
 import { NOTEBOOK_TYPE } from "../../constants.ts";
 import { marimoConfigFixture } from "../../lib/__tests__/branded.ts";
@@ -46,7 +47,7 @@ const constantsLayer = Layer.succeed(
 const marimoLayer = Layer.succeed(
   MarimoClient,
   MarimoClient.make({
-    mode: "uv",
+    server: MarimoLspServer.Python(),
     channel: { name: "marimo-lsp-test", show() {} },
     restart: () => Effect.void,
     ...makeMarimoCommands({

--- a/extension/src/config/Config.ts
+++ b/extension/src/config/Config.ts
@@ -1,8 +1,109 @@
-import { Effect, Option } from "effect";
+import { Data, Effect, Option, Schema } from "effect";
 import type * as vscode from "vscode";
 
 import { DEFAULT_NOTEBOOK_FILE_ROOT } from "../kernel/NotebookFileRoot.ts";
 import { VsCode } from "../platform/VsCode.ts";
+
+const MarimoLspServerSetting = Schema.Literal("wasm", "python", "custom");
+const MarimoLspCommand = Schema.NonEmptyArray(Schema.String).pipe(
+  Schema.filter(([command]) => command.trim().length > 0, {
+    message: () => "The marimo-lsp command must not be empty",
+  }),
+);
+
+export type MarimoLspCommand = typeof MarimoLspCommand.Type;
+
+export const MarimoLspServer = Data.taggedEnum<MarimoLspServer>();
+export type MarimoLspServer = Data.TaggedEnum<{
+  Wasm: {};
+  Python: {};
+  Custom: { readonly command: MarimoLspCommand };
+}>;
+
+export class InvalidMarimoLspConfiguration extends Data.TaggedError(
+  "InvalidMarimoLspConfiguration",
+)<{
+  readonly setting: "marimo.lsp.path" | "marimo.lsp.server";
+  readonly message: string;
+  readonly cause: unknown;
+}> {}
+
+const decodeServerSetting = (value: unknown) =>
+  Schema.decodeUnknown(MarimoLspServerSetting)(value).pipe(
+    Effect.mapError(
+      (cause) =>
+        new InvalidMarimoLspConfiguration({
+          setting: "marimo.lsp.server",
+          message:
+            "Invalid marimo.lsp.server value. Choose wasm, python, or custom.",
+          cause,
+        }),
+    ),
+  );
+
+const decodeCommand = (value: unknown) =>
+  Schema.decodeUnknown(MarimoLspCommand)(value).pipe(
+    Effect.mapError(
+      (cause) =>
+        new InvalidMarimoLspConfiguration({
+          setting: "marimo.lsp.path",
+          message:
+            "marimo.lsp.server is set to custom, but marimo.lsp.path does not contain a valid command.",
+          cause,
+        }),
+    ),
+  );
+
+export const resolveMarimoLspServer = Effect.fn(
+  "Config.resolveMarimoLspServer",
+)(function* ({
+  server,
+  path,
+}: {
+  readonly server: unknown;
+  readonly path: unknown;
+}) {
+  const configured = yield* decodeServerSetting(
+    server === undefined ? "wasm" : server,
+  );
+  switch (configured) {
+    case "wasm":
+      return MarimoLspServer.Wasm();
+    case "python":
+      return MarimoLspServer.Python();
+    case "custom":
+      return MarimoLspServer.Custom({
+        command: yield* decodeCommand(path),
+      });
+    default: {
+      const exhaustive: never = configured;
+      return exhaustive;
+    }
+  }
+});
+
+interface ConfigService {
+  readonly uv: {
+    readonly path: Effect.Effect<Option.Option<string>>;
+    readonly enabled: Effect.Effect<boolean>;
+  };
+  readonly ruff: {
+    readonly path: Effect.Effect<Option.Option<string>>;
+  };
+  readonly ty: {
+    readonly path: Effect.Effect<Option.Option<string>>;
+  };
+  readonly lsp: {
+    readonly server: Effect.Effect<
+      MarimoLspServer,
+      InvalidMarimoLspConfiguration
+    >;
+  };
+  readonly notebookFileRoot: (
+    scope?: vscode.ConfigurationScope,
+  ) => Effect.Effect<string>;
+  readonly getManagedLanguageFeaturesEnabled: () => Effect.Effect<boolean>;
+}
 
 /**
  * Provides access to the extension configuration settings.
@@ -15,7 +116,7 @@ export class Config extends Effect.Service<Config>()("Config", {
       yield* Effect.logWarning(
         "VsCode API is not available. Using default configuration values.",
       );
-      return {
+      const defaults: ConfigService = {
         uv: {
           path: Effect.succeed(Option.none<string>()),
           enabled: Effect.succeed(false),
@@ -27,8 +128,7 @@ export class Config extends Effect.Service<Config>()("Config", {
           path: Effect.succeed(Option.none<string>()),
         },
         lsp: {
-          executable: Effect.succeed(Option.none()),
-          wasm: Effect.succeed(false),
+          server: Effect.succeed(MarimoLspServer.Wasm()),
         },
         notebookFileRoot() {
           return Effect.succeed(DEFAULT_NOTEBOOK_FILE_ROOT);
@@ -37,9 +137,10 @@ export class Config extends Effect.Service<Config>()("Config", {
           return Effect.succeed(false);
         },
       };
+      return defaults;
     }
 
-    return {
+    const configured: ConfigService = {
       uv: {
         get path() {
           return Effect.map(
@@ -80,24 +181,15 @@ export class Config extends Effect.Service<Config>()("Config", {
         },
       },
       lsp: {
-        get executable() {
+        get server() {
           return Effect.gen(function* () {
-            const config =
+            const lspConfig =
               yield* code.value.workspace.getConfiguration("marimo.lsp");
-            return Option.fromNullable(config.get<string[]>("path")).pipe(
-              Option.filter((path) => path.length > 0),
-              Option.map(([command, ...args]) => ({
-                command,
-                args,
-              })),
-            );
+            return yield* resolveMarimoLspServer({
+              server: lspConfig.get<unknown>("server"),
+              path: lspConfig.get<unknown>("path") ?? [],
+            });
           });
-        },
-        get wasm() {
-          return Effect.andThen(
-            code.value.workspace.getConfiguration("marimo.experimental"),
-            (config) => config.get("wasmLsp", false),
-          );
         },
       },
       notebookFileRoot(scope?: vscode.ConfigurationScope) {
@@ -115,5 +207,6 @@ export class Config extends Effect.Service<Config>()("Config", {
         );
       },
     };
+    return configured;
   }),
 }) {}

--- a/extension/src/config/__tests__/Config.test.ts
+++ b/extension/src/config/__tests__/Config.test.ts
@@ -1,8 +1,8 @@
-import { expect, it } from "@effect/vitest";
-import { Effect, Layer } from "effect";
+import { assert, expect, it } from "@effect/vitest";
+import { Effect, Either, Layer } from "effect";
 
 import { TestVsCode } from "../../__mocks__/TestVsCode.ts";
-import { Config } from "../../config/Config.ts";
+import { Config, resolveMarimoLspServer } from "../../config/Config.ts";
 
 const ConfigLive = Layer.empty.pipe(
   Layer.provideMerge(Config.Default),
@@ -20,10 +20,115 @@ it.layer(ConfigLive)("Config", (it) => {
 });
 
 it.effect(
-  "defaults to the uv language server without the VS Code API",
+  "defaults to the WASM language server without the VS Code API",
   Effect.fn(function* () {
     const config = yield* Config.pipe(Effect.provide(Config.Default));
 
-    expect(yield* config.lsp.wasm).toBe(false);
+    expect(yield* config.lsp.server).toEqual({ _tag: "Wasm" });
+  }),
+);
+
+it.effect(
+  "defaults to WASM when no language-server setting is explicit",
+  Effect.fn(function* () {
+    expect(
+      yield* resolveMarimoLspServer({
+        server: undefined,
+        path: [],
+      }),
+    ).toEqual({ _tag: "Wasm" });
+  }),
+);
+
+it.effect(
+  "resolves every explicit language-server mode",
+  Effect.fn(function* () {
+    const wasm = yield* resolveMarimoLspServer({
+      server: "wasm",
+      path: [],
+    });
+    const python = yield* resolveMarimoLspServer({
+      server: "python",
+      path: [],
+    });
+    const custom = yield* resolveMarimoLspServer({
+      server: "custom",
+      path: ["/opt/marimo-lsp", "--stdio"],
+    });
+
+    expect([wasm, python, custom]).toEqual([
+      { _tag: "Wasm" },
+      { _tag: "Python" },
+      {
+        _tag: "Custom",
+        command: ["/opt/marimo-lsp", "--stdio"],
+      },
+    ]);
+  }),
+);
+
+it.effect(
+  "ignores the custom path unless custom mode is selected",
+  Effect.fn(function* () {
+    expect(
+      yield* resolveMarimoLspServer({
+        server: undefined,
+        path: ["/legacy/marimo-lsp"],
+      }),
+    ).toEqual({ _tag: "Wasm" });
+  }),
+);
+
+it.effect(
+  "rejects custom mode without a command before it reaches MarimoClient",
+  Effect.fn(function* () {
+    const result = yield* Effect.either(
+      resolveMarimoLspServer({
+        server: "custom",
+        path: [],
+      }),
+    );
+
+    assert(Either.isLeft(result));
+    expect(result.left).toMatchObject({
+      _tag: "InvalidMarimoLspConfiguration",
+      setting: "marimo.lsp.path",
+    });
+  }),
+);
+
+it.effect(
+  "rejects an unsupported language-server mode at the configuration boundary",
+  Effect.fn(function* () {
+    const result = yield* Effect.either(
+      resolveMarimoLspServer({
+        server: "auto",
+        path: [],
+      }),
+    );
+
+    assert(Either.isLeft(result));
+    expect(result.left).toMatchObject({
+      _tag: "InvalidMarimoLspConfiguration",
+      setting: "marimo.lsp.server",
+    });
+  }),
+);
+
+it.effect(
+  "rejects a custom command with a blank executable",
+  Effect.fn(function* () {
+    const result = yield* Effect.either(
+      resolveMarimoLspServer({
+        server: "custom",
+        path: ["   ", "--stdio"],
+      }),
+    );
+
+    assert(Either.isLeft(result));
+    expect(result.left).toMatchObject({
+      _tag: "InvalidMarimoLspConfiguration",
+      setting: "marimo.lsp.path",
+    });
   }),
 );

--- a/extension/src/features/ReloadOnConfigChange.ts
+++ b/extension/src/features/ReloadOnConfigChange.ts
@@ -24,12 +24,14 @@ export const watchForConfigurationChanges = Effect.fn(function* () {
   const pendingFileRootChanges = new Set<string>();
 
   const watchForWindowReload = Effect.fn(function* (
-    section: string,
+    sections: readonly string[],
     message: string,
   ) {
     yield* Effect.forkScoped(
       code.workspace.configurationChanges().pipe(
-        Stream.filter((event) => event.affectsConfiguration(section)),
+        Stream.filter((event) =>
+          sections.some((section) => event.affectsConfiguration(section)),
+        ),
         Stream.runForEach(
           Effect.fn(function* () {
             const reload = yield* code.window.showInformationMessage(message, {
@@ -68,15 +70,15 @@ export const watchForConfigurationChanges = Effect.fn(function* () {
   });
 
   yield* watchForWindowReload(
-    "marimo.telemetry",
+    ["marimo.telemetry"],
     "Changing telemetry requires reloading the window to take effect.",
   );
   yield* watchForWindowReload(
-    "marimo.disableManagedLanguageFeatures",
+    ["marimo.disableManagedLanguageFeatures"],
     "Changing managed language features requires reloading the window to take effect.",
   );
   yield* watchForWindowReload(
-    "marimo.experimental.wasmLsp",
+    ["marimo.lsp.server", "marimo.lsp.path"],
     "Changing the language-server runtime requires reloading the window to take effect.",
   );
 

--- a/extension/src/features/__tests__/ReloadOnConfigChange.test.ts
+++ b/extension/src/features/__tests__/ReloadOnConfigChange.test.ts
@@ -94,13 +94,15 @@ it.scoped(
   "prompts to reload after changing the language-server runtime",
   Effect.fn(function* () {
     const prompted = yield* Deferred.make<void>();
+    const prompts = yield* Ref.make(0);
     const vscode = yield* TestVsCode.make({
       window: {
         showInformationMessage: (message, options = {}) => {
           expect(message).toBe(
             "Changing the language-server runtime requires reloading the window to take effect.",
           );
-          return Deferred.succeed(prompted, undefined).pipe(
+          return Ref.update(prompts, (count) => count + 1).pipe(
+            Effect.andThen(Deferred.succeed(prompted, undefined)),
             Effect.as(Option.fromNullable(options.items?.[0])),
           );
         },
@@ -109,7 +111,7 @@ it.scoped(
         configurationChanges: () =>
           Stream.make({
             affectsConfiguration: (section: string) =>
-              section === "marimo.experimental.wasmLsp",
+              ["marimo.lsp.server", "marimo.lsp.path"].includes(section),
           }),
       },
     });
@@ -117,11 +119,13 @@ it.scoped(
 
     yield* watchForConfigurationChanges().pipe(Effect.provide(services));
     yield* Deferred.await(prompted);
+    yield* Effect.yieldNow();
 
     expect(yield* Ref.get(vscode.executions)).toContainEqual({
       command: "workbench.action.reloadWindow",
       args: [],
     });
+    expect(yield* Ref.get(prompts)).toBe(1);
   }),
 );
 

--- a/extension/src/lsp/MarimoClient.ts
+++ b/extension/src/lsp/MarimoClient.ts
@@ -3,19 +3,10 @@ import * as NodeFs from "node:fs";
 import * as NodePath from "node:path";
 import * as NodeProcess from "node:process";
 
-import {
-  Cause,
-  Data,
-  Effect,
-  Option,
-  PubSub,
-  Redacted,
-  Runtime,
-  Stream,
-} from "effect";
+import { Cause, Data, Effect, PubSub, Redacted, Runtime, Stream } from "effect";
 import * as lsp from "vscode-languageclient/node";
 
-import { Config } from "../config/Config.ts";
+import { Config, MarimoLspServer } from "../config/Config.ts";
 import { NOTEBOOK_TYPE } from "../constants.ts";
 import { acquireDisposable } from "../lib/acquireDisposable.ts";
 import { showErrorAndPromptLogs } from "../lib/showErrorAndPromptLogs.ts";
@@ -122,16 +113,27 @@ export class MarimoClient extends Effect.Service<MarimoClient>()(
       const config = yield* Config;
       const telemetry = yield* Telemetry;
 
-      const configuredExec = yield* config.lsp.executable;
-      const useWasm = yield* config.lsp.wasm;
-      const uvBinary =
-        Option.isNone(configuredExec) && !useWasm
-          ? (yield* (yield* Uv).bin).executable
-          : undefined;
+      const lspServer = yield* config.lsp.server.pipe(
+        Effect.catchTag(
+          "InvalidMarimoLspConfiguration",
+          Effect.fn(function* (error) {
+            yield* Effect.logError("Invalid marimo-lsp configuration").pipe(
+              Effect.annotateLogs({
+                cause: Cause.fail(error),
+                setting: error.setting,
+              }),
+            );
+            yield* code.window.showErrorMessage(
+              `${error.message} Falling back to the WASM language server.`,
+            );
+            return MarimoLspServer.Wasm();
+          }),
+        ),
+      );
+      const uv = yield* Uv;
       const selection = yield* selectMarimoLspExecutable({
-        configuredExec,
-        useWasm,
-        uvBinary,
+        server: lspServer,
+        resolveUvBinary: Effect.map(uv.bin, ({ executable }) => executable),
       });
       const { exec } = selection;
       const mode = marimoLspMode(selection);
@@ -350,7 +352,7 @@ export class MarimoClient extends Effect.Service<MarimoClient>()(
       };
 
       return {
-        mode,
+        server: lspServer,
         channel: {
           name: outputChannel.name,
           show: outputChannel.show.bind(outputChannel),
@@ -420,31 +422,34 @@ export const findMarimoLspExecutable = Effect.fn("findMarimoLspExecutable")(
 
 export const selectMarimoLspExecutable = Effect.fn("selectMarimoLspExecutable")(
   function* ({
-    configuredExec,
-    useWasm,
-    uvBinary,
+    server,
+    resolveUvBinary,
     searchDirectory = __dirname,
   }: {
-    readonly configuredExec: Option.Option<lsp.Executable>;
-    readonly useWasm: boolean;
-    readonly uvBinary?: string;
+    readonly server: MarimoLspServer;
+    readonly resolveUvBinary: Effect.Effect<string>;
     readonly searchDirectory?: string;
   }) {
-    if (Option.isSome(configuredExec)) {
-      return MarimoLspExecutable.Configured({ exec: configuredExec.value });
-    }
-    if (useWasm) {
-      return MarimoLspExecutable.Wasm({
-        exec: findWasmMarimoLspExecutable(searchDirectory),
-      });
-    }
-    if (uvBinary === undefined) {
-      throw new Error(
-        "uv is required when the WASM language server is disabled",
-      );
-    }
-    return MarimoLspExecutable.Uv({
-      exec: yield* findMarimoLspExecutable(uvBinary, searchDirectory),
+    return yield* MarimoLspServer.$match(server, {
+      Custom: ({ command: [executable, ...args] }) =>
+        Effect.succeed(
+          MarimoLspExecutable.Configured({
+            exec: { command: executable, args },
+          }),
+        ),
+      Wasm: () =>
+        Effect.succeed(
+          MarimoLspExecutable.Wasm({
+            exec: findWasmMarimoLspExecutable(searchDirectory),
+          }),
+        ),
+      Python: () =>
+        Effect.flatMap(resolveUvBinary, (uvBinary) =>
+          Effect.map(
+            findMarimoLspExecutable(uvBinary, searchDirectory),
+            (exec) => MarimoLspExecutable.Uv({ exec }),
+          ),
+        ),
     });
   },
 );

--- a/extension/src/lsp/__tests__/MarimoClient.test.ts
+++ b/extension/src/lsp/__tests__/MarimoClient.test.ts
@@ -6,6 +6,7 @@ import { assert, describe, expect, it } from "@effect/vitest";
 import { Effect, Exit, Option, Ref, Stream } from "effect";
 import { vi } from "vite-plus/test";
 
+import { MarimoLspServer } from "../../config/Config.ts";
 import { notebookId } from "../../lib/__tests__/branded.ts";
 import type { MarimoApiCall, MarimoOperation } from "../../types.ts";
 import {
@@ -213,27 +214,29 @@ describe("findWasmMarimoLspExecutable", () => {
 
 describe("selectMarimoLspExecutable", () => {
   it.effect(
-    "prefers an explicitly configured executable",
+    "uses the command carried by the custom server variant",
     Effect.fn(function* () {
-      const exec = { command: "/custom/marimo-lsp", args: ["--stdio"] };
       const selection = yield* selectMarimoLspExecutable({
-        configuredExec: Option.some(exec),
-        useWasm: true,
-        uvBinary: "bundled-uv",
+        server: MarimoLspServer.Custom({
+          command: ["/custom/marimo-lsp", "--stdio"],
+        }),
+        resolveUvBinary: Effect.die("custom mode must not resolve uv"),
         searchDirectory: "/does/not/exist",
       });
 
-      expect(selection).toEqual({ _tag: "Configured", exec });
+      expect(selection).toEqual({
+        _tag: "Configured",
+        exec: { command: "/custom/marimo-lsp", args: ["--stdio"] },
+      });
     }),
   );
 
   it.effect(
-    "prefers WASM over uv when enabled",
+    "uses WASM without resolving uv",
     Effect.fn(function* () {
       const selection = yield* selectMarimoLspExecutable({
-        configuredExec: Option.none(),
-        useWasm: true,
-        uvBinary: "bundled-uv",
+        server: MarimoLspServer.Wasm(),
+        resolveUvBinary: Effect.die("WASM mode must not resolve uv"),
         searchDirectory: "/extension/dist",
       });
 
@@ -244,7 +247,7 @@ describe("selectMarimoLspExecutable", () => {
     }),
   );
 
-  it.scoped("falls back to uv when WASM is disabled", () =>
+  it.scoped("resolves uv only for the Python server variant", () =>
     Effect.acquireUseRelease(
       Effect.sync(() =>
         NodeFs.mkdtempDisposableSync(
@@ -254,9 +257,8 @@ describe("selectMarimoLspExecutable", () => {
       (directory) =>
         Effect.gen(function* () {
           const selection = yield* selectMarimoLspExecutable({
-            configuredExec: Option.none(),
-            useWasm: false,
-            uvBinary: "bundled-uv",
+            server: MarimoLspServer.Python(),
+            resolveUvBinary: Effect.succeed("bundled-uv"),
             searchDirectory: directory.path,
           });
 

--- a/extension/src/telemetry/HealthService.ts
+++ b/extension/src/telemetry/HealthService.ts
@@ -3,12 +3,12 @@ import * as NodeProcess from "node:process";
 import * as semver from "@std/semver";
 import { Effect, Option } from "effect";
 
-import { Config } from "../config/Config.ts";
+import { Config, MarimoLspServer } from "../config/Config.ts";
 import { MINIMUM_MARIMO_KERNEL_VERSION } from "../constants.ts";
 import { NotebookRuntime } from "../kernel/NotebookRuntime.ts";
 import { BinarySource } from "../lib/binaryResolution.ts";
 import { getExtensionVersion } from "../lib/getExtensionVersion.ts";
-import { MarimoClient, type MarimoLspMode } from "../lsp/MarimoClient.ts";
+import { MarimoClient } from "../lsp/MarimoClient.ts";
 import {
   RuffLanguageServer,
   RuffLanguageServerStatus,
@@ -40,8 +40,7 @@ export class HealthService extends Effect.Service<HealthService>()(
 
       const formatDiagnostics = () =>
         Effect.gen(function* () {
-          const [lspCustomPath, uvDisabled, extVersion] = yield* Effect.all([
-            config.lsp.executable,
+          const [uvDisabled, extVersion] = yield* Effect.all([
             Effect.map(config.uv.enabled, (enabled) => !enabled),
             getExtensionVersion().pipe(Effect.provideService(VsCode, code)),
           ]);
@@ -55,12 +54,12 @@ export class HealthService extends Effect.Service<HealthService>()(
 
           // LSP Status
           lines.push("Language Server (LSP):");
-          const uvBin =
-            marimo.mode === "uv" ? Option.some(yield* uv.bin) : Option.none();
+          const uvBin = MarimoLspServer.$is("Python")(marimo.server)
+            ? Option.some(yield* uv.bin)
+            : Option.none();
           lines.push(
             ...formatMarimoLspDiagnostics({
-              mode: marimo.mode,
-              customExecutable: lspCustomPath,
+              server: marimo.server,
               uvBin,
             }),
           );
@@ -258,54 +257,43 @@ function formatBinarySource(source: BinarySource): string {
 }
 
 export function formatMarimoLspDiagnostics({
-  mode,
-  customExecutable,
+  server,
   uvBin,
 }: {
-  mode: MarimoLspMode;
-  customExecutable: Option.Option<{
-    readonly command: string;
-    readonly args?: readonly string[];
-  }>;
+  server: MarimoLspServer;
   uvBin: Option.Option<UvBin>;
 }): readonly string[] {
-  if (mode === "wasm") {
-    return ["\tMode: WASM (bundled Pyodide)"];
-  }
-  if (mode === "configured") {
-    return [
+  return MarimoLspServer.$match(server, {
+    Wasm: () => ["\tMode: WASM (bundled Pyodide)"],
+    Custom: ({ command: [executable, ...args] }) => [
       "\tMode: Native (configured)",
-      Option.match(customExecutable, {
-        onNone: () => "\tCustom path: unavailable",
-        onSome: ({ command, args = [] }) =>
-          `\tCustom path: ${command} ${args.join(" ")}`,
+      `\tCustom path: ${executable} ${args.join(" ")}`,
+    ],
+    Python: () =>
+      Option.match(uvBin, {
+        onNone: () => ["\tMode: Native (uv)", "\tUV: Not found ✗"],
+        onSome: (bin) => {
+          const lines = ["\tMode: Native (uv)"];
+          UvBin.$match(bin, {
+            Bundled: ({ executable }) =>
+              lines.push(`\tUV Bin: Bundled (${executable})`),
+            Default: ({ executable }) =>
+              lines.push(`\tUV Bin: Default (${executable})`),
+            Configured: ({ executable }) =>
+              lines.push(`\tUV Bin: Configured (${executable})`),
+            Discovered: ({ executable }) =>
+              lines.push(`\tUV Bin: Discovered (${executable})`),
+          });
+          lines.push(
+            Option.match(bin.version, {
+              onSome: (version) => `\tUV: ${version.format()} ✓`,
+              onNone: () => "\tUV: Version unknown",
+            }),
+          );
+          lines.push("\tUsing bundled marimo-lsp via uvx");
+          return lines;
+        },
       }),
-    ];
-  }
-
-  return Option.match(uvBin, {
-    onNone: () => ["\tMode: Native (uv)", "\tUV: Not found ✗"],
-    onSome: (bin) => {
-      const lines = ["\tMode: Native (uv)"];
-      UvBin.$match(bin, {
-        Bundled: ({ executable }) =>
-          lines.push(`\tUV Bin: Bundled (${executable})`),
-        Default: ({ executable }) =>
-          lines.push(`\tUV Bin: Default (${executable})`),
-        Configured: ({ executable }) =>
-          lines.push(`\tUV Bin: Configured (${executable})`),
-        Discovered: ({ executable }) =>
-          lines.push(`\tUV Bin: Discovered (${executable})`),
-      });
-      lines.push(
-        Option.match(bin.version, {
-          onSome: (version) => `\tUV: ${version.format()} ✓`,
-          onNone: () => "\tUV: Version unknown",
-        }),
-      );
-      lines.push("\tUsing bundled marimo-lsp via uvx");
-      return lines;
-    },
   });
 }
 

--- a/extension/src/telemetry/__tests__/HealthService.test.ts
+++ b/extension/src/telemetry/__tests__/HealthService.test.ts
@@ -1,14 +1,14 @@
 import { expect, it } from "@effect/vitest";
 import { Option } from "effect";
 
+import { MarimoLspServer } from "../../config/Config.ts";
 import { UvBin } from "../../python/Uv.ts";
 import { formatMarimoLspDiagnostics } from "../HealthService.ts";
 
 it("reports the bundled WASM runtime without uv diagnostics", () => {
   expect(
     formatMarimoLspDiagnostics({
-      mode: "wasm",
-      customExecutable: Option.none(),
+      server: MarimoLspServer.Wasm(),
       uvBin: Option.none(),
     }),
   ).toEqual(["\tMode: WASM (bundled Pyodide)"]);
@@ -17,8 +17,7 @@ it("reports the bundled WASM runtime without uv diagnostics", () => {
 it("reports the uv-provisioned native runtime", () => {
   expect(
     formatMarimoLspDiagnostics({
-      mode: "uv",
-      customExecutable: Option.none(),
+      server: MarimoLspServer.Python(),
       uvBin: Option.some(
         UvBin.Bundled({
           executable: "/extension/bundled/uv",
@@ -37,10 +36,8 @@ it("reports the uv-provisioned native runtime", () => {
 it("reports the configured native runtime", () => {
   expect(
     formatMarimoLspDiagnostics({
-      mode: "configured",
-      customExecutable: Option.some({
-        command: "/opt/marimo-lsp",
-        args: ["--stdio"],
+      server: MarimoLspServer.Custom({
+        command: ["/opt/marimo-lsp", "--stdio"],
       }),
       uvBin: Option.none(),
     }),


### PR DESCRIPTION
`marimo.lsp.server` is the sole runtime selector:

```ts
export const MarimoLspServer = Data.taggedEnum<MarimoLspServer>();
export type MarimoLspServer = Data.TaggedEnum<{
  Wasm: {};
  Python: {};
  Custom: { readonly command: MarimoLspCommand };
}>;
```

`marimo.lsp.path` is read only for Custom, so stale paths cannot override the WASM default. Invalid Custom configuration reports the problem and falls back to WASM without aborting extension activation.

The retired experimental key remains registered only so VS Code can link existing configurations to its replacement; it no longer participates in runtime selection.
