### PR TITLE
Fingerprint command errors by root cause

### DIFF
--- a/extension/src/lib/__tests__/errorClassification.test.ts
+++ b/extension/src/lib/__tests__/errorClassification.test.ts
@@ -30,6 +30,9 @@ describe("errorClassification", () => {
     expect(exceptionClassFromMessage("KeyboardInterrupt: stopped")).toBe(
       "KeyboardInterrupt",
     );
+    expect(exceptionClassFromMessage("BaseException: stopped")).toBe(
+      "BaseException",
+    );
     expect(exceptionClassFromMessage("my_package.Abort: stopped")).toBe(
       "Abort",
     );

--- a/extension/src/lib/__tests__/errorClassification.test.ts
+++ b/extension/src/lib/__tests__/errorClassification.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  exceptionClassFromMessage,
+  hasExceptionClassPrefix,
+  nestedErrorClassName,
+  safeErrorClassName,
+} from "../errorClassification.ts";
+
+describe("errorClassification", () => {
+  it("uses a custom Error constructor when name is inherited", () => {
+    class KernelStartFailure extends Error {}
+
+    const error = new KernelStartFailure("could not start");
+    expect(error.name).toBe("Error");
+    expect(safeErrorClassName(error)).toBe("KernelStartFailure");
+    expect(nestedErrorClassName(error)).toBe("KernelStartFailure");
+  });
+
+  it("preserves an explicit Error name on RPC-shaped objects", () => {
+    expect(safeErrorClassName({ name: "Error", message: "failed" })).toBe(
+      "Error",
+    );
+  });
+
+  it("parses bounded exception identifiers without requiring a suffix", () => {
+    expect(
+      exceptionClassFromMessage("builtins.KeyboardInterrupt: stopped"),
+    ).toBe("KeyboardInterrupt");
+  });
+
+  it("excludes traceback headers", () => {
+    expect(exceptionClassFromMessage("Traceback: unavailable")).toBeUndefined();
+    expect(hasExceptionClassPrefix("Traceback: unavailable")).toBe(false);
+  });
+
+  it("keeps user-facing detection separate from telemetry bounds", () => {
+    const className = `${"VeryLong".repeat(12)}Error`;
+    const line = `${className}: failed`;
+
+    expect(hasExceptionClassPrefix(line)).toBe(true);
+    expect(exceptionClassFromMessage(line)).toBeUndefined();
+  });
+});

--- a/extension/src/lib/__tests__/errorClassification.test.ts
+++ b/extension/src/lib/__tests__/errorClassification.test.ts
@@ -27,11 +27,22 @@ describe("errorClassification", () => {
     expect(
       exceptionClassFromMessage("builtins.KeyboardInterrupt: stopped"),
     ).toBe("KeyboardInterrupt");
+    expect(exceptionClassFromMessage("KeyboardInterrupt: stopped")).toBe(
+      "KeyboardInterrupt",
+    );
+    expect(exceptionClassFromMessage("my_package.Abort: stopped")).toBe(
+      "Abort",
+    );
   });
 
-  it("excludes traceback headers", () => {
+  it("excludes traceback headers and continuation labels", () => {
     expect(exceptionClassFromMessage("Traceback: unavailable")).toBeUndefined();
     expect(hasExceptionClassPrefix("Traceback: unavailable")).toBe(false);
+    expect(exceptionClassFromMessage("Hint: rename this file")).toBeUndefined();
+    expect(hasExceptionClassPrefix("Note: retrying may help")).toBe(false);
+    expect(nestedErrorClassName(new Error("Hint: rename this file"))).toBe(
+      "Error",
+    );
   });
 
   it("keeps user-facing detection separate from telemetry bounds", () => {

--- a/extension/src/lib/__tests__/extractPythonError.test.ts
+++ b/extension/src/lib/__tests__/extractPythonError.test.ts
@@ -46,6 +46,38 @@ describe("extractPythonError", () => {
     );
   });
 
+  it("extracts Python exceptions without Error or Exception suffixes", () => {
+    const error = new Error("An error has occurred", {
+      cause: new Error(
+        "Traceback (most recent call last):\n" +
+          '    File "/path/to/launch_kernel.py", line 28, in main\n' +
+          "  KeyboardInterrupt: interrupted while starting the kernel",
+      ),
+    });
+
+    expect(extractPythonError(error)).toEqual(
+      Option.some("KeyboardInterrupt: interrupted while starting the kernel"),
+    );
+  });
+
+  it("preserves exception lines with class names longer than telemetry bounds", () => {
+    const className = `${"VeryLong".repeat(12)}Error`;
+    const detail = `${className}: kernel startup failed`;
+    const error = new Error("An error has occurred", {
+      cause: new Error(`Traceback (most recent call last):\n  ${detail}`),
+    });
+
+    expect(extractPythonError(error)).toEqual(Option.some(detail));
+  });
+
+  it("does not treat a traceback header as an exception", () => {
+    const error = new Error("An error has occurred", {
+      cause: new Error("Traceback: no exception detail was returned"),
+    });
+
+    expect(extractPythonError(error)).toEqual(Option.none());
+  });
+
   it("extracts AttributeError for file name shadowing", () => {
     const error = new Error("An error has occurred", {
       cause: new Error(

--- a/extension/src/lib/__tests__/extractPythonError.test.ts
+++ b/extension/src/lib/__tests__/extractPythonError.test.ts
@@ -78,6 +78,21 @@ describe("extractPythonError", () => {
     expect(extractPythonError(error)).toEqual(Option.none());
   });
 
+  it("skips continuation labels below the exception line", () => {
+    const error = new Error("An error has occurred", {
+      cause: new Error(
+        "Traceback (most recent call last):\n" +
+          "  RuntimeError: kernel startup failed\n" +
+          "  Note: this environment may be misconfigured\n" +
+          "  Hint: check the selected interpreter",
+      ),
+    });
+
+    expect(extractPythonError(error)).toEqual(
+      Option.some("RuntimeError: kernel startup failed"),
+    );
+  });
+
   it("extracts AttributeError for file name shadowing", () => {
     const error = new Error("An error has occurred", {
       cause: new Error(

--- a/extension/src/lib/errorClassification.ts
+++ b/extension/src/lib/errorClassification.ts
@@ -2,6 +2,7 @@ const SAFE_CLASS_NAME = /^[A-Za-z_$][\w$.-]{0,79}$/;
 const EXCEPTION_CLASS = /^\s*((?:[A-Za-z_$][\w$]*\.)*)([A-Za-z_$][\w$]*):/m;
 const EXCEPTION_SUFFIX = /(?:Error|Exception|Warning)$/;
 const NON_SUFFIX_BUILTIN_EXCEPTIONS = new Set([
+  "BaseException",
   "BaseExceptionGroup",
   "ExceptionGroup",
   "GeneratorExit",

--- a/extension/src/lib/errorClassification.ts
+++ b/extension/src/lib/errorClassification.ts
@@ -1,19 +1,30 @@
 const SAFE_CLASS_NAME = /^[A-Za-z_$][\w$.-]{0,79}$/;
-const EXCEPTION_CLASS = /(?:^|\.)\s*([A-Za-z_$][\w$]*(?:Error|Exception)):/m;
+const EXCEPTION_CLASS =
+  /^\s*(?:[A-Za-z_$][\w$]*\.)*((?!Traceback\b)[A-Za-z_$][\w$]*):/m;
 
 export function safeErrorClassName(value: unknown): string {
   if (!isRecord(value)) return typeof value;
+  let fallback: string | undefined;
   for (const candidate of [value._tag, value.name, value.constructor?.name]) {
     if (typeof candidate === "string" && SAFE_CLASS_NAME.test(candidate)) {
-      return candidate;
+      if (candidate === "Error" && value instanceof Error) {
+        fallback ??= candidate;
+      } else {
+        return candidate;
+      }
     }
   }
-  return "Error";
+  return fallback ?? "Error";
 }
 
 export function exceptionClassFromMessage(text: string): string | undefined {
   const match = text.match(EXCEPTION_CLASS);
   return match && SAFE_CLASS_NAME.test(match[1]) ? match[1] : undefined;
+}
+
+/** Whether text starts a Python-style exception line, without telemetry bounds. */
+export function hasExceptionClassPrefix(text: string): boolean {
+  return EXCEPTION_CLASS.test(text);
 }
 
 export function nestedErrorClassName(error: Error): string {

--- a/extension/src/lib/errorClassification.ts
+++ b/extension/src/lib/errorClassification.ts
@@ -1,0 +1,28 @@
+const SAFE_CLASS_NAME = /^[A-Za-z_$][\w$.-]{0,79}$/;
+const EXCEPTION_CLASS = /(?:^|\.)\s*([A-Za-z_$][\w$]*(?:Error|Exception)):/m;
+
+export function safeErrorClassName(value: unknown): string {
+  if (!isRecord(value)) return typeof value;
+  for (const candidate of [value._tag, value.name, value.constructor?.name]) {
+    if (typeof candidate === "string" && SAFE_CLASS_NAME.test(candidate)) {
+      return candidate;
+    }
+  }
+  return "Error";
+}
+
+export function exceptionClassFromMessage(text: string): string | undefined {
+  const match = text.match(EXCEPTION_CLASS);
+  return match && SAFE_CLASS_NAME.test(match[1]) ? match[1] : undefined;
+}
+
+export function nestedErrorClassName(error: Error): string {
+  const direct = safeErrorClassName(error);
+  return direct === "Error"
+    ? (exceptionClassFromMessage(error.message) ?? "Error")
+    : direct;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/extension/src/lib/errorClassification.ts
+++ b/extension/src/lib/errorClassification.ts
@@ -1,6 +1,15 @@
 const SAFE_CLASS_NAME = /^[A-Za-z_$][\w$.-]{0,79}$/;
-const EXCEPTION_CLASS =
-  /^\s*(?:[A-Za-z_$][\w$]*\.)*((?!Traceback\b)[A-Za-z_$][\w$]*):/m;
+const EXCEPTION_CLASS = /^\s*((?:[A-Za-z_$][\w$]*\.)*)([A-Za-z_$][\w$]*):/m;
+const EXCEPTION_SUFFIX = /(?:Error|Exception|Warning)$/;
+const NON_SUFFIX_BUILTIN_EXCEPTIONS = new Set([
+  "BaseExceptionGroup",
+  "ExceptionGroup",
+  "GeneratorExit",
+  "KeyboardInterrupt",
+  "StopAsyncIteration",
+  "StopIteration",
+  "SystemExit",
+]);
 
 export function safeErrorClassName(value: unknown): string {
   if (!isRecord(value)) return typeof value;
@@ -18,13 +27,13 @@ export function safeErrorClassName(value: unknown): string {
 }
 
 export function exceptionClassFromMessage(text: string): string | undefined {
-  const match = text.match(EXCEPTION_CLASS);
-  return match && SAFE_CLASS_NAME.test(match[1]) ? match[1] : undefined;
+  const candidate = likelyExceptionClass(text);
+  return candidate && SAFE_CLASS_NAME.test(candidate) ? candidate : undefined;
 }
 
 /** Whether text starts a Python-style exception line, without telemetry bounds. */
 export function hasExceptionClassPrefix(text: string): boolean {
-  return EXCEPTION_CLASS.test(text);
+  return likelyExceptionClass(text) !== undefined;
 }
 
 export function nestedErrorClassName(error: Error): string {
@@ -36,4 +45,16 @@ export function nestedErrorClassName(error: Error): string {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
+}
+
+function likelyExceptionClass(text: string): string | undefined {
+  const match = text.match(EXCEPTION_CLASS);
+  if (!match) return undefined;
+
+  const [, qualifier, className] = match;
+  const isRecognizable =
+    Boolean(qualifier) ||
+    EXCEPTION_SUFFIX.test(className) ||
+    NON_SUFFIX_BUILTIN_EXCEPTIONS.has(className);
+  return isRecognizable ? className : undefined;
 }

--- a/extension/src/lib/extractPythonError.ts
+++ b/extension/src/lib/extractPythonError.ts
@@ -1,6 +1,6 @@
 import { Option } from "effect";
 
-import { exceptionClassFromMessage } from "./errorClassification.ts";
+import { hasExceptionClassPrefix } from "./errorClassification.ts";
 
 /**
  * Extract the last Python exception line from a MarimoCommandError cause.
@@ -43,7 +43,7 @@ function extractLastException(text: string): Option.Option<string> {
   const lines = text.split("\n");
   for (let i = lines.length - 1; i >= 0; i--) {
     const line = lines[i].trim();
-    if (line && exceptionClassFromMessage(line)) {
+    if (line && hasExceptionClassPrefix(line)) {
       return Option.some(truncate(line, 500));
     }
   }

--- a/extension/src/lib/extractPythonError.ts
+++ b/extension/src/lib/extractPythonError.ts
@@ -1,5 +1,7 @@
 import { Option } from "effect";
 
+import { exceptionClassFromMessage } from "./errorClassification.ts";
+
 /**
  * Extract the last Python exception line from a MarimoCommandError cause.
  *
@@ -41,7 +43,7 @@ function extractLastException(text: string): Option.Option<string> {
   const lines = text.split("\n");
   for (let i = lines.length - 1; i >= 0; i--) {
     const line = lines[i].trim();
-    if (line && /^\w+(\.\w+)*(Error|Exception):/.test(line)) {
+    if (line && exceptionClassFromMessage(line)) {
       return Option.some(truncate(line, 500));
     }
   }

--- a/extension/src/telemetry/__tests__/sentrySink.test.ts
+++ b/extension/src/telemetry/__tests__/sentrySink.test.ts
@@ -2,9 +2,10 @@ import { expect, it } from "@effect/vitest";
 import { Redacted } from "effect";
 
 import { MarimoCommandError } from "../../lsp/MarimoClient.ts";
+import { classifyNotebookDeserializeError } from "../classifyNotebookDeserializeError.ts";
 import { classifySentryError } from "../sentrySink.ts";
 
-function marimoCommandError(rootCause: Error): MarimoCommandError {
+function commandError(cause: Error): MarimoCommandError {
   return new MarimoCommandError({
     command: Redacted.make({
       command: "marimo.api",
@@ -13,37 +14,64 @@ function marimoCommandError(rootCause: Error): MarimoCommandError {
         params: { source: "" },
       },
     }),
-    cause: new Error("An error has occurred", { cause: rootCause }),
+    cause,
     mode: "wasm",
   });
 }
 
+function rpcCommandError(rootCause: Error): MarimoCommandError {
+  return commandError(
+    Object.assign(new Error("An error has occurred", { cause: rootCause }), {
+      name: "ResponseError",
+      code: -32603,
+    }),
+  );
+}
+
+function deserializeErrorData(error: MarimoCommandError) {
+  const classification = classifyNotebookDeserializeError(error);
+  return {
+    "error.domain": classification.domain,
+    "error.kind": classification.kind,
+    ...classification.safeContext,
+  };
+}
+
 it("fingerprints command errors by their nested Python failure", () => {
-  const kernelExit = classifySentryError(
-    marimoCommandError(
-      new Error(
-        "marimo_lsp.kernels.KernelOpenError: Kernel bridge exited unexpectedly (code=1, signal=jsnull)",
-      ),
+  const kernelError = rpcCommandError(
+    new Error(
+      "marimo_lsp.kernels.KernelOpenError: Kernel bridge exited unexpectedly (code=1, signal=jsnull)",
     ),
-    undefined,
+  );
+  const kernelExit = classifySentryError(
+    kernelError,
+    deserializeErrorData(kernelError),
+  );
+  const duplicateError = rpcCommandError(
+    new Error("ValueError: Cell 'xXTn' already exists"),
   );
   const duplicateCell = classifySentryError(
-    marimoCommandError(new Error("ValueError: Cell 'xXTn' already exists")),
-    undefined,
+    duplicateError,
+    deserializeErrorData(duplicateError),
+  );
+  const duplicateStableIdError = rpcCommandError(
+    new Error(
+      "marimo_lsp.app_file_manager.DuplicateCellIdError: Notebook contains duplicate stable cell IDs: DnEU",
+    ),
   );
   const duplicateStableId = classifySentryError(
-    marimoCommandError(
-      new Error(
-        "marimo_lsp.app_file_manager.DuplicateCellIdError: Notebook contains duplicate stable cell IDs: DnEU",
-      ),
-    ),
-    undefined,
+    duplicateStableIdError,
+    deserializeErrorData(duplicateStableIdError),
   );
 
   expect(kernelExit).toEqual({
     tags: {
+      "error.domain": "notebook.deserialize",
       "error.exception_class": "KernelOpenError",
       "error.kind": "marimo-command.kernel-bridge-exit",
+      "rpc.method": "deserialize",
+      "rpc.code": "-32603",
+      "lsp.mode": "wasm",
     },
     fingerprint: ["marimo command error", "kernel-bridge-exit"],
   });
@@ -56,4 +84,23 @@ it("fingerprints command errors by their nested Python failure", () => {
     "DuplicateCellIdError",
   );
   expect(kernelExit.fingerprint).not.toEqual(duplicateCell.fingerprint);
+});
+
+it("preserves specific transport classifications for command failures", () => {
+  const error = commandError(new Error("Client is not running"));
+
+  expect(classifySentryError(error, deserializeErrorData(error))).toEqual({
+    tags: {
+      "error.domain": "notebook.deserialize",
+      "error.exception_class": "Error",
+      "error.kind": "transport.client-not-running",
+      "rpc.method": "deserialize",
+      "lsp.mode": "wasm",
+    },
+    fingerprint: [
+      "notebook.deserialize",
+      "transport.client-not-running",
+      "Error",
+    ],
+  });
 });

--- a/extension/src/telemetry/__tests__/sentrySink.test.ts
+++ b/extension/src/telemetry/__tests__/sentrySink.test.ts
@@ -1,0 +1,59 @@
+import { expect, it } from "@effect/vitest";
+import { Redacted } from "effect";
+
+import { MarimoCommandError } from "../../lsp/MarimoClient.ts";
+import { classifySentryError } from "../sentrySink.ts";
+
+function marimoCommandError(rootCause: Error): MarimoCommandError {
+  return new MarimoCommandError({
+    command: Redacted.make({
+      command: "marimo.api",
+      params: {
+        method: "deserialize",
+        params: { source: "" },
+      },
+    }),
+    cause: new Error("An error has occurred", { cause: rootCause }),
+    mode: "wasm",
+  });
+}
+
+it("fingerprints command errors by their nested Python failure", () => {
+  const kernelExit = classifySentryError(
+    marimoCommandError(
+      new Error(
+        "marimo_lsp.kernels.KernelOpenError: Kernel bridge exited unexpectedly (code=1, signal=jsnull)",
+      ),
+    ),
+    undefined,
+  );
+  const duplicateCell = classifySentryError(
+    marimoCommandError(new Error("ValueError: Cell 'xXTn' already exists")),
+    undefined,
+  );
+  const duplicateStableId = classifySentryError(
+    marimoCommandError(
+      new Error(
+        "marimo_lsp.app_file_manager.DuplicateCellIdError: Notebook contains duplicate stable cell IDs: DnEU",
+      ),
+    ),
+    undefined,
+  );
+
+  expect(kernelExit).toEqual({
+    tags: {
+      "error.exception_class": "KernelOpenError",
+      "error.kind": "marimo-command.kernel-bridge-exit",
+    },
+    fingerprint: ["marimo command error", "kernel-bridge-exit"],
+  });
+  expect(duplicateCell.fingerprint).toEqual([
+    "marimo command error",
+    "duplicate-cell-id",
+  ]);
+  expect(duplicateStableId.fingerprint).toEqual(duplicateCell.fingerprint);
+  expect(duplicateStableId.tags["error.exception_class"]).toBe(
+    "DuplicateCellIdError",
+  );
+  expect(kernelExit.fingerprint).not.toEqual(duplicateCell.fingerprint);
+});

--- a/extension/src/telemetry/classifyNotebookDeserializeError.ts
+++ b/extension/src/telemetry/classifyNotebookDeserializeError.ts
@@ -1,5 +1,6 @@
 import { Cause, Redacted } from "effect";
 
+import { safeErrorClassName } from "../lib/errorClassification.ts";
 import {
   MarimoClientStartError,
   MarimoCommandError,
@@ -58,7 +59,7 @@ export function classifyNotebookDeserializeError(
   if (error instanceof MarimoCommandError) {
     const method = commandMethod(error);
     const code = rpcCode(error.cause);
-    const exceptionClass = safeClassName(error.cause);
+    const exceptionClass = safeErrorClassName(error.cause);
     const kind = isClientNotRunning(error.cause)
       ? "transport.client-not-running"
       : "rpc.internal";
@@ -75,7 +76,7 @@ export function classifyNotebookDeserializeError(
     };
   }
 
-  const exceptionClass = safeClassName(error);
+  const exceptionClass = safeErrorClassName(error);
   return {
     report: true,
     domain: "notebook.deserialize",
@@ -101,19 +102,6 @@ function isClientNotRunning(error: unknown): boolean {
     typeof error.message === "string" &&
     error.message.toLowerCase().includes("client is not running")
   );
-}
-
-function safeClassName(value: unknown): string {
-  if (!isRecord(value)) return typeof value;
-  for (const candidate of [value._tag, value.name, value.constructor?.name]) {
-    if (
-      typeof candidate === "string" &&
-      /^[A-Za-z_$][\w$.-]{0,79}$/.test(candidate)
-    ) {
-      return candidate;
-    }
-  }
-  return "Error";
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/extension/src/telemetry/sentrySink.ts
+++ b/extension/src/telemetry/sentrySink.ts
@@ -75,7 +75,7 @@ export const acquireSentryAdapter = Effect.fn("telemetry.acquireSentryAdapter")(
 
     const captureError: SentryAdapter["captureError"] = (error, data) => {
       try {
-        const classification = classify(data);
+        const classification = classifySentryError(error, data);
         scope.captureException(error, {
           captureContext: {
             ...(data ? { extra: data } : {}),
@@ -126,7 +126,10 @@ export const acquireSentryAdapter = Effect.fn("telemetry.acquireSentryAdapter")(
   },
 );
 
-function classify(data: Record<string, unknown> | undefined) {
+export function classifySentryError(
+  error: Error,
+  data: Record<string, unknown> | undefined,
+) {
   const tags: Record<string, string> = {};
   for (const key of [
     "error.domain",
@@ -148,6 +151,11 @@ function classify(data: Record<string, unknown> | undefined) {
   const code = tags["rpc.code"];
   const exceptionClass = tags["error.exception_class"];
   const errorTag = tags["error.tag"];
+  const commandCause = classifyMarimoCommandCause(error);
+  if (commandCause) {
+    tags["error.exception_class"] ??= commandCause.exceptionClass;
+    tags["error.kind"] ??= `marimo-command.${commandCause.kind}`;
+  }
   const fingerprint =
     domain && kind
       ? [
@@ -158,6 +166,65 @@ function classify(data: Record<string, unknown> | undefined) {
         ]
       : errorTag
         ? ["marimo extension error", errorTag]
-        : undefined;
+        : commandCause
+          ? ["marimo command error", commandCause.kind]
+          : undefined;
   return { tags, fingerprint };
+}
+
+function classifyMarimoCommandCause(
+  error: Error,
+): { readonly exceptionClass: string; readonly kind: string } | undefined {
+  if (error.name !== "MarimoCommandError") {
+    return undefined;
+  }
+
+  const causes = errorCauseChain(error.cause);
+  if (causes.length === 0) return undefined;
+
+  const message = causes.map((cause) => cause.message).join("\n");
+  let exceptionClass = "Error";
+  for (let index = causes.length - 1; index >= 0; index--) {
+    const candidate = nestedExceptionClass(causes[index]);
+    if (candidate !== "Error") {
+      exceptionClass = candidate;
+      break;
+    }
+  }
+  if (message.includes("Kernel bridge exited unexpectedly")) {
+    return { exceptionClass, kind: "kernel-bridge-exit" };
+  }
+  if (
+    exceptionClass === "DuplicateCellIdError" ||
+    /Cell\s+['"`][^'"`]+['"`]\s+already exists/i.test(message)
+  ) {
+    return { exceptionClass, kind: "duplicate-cell-id" };
+  }
+  if (exceptionClass !== "Error") {
+    return { exceptionClass, kind: exceptionClass };
+  }
+  return { exceptionClass, kind: "rpc-error" };
+}
+
+function errorCauseChain(value: unknown): Error[] {
+  const causes: Error[] = [];
+  const seen = new Set<Error>();
+  while (value instanceof Error && !seen.has(value)) {
+    causes.push(value);
+    seen.add(value);
+    value = value.cause;
+  }
+  return causes;
+}
+
+function nestedExceptionClass(error: Error): string {
+  if (error.name !== "Error" && isSafeClassName(error.name)) return error.name;
+  const match = error.message.match(
+    /(?:^|\.)\s*([A-Za-z_$][\w$]*(?:Error|Exception)):/,
+  );
+  return match && isSafeClassName(match[1]) ? match[1] : "Error";
+}
+
+function isSafeClassName(value: string): boolean {
+  return /^[A-Za-z_$][\w$.-]{0,79}$/.test(value);
 }

--- a/extension/src/telemetry/sentrySink.ts
+++ b/extension/src/telemetry/sentrySink.ts
@@ -1,6 +1,8 @@
 import * as SentrySDK from "@sentry/node";
 import { Effect } from "effect";
 
+import { nestedErrorClassName } from "../lib/errorClassification.ts";
+
 // Public DSN (not a secret)
 const SENTRY_DSN =
   "https://717e07e6f9831ef39f872ab4a7a63dc2@o4505919839862784.ingest.us.sentry.io/4510382050770944";
@@ -146,18 +148,23 @@ export function classifySentryError(
     }
   }
 
+  const commandCause = classifyMarimoCommandCause(error);
+  const useCommandCause =
+    commandCause !== undefined &&
+    (tags["error.kind"] === undefined || tags["error.kind"] === "rpc.internal");
+  if (useCommandCause) {
+    tags["error.exception_class"] = commandCause.exceptionClass;
+    tags["error.kind"] = `marimo-command.${commandCause.kind}`;
+  }
+
   const domain = tags["error.domain"];
   const kind = tags["error.kind"];
   const code = tags["rpc.code"];
   const exceptionClass = tags["error.exception_class"];
   const errorTag = tags["error.tag"];
-  const commandCause = classifyMarimoCommandCause(error);
-  if (commandCause) {
-    tags["error.exception_class"] ??= commandCause.exceptionClass;
-    tags["error.kind"] ??= `marimo-command.${commandCause.kind}`;
-  }
-  const fingerprint =
-    domain && kind
+  const fingerprint = useCommandCause
+    ? ["marimo command error", commandCause.kind]
+    : domain && kind
       ? [
           domain,
           kind,
@@ -166,9 +173,7 @@ export function classifySentryError(
         ]
       : errorTag
         ? ["marimo extension error", errorTag]
-        : commandCause
-          ? ["marimo command error", commandCause.kind]
-          : undefined;
+        : undefined;
   return { tags, fingerprint };
 }
 
@@ -185,7 +190,7 @@ function classifyMarimoCommandCause(
   const message = causes.map((cause) => cause.message).join("\n");
   let exceptionClass = "Error";
   for (let index = causes.length - 1; index >= 0; index--) {
-    const candidate = nestedExceptionClass(causes[index]);
+    const candidate = nestedErrorClassName(causes[index]);
     if (candidate !== "Error") {
       exceptionClass = candidate;
       break;
@@ -215,16 +220,4 @@ function errorCauseChain(value: unknown): Error[] {
     value = value.cause;
   }
   return causes;
-}
-
-function nestedExceptionClass(error: Error): string {
-  if (error.name !== "Error" && isSafeClassName(error.name)) return error.name;
-  const match = error.message.match(
-    /(?:^|\.)\s*([A-Za-z_$][\w$]*(?:Error|Exception)):/,
-  );
-  return match && isSafeClassName(match[1]) ? match[1] : "Error";
-}
-
-function isSafeClassName(value: string): boolean {
-  return /^[A-Za-z_$][\w$.-]{0,79}$/.test(value);
 }


### PR DESCRIPTION
`MarimoCommandError` wraps an LSP response error around the Python failure, so the outer exception grouped unrelated RPC failures together. Walk the cause chain to separate kernel exits from duplicate-cell errors while keeping dynamic cell IDs out of the fingerprint.