### PR TITLE
Address cell commands by run

### DIFF
--- a/extension/src/kernel/CellExecutions.ts
+++ b/extension/src/kernel/CellExecutions.ts
@@ -51,11 +51,12 @@ import {
 } from "./CellOutputProjection.ts";
 import {
   AcceptedSource,
-  Action,
+  CellCommand,
   type CellRunEntry,
   makeCellRunEntry,
   Op,
   parseOp,
+  RunId,
   step,
   transitionCell,
 } from "./CellRunReducer.ts";
@@ -84,6 +85,7 @@ class InvalidCellError extends Data.TaggedError("InvalidCellError")<{
 
 /** A run's live VS Code execution and the projection driving its outputs. */
 interface RunResource {
+  readonly runId: RunId;
   readonly execution: vscode.NotebookCellExecution;
   readonly projection: CellOutputProjection;
 }
@@ -111,9 +113,9 @@ interface RunRecord {
 }
 
 /**
- * What the {@link Action} interpreter needs to perform a single op's actions.
+ * What the {@link CellCommand} interpreter needs to drive a single command.
  * `notebookCell` / `controller` are absent for interrupts (which only end
- * executions); actions that require them assert their presence.
+ * runs); commands that require them assert their presence.
  */
 interface PerformContext {
   readonly key: CellExecutionKey;
@@ -354,19 +356,22 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
       // none (a benign race: the execution was ended concurrently).
       const withResource = (
         key: CellExecutionKey,
+        runId: RunId,
         f: (resource: RunResource) => Effect.Effect<void>,
       ) =>
         getResource(key).pipe(
+          Effect.map(Option.filter((resource) => resource.runId === runId)),
           Effect.flatMap(
             Option.match({
               onSome: f,
               onNone: () =>
                 Effect.logDebug(
-                  "No live execution for cell; skipping action",
+                  "No live execution for cell run; skipping command",
                 ).pipe(
                   Effect.annotateLogs({
                     notebookId: key.notebookId,
                     cellId: key.cellId,
+                    runId,
                   }),
                 ),
             }),
@@ -375,10 +380,11 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
 
       const emitOutputs = (
         ctx: PerformContext,
+        runId: RunId,
         state: CellRuntimeState,
         final: boolean,
       ) =>
-        withResource(ctx.key, ({ projection }) => {
+        withResource(ctx.key, runId, ({ projection }) => {
           const keyed = buildKeyedCellOutputs(
             ctx.cellId,
             state,
@@ -397,14 +403,14 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
           );
         });
 
-      // The operation interpreter: perform one Action against the real world.
-      const perform = (action: Action, ctx: PerformContext) =>
-        Action.$match(action, {
-          CreateExecution: () =>
+      // The operation interpreter: drive one command against the real world.
+      const drive = (command: CellCommand, ctx: PerformContext) =>
+        CellCommand.$match(command, {
+          OpenRun: ({ runId }) =>
             Effect.gen(function* () {
               assert(
                 ctx.notebookCell !== undefined && ctx.controller !== undefined,
-                "CreateExecution requires a notebook cell and controller",
+                "OpenRun requires a notebook cell and controller",
               );
               const notebookCell = ctx.notebookCell;
               const controller = ctx.controller;
@@ -416,40 +422,39 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
               yield* setResource(
                 ctx.key,
                 Option.some({
+                  runId,
                   execution,
                   projection: new CellOutputProjection(execution),
                 }),
               );
             }),
-          StartExecution: ({ startTime }) =>
-            withResource(ctx.key, ({ execution }) =>
-              Effect.sync(() => execution.start(startTime)),
+          StartRun: ({ runId, at }) =>
+            withResource(ctx.key, runId, ({ execution }) =>
+              Effect.sync(() => execution.start(at)),
             ),
-          EmitOutputs: ({ state }) => emitOutputs(ctx, state, false),
-          FinalizeOutputs: ({ state }) => emitOutputs(ctx, state, true),
-          EndExecution: ({ success, endTime }) =>
-            withResource(ctx.key, ({ execution }) =>
+          RenderOutputs: ({ runId, state, final }) =>
+            emitOutputs(ctx, runId, state, final),
+          CloseRun: ({ runId, success, at }) =>
+            withResource(ctx.key, runId, ({ execution }) =>
               Effect.gen(function* () {
                 // `end` throws if already ended (a race); swallow it.
-                yield* Effect.try(() => execution.end(success, endTime)).pipe(
+                yield* Effect.try(() => execution.end(success, at)).pipe(
                   Effect.ignore,
                 );
                 yield* setResource(ctx.key, Option.none());
               }),
             ),
-          ApplyRuntimeError: ({ state }) => {
+          SetDiagnostic: ({ state }) => {
             assert(
               ctx.notebookCell !== undefined,
-              "ApplyRuntimeError requires a notebook cell",
+              "SetDiagnostic requires a notebook cell",
             );
-            return applyErrorDiagnostic(ctx.notebookCell, ctx.cellId, state);
-          },
-          ClearRuntimeError: () => {
-            assert(
-              ctx.notebookCell !== undefined,
-              "ClearRuntimeError requires a notebook cell",
-            );
-            return clearErrorDiagnostic(ctx.notebookCell.document.uri);
+            const notebookCell = ctx.notebookCell;
+            return Option.match(state, {
+              onNone: () => clearErrorDiagnostic(notebookCell.document.uri),
+              onSome: (runtime) =>
+                applyErrorDiagnostic(notebookCell, ctx.cellId, runtime),
+            });
           },
         });
 
@@ -490,7 +495,7 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
               ([, record]) => record.editor === editor,
             );
             for (const [key, record] of targets) {
-              const { entry, actions } = step(record.entry, Op.Interrupt());
+              const { entry, commands } = step(record.entry, Op.Interrupt());
               yield* Effect.sync(() =>
                 MutableHashMap.set(records, key, { ...record, entry }),
               );
@@ -501,9 +506,9 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
                 controller: undefined,
                 notebook: undefined,
               };
-              for (const action of actions) {
+              for (const command of commands) {
                 // oxlint-disable-next-line eslint/no-await-in-loop -- ordered
-                yield* perform(action, ctx);
+                yield* drive(command, ctx);
               }
             }
           }),
@@ -531,7 +536,7 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
             // Fold the cell-op into the run state once, up front, so the folded
             // state is persisted even for an op we end up dropping.
             const next = transitionCell(record.entry.state, msg);
-            const op = parseOp(next, msg);
+            const op = parseOp(next, msg, RunId(crypto.randomUUID()));
             if (Option.isNone(op)) {
               yield* Effect.logWarning(
                 "Queued cell-op missing run_id; cannot track execution",
@@ -574,17 +579,16 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
               controller,
               notebook: editor.notebook,
             };
-            for (const action of result.actions) {
+            for (const command of result.commands) {
               if (
                 options.renderOutput === false &&
-                (action._tag === "EmitOutputs" ||
-                  action._tag === "FinalizeOutputs")
+                command._tag === "RenderOutputs"
               ) {
                 continue;
               }
-              // oxlint-disable-next-line eslint/no-await-in-loop -- actions are
-              // ordered (e.g. FinalizeOutputs must land before EndExecution)
-              yield* perform(action, ctx);
+              // oxlint-disable-next-line eslint/no-await-in-loop -- commands
+              // are ordered (e.g. RenderOutputs lands before CloseRun)
+              yield* drive(command, ctx);
             }
           }).pipe(
             Effect.catchTag("NotebookCellNotFoundError", () =>

--- a/extension/src/kernel/CellExecutions.ts
+++ b/extension/src/kernel/CellExecutions.ts
@@ -543,7 +543,6 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
             if (
               msg.status !== "queued" &&
               receivedRunId !== undefined &&
-              activeRunId !== undefined &&
               receivedRunId !== activeRunId
             ) {
               yield* Effect.logWarning(

--- a/extension/src/kernel/CellExecutions.ts
+++ b/extension/src/kernel/CellExecutions.ts
@@ -531,6 +531,33 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
               () => emptyRecord(cellId, editor),
             );
 
+            const activeRunId =
+              record.entry.phase._tag === "Queued" ||
+              record.entry.phase._tag === "Running"
+                ? record.entry.phase.runId
+                : undefined;
+            const receivedRunId =
+              typeof msg.run_id === "string" && msg.run_id.length > 0
+                ? msg.run_id
+                : undefined;
+            if (
+              msg.status !== "queued" &&
+              receivedRunId !== undefined &&
+              activeRunId !== undefined &&
+              receivedRunId !== activeRunId
+            ) {
+              yield* Effect.logWarning(
+                "Cell operation targets a superseded run; skipping",
+              ).pipe(
+                Effect.annotateLogs({
+                  expectedRunId: activeRunId,
+                  receivedRunId,
+                  status: msg.status,
+                }),
+              );
+              return;
+            }
+
             const notebookCell = yield* findNotebookCell(notebook, cellId);
 
             // Fold the cell-op into the run state once, up front, so the folded

--- a/extension/src/kernel/CellRunReducer.ts
+++ b/extension/src/kernel/CellRunReducer.ts
@@ -39,33 +39,39 @@ export const AcceptedSource = Data.taggedEnum<AcceptedSource>();
  */
 export type Op = Data.TaggedEnum<{
   Queue: { readonly runId: RunId; readonly next: CellRuntimeState };
-  Start: { readonly startTime: number; readonly next: CellRuntimeState };
+  Start: {
+    readonly startTime: number;
+    readonly next: CellRuntimeState;
+    readonly ephemeralRunId: RunId;
+  };
   Settle: {
     readonly success: boolean;
     readonly endTime: number | undefined;
     readonly next: CellRuntimeState;
+    readonly ephemeralRunId: RunId;
   };
-  Update: { readonly next: CellRuntimeState };
+  Update: { readonly next: CellRuntimeState; readonly ephemeralRunId: RunId };
   Interrupt: {};
 }>;
 export const Op = Data.taggedEnum<Op>();
 
-/**
- * One side effect the reducer wants done, as data. The interpreter performs it.
- */
-export type Action = Data.TaggedEnum<{
-  CreateExecution: {};
-  StartExecution: { readonly startTime: number | undefined };
-  EmitOutputs: { readonly state: CellRuntimeState };
-  FinalizeOutputs: { readonly state: CellRuntimeState };
-  EndExecution: {
-    readonly success: boolean;
-    readonly endTime: number | undefined;
+/** One host effect requested by the reducer. */
+export type CellCommand = Data.TaggedEnum<{
+  OpenRun: { readonly runId: RunId };
+  StartRun: { readonly runId: RunId; readonly at: number | undefined };
+  RenderOutputs: {
+    readonly runId: RunId;
+    readonly state: CellRuntimeState;
+    readonly final: boolean;
   };
-  ApplyRuntimeError: { readonly state: CellRuntimeState };
-  ClearRuntimeError: {};
+  CloseRun: {
+    readonly runId: RunId;
+    readonly success: boolean;
+    readonly at: number | undefined;
+  };
+  SetDiagnostic: { readonly state: Option.Option<CellRuntimeState> };
 }>;
-export const Action = Data.taggedEnum<Action>();
+export const CellCommand = Data.taggedEnum<CellCommand>();
 
 /** Pure, vscode-free per-cell reducer state. */
 export interface CellRunEntry {
@@ -102,6 +108,7 @@ export function transitionCell(
 export function parseOp(
   next: CellRuntimeState,
   msg: CellOperationNotification,
+  ephemeralRunId: RunId,
 ): Option.Option<Op> {
   switch (msg.status) {
     case "queued": {
@@ -110,7 +117,11 @@ export function parseOp(
     }
     case "running":
       return Option.some(
-        Op.Start({ startTime: (msg.timestamp ?? 0) * 1000, next }),
+        Op.Start({
+          startTime: (msg.timestamp ?? 0) * 1000,
+          next,
+          ephemeralRunId,
+        }),
       );
     case "idle":
       return Option.some(
@@ -120,54 +131,67 @@ export function parseOp(
           success: next.output?.channel !== "marimo-error",
           endTime: msg.timestamp == null ? undefined : msg.timestamp * 1000,
           next,
+          ephemeralRunId,
         }),
       );
     default:
-      return Option.some(Op.Update({ next }));
+      return Option.some(Op.Update({ next, ephemeralRunId }));
   }
 }
 
-const hasExecution = (phase: RunPhase): boolean =>
-  phase._tag === "Queued" || phase._tag === "Running";
+const activeRunId = (phase: RunPhase): RunId | undefined =>
+  phase._tag === "Queued" || phase._tag === "Running" ? phase.runId : undefined;
 
 const isError = (state: CellRuntimeState): boolean =>
   state.output?.channel === "marimo-error";
 
 /**
  * The cell run reducer: pure, total, vscode-free. Decides the next
- * {@link RunPhase} and the ordered {@link Action}s a single {@link Op} causes.
+ * {@link RunPhase} and the ordered {@link CellCommand}s a single
+ * {@link Op} causes.
  * The one place that decides what a cell-op *means*.
  */
 export function step(
   entry: CellRunEntry,
   op: Op,
   source?: string,
-): { readonly entry: CellRunEntry; readonly actions: ReadonlyArray<Action> } {
+): {
+  readonly entry: CellRunEntry;
+  readonly commands: ReadonlyArray<CellCommand>;
+} {
   return Op.$match(op, {
     Interrupt: () => {
-      if (!hasExecution(entry.phase)) return { entry, actions: [] };
+      const runId = activeRunId(entry.phase);
+      if (runId === undefined) return { entry, commands: [] };
       return {
         entry: { ...entry, phase: RunPhase.Completed() },
-        actions: [Action.EndExecution({ success: false, endTime: undefined })],
+        commands: [
+          CellCommand.CloseRun({ runId, success: false, at: undefined }),
+        ],
       };
     },
 
     Queue: ({ runId, next }) => {
-      const actions: Action[] = [];
+      const commands: CellCommand[] = [];
       // Queue is the kernel's acknowledgement that it accepted this source.
       // It wins over `staleInputs` when both arrive on the same operation.
       const acceptedSource =
         source === undefined
           ? entry.acceptedSource
           : AcceptedSource.Accepted({ source });
-      actions.push(Action.ClearRuntimeError());
+      commands.push(CellCommand.SetDiagnostic({ state: Option.none() }));
       // End any still-running prior execution before creating the new one.
-      if (hasExecution(entry.phase)) {
-        actions.push(
-          Action.EndExecution({ success: true, endTime: undefined }),
+      const previousRunId = activeRunId(entry.phase);
+      if (previousRunId !== undefined) {
+        commands.push(
+          CellCommand.CloseRun({
+            runId: previousRunId,
+            success: true,
+            at: undefined,
+          }),
         );
       }
-      actions.push(Action.CreateExecution());
+      commands.push(CellCommand.OpenRun({ runId }));
       return {
         entry: {
           ...entry,
@@ -175,21 +199,33 @@ export function step(
           phase: RunPhase.Queued({ runId }),
           acceptedSource,
         },
-        actions,
+        commands,
       };
     },
 
-    Start: ({ startTime, next }) => {
-      const actions: Action[] = [];
+    Start: ({ startTime, next, ephemeralRunId }) => {
+      const commands: CellCommand[] = [];
       let phase = entry.phase;
       if (entry.phase._tag === "Queued") {
-        actions.push(Action.StartExecution({ startTime }));
+        commands.push(
+          CellCommand.StartRun({
+            runId: entry.phase.runId,
+            at: startTime,
+          }),
+        );
         phase = RunPhase.Running({ runId: entry.phase.runId });
       }
-      if (hasExecution(phase)) {
-        actions.push(Action.EmitOutputs({ state: next }));
+      const runId = activeRunId(phase);
+      if (runId !== undefined) {
+        commands.push(
+          CellCommand.RenderOutputs({ runId, state: next, final: false }),
+        );
       } else if (isError(next)) {
-        actions.push(...ephemeralError(next, { applyDiagnostic: false }));
+        commands.push(
+          ...ephemeralError(ephemeralRunId, next, {
+            applyDiagnostic: false,
+          }),
+        );
       }
       return {
         entry: {
@@ -200,16 +236,23 @@ export function step(
             ? AcceptedSource.Invalidated()
             : entry.acceptedSource,
         },
-        actions,
+        commands,
       };
     },
 
-    Update: ({ next }) => {
-      const actions: Action[] = [];
-      if (hasExecution(entry.phase)) {
-        actions.push(Action.EmitOutputs({ state: next }));
+    Update: ({ next, ephemeralRunId }) => {
+      const commands: CellCommand[] = [];
+      const runId = activeRunId(entry.phase);
+      if (runId !== undefined) {
+        commands.push(
+          CellCommand.RenderOutputs({ runId, state: next, final: false }),
+        );
       } else if (isError(next)) {
-        actions.push(...ephemeralError(next, { applyDiagnostic: false }));
+        commands.push(
+          ...ephemeralError(ephemeralRunId, next, {
+            applyDiagnostic: false,
+          }),
+        );
       }
       return {
         entry: {
@@ -219,20 +262,21 @@ export function step(
             ? AcceptedSource.Invalidated()
             : entry.acceptedSource,
         },
-        actions,
+        commands,
       };
     },
 
-    Settle: ({ success, endTime, next }) => {
-      const actions: Action[] = [];
+    Settle: ({ success, endTime, next, ephemeralRunId }) => {
+      const commands: CellCommand[] = [];
       const acceptedSource = next.staleInputs
         ? AcceptedSource.Invalidated()
         : entry.acceptedSource;
-      if (hasExecution(entry.phase)) {
-        actions.push(
-          Action.FinalizeOutputs({ state: next }),
-          Action.ApplyRuntimeError({ state: next }),
-          Action.EndExecution({ success, endTime }),
+      const runId = activeRunId(entry.phase);
+      if (runId !== undefined) {
+        commands.push(
+          CellCommand.RenderOutputs({ runId, state: next, final: true }),
+          CellCommand.SetDiagnostic({ state: Option.some(next) }),
+          CellCommand.CloseRun({ runId, success, at: endTime }),
         );
         return {
           entry: {
@@ -241,41 +285,46 @@ export function step(
             phase: RunPhase.Completed(),
             acceptedSource,
           },
-          actions,
+          commands,
         };
       }
       // No live execution: show a one-off execution for an error, and always
       // reconcile the squiggle (clears it when there's no in-cell frame).
       if (isError(next)) {
-        actions.push(...ephemeralError(next, { applyDiagnostic: true }));
+        commands.push(
+          ...ephemeralError(ephemeralRunId, next, {
+            applyDiagnostic: true,
+          }),
+        );
       } else {
-        actions.push(Action.ApplyRuntimeError({ state: next }));
+        commands.push(CellCommand.SetDiagnostic({ state: Option.some(next) }));
       }
       return {
         entry: { ...entry, state: next, acceptedSource },
-        actions,
+        commands,
       };
     },
   });
 }
 
 /**
- * Actions to render an error from a cell that never queued (e.g. a compile
+ * Commands to render an error from a cell that never queued (e.g. a compile
  * error), which has no live execution: spin up a one-off execution, emit the
  * error, end it. `applyDiagnostic` also reconciles the squiggle, which only the
  * terminal `idle` op does.
  */
 function ephemeralError(
+  runId: RunId,
   next: CellRuntimeState,
   opts: { readonly applyDiagnostic: boolean },
-): Action[] {
+): CellCommand[] {
   return [
-    Action.CreateExecution(),
-    Action.StartExecution({ startTime: undefined }),
-    Action.FinalizeOutputs({ state: next }),
+    CellCommand.OpenRun({ runId }),
+    CellCommand.StartRun({ runId, at: undefined }),
+    CellCommand.RenderOutputs({ runId, state: next, final: true }),
     ...(opts.applyDiagnostic
-      ? [Action.ApplyRuntimeError({ state: next })]
+      ? [CellCommand.SetDiagnostic({ state: Option.some(next) })]
       : []),
-    Action.EndExecution({ success: false, endTime: undefined }),
+    CellCommand.CloseRun({ runId, success: false, at: undefined }),
   ];
 }

--- a/extension/src/kernel/__tests__/CellExecutions.test.ts
+++ b/extension/src/kernel/__tests__/CellExecutions.test.ts
@@ -1335,6 +1335,96 @@ it.effect(
 );
 
 it.effect(
+  "ignores a tagged operation after its run completes",
+  Effect.fn(function* () {
+    const editor = TestVsCode.makeNotebookEditor(
+      "file:///test/notebook_mo.py",
+      {
+        data: {
+          cells: [
+            {
+              kind: 1,
+              value: "x = 1",
+              languageId: "python",
+              metadata: MarimoNotebookCell.createMetadata({
+                marimoRuntime: { stableId: "cell-1" },
+              }),
+            },
+          ],
+        },
+      },
+    );
+    const ctx = yield* withTestCtx({ initialDocuments: [editor.notebook] });
+
+    yield* Effect.gen(function* () {
+      const executions = yield* CellExecutions;
+      const notebook = MarimoNotebookDocument.from(editor.notebook);
+      const cell = notebook.cellAt(0);
+      const cid = Option.getOrThrow(cell.id);
+      let created = 0;
+      const controller = {
+        createNotebookCellExecution(): vscode.NotebookCellExecution {
+          created += 1;
+          return {
+            cell: cell.rawNotebookCell,
+            executionOrder: undefined,
+            token: {
+              isCancellationRequested: false,
+              onCancellationRequested: () => ({ dispose() {} }),
+            },
+            start() {},
+            end() {},
+            async clearOutput() {},
+            async appendOutput() {},
+            async appendOutputItems() {},
+            async replaceOutput() {},
+            async replaceOutputItems() {},
+          };
+        },
+      };
+
+      yield* executions.handleOperation(
+        {
+          op: "cell-op",
+          cell_id: cid,
+          status: "queued",
+          run_id: "run-1",
+        },
+        { editor, controller },
+      );
+      yield* executions.handleOperation(
+        {
+          op: "cell-op",
+          cell_id: cid,
+          status: "idle",
+          run_id: "run-1",
+          timestamp: 1,
+        },
+        { editor, controller },
+      );
+      expect(created).toBe(1);
+
+      yield* executions.handleOperation(
+        {
+          op: "cell-op",
+          cell_id: cid,
+          status: "idle",
+          run_id: "run-1",
+          output: {
+            mimetype: "application/vnd.marimo+error",
+            channel: "marimo-error",
+            data: [{ type: "syntax", msg: "late error" }],
+          },
+        },
+        { editor, controller },
+      );
+
+      expect(created).toBe(1);
+    }).pipe(Effect.provide(ctx.layer));
+  }),
+);
+
+it.effect(
   "marks cell as stale when message has staleInputs",
   Effect.fn(function* () {
     const editor = TestVsCode.makeNotebookEditor(

--- a/extension/src/kernel/__tests__/CellExecutions.test.ts
+++ b/extension/src/kernel/__tests__/CellExecutions.test.ts
@@ -1247,6 +1247,94 @@ it.effect(
 );
 
 it.effect(
+  "ignores a tagged operation from a superseded run",
+  Effect.fn(function* () {
+    const editor = TestVsCode.makeNotebookEditor(
+      "file:///test/notebook_mo.py",
+      {
+        data: {
+          cells: [
+            {
+              kind: 1,
+              value: "x = 1",
+              languageId: "python",
+              metadata: MarimoNotebookCell.createMetadata({
+                marimoRuntime: { stableId: "cell-1" },
+              }),
+            },
+          ],
+        },
+      },
+    );
+    const ctx = yield* withTestCtx({ initialDocuments: [editor.notebook] });
+
+    yield* Effect.gen(function* () {
+      const executions = yield* CellExecutions;
+      const notebook = MarimoNotebookDocument.from(editor.notebook);
+      const cell = notebook.cellAt(0);
+      const cid = Option.getOrThrow(cell.id);
+      const starts: Array<number | undefined> = [];
+      const controller = {
+        createNotebookCellExecution(): vscode.NotebookCellExecution {
+          return {
+            cell: cell.rawNotebookCell,
+            executionOrder: undefined,
+            token: {
+              isCancellationRequested: false,
+              onCancellationRequested: () => ({ dispose() {} }),
+            },
+            start(at) {
+              starts.push(at);
+            },
+            end() {},
+            async clearOutput() {},
+            async appendOutput() {},
+            async appendOutputItems() {},
+            async replaceOutput() {},
+            async replaceOutputItems() {},
+          };
+        },
+      };
+
+      yield* executions.handleOperation(
+        {
+          op: "cell-op",
+          cell_id: cid,
+          status: "queued",
+          run_id: "run-2",
+        },
+        { editor, controller },
+      );
+      yield* executions.handleOperation(
+        {
+          op: "cell-op",
+          cell_id: cid,
+          status: "running",
+          run_id: "run-1",
+          timestamp: 1,
+        },
+        { editor, controller, renderOutput: false },
+      );
+
+      expect(starts).toEqual([]);
+
+      yield* executions.handleOperation(
+        {
+          op: "cell-op",
+          cell_id: cid,
+          status: "running",
+          run_id: "run-2",
+          timestamp: 2,
+        },
+        { editor, controller, renderOutput: false },
+      );
+
+      expect(starts).toEqual([2_000]);
+    }).pipe(Effect.provide(ctx.layer));
+  }),
+);
+
+it.effect(
   "marks cell as stale when message has staleInputs",
   Effect.fn(function* () {
     const editor = TestVsCode.makeNotebookEditor(

--- a/extension/src/kernel/__tests__/CellRunReducer.test.ts
+++ b/extension/src/kernel/__tests__/CellRunReducer.test.ts
@@ -5,7 +5,7 @@ import { cellId } from "../../lib/__tests__/branded.ts";
 import type { CellRuntimeState } from "../../types.ts";
 import {
   AcceptedSource,
-  Action,
+  CellCommand,
   type CellRunEntry,
   Op,
   RunId,
@@ -15,6 +15,7 @@ import {
 
 const ID = cellId("cell-1");
 const RUN = RunId("run-1");
+const EPHEMERAL_RUN = RunId("ephemeral-run");
 
 const entry = (phase: RunPhase): CellRunEntry => ({
   id: ID,
@@ -38,72 +39,86 @@ const staleState = (): CellRuntimeState => ({
   staleInputs: true,
 });
 
-/** The sequence of action tags — the load-bearing, order-sensitive bit. */
-const tags = (actions: ReadonlyArray<Action>) => actions.map((a) => a._tag);
+/** The sequence of command tags — the load-bearing, order-sensitive bit. */
+const tags = (commands: ReadonlyArray<CellCommand>) =>
+  commands.map((command) => command._tag);
 
 describe("cell run reducer", () => {
   it("drives a normal run: queue → start → update → settle", () => {
     let e = entry(RunPhase.Idle());
 
     const queued = step(e, Op.Queue({ runId: RUN, next: okState() }), "x = 1");
-    expect(tags(queued.actions)).toEqual([
-      "ClearRuntimeError",
-      "CreateExecution",
-    ]);
+    expect(tags(queued.commands)).toEqual(["SetDiagnostic", "OpenRun"]);
     expect(queued.entry.phase).toEqual(RunPhase.Queued({ runId: RUN }));
     expect(queued.entry.acceptedSource).toEqual(
       AcceptedSource.Accepted({ source: "x = 1" }),
     );
     e = queued.entry;
 
-    const started = step(e, Op.Start({ startTime: 5, next: okState() }));
-    expect(tags(started.actions)).toEqual(["StartExecution", "EmitOutputs"]);
+    const started = step(
+      e,
+      Op.Start({
+        startTime: 5,
+        next: okState(),
+        ephemeralRunId: EPHEMERAL_RUN,
+      }),
+    );
+    expect(tags(started.commands)).toEqual(["StartRun", "RenderOutputs"]);
     expect(started.entry.phase).toEqual(RunPhase.Running({ runId: RUN }));
     e = started.entry;
 
-    const updated = step(e, Op.Update({ next: okState() }));
-    expect(tags(updated.actions)).toEqual(["EmitOutputs"]);
+    const updated = step(
+      e,
+      Op.Update({ next: okState(), ephemeralRunId: EPHEMERAL_RUN }),
+    );
+    expect(tags(updated.commands)).toEqual(["RenderOutputs"]);
     e = updated.entry;
 
     const settled = step(
       e,
-      Op.Settle({ success: true, endTime: 9, next: okState() }),
+      Op.Settle({
+        success: true,
+        endTime: 9,
+        next: okState(),
+        ephemeralRunId: EPHEMERAL_RUN,
+      }),
     );
-    expect(tags(settled.actions)).toEqual([
-      "FinalizeOutputs",
-      "ApplyRuntimeError",
-      "EndExecution",
+    expect(tags(settled.commands)).toEqual([
+      "RenderOutputs",
+      "SetDiagnostic",
+      "CloseRun",
     ]);
     expect(settled.entry.phase).toEqual(RunPhase.Completed());
   });
 
   it("settles a raised cell as a failure", () => {
     const running = entry(RunPhase.Running({ runId: RUN }));
-    const { actions } = step(
+    const { commands } = step(
       running,
-      Op.Settle({ success: false, endTime: undefined, next: errorState() }),
+      Op.Settle({
+        success: false,
+        endTime: undefined,
+        next: errorState(),
+        ephemeralRunId: EPHEMERAL_RUN,
+      }),
     );
-    const end = actions.find((a) => a._tag === "EndExecution");
+    const end = commands.find((command) => command._tag === "CloseRun");
     expect(end).toEqual(
-      Action.EndExecution({ success: false, endTime: undefined }),
+      CellCommand.CloseRun({ runId: RUN, success: false, at: undefined }),
     );
   });
 
   it("ends the prior execution before re-queuing (race guard)", () => {
     const running = entry(RunPhase.Running({ runId: RUN }));
-    const { actions } = step(
+    const { commands } = step(
       running,
       Op.Queue({ runId: RunId("run-2"), next: okState() }),
     );
-    expect(tags(actions)).toEqual([
-      "ClearRuntimeError",
-      "EndExecution",
-      "CreateExecution",
-    ]);
+    expect(tags(commands)).toEqual(["SetDiagnostic", "CloseRun", "OpenRun"]);
     // The prior run is ended as a success — it's superseded, not failed.
-    const end = actions.find((a) => a._tag === "EndExecution");
+    const end = commands.find((command) => command._tag === "CloseRun");
     expect(end).toEqual(
-      Action.EndExecution({ success: true, endTime: undefined }),
+      CellCommand.CloseRun({ runId: RUN, success: true, at: undefined }),
     );
   });
 
@@ -112,42 +127,58 @@ describe("cell run reducer", () => {
       entry(RunPhase.Running({ runId: RUN })),
       Op.Interrupt(),
     );
-    expect(tags(running.actions)).toEqual(["EndExecution"]);
+    expect(tags(running.commands)).toEqual(["CloseRun"]);
     expect(running.entry.phase).toEqual(RunPhase.Completed());
 
     const idle = step(entry(RunPhase.Idle()), Op.Interrupt());
-    expect(idle.actions).toEqual([]);
+    expect(idle.commands).toEqual([]);
     expect(idle.entry.phase).toEqual(RunPhase.Idle());
   });
 
   it("renders a compile error with no prior run via an ephemeral execution", () => {
-    const { actions, entry: next } = step(
+    const { commands, entry: next } = step(
       entry(RunPhase.Idle()),
-      Op.Settle({ success: false, endTime: undefined, next: errorState() }),
+      Op.Settle({
+        success: false,
+        endTime: undefined,
+        next: errorState(),
+        ephemeralRunId: EPHEMERAL_RUN,
+      }),
     );
-    expect(tags(actions)).toEqual([
-      "CreateExecution",
-      "StartExecution",
-      "FinalizeOutputs",
-      "ApplyRuntimeError",
-      "EndExecution",
+    expect(tags(commands)).toEqual([
+      "OpenRun",
+      "StartRun",
+      "RenderOutputs",
+      "SetDiagnostic",
+      "CloseRun",
     ]);
+    expect(
+      commands.every(
+        (command) =>
+          command._tag === "SetDiagnostic" || command.runId === EPHEMERAL_RUN,
+      ),
+    ).toBe(true);
     // The cell never entered a tracked run, so it stays Idle.
     expect(next.phase).toEqual(RunPhase.Idle());
   });
 
   it("reconciles the squiggle on an idle with nothing to render", () => {
-    const { actions } = step(
+    const { commands } = step(
       entry(RunPhase.Idle()),
-      Op.Settle({ success: true, endTime: undefined, next: okState() }),
+      Op.Settle({
+        success: true,
+        endTime: undefined,
+        next: okState(),
+        ephemeralRunId: EPHEMERAL_RUN,
+      }),
     );
-    expect(tags(actions)).toEqual(["ApplyRuntimeError"]);
+    expect(tags(commands)).toEqual(["SetDiagnostic"]);
   });
 
   it("invalidates the accepted source when an op carries stale inputs", () => {
     const { entry: next } = step(
       entry(RunPhase.Running({ runId: RUN })),
-      Op.Update({ next: staleState() }),
+      Op.Update({ next: staleState(), ephemeralRunId: EPHEMERAL_RUN }),
     );
     expect(next.acceptedSource).toEqual(AcceptedSource.Invalidated());
   });


### PR DESCRIPTION
Every command that touches a live run carries the run identity it targets.

```ts
type CellCommand = Data.TaggedEnum<{
  OpenRun: { readonly runId: RunId };
  StartRun: { readonly runId: RunId; readonly at: number | undefined };
  RenderOutputs: {
    readonly runId: RunId;
    readonly state: CellRuntimeState;
    readonly final: boolean;
  };
  CloseRun: {
    readonly runId: RunId;
    readonly success: boolean;
    readonly at: number | undefined;
  };
  SetDiagnostic: { readonly state: Option.Option<CellRuntimeState> };
}>;
```

One-off errors receive a local run ID. Later commands address the exact execution opened for that run.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
