### PR TITLE
Include bridge stderr in WASM kernel errors

### DIFF
--- a/extension/src/wasm/Processes.ts
+++ b/extension/src/wasm/Processes.ts
@@ -2,6 +2,9 @@ import * as NodeChildProcess from "node:child_process";
 import type { EventEmitter } from "node:events";
 import * as NodePath from "node:path";
 import type { Readable, Writable } from "node:stream";
+import { StringDecoder } from "node:string_decoder";
+
+const MAX_STDERR_TAIL_LENGTH = 16_000;
 
 interface SpawnedProcess extends EventEmitter {
   readonly stdin: Writable | null;
@@ -19,6 +22,8 @@ type SpawnProcess = (
 interface ProcessState {
   readonly child: SpawnedProcess;
   readonly input: Writable;
+  readonly stderrDecoder: StringDecoder;
+  stderrTail: string;
   expectedClose: boolean;
   exited: boolean;
 }
@@ -29,7 +34,15 @@ interface ProcessCallbacks {
     processId: string,
     code: number | null,
     signal: NodeJS.Signals | null,
+    stderr: string | undefined,
   ) => void;
+}
+
+function appendStderr(state: ProcessState, text: string): void {
+  if (text.length === 0) return;
+  state.stderrTail = `${state.stderrTail}${text}`.slice(
+    -MAX_STDERR_TAIL_LENGTH,
+  );
 }
 
 /** Brokers opaque bytes between Pyodide and selected-Python processes. */
@@ -69,6 +82,8 @@ export class Processes {
     const state: ProcessState = {
       child,
       input: child.stdin,
+      stderrDecoder: new StringDecoder("utf8"),
+      stderrTail: "",
       expectedClose: false,
       exited: false,
     };
@@ -79,14 +94,27 @@ export class Processes {
         new Uint8Array(chunk.buffer, chunk.byteOffset, chunk.byteLength),
       );
     });
-    child.stderr?.on("data", (chunk: Buffer) => process.stderr.write(chunk));
+    child.stderr?.on("data", (chunk: Buffer) => {
+      appendStderr(state, state.stderrDecoder.write(chunk));
+      process.stderr.write(chunk);
+    });
     const exited = (code: number | null, signal: NodeJS.Signals | null) => {
       if (state.exited) return;
       state.exited = true;
+      appendStderr(state, state.stderrDecoder.end());
       this.#processes.delete(processId);
-      if (!state.expectedClose) this.#callbacks.exited(processId, code, signal);
+      if (!state.expectedClose) {
+        const stderr = state.stderrTail.trim();
+        this.#callbacks.exited(
+          processId,
+          code,
+          signal,
+          stderr.length > 0 ? stderr : undefined,
+        );
+      }
     };
     child.once("error", (error) => {
+      appendStderr(state, `${error.message}\n`);
       process.stderr.write(`${error.message}\n`);
     });
     // `exit` can precede the final stdout data. `close` is emitted only after

--- a/extension/src/wasm/WasmBridgeRuntime.ts
+++ b/extension/src/wasm/WasmBridgeRuntime.ts
@@ -7,6 +7,7 @@ interface WasmBridge {
     processId: string,
     code: number | null,
     signal: string | null,
+    stderr: string | null,
   ) => void;
   readonly close: () => void;
   readonly destroy: () => void;
@@ -59,10 +60,15 @@ export class WasmBridgeRuntime {
           state.bridge.handle_kernel_bytes(processId, chunk);
         }
       },
-      exited: (processId, code, signal) => {
+      exited: (processId, code, signal, stderr) => {
         const state = this.#state;
         if (state.status === "running") {
-          state.bridge.handle_kernel_exit(processId, code, signal);
+          state.bridge.handle_kernel_exit(
+            processId,
+            code,
+            signal,
+            stderr ?? null,
+          );
         }
       },
     });

--- a/extension/src/wasm/__tests__/Processes.test.ts
+++ b/extension/src/wasm/__tests__/Processes.test.ts
@@ -11,10 +11,12 @@ it("reports a selected-Python spawn failure", async () => {
   const exited = Promise.withResolvers<{
     code: number | null;
     signal: NodeJS.Signals | null;
+    stderr: string | undefined;
   }>();
   const processes = new Processes({
     stdout: () => {},
-    exited: (_processId, code, signal) => exited.resolve({ code, signal }),
+    exited: (_processId, code, signal, processStderr) =>
+      exited.resolve({ code, signal, stderr: processStderr }),
   });
 
   processes.spawn("kernel", "/definitely-not-a-marimo-python", process.cwd());
@@ -22,6 +24,7 @@ it("reports a selected-Python spawn failure", async () => {
   const result = await exited.promise;
   expect(result.code).not.toBe(0);
   expect(result.signal).toBeNull();
+  expect(result.stderr).toContain("definitely-not-a-marimo-python");
   expect(() => processes.write("kernel", new Uint8Array())).toThrow(
     "No process with id kernel",
   );
@@ -53,4 +56,31 @@ it("drains stdout before reporting process exit", () => {
 
   child.emit("close", 0, null);
   expect(events).toEqual(["final output", "exited"]);
+});
+
+it("includes captured stderr when reporting process exit", () => {
+  const child = Object.assign(new EventEmitter(), {
+    stdin: new PassThrough(),
+    stdout: new PassThrough(),
+    stderr: new PassThrough(),
+    kill: vi.fn(() => true),
+  });
+  const spawn = vi.fn(() => child);
+  const captured: Array<string | undefined> = [];
+  const stderr = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+  const processes = new Processes(
+    {
+      stdout: () => {},
+      exited: (_processId, _code, _signal, processStderr) =>
+        captured.push(processStderr),
+    },
+    spawn,
+  );
+
+  processes.spawn("kernel", "/python", "/workspace");
+  child.stderr.write("Traceback: missing dependency\n");
+  child.emit("close", 1, null);
+
+  expect(captured).toEqual(["Traceback: missing dependency"]);
+  stderr.mockRestore();
 });

--- a/src/marimo_lsp/wasm/__init__.py
+++ b/src/marimo_lsp/wasm/__init__.py
@@ -100,9 +100,10 @@ class WasmServer:
         process_id: str,
         code: int | None,
         signal: str | None,
+        stderr: str | None,
     ) -> None:
         """Route a native process exit into its WASM kernel."""
-        self._kernels.exited(process_id, code, signal)
+        self._kernels.exited(process_id, code, signal, stderr)
 
 
 def create_bridge(

--- a/src/marimo_lsp/wasm/kernels.py
+++ b/src/marimo_lsp/wasm/kernels.py
@@ -104,11 +104,21 @@ class WasmKernel:
             elif isinstance(message, Log):
                 logger.info(message.message)
 
-    def exited(self, code: int | None, signal: str | None) -> None:
+    def exited(
+        self,
+        code: int | None,
+        signal: str | None,
+        stderr: str | None,
+    ) -> None:
         """Report an unexpected kernel bridge exit."""
         if not self._closed:
+            message = (
+                f"Kernel bridge exited unexpectedly (code={code}, signal={signal})"
+            )
+            if stderr:
+                message = f"{message}\nBridge stderr:\n{stderr}"
             self._fail(
-                f"Kernel bridge exited unexpectedly (code={code}, signal={signal})",
+                message,
                 close_process=False,
             )
 
@@ -242,11 +252,12 @@ class WasmKernels:
         process_id: str,
         code: int | None,
         signal: str | None,
+        stderr: str | None,
     ) -> None:
         """Report a kernel bridge exit to its WASM kernel."""
         kernel = self._kernels.get(process_id)
         if kernel is not None:
-            kernel.exited(code, signal)
+            kernel.exited(code, signal, stderr)
 
     def close_all(self) -> None:
         """Close every tracked kernel bridge."""

--- a/tests/test_wasm_kernel.py
+++ b/tests/test_wasm_kernel.py
@@ -101,6 +101,22 @@ async def test_wasm_launch_fails_before_publishing_unready_kernel() -> None:
 
 
 @pytest.mark.asyncio
+async def test_wasm_process_exit_includes_stderr_in_open_error() -> None:
+    callbacks, kernels, launch, _messages = await _begin_launch()
+    process_id = callbacks.spawns[0][0]
+
+    kernels.exited(process_id, 1, None, "ModuleNotFoundError: No module named 'marimo'")
+
+    with pytest.raises(KernelOpenError) as exc_info:
+        await launch
+    assert "Kernel bridge exited unexpectedly (code=1, signal=None)" in str(
+        exc_info.value
+    )
+    assert "Bridge stderr:" in str(exc_info.value)
+    assert "ModuleNotFoundError" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
 async def test_cancelled_wasm_launch_releases_bridge() -> None:
     callbacks, _kernels, launch, _messages = await _begin_launch()
     process_id = callbacks.spawns[0][0]


### PR DESCRIPTION
Native bridge failures previously surfaced only an exit code and signal, concealing the startup error that explains the failure. Retain a bounded stderr tail and carry it through Pyodide into `KernelOpenError`.