### PR TITLE
Keep accepted source with cell state

### DIFF
--- a/extension/src/kernel/CellExecutions.ts
+++ b/extension/src/kernel/CellExecutions.ts
@@ -8,7 +8,6 @@ import {
   Context,
   Data,
   Effect,
-  HashMap,
   Layer,
   MutableHashMap,
   Option,
@@ -50,6 +49,7 @@ import {
   type KeyedCellOutput,
 } from "./CellOutputProjection.ts";
 import {
+  AcceptedSource,
   Action,
   type CellRunEntry,
   makeCellRunEntry,
@@ -105,7 +105,7 @@ const cellExecutionKey = (
  */
 interface RunRecord {
   readonly entry: CellRunEntry;
-  readonly editor: vscode.NotebookEditor;
+  readonly editor: vscode.NotebookEditor | undefined;
   readonly resource: Option.Option<RunResource>;
 }
 
@@ -141,12 +141,16 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
       // walks the RunRecord by structure. The RunRecord holds a live
       // vscode.NotebookCellExecution. It is not safe to hash its getters.
       const records = MutableHashMap.empty<CellExecutionKey, RunRecord>();
-      const lastExecutedCodeRef = yield* SubscriptionRef.make(
-        HashMap.empty<
-          NotebookId,
-          HashMap.HashMap<NotebookCellId, Option.Option<string>>
-        >(),
-      );
+      const revision = yield* SubscriptionRef.make(0);
+
+      const emptyRecord = (
+        cellId: NotebookCellId,
+        editor?: vscode.NotebookEditor,
+      ): RunRecord => ({
+        entry: makeCellRunEntry(cellId),
+        editor,
+        resource: Option.none(),
+      });
 
       const isCellStale = (cell: MarimoNotebookCell) => {
         const cellId = cell.id;
@@ -156,21 +160,21 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
         const notebookId = cell.notebook.id;
         const currentCode = cell.document.getText();
 
-        return SubscriptionRef.get(lastExecutedCodeRef).pipe(
-          Effect.map((map) =>
-            Option.match(
-              HashMap.get(map, notebookId).pipe(
-                Option.flatMap(HashMap.get(cellId.value)),
-              ),
-              {
-                onNone: () => false,
-                onSome: (lastExecutedCode) =>
-                  Option.match(lastExecutedCode, {
-                    onNone: () => true,
-                    onSome: (executedCode) => executedCode !== currentCode,
-                  }),
-              },
+        return Effect.sync(() =>
+          Option.match(
+            MutableHashMap.get(
+              records,
+              cellExecutionKey(notebookId, cellId.value),
             ),
+            {
+              onNone: () => false,
+              onSome: ({ entry }) =>
+                AcceptedSource.$match(entry.acceptedSource, {
+                  Unknown: () => false,
+                  Invalidated: () => true,
+                  Accepted: ({ source }) => source !== currentCode,
+                }),
+            },
           ),
         );
       };
@@ -213,7 +217,7 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
       );
 
       yield* Effect.forkScoped(
-        SubscriptionRef.changes(lastExecutedCodeRef).pipe(
+        SubscriptionRef.changes(revision).pipe(
           Stream.runForEach(updateStaleContext),
         ),
       );
@@ -229,40 +233,37 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
         ),
       );
 
-      const recordExecution = (cell: MarimoNotebookCell) => {
+      const updateAcceptedSource = (
+        cell: MarimoNotebookCell,
+        acceptedSource: AcceptedSource,
+      ) => {
         const cellId = cell.id;
         if (Option.isNone(cellId)) return Effect.void;
-        const notebookId = cell.notebook.id;
-        const currentCode = cell.document.getText();
-        return SubscriptionRef.update(lastExecutedCodeRef, (map) => {
-          const notebookMap = Option.getOrElse(
-            HashMap.get(map, notebookId),
-            () => HashMap.empty<NotebookCellId, Option.Option<string>>(),
+        const key = cellExecutionKey(cell.notebook.id, cellId.value);
+        return Effect.sync(() => {
+          const record = Option.getOrElse(
+            MutableHashMap.get(records, key),
+            () => emptyRecord(cellId.value),
           );
-          return HashMap.set(
-            map,
-            notebookId,
-            HashMap.set(notebookMap, cellId.value, Option.some(currentCode)),
-          );
-        });
+          MutableHashMap.set(records, key, {
+            ...record,
+            entry: { ...record.entry, acceptedSource },
+          });
+        }).pipe(
+          Effect.andThen(
+            SubscriptionRef.update(revision, (value) => value + 1),
+          ),
+        );
       };
 
-      const invalidateCell = (cell: MarimoNotebookCell) => {
-        const cellId = cell.id;
-        if (Option.isNone(cellId)) return Effect.void;
-        const notebookId = cell.notebook.id;
-        return SubscriptionRef.update(lastExecutedCodeRef, (map) => {
-          const notebookMap = Option.getOrElse(
-            HashMap.get(map, notebookId),
-            () => HashMap.empty<NotebookCellId, Option.Option<string>>(),
-          );
-          return HashMap.set(
-            map,
-            notebookId,
-            HashMap.set(notebookMap, cellId.value, Option.none()),
-          );
-        });
-      };
+      const recordExecution = (cell: MarimoNotebookCell) =>
+        updateAcceptedSource(
+          cell,
+          AcceptedSource.Accepted({ source: cell.document.getText() }),
+        );
+
+      const invalidateCell = (cell: MarimoNotebookCell) =>
+        updateAcceptedSource(cell, AcceptedSource.Invalidated());
 
       yield* Effect.addFinalizer(() =>
         Effect.sync(() => {
@@ -443,20 +444,6 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
             );
             return clearErrorDiagnostic(ctx.notebookCell.document.uri);
           },
-          RecordExecution: () => {
-            assert(
-              ctx.notebookCell !== undefined,
-              "RecordExecution requires a notebook cell",
-            );
-            return recordExecution(ctx.notebookCell);
-          },
-          InvalidateCell: () => {
-            assert(
-              ctx.notebookCell !== undefined,
-              "InvalidateCell requires a notebook cell",
-            );
-            return invalidateCell(ctx.notebookCell);
-          },
         });
 
       return {
@@ -464,18 +451,29 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
         recordExecution,
         invalidateCell,
         forgetCell(notebookId: NotebookId, cellId: NotebookCellId) {
-          return SubscriptionRef.update(lastExecutedCodeRef, (map) => {
-            const notebookMap = HashMap.get(map, notebookId);
-            if (Option.isNone(notebookMap)) return map;
-            const updated = HashMap.remove(notebookMap.value, cellId);
-            return HashMap.isEmpty(updated)
-              ? HashMap.remove(map, notebookId)
-              : HashMap.set(map, notebookId, updated);
-          });
+          const key = cellExecutionKey(notebookId, cellId);
+          return Effect.sync(() => {
+            const record = MutableHashMap.get(records, key);
+            if (Option.isNone(record)) return false;
+            MutableHashMap.set(records, key, {
+              ...record.value,
+              entry: {
+                ...record.value.entry,
+                acceptedSource: AcceptedSource.Unknown(),
+              },
+            });
+            return true;
+          }).pipe(
+            Effect.flatMap((changed) =>
+              changed
+                ? SubscriptionRef.update(revision, (value) => value + 1)
+                : Effect.void,
+            ),
+          );
         },
         get changes(): Stream.Stream<void> {
           return Stream.merge(
-            Stream.map(SubscriptionRef.changes(lastExecutedCodeRef), constVoid),
+            Stream.map(SubscriptionRef.changes(revision), constVoid),
             Stream.map(contentChanges, constVoid),
           );
         },
@@ -518,11 +516,7 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
 
             const record = Option.getOrElse(
               MutableHashMap.get(records, key),
-              () => ({
-                entry: makeCellRunEntry(cellId),
-                editor,
-                resource: Option.none<RunResource>(),
-              }),
+              () => emptyRecord(cellId, editor),
             );
 
             const notebookCell = yield* findNotebookCell(notebook, cellId);
@@ -538,19 +532,28 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
               yield* Effect.sync(() =>
                 MutableHashMap.set(records, key, {
                   ...record,
+                  editor,
                   entry: { ...record.entry, state: next },
                 }),
               );
               return;
             }
 
-            const result = step(record.entry, op.value);
+            const result = step(
+              record.entry,
+              op.value,
+              notebookCell.document.getText(),
+            );
             yield* Effect.sync(() =>
               MutableHashMap.set(records, key, {
                 ...record,
+                editor,
                 entry: result.entry,
               }),
             );
+            if (result.entry.acceptedSource !== record.entry.acceptedSource) {
+              yield* SubscriptionRef.update(revision, (value) => value + 1);
+            }
 
             const ctx: PerformContext = {
               key,

--- a/extension/src/kernel/CellExecutions.ts
+++ b/extension/src/kernel/CellExecutions.ts
@@ -8,6 +8,7 @@ import {
   Context,
   Data,
   Effect,
+  Equal,
   Layer,
   MutableHashMap,
   Option,
@@ -245,13 +246,19 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
             MutableHashMap.get(records, key),
             () => emptyRecord(cellId.value),
           );
+          if (Equal.equals(record.entry.acceptedSource, acceptedSource)) {
+            return false;
+          }
           MutableHashMap.set(records, key, {
             ...record,
             entry: { ...record.entry, acceptedSource },
           });
+          return true;
         }).pipe(
-          Effect.andThen(
-            SubscriptionRef.update(revision, (value) => value + 1),
+          Effect.flatMap((changed) =>
+            changed
+              ? SubscriptionRef.update(revision, (value) => value + 1)
+              : Effect.void,
           ),
         );
       };
@@ -551,7 +558,12 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
                 entry: result.entry,
               }),
             );
-            if (result.entry.acceptedSource !== record.entry.acceptedSource) {
+            if (
+              !Equal.equals(
+                result.entry.acceptedSource,
+                record.entry.acceptedSource,
+              )
+            ) {
               yield* SubscriptionRef.update(revision, (value) => value + 1);
             }
 

--- a/extension/src/kernel/CellRunReducer.ts
+++ b/extension/src/kernel/CellRunReducer.ts
@@ -23,6 +23,14 @@ export type RunPhase = Data.TaggedEnum<{
 }>;
 export const RunPhase = Data.taggedEnum<RunPhase>();
 
+/** The source most recently accepted by the kernel. */
+export type AcceptedSource = Data.TaggedEnum<{
+  Unknown: {};
+  Invalidated: {};
+  Accepted: { readonly source: string };
+}>;
+export const AcceptedSource = Data.taggedEnum<AcceptedSource>();
+
 /**
  * A `cell-op`, normalized for the reducer.
  *
@@ -56,8 +64,6 @@ export type Action = Data.TaggedEnum<{
   };
   ApplyRuntimeError: { readonly state: CellRuntimeState };
   ClearRuntimeError: {};
-  RecordExecution: {};
-  InvalidateCell: {};
 }>;
 export const Action = Data.taggedEnum<Action>();
 
@@ -66,10 +72,16 @@ export interface CellRunEntry {
   readonly id: NotebookCellId;
   readonly state: CellRuntimeState;
   readonly phase: RunPhase;
+  readonly acceptedSource: AcceptedSource;
 }
 
 export function makeCellRunEntry(id: NotebookCellId): CellRunEntry {
-  return { id, state: createCellRuntimeState(), phase: RunPhase.Idle() };
+  return {
+    id,
+    state: createCellRuntimeState(),
+    phase: RunPhase.Idle(),
+    acceptedSource: AcceptedSource.Unknown(),
+  };
 }
 
 /** Type-safe wrapper around marimo's imported `transitionCell`. */
@@ -129,6 +141,7 @@ const isError = (state: CellRuntimeState): boolean =>
 export function step(
   entry: CellRunEntry,
   op: Op,
+  source?: string,
 ): { readonly entry: CellRunEntry; readonly actions: ReadonlyArray<Action> } {
   return Op.$match(op, {
     Interrupt: () => {
@@ -141,9 +154,13 @@ export function step(
 
     Queue: ({ runId, next }) => {
       const actions: Action[] = [];
-      if (next.staleInputs) actions.push(Action.InvalidateCell());
-      // Record clears stale; clear any prior runtime-error squiggle.
-      actions.push(Action.RecordExecution(), Action.ClearRuntimeError());
+      // Queue is the kernel's acknowledgement that it accepted this source.
+      // It wins over `staleInputs` when both arrive on the same operation.
+      const acceptedSource =
+        source === undefined
+          ? entry.acceptedSource
+          : AcceptedSource.Accepted({ source });
+      actions.push(Action.ClearRuntimeError());
       // End any still-running prior execution before creating the new one.
       if (hasExecution(entry.phase)) {
         actions.push(
@@ -152,14 +169,18 @@ export function step(
       }
       actions.push(Action.CreateExecution());
       return {
-        entry: { ...entry, state: next, phase: RunPhase.Queued({ runId }) },
+        entry: {
+          ...entry,
+          state: next,
+          phase: RunPhase.Queued({ runId }),
+          acceptedSource,
+        },
         actions,
       };
     },
 
     Start: ({ startTime, next }) => {
       const actions: Action[] = [];
-      if (next.staleInputs) actions.push(Action.InvalidateCell());
       let phase = entry.phase;
       if (entry.phase._tag === "Queued") {
         actions.push(Action.StartExecution({ startTime }));
@@ -170,23 +191,43 @@ export function step(
       } else if (isError(next)) {
         actions.push(...ephemeralError(next, { applyDiagnostic: false }));
       }
-      return { entry: { ...entry, state: next, phase }, actions };
+      return {
+        entry: {
+          ...entry,
+          state: next,
+          phase,
+          acceptedSource: next.staleInputs
+            ? AcceptedSource.Invalidated()
+            : entry.acceptedSource,
+        },
+        actions,
+      };
     },
 
     Update: ({ next }) => {
       const actions: Action[] = [];
-      if (next.staleInputs) actions.push(Action.InvalidateCell());
       if (hasExecution(entry.phase)) {
         actions.push(Action.EmitOutputs({ state: next }));
       } else if (isError(next)) {
         actions.push(...ephemeralError(next, { applyDiagnostic: false }));
       }
-      return { entry: { ...entry, state: next, phase: entry.phase }, actions };
+      return {
+        entry: {
+          ...entry,
+          state: next,
+          acceptedSource: next.staleInputs
+            ? AcceptedSource.Invalidated()
+            : entry.acceptedSource,
+        },
+        actions,
+      };
     },
 
     Settle: ({ success, endTime, next }) => {
       const actions: Action[] = [];
-      if (next.staleInputs) actions.push(Action.InvalidateCell());
+      const acceptedSource = next.staleInputs
+        ? AcceptedSource.Invalidated()
+        : entry.acceptedSource;
       if (hasExecution(entry.phase)) {
         actions.push(
           Action.FinalizeOutputs({ state: next }),
@@ -194,7 +235,12 @@ export function step(
           Action.EndExecution({ success, endTime }),
         );
         return {
-          entry: { ...entry, state: next, phase: RunPhase.Completed() },
+          entry: {
+            ...entry,
+            state: next,
+            phase: RunPhase.Completed(),
+            acceptedSource,
+          },
           actions,
         };
       }
@@ -205,7 +251,10 @@ export function step(
       } else {
         actions.push(Action.ApplyRuntimeError({ state: next }));
       }
-      return { entry: { ...entry, state: next, phase: entry.phase }, actions };
+      return {
+        entry: { ...entry, state: next, acceptedSource },
+        actions,
+      };
     },
   });
 }

--- a/extension/src/kernel/__tests__/CellRunReducer.test.ts
+++ b/extension/src/kernel/__tests__/CellRunReducer.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vite-plus/test";
 import { cellId } from "../../lib/__tests__/branded.ts";
 import type { CellRuntimeState } from "../../types.ts";
 import {
+  AcceptedSource,
   Action,
   type CellRunEntry,
   Op,
@@ -19,6 +20,7 @@ const entry = (phase: RunPhase): CellRunEntry => ({
   id: ID,
   state: createCellRuntimeState(),
   phase,
+  acceptedSource: AcceptedSource.Unknown(),
 });
 
 const okState = (): CellRuntimeState => createCellRuntimeState();
@@ -43,13 +45,15 @@ describe("cell run reducer", () => {
   it("drives a normal run: queue → start → update → settle", () => {
     let e = entry(RunPhase.Idle());
 
-    const queued = step(e, Op.Queue({ runId: RUN, next: okState() }));
+    const queued = step(e, Op.Queue({ runId: RUN, next: okState() }), "x = 1");
     expect(tags(queued.actions)).toEqual([
-      "RecordExecution",
       "ClearRuntimeError",
       "CreateExecution",
     ]);
     expect(queued.entry.phase).toEqual(RunPhase.Queued({ runId: RUN }));
+    expect(queued.entry.acceptedSource).toEqual(
+      AcceptedSource.Accepted({ source: "x = 1" }),
+    );
     e = queued.entry;
 
     const started = step(e, Op.Start({ startTime: 5, next: okState() }));
@@ -92,7 +96,6 @@ describe("cell run reducer", () => {
       Op.Queue({ runId: RunId("run-2"), next: okState() }),
     );
     expect(tags(actions)).toEqual([
-      "RecordExecution",
       "ClearRuntimeError",
       "EndExecution",
       "CreateExecution",
@@ -141,11 +144,22 @@ describe("cell run reducer", () => {
     expect(tags(actions)).toEqual(["ApplyRuntimeError"]);
   });
 
-  it("invalidates the cell when an op carries stale inputs", () => {
-    const { actions } = step(
+  it("invalidates the accepted source when an op carries stale inputs", () => {
+    const { entry: next } = step(
       entry(RunPhase.Running({ runId: RUN })),
       Op.Update({ next: staleState() }),
     );
-    expect(actions[0]).toEqual(Action.InvalidateCell());
+    expect(next.acceptedSource).toEqual(AcceptedSource.Invalidated());
+  });
+
+  it("records a queued source even when the operation carries stale inputs", () => {
+    const { entry: next } = step(
+      entry(RunPhase.Idle()),
+      Op.Queue({ runId: RUN, next: staleState() }),
+      "x = 1",
+    );
+    expect(next.acceptedSource).toEqual(
+      AcceptedSource.Accepted({ source: "x = 1" }),
+    );
   });
 });


### PR DESCRIPTION
The reducer state now owns the source last accepted by the kernel.

```ts
interface CellRunEntry {
  readonly id: NotebookCellId;
  readonly state: CellRuntimeState;
  readonly phase: RunPhase;
  readonly acceptedSource: AcceptedSource;
}
```

Queue records source in the same transition that opens a run. `stale_inputs` invalidates it. This removes the separate `lastExecutedCodeRef` and the internal `RecordExecution` and `InvalidateCell` actions.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
