### PR TITLE
Sync extension/package.json to 0.16.0

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vscode-marimo",
   "displayName": "marimo",
-  "version": "0.15.5",
+  "version": "0.16.0",
   "description": "A marimo notebook extension for VS Code.",
   "categories": [
     "Data Science",


### PR DESCRIPTION
The 0.16.0 release succeeded, but its version bump was not pushed back to main, so extension/package.json stayed at 0.15.5 and the next patch release tried to publish 0.15.6.

Bumping to 0.16.0 so the next patch release lands on 0.16.1.