### PR TITLE
Reject duplicate notebook cell IDs

### DIFF
--- a/src/marimo_lsp/app_file_manager.py
+++ b/src/marimo_lsp/app_file_manager.py
@@ -35,6 +35,15 @@ if TYPE_CHECKING:
     from marimo_lsp.sessions import Session
 
 
+class DuplicateCellIdError(ValueError):
+    """Raised when multiple notebook cells share one runtime stable ID."""
+
+    def __init__(self, cell_ids: list[CellId_t]) -> None:
+        self.cell_ids = tuple(cell_ids)
+        joined = ", ".join(str(cell_id) for cell_id in cell_ids)
+        super().__init__(f"Notebook contains duplicate stable cell IDs: {joined}")
+
+
 class LspAppFileManager:
     """AppFileManager implementation for marimo LSP integration.
 
@@ -180,10 +189,6 @@ def sync_app_with_workspace(
 
     metadata = decode_notebook_document_metadata(notebook)
     app_options = metadata.app_config
-    if app is None:
-        app = InternalApp(App(**app_options))
-
-    app.update_config(app_options)
 
     cell_ids: list[CellId_t] = []
     codes: list[str] = []
@@ -197,6 +202,19 @@ def sync_app_with_workspace(
         # `config.column` off these (a dict raises AttributeError).
         configs.append(CellConfig.from_dict(dict(config)))
         names.append(name)
+
+    seen: set[CellId_t] = set()
+    duplicate_ids: set[CellId_t] = set()
+    for cell_id in cell_ids:
+        if cell_id in seen:
+            duplicate_ids.add(cell_id)
+        seen.add(cell_id)
+    if duplicate_ids:
+        raise DuplicateCellIdError(sorted(duplicate_ids))
+
+    if app is None:
+        app = InternalApp(App(**app_options))
+    app.update_config(app_options)
 
     return app.with_data(
         cell_ids=cell_ids,

--- a/tests/test_app_file_manager.py
+++ b/tests/test_app_file_manager.py
@@ -11,7 +11,11 @@ import lsprotocol.types as lsp
 import msgspec
 import pytest
 
-from marimo_lsp.app_file_manager import find_notebook_document, sync_app_with_workspace
+from marimo_lsp.app_file_manager import (
+    DuplicateCellIdError,
+    find_notebook_document,
+    sync_app_with_workspace,
+)
 
 
 def _lsp_object(d: dict[str, object] | None) -> lsp.LSPObject | None:
@@ -90,6 +94,42 @@ def _make_workspace_with_metadata(
 
 
 class TestSyncAppWithWorkspace:
+    def test_rejects_duplicate_stable_cell_ids_before_mutating_app(self) -> None:
+        uri = "file:///test/notebook.py"
+        original = _make_workspace_with_metadata(
+            uri,
+            metadata={"marimo": {"appConfig": {"width": "wide"}}},
+        )
+        app = sync_app_with_workspace(
+            workspace=original,
+            notebook_uri=uri,
+            app=None,
+        )
+        cell_uris = [f"{uri}#cell-1", f"{uri}#cell-2"]
+        cells = [
+            lsp.NotebookCell(
+                kind=lsp.NotebookCellKind.Code,
+                document=cell_uri,
+                metadata=_lsp_object({"marimoRuntime": {"stableId": "duplicate-id"}}),
+            )
+            for cell_uri in cell_uris
+        ]
+        ws = _make_workspace_with_metadata(
+            uri,
+            metadata={"marimo": {"appConfig": {"width": "medium"}}},
+            cells=cells,
+        )
+        ws.text_documents = {
+            cell_uri: MagicMock(source=f"value_{index} = {index}", language_id="python")
+            for index, cell_uri in enumerate(cell_uris)
+        }
+
+        with pytest.raises(DuplicateCellIdError) as exc_info:
+            sync_app_with_workspace(workspace=ws, notebook_uri=uri, app=app)
+
+        assert exc_info.value.cell_ids == ("duplicate-id",)
+        assert app.config.width == "wide"
+
     def test_extracts_app_options_from_metadata(self) -> None:
         """App config should come from namespaced notebook metadata."""
         uri = "file:///test/notebook.py"


### PR DESCRIPTION
VS Code metadata can retain one stable ID on multiple cells. Validate the complete cell list before updating an existing app so a failed sync cannot leave its configuration partially updated.