### PR TITLE
Warn when custom language servers fail

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -88,7 +88,7 @@
           "markdownEnumDescriptions": [
             "Default. Run the self-contained language server using the bundled Pyodide runtime.",
             "Run the bundled Python language server in a uv-managed CPython environment.",
-            "Run the command configured by `marimo.lsp.path`."
+            "Development only. Run the command configured by `marimo.lsp.path`; it must match the extension source revision and has no compatibility guarantee."
           ],
           "markdownDescription": "Select how the extension runs the marimo language server. This does not change the Python interpreter used by notebook kernels.",
           "scope": "window"
@@ -99,7 +99,7 @@
             "type": "string"
           },
           "default": [],
-          "markdownDescription": "Command and arguments used when `marimo.lsp.server` is `custom`, e.g., `[\"/path/to/marimo-lsp\"]`.",
+          "markdownDescription": "Development-only command and arguments used when `marimo.lsp.server` is `custom`, e.g., `[\"/path/to/marimo-lsp\"]`. The server must match the extension source revision.",
           "scope": "window"
         },
         "marimo.experimental.wasmLsp": {

--- a/extension/src/lsp/MarimoClient.ts
+++ b/extension/src/lsp/MarimoClient.ts
@@ -9,6 +9,7 @@ import {
   Data,
   Effect,
   Layer,
+  Option,
   PubSub,
   Queue,
   Redacted,
@@ -32,6 +33,8 @@ import type {
 } from "../types.ts";
 
 const MAX_STDERR_LINES = 200;
+const CUSTOM_LSP_FAILURE_MESSAGE =
+  "The configured marimo-lsp command failed. Custom language servers are for extension development and may be incompatible with this extension build. Update marimo.lsp.path or switch to a bundled language server.";
 
 export type MarimoLspMode = "wasm" | "uv" | "configured";
 
@@ -164,6 +167,10 @@ export class MarimoClient extends Context.Service<MarimoClient>()(
 
       const outputChannel =
         yield* code.window.createLogOutputChannel("marimo-lsp");
+      const notifyCustomLspFailure = yield* makeCustomLspFailureNotifier({
+        mode,
+        channel: outputChannel,
+      });
 
       interface SpawnState {
         readonly stderrTail: string[];
@@ -340,6 +347,7 @@ export class MarimoClient extends Context.Service<MarimoClient>()(
                 mode,
               }),
           }).pipe(
+            Effect.tapError(() => Effect.forkDetach(notifyCustomLspFailure)),
             Effect.withSpan("lsp.executeCommand", {
               attributes: {
                 command: command.command,
@@ -374,6 +382,37 @@ export class MarimoClient extends Context.Service<MarimoClient>()(
     Layer.provide([Config.layer, Uv.layer]),
   );
 }
+
+export const makeCustomLspFailureNotifier = Effect.fn(
+  "MarimoClient.makeCustomLspFailureNotifier",
+)(function* ({
+  mode,
+  channel,
+}: {
+  readonly mode: MarimoLspMode;
+  readonly channel: { readonly name: string; show(): void };
+}) {
+  const code = yield* VsCode;
+  return yield* Effect.cached(
+    Effect.gen(function* () {
+      if (mode !== "configured") return;
+      const selection = yield* code.window.showErrorMessage(
+        CUSTOM_LSP_FAILURE_MESSAGE,
+        { items: ["Open Logs", "Open Settings"] },
+      );
+      if (Option.isNone(selection)) return;
+
+      if (selection.value === "Open Logs") {
+        channel.show();
+        return;
+      }
+      yield* code.commands.executeVSCode(
+        "workbench.action.openSettings",
+        "marimo.lsp",
+      );
+    }),
+  );
+});
 
 function marimoLspMode(selection: MarimoLspExecutable): MarimoLspMode {
   return MarimoLspExecutable.$match(selection, {

--- a/extension/src/lsp/__tests__/MarimoClient.test.ts
+++ b/extension/src/lsp/__tests__/MarimoClient.test.ts
@@ -6,6 +6,7 @@ import { assert, describe, expect, it } from "@effect/vitest";
 import { Effect, Exit, Option, Ref, Stream } from "effect";
 import { vi } from "vite-plus/test";
 
+import { TestVsCode } from "../../__mocks__/TestVsCode.ts";
 import { MarimoLspServer } from "../../config/Config.ts";
 import { notebookId } from "../../lib/__tests__/branded.ts";
 import type { MarimoApiCall, MarimoOperation } from "../../types.ts";
@@ -14,11 +15,111 @@ import {
   findMarimoLspExecutable,
   findWasmMarimoLspExecutable,
   makeMarimoCommands,
+  makeCustomLspFailureNotifier,
   makeMarimoOperationStream,
   selectMarimoLspExecutable,
 } from "../MarimoClient.ts";
 
 const notebook = notebookId("notebook-a");
+
+describe("custom language-server failures", () => {
+  it.effect(
+    "prompts once and opens the selected recovery surface",
+    Effect.fn(function* () {
+      const prompts = yield* Ref.make(0);
+      let logsOpened = 0;
+      const vscode = yield* TestVsCode.make({
+        window: {
+          showErrorMessage: (message, options = {}) => {
+            expect(message).toContain(
+              "Custom language servers are for extension development",
+            );
+            return Ref.update(prompts, (count) => count + 1).pipe(
+              Effect.as(
+                Option.fromNullishOr(
+                  options.items?.find((item) => item === "Open Settings"),
+                ),
+              ),
+            );
+          },
+        },
+      });
+      const notify = yield* makeCustomLspFailureNotifier({
+        mode: "configured",
+        channel: {
+          name: "marimo-lsp",
+          show: () => {
+            logsOpened += 1;
+          },
+        },
+      }).pipe(Effect.provide(vscode.layer));
+
+      yield* Effect.all([notify, notify], { concurrency: "unbounded" });
+
+      expect(yield* Ref.get(prompts)).toBe(1);
+      expect(logsOpened).toBe(0);
+      expect(yield* Ref.get(vscode.executions)).toContainEqual({
+        command: "workbench.action.openSettings",
+        args: ["marimo.lsp"],
+      });
+    }),
+  );
+
+  it.effect(
+    "opens logs when selected",
+    Effect.fn(function* () {
+      let logsOpened = 0;
+      const vscode = yield* TestVsCode.make({
+        window: {
+          showErrorMessage: (_message, options = {}) =>
+            Effect.succeed(
+              Option.fromNullishOr(
+                options.items?.find((item) => item === "Open Logs"),
+              ),
+            ),
+        },
+      });
+      const notify = yield* makeCustomLspFailureNotifier({
+        mode: "configured",
+        channel: {
+          name: "marimo-lsp",
+          show: () => {
+            logsOpened += 1;
+          },
+        },
+      }).pipe(Effect.provide(vscode.layer));
+
+      yield* notify;
+
+      expect(logsOpened).toBe(1);
+      expect(yield* Ref.get(vscode.executions)).toEqual([]);
+    }),
+  );
+
+  it.effect(
+    "does not prompt for bundled language servers",
+    Effect.fn(function* () {
+      const prompts = yield* Ref.make(0);
+      const vscode = yield* TestVsCode.make({
+        window: {
+          showErrorMessage: () =>
+            Ref.update(prompts, (count) => count + 1).pipe(
+              Effect.as(Option.none()),
+            ),
+        },
+      });
+      for (const mode of ["wasm", "uv"] as const) {
+        const notify = yield* makeCustomLspFailureNotifier({
+          mode,
+          channel: { name: "marimo-lsp", show() {} },
+        }).pipe(Effect.provide(vscode.layer));
+        yield* notify;
+      }
+
+      expect(yield* Ref.get(prompts)).toBe(0);
+    }),
+  );
+});
 
 it.effect(
   "does not fail scope cleanup when language-client disposal rejects",


### PR DESCRIPTION
`marimo.lsp.path` is a development escape hatch, not a supported distribution boundary. A version handshake would turn the private command schema into a compatibility contract while still missing source-level drift between local builds.

When a custom server fails its first command, explain that risk once and point developers to logs or settings. Bundled servers keep the existing error path.