### PR TITLE
Address cell presentations by run

### DIFF
--- a/extension/src/kernel/CellRunReducer.ts
+++ b/extension/src/kernel/CellRunReducer.ts
@@ -27,17 +27,27 @@ export const RunPhase = Data.taggedEnum<RunPhase>();
  * A `cell-op`, normalized for the reducer.
  *
  * {@link parseOp} folds the raw op into `CellRuntimeState` and pulls out the run
- * id and timings, so the reducer never sees marimo's nullable wire status.
+ * id and timings, so the reducer never sees marimo's nullable wire status. The
+ * caller supplies an identity for one-off error presentations that have no
+ * upstream run.
  */
 export type Op = Data.TaggedEnum<{
   Queue: { readonly runId: CellRunId; readonly next: CellRuntimeState };
-  Start: { readonly startTime: number; readonly next: CellRuntimeState };
+  Start: {
+    readonly startTime: number;
+    readonly next: CellRuntimeState;
+    readonly ephemeralRunId: CellRunId;
+  };
   Settle: {
     readonly success: boolean;
     readonly endTime: number | undefined;
     readonly next: CellRuntimeState;
+    readonly ephemeralRunId: CellRunId;
   };
-  Update: { readonly next: CellRuntimeState };
+  Update: {
+    readonly next: CellRuntimeState;
+    readonly ephemeralRunId: CellRunId;
+  };
   Interrupt: {};
 }>;
 export const Op = Data.taggedEnum<Op>();
@@ -46,11 +56,21 @@ export const Op = Data.taggedEnum<Op>();
  * One side effect the reducer wants done, as data. The interpreter performs it.
  */
 export type Action = Data.TaggedEnum<{
-  CreateExecution: {};
-  StartExecution: { readonly startTime: number | undefined };
-  EmitOutputs: { readonly state: CellRuntimeState };
-  FinalizeOutputs: { readonly state: CellRuntimeState };
+  CreateExecution: { readonly runId: CellRunId };
+  StartExecution: {
+    readonly runId: CellRunId;
+    readonly startTime: number | undefined;
+  };
+  EmitOutputs: {
+    readonly runId: CellRunId;
+    readonly state: CellRuntimeState;
+  };
+  FinalizeOutputs: {
+    readonly runId: CellRunId;
+    readonly state: CellRuntimeState;
+  };
   EndExecution: {
+    readonly runId: CellRunId;
     readonly success: boolean;
     readonly endTime: number | undefined;
   };
@@ -90,6 +110,7 @@ export function transitionCell(
 export function parseOp(
   next: CellRuntimeState,
   msg: CellOperationNotification,
+  ephemeralRunId: CellRunId,
 ): Option.Option<Op> {
   switch (msg.status) {
     case "queued": {
@@ -100,7 +121,11 @@ export function parseOp(
     }
     case "running":
       return Option.some(
-        Op.Start({ startTime: (msg.timestamp ?? 0) * 1000, next }),
+        Op.Start({
+          startTime: (msg.timestamp ?? 0) * 1000,
+          next,
+          ephemeralRunId,
+        }),
       );
     case "idle":
       return Option.some(
@@ -110,15 +135,16 @@ export function parseOp(
           success: next.output?.channel !== "marimo-error",
           endTime: msg.timestamp == null ? undefined : msg.timestamp * 1000,
           next,
+          ephemeralRunId,
         }),
       );
     default:
-      return Option.some(Op.Update({ next }));
+      return Option.some(Op.Update({ next, ephemeralRunId }));
   }
 }
 
-const hasExecution = (phase: RunPhase): boolean =>
-  phase._tag === "Queued" || phase._tag === "Running";
+const activeRunId = (phase: RunPhase): CellRunId | undefined =>
+  phase._tag === "Queued" || phase._tag === "Running" ? phase.runId : undefined;
 
 const isError = (state: CellRuntimeState): boolean =>
   state.output?.channel === "marimo-error";
@@ -134,10 +160,17 @@ export function step(
 ): { readonly entry: CellRunState; readonly actions: ReadonlyArray<Action> } {
   return Op.$match(op, {
     Interrupt: () => {
-      if (!hasExecution(entry.phase)) return { entry, actions: [] };
+      const runId = activeRunId(entry.phase);
+      if (runId === undefined) return { entry, actions: [] };
       return {
         entry: { ...entry, phase: RunPhase.Completed() },
-        actions: [Action.EndExecution({ success: false, endTime: undefined })],
+        actions: [
+          Action.EndExecution({
+            runId,
+            success: false,
+            endTime: undefined,
+          }),
+        ],
       };
     },
 
@@ -147,53 +180,71 @@ export function step(
       // Record clears stale; clear any prior runtime-error squiggle.
       actions.push(Action.RecordExecution(), Action.ClearRuntimeError());
       // End any still-running prior execution before creating the new one.
-      if (hasExecution(entry.phase)) {
+      const previousRunId = activeRunId(entry.phase);
+      if (previousRunId !== undefined) {
         actions.push(
-          Action.EndExecution({ success: true, endTime: undefined }),
+          Action.EndExecution({
+            runId: previousRunId,
+            success: true,
+            endTime: undefined,
+          }),
         );
       }
-      actions.push(Action.CreateExecution());
+      actions.push(Action.CreateExecution({ runId }));
       return {
         entry: { ...entry, state: next, phase: RunPhase.Queued({ runId }) },
         actions,
       };
     },
 
-    Start: ({ startTime, next }) => {
+    Start: ({ ephemeralRunId, startTime, next }) => {
       const actions: Action[] = [];
       if (next.staleInputs) actions.push(Action.InvalidateCell());
       let phase = entry.phase;
       if (entry.phase._tag === "Queued") {
-        actions.push(Action.StartExecution({ startTime }));
+        actions.push(
+          Action.StartExecution({ runId: entry.phase.runId, startTime }),
+        );
         phase = RunPhase.Running({ runId: entry.phase.runId });
       }
-      if (hasExecution(phase)) {
-        actions.push(Action.EmitOutputs({ state: next }));
+      const runId = activeRunId(phase);
+      if (runId !== undefined) {
+        actions.push(Action.EmitOutputs({ runId, state: next }));
       } else if (isError(next)) {
-        actions.push(...ephemeralError(next, { applyDiagnostic: false }));
+        actions.push(
+          ...ephemeralError(ephemeralRunId, next, {
+            applyDiagnostic: false,
+          }),
+        );
       }
       return { entry: { ...entry, state: next, phase }, actions };
     },
 
-    Update: ({ next }) => {
+    Update: ({ ephemeralRunId, next }) => {
       const actions: Action[] = [];
       if (next.staleInputs) actions.push(Action.InvalidateCell());
-      if (hasExecution(entry.phase)) {
-        actions.push(Action.EmitOutputs({ state: next }));
+      const runId = activeRunId(entry.phase);
+      if (runId !== undefined) {
+        actions.push(Action.EmitOutputs({ runId, state: next }));
       } else if (isError(next)) {
-        actions.push(...ephemeralError(next, { applyDiagnostic: false }));
+        actions.push(
+          ...ephemeralError(ephemeralRunId, next, {
+            applyDiagnostic: false,
+          }),
+        );
       }
       return { entry: { ...entry, state: next, phase: entry.phase }, actions };
     },
 
-    Settle: ({ success, endTime, next }) => {
+    Settle: ({ success, endTime, ephemeralRunId, next }) => {
       const actions: Action[] = [];
       if (next.staleInputs) actions.push(Action.InvalidateCell());
-      if (hasExecution(entry.phase)) {
+      const runId = activeRunId(entry.phase);
+      if (runId !== undefined) {
         actions.push(
-          Action.FinalizeOutputs({ state: next }),
+          Action.FinalizeOutputs({ runId, state: next }),
           Action.ApplyRuntimeError({ state: next }),
-          Action.EndExecution({ success, endTime }),
+          Action.EndExecution({ runId, success, endTime }),
         );
         return {
           entry: { ...entry, state: next, phase: RunPhase.Completed() },
@@ -203,7 +254,9 @@ export function step(
       // No live execution: show a one-off execution for an error, and always
       // reconcile the squiggle (clears it when there's no in-cell frame).
       if (isError(next)) {
-        actions.push(...ephemeralError(next, { applyDiagnostic: true }));
+        actions.push(
+          ...ephemeralError(ephemeralRunId, next, { applyDiagnostic: true }),
+        );
       } else {
         actions.push(Action.ApplyRuntimeError({ state: next }));
       }
@@ -219,16 +272,17 @@ export function step(
  * terminal `idle` op does.
  */
 function ephemeralError(
+  runId: CellRunId,
   next: CellRuntimeState,
   opts: { readonly applyDiagnostic: boolean },
 ): Action[] {
   return [
-    Action.CreateExecution(),
-    Action.StartExecution({ startTime: undefined }),
-    Action.FinalizeOutputs({ state: next }),
+    Action.CreateExecution({ runId }),
+    Action.StartExecution({ runId, startTime: undefined }),
+    Action.FinalizeOutputs({ runId, state: next }),
     ...(opts.applyDiagnostic
       ? [Action.ApplyRuntimeError({ state: next })]
       : []),
-    Action.EndExecution({ success: false, endTime: undefined }),
+    Action.EndExecution({ runId, success: false, endTime: undefined }),
   ];
 }

--- a/extension/src/kernel/CellRuns.ts
+++ b/extension/src/kernel/CellRuns.ts
@@ -18,7 +18,8 @@ import type {
 } from "../schemas/MarimoNotebookDocument.ts";
 import type { CellOperationNotification } from "../types.ts";
 import {
-  type Action,
+  Action,
+  CellRunId,
   type CellRunState,
   makeCellRunState,
   Op,
@@ -79,7 +80,10 @@ type CellRunOperationsInput = Extract<
 
 interface CellRunRecord {
   readonly state: CellRunState;
-  readonly presentation: CellRunPresentation;
+  readonly presentation: Option.Option<{
+    readonly runId: CellRunId;
+    readonly adapter: CellRunPresentation;
+  }>;
 }
 
 const cellRunRef = (
@@ -132,7 +136,7 @@ export class CellRuns extends Context.Service<CellRuns>()("CellRuns", {
       options: {
         readonly cell: CellRunRef;
         readonly source: string | undefined;
-        readonly presentation: CellRunPresentation;
+        readonly presentation: Option.Option<CellRunPresentation>;
       },
     ) => {
       switch (action._tag) {
@@ -145,8 +149,68 @@ export class CellRuns extends Context.Service<CellRuns>()("CellRuns", {
         case "InvalidateCell":
           return invalidate(options.cell);
         default:
-          return options.presentation.apply(options.cell, action);
+          return Option.match(options.presentation, {
+            onNone: () =>
+              Effect.logWarning(
+                "Cell run has no presentation Adapter; skipping action",
+              ).pipe(
+                Effect.annotateLogs({
+                  ...options.cell,
+                  action: action._tag,
+                }),
+              ),
+            onSome: (presentation) => presentation.apply(options.cell, action),
+          });
       }
+    };
+
+    const presentationFor = (
+      action: Action,
+      record: CellRunRecord,
+      current: Option.Option<CellRunPresentation>,
+      createdRunIds: ReadonlySet<CellRunId>,
+    ): Option.Option<CellRunPresentation> => {
+      const forRun = (runId: CellRunId) =>
+        Option.filter(
+          record.presentation,
+          (binding) => binding.runId === runId,
+        ).pipe(
+          Option.map((binding) => binding.adapter),
+          Option.orElse(() =>
+            createdRunIds.has(runId) ? current : Option.none(),
+          ),
+        );
+
+      return Action.$match(action, {
+        CreateExecution: () => current,
+        StartExecution: ({ runId }) => forRun(runId),
+        EmitOutputs: ({ runId }) => forRun(runId),
+        FinalizeOutputs: ({ runId }) => forRun(runId),
+        EndExecution: ({ runId }) => forRun(runId),
+        ApplyRuntimeError: () => current,
+        ClearRuntimeError: () => current,
+        RecordExecution: () => Option.none(),
+        InvalidateCell: () => Option.none(),
+      });
+    };
+
+    const presentationAfter = (
+      state: CellRunState,
+      record: CellRunRecord,
+      current: CellRunPresentation,
+      createdRunIds: ReadonlySet<CellRunId>,
+    ): CellRunRecord["presentation"] => {
+      if (state.phase._tag !== "Queued" && state.phase._tag !== "Running") {
+        return Option.none();
+      }
+      const runId = state.phase.runId;
+      if (createdRunIds.has(runId)) {
+        return Option.some({ runId, adapter: current });
+      }
+      return Option.filter(
+        record.presentation,
+        (binding) => binding.runId === runId,
+      );
     };
 
     const interruptRecords = (
@@ -160,7 +224,10 @@ export class CellRuns extends Context.Service<CellRuns>()("CellRuns", {
           if (options.remove) {
             MutableHashMap.remove(records, cell);
           } else {
-            MutableHashMap.set(records, cell, { ...record, state: entry });
+            MutableHashMap.set(records, cell, {
+              state: entry,
+              presentation: Option.none(),
+            });
           }
           yield* Effect.forEach(
             actions,
@@ -168,7 +235,12 @@ export class CellRuns extends Context.Service<CellRuns>()("CellRuns", {
               perform(action, {
                 cell,
                 source: undefined,
-                presentation: record.presentation,
+                presentation: presentationFor(
+                  action,
+                  record,
+                  Option.map(record.presentation, (binding) => binding.adapter),
+                  new Set(),
+                ),
               }),
             { discard: true },
           );
@@ -203,16 +275,16 @@ export class CellRuns extends Context.Service<CellRuns>()("CellRuns", {
             MutableHashMap.get(records, cell),
             () => ({
               state: makeCellRunState(cell.cellId),
-              presentation: input.presentation,
+              presentation: Option.none(),
             }),
           );
 
           const next = transitionCell(record.state.state, message);
-          const op = parseOp(next, message);
+          const op = parseOp(next, message, CellRunId(crypto.randomUUID()));
           if (Option.isNone(op)) {
             MutableHashMap.set(records, cell, {
               state: { ...record.state, state: next },
-              presentation: input.presentation,
+              presentation: record.presentation,
             });
             return Effect.logWarning(
               "Queued cell-op missing run_id; cannot track execution",
@@ -225,9 +297,20 @@ export class CellRuns extends Context.Service<CellRuns>()("CellRuns", {
           }
 
           const result = step(record.state, op.value);
+          const createdRunIds = new Set<CellRunId>();
+          for (const action of result.actions) {
+            if (action._tag === "CreateExecution") {
+              createdRunIds.add(action.runId);
+            }
+          }
           MutableHashMap.set(records, cell, {
             state: result.entry,
-            presentation: input.presentation,
+            presentation: presentationAfter(
+              result.entry,
+              record,
+              input.presentation,
+              createdRunIds,
+            ),
           });
           const source = input.sourceByCell.get(cell.cellId);
 
@@ -244,7 +327,12 @@ export class CellRuns extends Context.Service<CellRuns>()("CellRuns", {
               return perform(action, {
                 cell,
                 source,
-                presentation: input.presentation,
+                presentation: presentationFor(
+                  action,
+                  record,
+                  Option.some(input.presentation),
+                  createdRunIds,
+                ),
               });
             },
             { discard: true },

--- a/extension/src/kernel/VsCodeCellRunPresentation.ts
+++ b/extension/src/kernel/VsCodeCellRunPresentation.ts
@@ -12,6 +12,7 @@ import {
 import type { NotebookCellId } from "../schemas/MarimoNotebookDocument.ts";
 import type { CellRuntimeState } from "../types.ts";
 import { CellOutputProjection } from "./CellOutputProjection.ts";
+import type { CellRunId } from "./CellRunReducer.ts";
 import type {
   CellRunPresentation,
   CellRunPresentationAction,
@@ -45,8 +46,8 @@ interface PresentedRun {
   readonly notebook: vscode.NotebookDocument;
 }
 
-const resourceKey = (cell: CellRunRef): string =>
-  JSON.stringify([cell.notebookId, cell.cellId]);
+const resourceKey = (cell: CellRunRef, runId: CellRunId): string =>
+  JSON.stringify([cell.notebookId, cell.cellId, runId]);
 
 /**
  * VS Code Adapter for Cell Runs.
@@ -54,7 +55,7 @@ const resourceKey = (cell: CellRunRef): string =>
  * This is the only Module that owns the token-like
  * `vscode.NotebookCellExecution` returned by VS Code. A bound presentation
  * closes over the selected controller, while live run resources remain
- * private here and are addressed by domain cell identity.
+ * private here and are addressed by exact domain run identity.
  */
 export class VsCodeCellRunPresentation extends Context.Service<VsCodeCellRunPresentation>()(
   "VsCodeCellRunPresentation",
@@ -81,12 +82,13 @@ export class VsCodeCellRunPresentation extends Context.Service<VsCodeCellRunPres
 
       const withResource = (
         cell: CellRunRef,
+        runId: CellRunId,
         apply: (resource: PresentedRun) => Effect.Effect<void>,
       ) => {
-        const resource = resources.get(resourceKey(cell));
+        const resource = resources.get(resourceKey(cell, runId));
         return resource === undefined
           ? Effect.logDebug("No live presentation for cell run").pipe(
-              Effect.annotateLogs({ ...cell }),
+              Effect.annotateLogs({ ...cell, runId }),
             )
           : apply(resource);
       };
@@ -107,10 +109,11 @@ export class VsCodeCellRunPresentation extends Context.Service<VsCodeCellRunPres
 
       const emitOutputs = (
         cell: CellRunRef,
+        runId: CellRunId,
         state: CellRuntimeState,
         final: boolean,
       ) =>
-        withResource(cell, ({ notebook, projection }) => {
+        withResource(cell, runId, ({ notebook, projection }) => {
           const keyed = buildKeyedCellOutputs(
             cell.cellId,
             state,
@@ -122,7 +125,7 @@ export class VsCodeCellRunPresentation extends Context.Service<VsCodeCellRunPres
           ).pipe(
             Effect.catchCause((cause) =>
               Effect.logWarning("Failed to update cell output").pipe(
-                Effect.annotateLogs({ cause, ...cell }),
+                Effect.annotateLogs({ cause, ...cell, runId }),
               ),
             ),
           );
@@ -190,27 +193,27 @@ export class VsCodeCellRunPresentation extends Context.Service<VsCodeCellRunPres
                   catch: (cause) =>
                     new InvalidCellError({ cellId: cell.cellId, cause }),
                 });
-                resources.set(resourceKey(cell), {
+                resources.set(resourceKey(cell, action.runId), {
                   execution,
                   projection: new CellOutputProjection(execution),
                   notebook: binding.notebook.rawNotebookDocument,
                 });
               });
             case "StartExecution":
-              return withResource(cell, ({ execution }) =>
+              return withResource(cell, action.runId, ({ execution }) =>
                 Effect.sync(() => execution.start(action.startTime)),
               );
             case "EmitOutputs":
-              return emitOutputs(cell, action.state, false);
+              return emitOutputs(cell, action.runId, action.state, false);
             case "FinalizeOutputs":
-              return emitOutputs(cell, action.state, true);
+              return emitOutputs(cell, action.runId, action.state, true);
             case "EndExecution":
-              return withResource(cell, ({ execution }) =>
+              return withResource(cell, action.runId, ({ execution }) =>
                 Effect.gen(function* () {
                   yield* Effect.try(() =>
                     execution.end(action.success, action.endTime),
                   ).pipe(Effect.ignore);
-                  resources.delete(resourceKey(cell));
+                  resources.delete(resourceKey(cell, action.runId));
                 }),
               );
             case "ApplyRuntimeError":

--- a/extension/src/kernel/__tests__/CellRunReducer.test.ts
+++ b/extension/src/kernel/__tests__/CellRunReducer.test.ts
@@ -14,6 +14,7 @@ import {
 
 const ID = cellId("cell-1");
 const RUN = CellRunId("run-1");
+const EPHEMERAL_RUN = CellRunId("ephemeral-run");
 
 const entry = (phase: RunPhase): CellRunState => ({
   id: ID,
@@ -52,18 +53,33 @@ describe("cell run reducer", () => {
     expect(queued.entry.phase).toEqual(RunPhase.Queued({ runId: RUN }));
     e = queued.entry;
 
-    const started = step(e, Op.Start({ startTime: 5, next: okState() }));
+    const started = step(
+      e,
+      Op.Start({
+        startTime: 5,
+        next: okState(),
+        ephemeralRunId: EPHEMERAL_RUN,
+      }),
+    );
     expect(tags(started.actions)).toEqual(["StartExecution", "EmitOutputs"]);
     expect(started.entry.phase).toEqual(RunPhase.Running({ runId: RUN }));
     e = started.entry;
 
-    const updated = step(e, Op.Update({ next: okState() }));
+    const updated = step(
+      e,
+      Op.Update({ next: okState(), ephemeralRunId: EPHEMERAL_RUN }),
+    );
     expect(tags(updated.actions)).toEqual(["EmitOutputs"]);
     e = updated.entry;
 
     const settled = step(
       e,
-      Op.Settle({ success: true, endTime: 9, next: okState() }),
+      Op.Settle({
+        success: true,
+        endTime: 9,
+        next: okState(),
+        ephemeralRunId: EPHEMERAL_RUN,
+      }),
     );
     expect(tags(settled.actions)).toEqual([
       "FinalizeOutputs",
@@ -77,11 +93,20 @@ describe("cell run reducer", () => {
     const running = entry(RunPhase.Running({ runId: RUN }));
     const { actions } = step(
       running,
-      Op.Settle({ success: false, endTime: undefined, next: errorState() }),
+      Op.Settle({
+        success: false,
+        endTime: undefined,
+        next: errorState(),
+        ephemeralRunId: EPHEMERAL_RUN,
+      }),
     );
     const end = actions.find((a) => a._tag === "EndExecution");
     expect(end).toEqual(
-      Action.EndExecution({ success: false, endTime: undefined }),
+      Action.EndExecution({
+        runId: RUN,
+        success: false,
+        endTime: undefined,
+      }),
     );
   });
 
@@ -100,7 +125,11 @@ describe("cell run reducer", () => {
     // The prior run is ended as a success — it's superseded, not failed.
     const end = actions.find((a) => a._tag === "EndExecution");
     expect(end).toEqual(
-      Action.EndExecution({ success: true, endTime: undefined }),
+      Action.EndExecution({
+        runId: RUN,
+        success: true,
+        endTime: undefined,
+      }),
     );
   });
 
@@ -120,7 +149,12 @@ describe("cell run reducer", () => {
   it("renders a compile error with no prior run via an ephemeral execution", () => {
     const { actions, entry: next } = step(
       entry(RunPhase.Idle()),
-      Op.Settle({ success: false, endTime: undefined, next: errorState() }),
+      Op.Settle({
+        success: false,
+        endTime: undefined,
+        next: errorState(),
+        ephemeralRunId: EPHEMERAL_RUN,
+      }),
     );
     expect(tags(actions)).toEqual([
       "CreateExecution",
@@ -129,6 +163,9 @@ describe("cell run reducer", () => {
       "ApplyRuntimeError",
       "EndExecution",
     ]);
+    expect(
+      actions.flatMap((action) => ("runId" in action ? [action.runId] : [])),
+    ).toEqual([EPHEMERAL_RUN, EPHEMERAL_RUN, EPHEMERAL_RUN, EPHEMERAL_RUN]);
     // The cell never entered a tracked run, so it stays Idle.
     expect(next.phase).toEqual(RunPhase.Idle());
   });
@@ -136,7 +173,12 @@ describe("cell run reducer", () => {
   it("reconciles the squiggle on an idle with nothing to render", () => {
     const { actions } = step(
       entry(RunPhase.Idle()),
-      Op.Settle({ success: true, endTime: undefined, next: okState() }),
+      Op.Settle({
+        success: true,
+        endTime: undefined,
+        next: okState(),
+        ephemeralRunId: EPHEMERAL_RUN,
+      }),
     );
     expect(tags(actions)).toEqual(["ApplyRuntimeError"]);
   });
@@ -144,7 +186,7 @@ describe("cell run reducer", () => {
   it("invalidates the cell when an op carries stale inputs", () => {
     const { actions } = step(
       entry(RunPhase.Running({ runId: RUN })),
-      Op.Update({ next: staleState() }),
+      Op.Update({ next: staleState(), ephemeralRunId: EPHEMERAL_RUN }),
     );
     expect(actions[0]).toEqual(Action.InvalidateCell());
   });

--- a/extension/src/kernel/__tests__/CellRuns.test.ts
+++ b/extension/src/kernel/__tests__/CellRuns.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "@effect/vitest";
 import { createCellRuntimeState } from "@marimo-team/frontend/unstable_internal/core/cells/types.ts";
-import { Effect, Layer, Option } from "effect";
+import { Effect, Layer, Option, Ref } from "effect";
 import { TestClock } from "effect/testing";
 import type * as vscode from "vscode";
 
@@ -12,7 +12,13 @@ import {
 } from "../../__mocks__/TestVsCode.ts";
 import { makeTestNotebookRuntime } from "../../__tests__/__utils__/TestMarimoClient.ts";
 import { NOTEBOOK_TYPE } from "../../constants.ts";
-import { CellRunInput, CellRuns } from "../../kernel/CellRuns.ts";
+import { Action, CellRunId } from "../../kernel/CellRunReducer.ts";
+import {
+  CellRunInput,
+  type CellRunPresentation,
+  type CellRunPresentationAction,
+  CellRuns,
+} from "../../kernel/CellRuns.ts";
 import { buildCellOutputs } from "../../kernel/VsCodeCellOutputs.ts";
 import {
   type VsCodeCellRunBinding,
@@ -1283,6 +1289,81 @@ it.effect(
       );
 
       expect(projectionCalls).toEqual(["clear", "append"]);
+    }).pipe(Effect.provide(ctx.layer));
+  }),
+);
+
+it.effect(
+  "keeps each run bound to the presentation that created it",
+  Effect.fn(function* () {
+    const editor = TestVsCode.makeNotebookEditor(
+      "file:///test/notebook_mo.py",
+      {
+        data: {
+          cells: [
+            {
+              kind: 1,
+              value: "x = 1",
+              languageId: "python",
+              metadata: MarimoNotebookCell.createMetadata({
+                marimoRuntime: { stableId: "cell-1" },
+              }),
+            },
+          ],
+        },
+      },
+    );
+    const ctx = yield* withTestCtx({ initialDocuments: [editor.notebook] });
+
+    yield* Effect.gen(function* () {
+      const cellRuns = yield* CellRuns;
+      const notebook = MarimoNotebookDocument.from(editor.notebook);
+      const cid = Option.getOrThrow(notebook.cellAt(0).id);
+      const firstActions = yield* Ref.make<
+        ReadonlyArray<CellRunPresentationAction>
+      >([]);
+      const secondActions = yield* Ref.make<
+        ReadonlyArray<CellRunPresentationAction>
+      >([]);
+      const recordingPresentation = (
+        actions: Ref.Ref<ReadonlyArray<CellRunPresentationAction>>,
+      ): CellRunPresentation => ({
+        apply: (_cell, action) =>
+          Ref.update(actions, (current) => [...current, action]),
+      });
+      const accept = (runId: string, presentation: CellRunPresentation) =>
+        cellRuns.accept(
+          CellRunInput.Operations({
+            notebookId: notebook.id,
+            operations: [
+              {
+                op: "cell-op",
+                cell_id: cid,
+                status: "queued",
+                run_id: runId,
+              },
+            ],
+            sourceByCell: new Map([[cid, "x = 1"]]),
+            presentation,
+          }),
+        );
+
+      yield* accept("run-1", recordingPresentation(firstActions));
+      yield* accept("run-2", recordingPresentation(secondActions));
+
+      expect(yield* Ref.get(firstActions)).toEqual([
+        Action.ClearRuntimeError(),
+        Action.CreateExecution({ runId: CellRunId("run-1") }),
+        Action.EndExecution({
+          runId: CellRunId("run-1"),
+          success: true,
+          endTime: undefined,
+        }),
+      ]);
+      expect(yield* Ref.get(secondActions)).toEqual([
+        Action.ClearRuntimeError(),
+        Action.CreateExecution({ runId: CellRunId("run-2") }),
+      ]);
     }).pipe(Effect.provide(ctx.layer));
   }),
 );


### PR DESCRIPTION
VS Code returns a live execution that later actions must address. Run-scoped reducer actions now carry the exact identity they target.

```ts
type Action = Data.TaggedEnum<{
  CreateExecution: { readonly runId: CellRunId };
  StartExecution: {
    readonly runId: CellRunId;
    readonly startTime: number | undefined;
  };
  EmitOutputs: { readonly runId: CellRunId; readonly state: CellRuntimeState };
  FinalizeOutputs: { readonly runId: CellRunId; readonly state: CellRuntimeState };
  EndExecution: {
    readonly runId: CellRunId;
    readonly success: boolean;
    readonly endTime: number | undefined;
  };
}>;
```

Presentation resources are keyed by notebook, cell, and run. One-off compile errors receive a local run ID for their presentation lifetime.
