### PR TITLE
Drive cell commands outside CellExecutions

### DIFF
--- a/extension/src/commands/restartKernel.ts
+++ b/extension/src/commands/restartKernel.ts
@@ -22,7 +22,7 @@ const handler = Effect.fn("command.restartKernel")(function* (
     return;
   }
 
-  const { document: notebook, editor } = target.value;
+  const { document: notebook } = target.value;
 
   if (Option.isNone(yield* sessions.find(notebook.id))) {
     yield* code.window.showInformationMessage(
@@ -55,7 +55,7 @@ const handler = Effect.fn("command.restartKernel")(function* (
 
       if (!succeeded) return false;
 
-      yield* executions.handleInterrupt(editor);
+      yield* executions.handleInterrupt(notebook.id);
 
       progress.report({ message: "Kernel restarted." });
       yield* Effect.sleep("500 millis");

--- a/extension/src/commands/sessionCommands.ts
+++ b/extension/src/commands/sessionCommands.ts
@@ -3,7 +3,6 @@ import { Effect, Option } from "effect";
 import { NOTEBOOK_TYPE } from "../constants.ts";
 import { CellExecutions } from "../kernel/CellExecutions.ts";
 import { showErrorAndPromptLogs } from "../lib/showErrorAndPromptLogs.ts";
-import { NotebookEditorRegistry } from "../notebook/NotebookEditorRegistry.ts";
 import { SessionsService } from "../panel/sessions/SessionsService.ts";
 import { VsCode } from "../platform/VsCode.ts";
 import { type NotebookId } from "../schemas/MarimoNotebookDocument.ts";
@@ -32,12 +31,8 @@ const openSessionNotebook = Effect.fn("command.openSessionNotebook")(function* (
 const endExecutions = Effect.fn("command.endSessionExecutions")(function* (
   notebookUri: NotebookId,
 ) {
-  const editors = yield* NotebookEditorRegistry;
   const executions = yield* CellExecutions;
-  const editor = yield* editors.getLastNotebookEditor(notebookUri);
-  if (Option.isSome(editor)) {
-    yield* executions.handleInterrupt(editor.value);
-  }
+  yield* executions.handleInterrupt(notebookUri);
 });
 
 export const openSession = Effect.fn("command.openSession")(function* ({

--- a/extension/src/features/RegisterLanguageModelTools.ts
+++ b/extension/src/features/RegisterLanguageModelTools.ts
@@ -11,8 +11,8 @@ import {
 } from "effect";
 
 import { SCRATCH_CELL_ID } from "../constants.ts";
-import { scratchCellNotificationsToVsCodeOutput } from "../kernel/CellExecutions.ts";
 import { NotebookRuntime } from "../kernel/NotebookRuntime.ts";
+import { scratchCellNotificationsToVsCodeOutput } from "../kernel/VsCodeCellOutputs.ts";
 import { signalFromToken } from "../lib/signalFromToken.ts";
 import { VsCode } from "../platform/VsCode.ts";
 import {

--- a/extension/src/features/__tests__/AutoExport.test.ts
+++ b/extension/src/features/__tests__/AutoExport.test.ts
@@ -28,9 +28,7 @@ import {
 
 const controller: NotebookController = {
   id: "test-controller",
-  createNotebookCellExecution() {
-    throw new Error("not used");
-  },
+  drive: () => () => Effect.void,
   resolveExecutable: () => Effect.succeed("/usr/bin/python"),
 };
 

--- a/extension/src/kernel/CellExecutions.ts
+++ b/extension/src/kernel/CellExecutions.ts
@@ -277,27 +277,24 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
           ),
         invalidateCell: (cell: MarimoNotebookCell) =>
           updateAcceptedSource(cell, AcceptedSource.Invalidated()),
-        forgetCell(notebookId: NotebookId, cellId: NotebookCellId) {
-          const key = cellExecutionKey(notebookId, cellId);
-          return Effect.sync(() => {
+        removeCell: (notebookId: NotebookId, cellId: NotebookCellId) =>
+          Effect.gen(function* () {
+            const key = cellExecutionKey(notebookId, cellId);
             const record = MutableHashMap.get(records, key);
-            if (Option.isNone(record)) return false;
-            MutableHashMap.set(records, key, {
-              ...record.value,
-              entry: {
-                ...record.value.entry,
-                acceptedSource: AcceptedSource.Unknown(),
-              },
-            });
-            return true;
-          }).pipe(
-            Effect.flatMap((changed) =>
-              changed
-                ? SubscriptionRef.update(revision, (value) => value + 1)
-                : Effect.void,
-            ),
-          );
-        },
+            if (Option.isNone(record)) return;
+
+            const result = step(record.value.entry, Op.Interrupt());
+            yield* Effect.sync(() => MutableHashMap.remove(records, key));
+            yield* SubscriptionRef.update(revision, (value) => value + 1);
+
+            for (const command of result.commands) {
+              yield* run(
+                key,
+                command,
+                driveFor(command, record.value, Option.none(), noOpenedRuns),
+              );
+            }
+          }),
         get changes(): Stream.Stream<void> {
           return Stream.merge(
             Stream.map(SubscriptionRef.changes(revision), constVoid),

--- a/extension/src/kernel/CellExecutions.ts
+++ b/extension/src/kernel/CellExecutions.ts
@@ -302,6 +302,15 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
         return submitted?.source;
       };
 
+      const clearSubmittedSources = (notebookId: NotebookId) => {
+        const targets = EffectArray.fromIterable(submittedSources).filter(
+          ([key]) => key.notebookId === notebookId,
+        );
+        for (const [key] of targets) {
+          MutableHashMap.remove(submittedSources, key);
+        }
+      };
+
       return {
         isCellStale,
         recordExecution: (cell: MarimoNotebookCell) =>
@@ -384,6 +393,7 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
         },
         handleInterrupt: (notebookId: NotebookId) =>
           Effect.gen(function* () {
+            clearSubmittedSources(notebookId);
             const targets = EffectArray.fromIterable(records).filter(
               ([key]) => key.notebookId === notebookId,
             );
@@ -451,6 +461,7 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
             const next = transitionCell(record.entry.state, message);
             const op = parseOp(next, message, RunId(crypto.randomUUID()));
             if (Option.isNone(op)) {
+              takeSubmittedSource(key);
               yield* Effect.logWarning(
                 "Queued cell-op missing run_id; cannot track execution",
               ).pipe(Effect.annotateLogs({ cellId, status: message.status }));
@@ -461,6 +472,10 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
                 }),
               );
               return;
+            }
+
+            if (message.status === "idle" && activeRunId === undefined) {
+              takeSubmittedSource(key);
             }
 
             const source =

--- a/extension/src/kernel/CellExecutions.ts
+++ b/extension/src/kernel/CellExecutions.ts
@@ -85,6 +85,20 @@ const openedRunIds = (commands: ReadonlyArray<CellCommand>) => {
 
 const noOpenedRuns = new Set<RunId>();
 
+const resolveDriveBinding = (
+  runId: RunId,
+  record: RunRecord,
+  current: Option.Option<Drive>,
+  opened: ReadonlySet<RunId>,
+): Option.Option<DriveBinding> =>
+  Option.filter(record.drive, (binding) => binding.runId === runId).pipe(
+    Option.orElse(() =>
+      opened.has(runId)
+        ? Option.map(current, (value) => ({ runId, value }))
+        : Option.none(),
+    ),
+  );
+
 const driveFor = (
   command: CellCommand,
   record: RunRecord,
@@ -92,9 +106,8 @@ const driveFor = (
   opened: ReadonlySet<RunId>,
 ): Option.Option<Drive> => {
   const forRun = (runId: RunId) =>
-    Option.filter(record.drive, (binding) => binding.runId === runId).pipe(
+    resolveDriveBinding(runId, record, current, opened).pipe(
       Option.map((binding) => binding.value),
-      Option.orElse(() => (opened.has(runId) ? current : Option.none())),
     );
 
   return CellCommand.$match(command, {
@@ -109,15 +122,14 @@ const driveFor = (
 const driveAfter = (
   entry: CellRunEntry,
   record: RunRecord,
-  current: Drive,
+  current: Option.Option<Drive>,
   opened: ReadonlySet<RunId>,
 ): Option.Option<DriveBinding> => {
   if (entry.phase._tag !== "Queued" && entry.phase._tag !== "Running") {
     return Option.none();
   }
   const runId = entry.phase.runId;
-  if (opened.has(runId)) return Option.some({ runId, value: current });
-  return Option.filter(record.drive, (binding) => binding.runId === runId);
+  return resolveDriveBinding(runId, record, current, opened);
 };
 
 /**
@@ -460,7 +472,12 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
             yield* Effect.sync(() =>
               MutableHashMap.set(records, key, {
                 entry: result.entry,
-                drive: driveAfter(result.entry, record, options.drive, opened),
+                drive: driveAfter(
+                  result.entry,
+                  record,
+                  Option.some(options.drive),
+                  opened,
+                ),
               }),
             );
             if (

--- a/extension/src/kernel/CellExecutions.ts
+++ b/extension/src/kernel/CellExecutions.ts
@@ -1,12 +1,6 @@
-import { createCellRuntimeState } from "@marimo-team/frontend/unstable_internal/core/cells/types.ts";
-import type {
-  CellOutput,
-  OutputMessage,
-} from "@marimo-team/frontend/unstable_internal/core/kernel/messages.ts";
 import {
   Cause,
   Context,
-  Data,
   Effect,
   Equal,
   Layer,
@@ -17,38 +11,17 @@ import {
   Array as EffectArray,
 } from "effect";
 import { constVoid } from "effect/Function";
-import type * as vscode from "vscode";
 
-import { assert, logUnreachable } from "../assert.ts";
-import { SCRATCH_CELL_ID } from "../constants.ts";
-import { acquireDisposable } from "../lib/acquireDisposable.ts";
-import { prettyErrorMessage } from "../lib/errors.ts";
-import {
-  extractCellFrames,
-  parseTraceback,
-  type TracebackCellFrame,
-} from "../lib/tracebacks.ts";
 import { NotebookEditorRegistry } from "../notebook/NotebookEditorRegistry.ts";
 import { VsCode } from "../platform/VsCode.ts";
 import {
-  findNotebookCell,
+  extractCellIdFromCellMessage,
   type MarimoNotebookCell,
   MarimoNotebookDocument,
-} from "../schemas/MarimoNotebookDocument.ts";
-import {
-  extractCellIdFromCellMessage,
   type NotebookCellId,
   type NotebookId,
 } from "../schemas/MarimoNotebookDocument.ts";
-import {
-  type CellOperationNotification,
-  type CellRuntimeState,
-  createCellNavigationLink,
-} from "../types.ts";
-import {
-  CellOutputProjection,
-  type KeyedCellOutput,
-} from "./CellOutputProjection.ts";
+import type { CellOperationNotification } from "../types.ts";
 import {
   AcceptedSource,
   CellCommand,
@@ -61,77 +34,89 @@ import {
   transitionCell,
 } from "./CellRunReducer.ts";
 
-/**
- * The VS Code API service shape. A `Context.Service` class is the context
- * key. Use `Context.Service.Shape` to get the type of the service value.
- */
-type VsCodeService = Context.Service.Shape<typeof VsCode>;
-
-interface CellExecutionController {
-  readonly createNotebookCellExecution: (
-    cell: MarimoNotebookCell,
-  ) => vscode.NotebookCellExecution;
-}
-
-/**
- * Thrown when VS Code's `createNotebookCellExecution` fails because the cell
- * is no longer part of the notebook (e.g., deleted between the time we looked
- * it up and the time we tried to create an execution for it).
- */
-class InvalidCellError extends Data.TaggedError("InvalidCellError")<{
+/** Stable identity of one cell whose commands can be driven. */
+export interface CellRef {
+  readonly notebookId: NotebookId;
   readonly cellId: NotebookCellId;
-  readonly cause: unknown;
-}> {}
-
-/** A run's live VS Code execution and the projection driving its outputs. */
-interface RunResource {
-  readonly runId: RunId;
-  readonly execution: vscode.NotebookCellExecution;
-  readonly projection: CellOutputProjection;
 }
+
+/** Effectful capability supplied by a host adapter. */
+export type Drive = (
+  cell: CellRef,
+  command: CellCommand,
+) => Effect.Effect<void>;
 
 interface CellExecutionKey {
   readonly notebookId: NotebookId;
   readonly cellId: NotebookCellId;
 }
 
-// A plain object is sufficient. HashMap compares plain objects by structure.
+interface DriveBinding {
+  readonly runId: RunId;
+  readonly value: Drive;
+}
+
+interface RunRecord {
+  readonly entry: CellRunEntry;
+  readonly drive: Option.Option<DriveBinding>;
+}
+
+// MutableHashMap compares plain object keys by structure.
 const cellExecutionKey = (
   notebookId: NotebookId,
   cellId: NotebookCellId,
 ): CellExecutionKey => ({ notebookId, cellId });
 
-/**
- * Everything the registry tracks for one cell: the pure {@link CellRunEntry},
- * the editor it belongs to (for interrupt fan-out), and its live execution
- * while a run is in flight.
- */
-interface RunRecord {
-  readonly entry: CellRunEntry;
-  readonly editor: vscode.NotebookEditor | undefined;
-  readonly resource: Option.Option<RunResource>;
-}
+const cellRef = (key: CellExecutionKey): CellRef => key;
+
+const openedRunIds = (commands: ReadonlyArray<CellCommand>) => {
+  const ids = new Set<RunId>();
+  for (const command of commands) {
+    if (command._tag === "OpenRun") ids.add(command.runId);
+  }
+  return ids;
+};
+
+const noOpenedRuns = new Set<RunId>();
+
+const driveFor = (
+  command: CellCommand,
+  record: RunRecord,
+  current: Option.Option<Drive>,
+  opened: ReadonlySet<RunId>,
+): Option.Option<Drive> => {
+  const forRun = (runId: RunId) =>
+    Option.filter(record.drive, (binding) => binding.runId === runId).pipe(
+      Option.map((binding) => binding.value),
+      Option.orElse(() => (opened.has(runId) ? current : Option.none())),
+    );
+
+  return CellCommand.$match(command, {
+    OpenRun: () => current,
+    StartRun: ({ runId }) => forRun(runId),
+    RenderOutputs: ({ runId }) => forRun(runId),
+    CloseRun: ({ runId }) => forRun(runId),
+    SetDiagnostic: () => current,
+  });
+};
+
+const driveAfter = (
+  entry: CellRunEntry,
+  record: RunRecord,
+  current: Drive,
+  opened: ReadonlySet<RunId>,
+): Option.Option<DriveBinding> => {
+  if (entry.phase._tag !== "Queued" && entry.phase._tag !== "Running") {
+    return Option.none();
+  }
+  const runId = entry.phase.runId;
+  if (opened.has(runId)) return Option.some({ runId, value: current });
+  return Option.filter(record.drive, (binding) => binding.runId === runId);
+};
 
 /**
- * What the {@link CellCommand} interpreter needs to drive a single command.
- * `notebookCell` / `controller` are absent for interrupts (which only end
- * runs); commands that require them assert their presence.
- */
-interface PerformContext {
-  readonly key: CellExecutionKey;
-  readonly cellId: NotebookCellId;
-  readonly notebookCell: MarimoNotebookCell | undefined;
-  readonly controller: CellExecutionController | undefined;
-  readonly notebook: vscode.NotebookDocument | undefined;
-}
-
-/**
- * Owns the state and VS Code resources for cell executions.
- *
- * Cell operations update the run state, diagnostics, and projected output for
- * one cell. The same execution record tracks the code last accepted by the
- * kernel, which is used to derive whether the cell is stale. Interrupts end
- * every active execution for an editor.
+ * Owns cell records and turns kernel operations into ordered host commands.
+ * Host resources stay private to the supplied {@link Drive} adapter.
  */
 export class CellExecutions extends Context.Service<CellExecutions>()(
   "CellExecutions",
@@ -139,35 +124,23 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
     make: Effect.gen(function* () {
       const code = yield* VsCode;
       const editorRegistry = yield* NotebookEditorRegistry;
-      // MutableHashMap hashes and compares only the keys. HashMap.set also
-      // compares the old value and the new value when the key exists. That
-      // walks the RunRecord by structure. The RunRecord holds a live
-      // vscode.NotebookCellExecution. It is not safe to hash its getters.
       const records = MutableHashMap.empty<CellExecutionKey, RunRecord>();
       const revision = yield* SubscriptionRef.make(0);
 
-      const emptyRecord = (
-        cellId: NotebookCellId,
-        editor?: vscode.NotebookEditor,
-      ): RunRecord => ({
+      const emptyRecord = (cellId: NotebookCellId): RunRecord => ({
         entry: makeCellRunEntry(cellId),
-        editor,
-        resource: Option.none(),
+        drive: Option.none(),
       });
 
       const isCellStale = (cell: MarimoNotebookCell) => {
         const cellId = cell.id;
-        if (Option.isNone(cellId)) {
-          return Effect.succeed(false);
-        }
-        const notebookId = cell.notebook.id;
+        if (Option.isNone(cellId)) return Effect.succeed(false);
         const currentCode = cell.document.getText();
-
         return Effect.sync(() =>
           Option.match(
             MutableHashMap.get(
               records,
-              cellExecutionKey(notebookId, cellId.value),
+              cellExecutionKey(cell.notebook.id, cellId.value),
             ),
             {
               onNone: () => false,
@@ -201,7 +174,6 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
               return false;
             }),
         });
-
         yield* code.commands.setContext(
           "marimo.notebook.hasStaleCells",
           hasStaleCells,
@@ -265,203 +237,46 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
         );
       };
 
-      const recordExecution = (cell: MarimoNotebookCell) =>
-        updateAcceptedSource(
-          cell,
-          AcceptedSource.Accepted({ source: cell.document.getText() }),
-        );
-
-      const invalidateCell = (cell: MarimoNotebookCell) =>
-        updateAcceptedSource(cell, AcceptedSource.Invalidated());
-
-      yield* Effect.addFinalizer(() =>
-        Effect.sync(() => {
-          MutableHashMap.forEach(records, (record) => {
-            if (Option.isSome(record.resource)) {
-              // Ensure all in-flight executions are ended on shutdown. `end`
-              // throws if one was already ended (a benign race); swallow it so
-              // disposal still completes.
-              try {
-                record.resource.value.execution.end(false);
-              } catch {
-                // already ended
-              }
-            }
-          });
-          MutableHashMap.clear(records);
-        }),
-      );
-
-      // Runtime-error diagnostics: a red squiggle on the cell line that
-      // raised, mirroring Jupyter. Kept in its own collection (separate from
-      // the LSP server's static diagnostics) so the two don't clobber each
-      // other; cleared when the cell re-runs.
-      const errorDiagnostics = yield* acquireDisposable(() =>
-        code.languages.createDiagnosticCollection("marimo-runtime"),
-      );
-
-      const clearErrorDiagnostic = (uri: vscode.Uri) =>
-        Effect.sync(() => errorDiagnostics.delete(uri));
-
-      const applyErrorDiagnostic = (
-        notebookCell: MarimoNotebookCell,
-        cellId: NotebookCellId,
-        state: CellRuntimeState,
-      ) =>
-        Effect.sync(() => {
-          const { document } = notebookCell;
-          const frame =
-            state.output?.channel === "marimo-error"
-              ? cellTracebackFrame(state, cellId)
-              : undefined;
-          if (frame === undefined) {
-            // Not an error (or no in-cell frame to point at, e.g. a syntax
-            // error already covered by the language server) — drop any stale
-            // squiggle.
-            errorDiagnostics.delete(document.uri);
-            return;
-          }
-          const lineIdx = Math.min(
-            Math.max(frame.line - 1, 0),
-            Math.max(document.lineCount - 1, 0),
-          );
-          const diagnostic = new code.Diagnostic(
-            document.lineAt(lineIdx).range,
-            diagnosticMessage(state),
-            code.DiagnosticSeverity.Error,
-          );
-          diagnostic.source = "marimo";
-          errorDiagnostics.set(document.uri, [diagnostic]);
-        });
-
-      const setResource = (
+      const run = (
         key: CellExecutionKey,
-        resource: Option.Option<RunResource>,
+        command: CellCommand,
+        drive: Option.Option<Drive>,
       ) =>
-        Effect.sync(() => {
-          MutableHashMap.modify(records, key, (record) => ({
-            ...record,
-            resource,
-          }));
-        });
-
-      const getResource = (key: CellExecutionKey) =>
-        Effect.sync(() =>
-          MutableHashMap.get(records, key).pipe(
-            Option.flatMap((record) => record.resource),
-          ),
-        );
-
-      // Run `f` against the cell's live execution, or log+skip when there is
-      // none (a benign race: the execution was ended concurrently).
-      const withResource = (
-        key: CellExecutionKey,
-        runId: RunId,
-        f: (resource: RunResource) => Effect.Effect<void>,
-      ) =>
-        getResource(key).pipe(
-          Effect.map(Option.filter((resource) => resource.runId === runId)),
-          Effect.flatMap(
-            Option.match({
-              onSome: f,
-              onNone: () =>
-                Effect.logDebug(
-                  "No live execution for cell run; skipping command",
-                ).pipe(
-                  Effect.annotateLogs({
-                    notebookId: key.notebookId,
-                    cellId: key.cellId,
-                    runId,
-                  }),
-                ),
-            }),
-          ),
-        );
-
-      const emitOutputs = (
-        ctx: PerformContext,
-        runId: RunId,
-        state: CellRuntimeState,
-        final: boolean,
-      ) =>
-        withResource(ctx.key, runId, ({ projection }) => {
-          const keyed = buildKeyedCellOutputs(
-            ctx.cellId,
-            state,
-            code,
-            ctx.notebook,
-          );
-          return Effect.tryPromise(() =>
-            final ? projection.commit(keyed) : projection.project(keyed),
-          ).pipe(
-            // A concurrent op may have ended the execution; not actionable.
-            Effect.catchCause((cause) =>
-              Effect.logWarning("Failed to update cell output").pipe(
-                Effect.annotateLogs({ cause, cellId: ctx.cellId }),
-              ),
-            ),
-          );
-        });
-
-      // The operation interpreter: drive one command against the real world.
-      const drive = (command: CellCommand, ctx: PerformContext) =>
-        CellCommand.$match(command, {
-          OpenRun: ({ runId }) =>
-            Effect.gen(function* () {
-              assert(
-                ctx.notebookCell !== undefined && ctx.controller !== undefined,
-                "OpenRun requires a notebook cell and controller",
-              );
-              const notebookCell = ctx.notebookCell;
-              const controller = ctx.controller;
-              const execution = yield* Effect.try({
-                try: () => controller.createNotebookCellExecution(notebookCell),
-                catch: (cause) =>
-                  new InvalidCellError({ cellId: ctx.cellId, cause }),
-              });
-              yield* setResource(
-                ctx.key,
-                Option.some({
-                  runId,
-                  execution,
-                  projection: new CellOutputProjection(execution),
-                }),
-              );
-            }),
-          StartRun: ({ runId, at }) =>
-            withResource(ctx.key, runId, ({ execution }) =>
-              Effect.sync(() => execution.start(at)),
-            ),
-          RenderOutputs: ({ runId, state, final }) =>
-            emitOutputs(ctx, runId, state, final),
-          CloseRun: ({ runId, success, at }) =>
-            withResource(ctx.key, runId, ({ execution }) =>
-              Effect.gen(function* () {
-                // `end` throws if already ended (a race); swallow it.
-                yield* Effect.try(() => execution.end(success, at)).pipe(
-                  Effect.ignore,
-                );
-                yield* setResource(ctx.key, Option.none());
+        Option.match(drive, {
+          onNone: () =>
+            Effect.logWarning("Cell run has no Drive; skipping command").pipe(
+              Effect.annotateLogs({
+                ...key,
+                command: command._tag,
+                ...("runId" in command ? { runId: command.runId } : {}),
               }),
             ),
-          SetDiagnostic: ({ state }) => {
-            assert(
-              ctx.notebookCell !== undefined,
-              "SetDiagnostic requires a notebook cell",
-            );
-            const notebookCell = ctx.notebookCell;
-            return Option.match(state, {
-              onNone: () => clearErrorDiagnostic(notebookCell.document.uri),
-              onSome: (runtime) =>
-                applyErrorDiagnostic(notebookCell, ctx.cellId, runtime),
-            });
-          },
+          onSome: (apply) =>
+            apply(cellRef(key), command).pipe(
+              Effect.catchCause((cause) =>
+                Cause.hasInterrupts(cause)
+                  ? Effect.failCause(cause)
+                  : Effect.logWarning("Failed to drive cell command").pipe(
+                      Effect.annotateLogs({
+                        cause,
+                        ...key,
+                        command: command._tag,
+                        ...("runId" in command ? { runId: command.runId } : {}),
+                      }),
+                    ),
+              ),
+            ),
         });
 
       return {
         isCellStale,
-        recordExecution,
-        invalidateCell,
+        recordExecution: (cell: MarimoNotebookCell) =>
+          updateAcceptedSource(
+            cell,
+            AcceptedSource.Accepted({ source: cell.document.getText() }),
+          ),
+        invalidateCell: (cell: MarimoNotebookCell) =>
+          updateAcceptedSource(cell, AcceptedSource.Invalidated()),
         forgetCell(notebookId: NotebookId, cellId: NotebookCellId) {
           const key = cellExecutionKey(notebookId, cellId);
           return Effect.sync(() => {
@@ -489,46 +304,44 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
             Stream.map(contentChanges, constVoid),
           );
         },
-        handleInterrupt: (editor: vscode.NotebookEditor) =>
+        handleInterrupt: (notebookId: NotebookId) =>
           Effect.gen(function* () {
             const targets = EffectArray.fromIterable(records).filter(
-              ([, record]) => record.editor === editor,
+              ([key]) => key.notebookId === notebookId,
             );
             for (const [key, record] of targets) {
-              const { entry, commands } = step(record.entry, Op.Interrupt());
+              const result = step(record.entry, Op.Interrupt());
               yield* Effect.sync(() =>
-                MutableHashMap.set(records, key, { ...record, entry }),
+                MutableHashMap.set(records, key, {
+                  ...record,
+                  entry: result.entry,
+                  drive: Option.none(),
+                }),
               );
-              const ctx: PerformContext = {
-                key,
-                cellId: key.cellId,
-                notebookCell: undefined,
-                controller: undefined,
-                notebook: undefined,
-              };
-              for (const command of commands) {
-                // oxlint-disable-next-line eslint/no-await-in-loop -- ordered
-                yield* drive(command, ctx);
+              for (const command of result.commands) {
+                yield* run(
+                  key,
+                  command,
+                  driveFor(command, record, Option.none(), noOpenedRuns),
+                );
               }
             }
           }),
         handleOperation: (
-          msg: CellOperationNotification,
+          message: CellOperationNotification,
           options: {
-            editor: vscode.NotebookEditor;
-            controller: CellExecutionController;
+            notebookId: NotebookId;
+            source: string;
+            drive: Drive;
             renderOutput?: boolean;
           },
         ) =>
           Effect.gen(function* () {
-            const { editor, controller } = options;
-            const cellId = extractCellIdFromCellMessage(msg);
-            const notebook = MarimoNotebookDocument.from(editor.notebook);
-            const key = cellExecutionKey(notebook.id, cellId);
-
+            const cellId = extractCellIdFromCellMessage(message);
+            const key = cellExecutionKey(options.notebookId, cellId);
             const record = Option.getOrElse(
               MutableHashMap.get(records, key),
-              () => emptyRecord(cellId, editor),
+              () => emptyRecord(cellId),
             );
 
             const activeRunId =
@@ -537,11 +350,11 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
                 ? record.entry.phase.runId
                 : undefined;
             const receivedRunId =
-              typeof msg.run_id === "string" && msg.run_id.length > 0
-                ? msg.run_id
+              typeof message.run_id === "string" && message.run_id.length > 0
+                ? message.run_id
                 : undefined;
             if (
-              msg.status !== "queued" &&
+              message.status !== "queued" &&
               receivedRunId !== undefined &&
               receivedRunId !== activeRunId
             ) {
@@ -551,42 +364,33 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
                 Effect.annotateLogs({
                   expectedRunId: activeRunId,
                   receivedRunId,
-                  status: msg.status,
+                  status: message.status,
                 }),
               );
               return;
             }
 
-            const notebookCell = yield* findNotebookCell(notebook, cellId);
-
-            // Fold the cell-op into the run state once, up front, so the folded
-            // state is persisted even for an op we end up dropping.
-            const next = transitionCell(record.entry.state, msg);
-            const op = parseOp(next, msg, RunId(crypto.randomUUID()));
+            const next = transitionCell(record.entry.state, message);
+            const op = parseOp(next, message, RunId(crypto.randomUUID()));
             if (Option.isNone(op)) {
               yield* Effect.logWarning(
                 "Queued cell-op missing run_id; cannot track execution",
-              ).pipe(Effect.annotateLogs({ cellId, status: msg.status }));
+              ).pipe(Effect.annotateLogs({ cellId, status: message.status }));
               yield* Effect.sync(() =>
                 MutableHashMap.set(records, key, {
                   ...record,
-                  editor,
                   entry: { ...record.entry, state: next },
                 }),
               );
               return;
             }
 
-            const result = step(
-              record.entry,
-              op.value,
-              notebookCell.document.getText(),
-            );
+            const result = step(record.entry, op.value, options.source);
+            const opened = openedRunIds(result.commands);
             yield* Effect.sync(() =>
               MutableHashMap.set(records, key, {
-                ...record,
-                editor,
                 entry: result.entry,
+                drive: driveAfter(result.entry, record, options.drive, opened),
               }),
             );
             if (
@@ -598,13 +402,6 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
               yield* SubscriptionRef.update(revision, (value) => value + 1);
             }
 
-            const ctx: PerformContext = {
-              key,
-              cellId,
-              notebookCell,
-              controller,
-              notebook: editor.notebook,
-            };
             for (const command of result.commands) {
               if (
                 options.renderOutput === false &&
@@ -612,20 +409,16 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
               ) {
                 continue;
               }
-              // oxlint-disable-next-line eslint/no-await-in-loop -- commands
-              // are ordered (e.g. RenderOutputs lands before CloseRun)
-              yield* drive(command, ctx);
+              yield* run(
+                key,
+                command,
+                driveFor(command, record, Option.some(options.drive), opened),
+              );
             }
           }).pipe(
-            Effect.catchTag("NotebookCellNotFoundError", () =>
-              Effect.logWarning("Notebook cell not found for cell operation"),
-            ),
-            Effect.catchTag("InvalidCellError", (error) =>
-              Effect.logWarning(
-                "Cell is no longer valid, skipping execution",
-              ).pipe(Effect.annotateLogs({ cause: Cause.fail(error.cause) })),
-            ),
-            Effect.annotateLogs({ cellId: extractCellIdFromCellMessage(msg) }),
+            Effect.annotateLogs({
+              cellId: extractCellIdFromCellMessage(message),
+            }),
           ),
       };
     }),
@@ -634,396 +427,4 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
   static readonly layer = Layer.effect(this, this.make).pipe(
     Layer.provide([NotebookEditorRegistry.layer]),
   );
-}
-
-/**
- * Convert CellOperationNotification(s) to VSCode NotebookCellOutput.
- *
- * Returns None if no outputs, Some if there are outputs.
- */
-export function scratchCellNotificationsToVsCodeOutput(
-  notifications:
-    | CellOperationNotification
-    | ReadonlyArray<CellOperationNotification>,
-  code: VsCodeService,
-) {
-  const arr = EffectArray.ensure(notifications);
-  const outputs = buildCellOutputs(
-    SCRATCH_CELL_ID,
-    arr.reduce(transitionCell, createCellRuntimeState()),
-    code,
-  );
-  const items = outputs.flatMap((o) => o.items);
-  if (items.length === 0) {
-    return Option.none<vscode.NotebookCellOutput>();
-  }
-  return Option.some(new code.NotebookCellOutput(items));
-}
-
-/**
- * Builds VSCode NotebookCellOutput items from CellRuntimeState
- * Separates outputs by channel (stdout, stderr, marimo-error, etc.)
- */
-export function buildCellOutputs(
-  cellId: NotebookCellId,
-  state: CellRuntimeState,
-  code: VsCodeService,
-  notebook?: vscode.NotebookDocument,
-): vscode.NotebookCellOutput[] {
-  return buildKeyedCellOutputs(cellId, state, code, notebook).map(
-    (keyed) => keyed.output,
-  );
-}
-
-/**
- * Like {@link buildCellOutputs}, but each output carries a stable {@link
- * KeyedCellOutput.key}.
- *
- * Outputs are emitted in **arrival order** — console streams (`stdout`,
- * `stderr`) first, then the cell's result / error / traceback — mirroring
- * Jupyter rather than marimo's historical result-first layout. Combined with
- * the append-based reconcile in {@link CellOutputProjection}, this means each
- * slot is created once, in the order it first appears, and tall built-in
- * outputs (a traceback) are measured once instead of on every cell-op.
- */
-function buildKeyedCellOutputs(
-  cellId: NotebookCellId,
-  state: CellRuntimeState,
-  code: VsCodeService,
-  notebook?: vscode.NotebookDocument,
-): KeyedCellOutput[] {
-  const outputs: KeyedCellOutput[] = [];
-
-  // Collect items by channel
-  const stdoutItems: vscode.NotebookCellOutputItem[] = [];
-  const stderrItems: vscode.NotebookCellOutputItem[] = [];
-  const stdinItems: vscode.NotebookCellOutputItem[] = [];
-  const errorItems: vscode.NotebookCellOutputItem[] = [];
-  const outputItems: vscode.NotebookCellOutputItem[] = [];
-  // Tracebacks share the stderr channel with plain log text but must stay in
-  // their own NotebookCellOutput: VS Code reads the items of one output as
-  // alternative MIME representations of a single value and renders only one.
-  const tracebackItems: vscode.NotebookCellOutputItem[] = [];
-
-  // Process console outputs (stdout, stderr, stdin)
-  if (state.consoleOutputs) {
-    for (const output of state.consoleOutputs) {
-      // Remove main output so it is not displayed in the console output location
-      const stateWithoutOutputs = { ...state, output: null };
-      const item = buildOutputItem(
-        output,
-        cellId,
-        stateWithoutOutputs,
-        code,
-        notebook,
-      );
-      if (!item) continue;
-
-      if (output.mimetype === TRACEBACK_MIME) {
-        tracebackItems.push(item);
-        continue;
-      }
-
-      switch (output.channel) {
-        case "stdout":
-          stdoutItems.push(item);
-          break;
-        case "stderr":
-          stderrItems.push(item);
-          break;
-        case "stdin":
-          stdinItems.push(item);
-          break;
-        case "media":
-          stdoutItems.push(item);
-          break;
-        case "output":
-        case "marimo-error":
-        case "pdb":
-          // PDB, output, and pdb not expected from console outputs
-          break;
-        default:
-          logUnreachable(output.channel);
-      }
-    }
-  }
-
-  // Process main output and errors
-  if (state.output && !isOutputEmpty(state.output)) {
-    // Remove console outputs so they are not displayed in the cell output location
-    const stateWithoutConsoleOutputs = { ...state, consoleOutputs: [] };
-    const item = buildOutputItem(
-      state.output,
-      cellId,
-      stateWithoutConsoleOutputs,
-      code,
-      notebook,
-    );
-    if (item) {
-      if (state.output.channel === "marimo-error") {
-        errorItems.push(item);
-      } else {
-        outputItems.push(item);
-      }
-    }
-  }
-
-  // Create keyed NotebookCellOutputs in arrival order: console streams first,
-  // then the cell's result / error / traceback. Each `key` is the logical slot
-  // the output reconciler tracks across cell-ops, so it must be stable for a
-  // given channel within a run.
-  if (stdoutItems.length > 0) {
-    outputs.push({
-      key: "stdout",
-      output: new code.NotebookCellOutput(stdoutItems, { channel: "stdout" }),
-    });
-  }
-
-  if (stderrItems.length > 0) {
-    outputs.push({
-      key: "stderr",
-      output: new code.NotebookCellOutput(stderrItems, { channel: "stderr" }),
-    });
-  }
-
-  // Result, error, and (when the error is redundant with a traceback) the
-  // traceback all share one stable `"main"` key, so "error box, then traceback
-  // supersedes it" is an in-place swap rather than a remove+append. The
-  // marimo-error item is dropped when a traceback is present — the traceback
-  // already renders `<Type>: <message>` as its header.
-  const errorShown = errorItems.length > 0 && !shouldSuppressMarimoError(state);
-  let mainSlotTaken = false;
-  if (errorShown) {
-    outputs.push({
-      key: "main",
-      output: new code.NotebookCellOutput(errorItems, {
-        channel: "marimo-error",
-      }),
-    });
-    mainSlotTaken = true;
-  } else if (outputItems.length > 0) {
-    outputs.push({
-      key: "main",
-      output: new code.NotebookCellOutput(outputItems),
-    });
-    mainSlotTaken = true;
-  }
-
-  tracebackItems.forEach((tracebackItem, index) => {
-    // The first traceback claims the `"main"` slot when nothing else does (the
-    // suppressed-error case), so an error box already shown there is swapped to
-    // the traceback in place rather than removed.
-    const key = !mainSlotTaken && index === 0 ? "main" : `traceback:${index}`;
-    if (key === "main") mainSlotTaken = true;
-    outputs.push({
-      key,
-      output: new code.NotebookCellOutput([tracebackItem], {
-        channel: "stderr",
-      }),
-    });
-  });
-
-  if (stdinItems.length > 0) {
-    outputs.push({
-      key: "stdin",
-      output: new code.NotebookCellOutput(stdinItems, { channel: "stdin" }),
-    });
-  }
-
-  return outputs;
-}
-
-const TRACEBACK_MIME = "application/vnd.marimo+traceback";
-
-function hasTraceback(state: CellRuntimeState): boolean {
-  if (state.output?.mimetype === TRACEBACK_MIME) return true;
-  return (state.consoleOutputs ?? []).some(
-    (o) => o?.mimetype === TRACEBACK_MIME,
-  );
-}
-
-/**
- * Innermost traceback frame inside `cellId` — i.e. the line in this cell where
- * the exception surfaced. Returns undefined when the cell has no traceback
- * (e.g. a structural marimo error) or the exception was raised entirely in
- * library/other-cell code, in which case there's no line here to underline.
- */
-function cellTracebackFrame(
-  state: CellRuntimeState,
-  cellId: NotebookCellId,
-): TracebackCellFrame | undefined {
-  const traceback = (state.consoleOutputs ?? []).find(
-    (o) => o?.mimetype === TRACEBACK_MIME,
-  );
-  if (!traceback) return undefined;
-  const text =
-    typeof traceback.data === "object"
-      ? JSON.stringify(traceback.data)
-      : traceback.data;
-  return extractCellFrames(text)
-    .filter((frame) => frame.cellId === cellId)
-    .at(-1);
-}
-
-/** Human-readable message for the runtime-error diagnostic. */
-function diagnosticMessage(state: CellRuntimeState): string {
-  const data = state.output?.data;
-  if (Array.isArray(data) && data.length > 0) {
-    return prettyErrorMessage(data[0]);
-  }
-  return "Cell execution failed";
-}
-
-// Only suppress when every item is a plain `exception` without `raising_cell`:
-// `strict-exception` carries `ref` and `blamed_cell`, and `exception` with
-// `raising_cell` carries the "raised in cell" pointer — neither appears in the
-// Python traceback, so the marimo-error block stays in those cases.
-function shouldSuppressMarimoError(state: CellRuntimeState): boolean {
-  const out = state.output;
-  if (!out || out.channel !== "marimo-error" || !Array.isArray(out.data)) {
-    return false;
-  }
-  const everyRedundant = out.data.every((e) => {
-    if (e == null || typeof e !== "object") return false;
-    if (!("type" in e) || e.type !== "exception") return false;
-    return !("raising_cell" in e) || !e.raising_cell;
-  });
-  return everyRedundant && hasTraceback(state);
-}
-
-/**
- * Creates a mapper function that converts cell URIs to clickable HTML links.
- *
- * Transforms error message cell references like "vscode-notebook-cell://...#W1sZmlsZQ%3D%3D"
- * into human-readable, clickable links like "<a ...>cell-2</a>".
- *
- * The links use onclick handlers to post messages to window.parent, which the renderer
- * catches and forwards to the extension. See types.ts for the full navigation flow.
- *
- * @param notebook - The notebook document containing the cells
- * @returns A function that maps cell URIs to HTML link strings
- */
-function createCellIdMapper(
-  notebook: MarimoNotebookDocument,
-): (cellId: NotebookCellId) => string | undefined {
-  return (cellId: NotebookCellId) => {
-    // Find the cell by matching its URI to get the visual index (0-based)
-    const cellIndex = notebook.getCells().findIndex((cell) =>
-      Option.match(cell.id, {
-        onSome: (id) => id === cellId,
-        onNone: () => false,
-      }),
-    );
-    if (cellIndex === -1) {
-      return undefined;
-    }
-    return createCellNavigationLink(cellId, cellIndex + 1);
-  };
-}
-
-function createCellIdToIndex(
-  notebook: MarimoNotebookDocument,
-): (cellId: string) => number | undefined {
-  return (cellId: string) => {
-    const cellIndex = notebook.getCells().findIndex((cell) =>
-      Option.match(cell.id, {
-        onSome: (id) => id === cellId,
-        onNone: () => false,
-      }),
-    );
-    return cellIndex === -1 ? undefined : cellIndex;
-  };
-}
-
-/**
- * Builds a single NotebookCellOutputItem from a CellOutput
- */
-function buildOutputItem(
-  output: CellOutput,
-  cellId: NotebookCellId,
-  state: CellRuntimeState,
-  code: VsCodeService,
-  notebook?: vscode.NotebookDocument,
-): vscode.NotebookCellOutputItem | null {
-  // Handle stdout/stderr with proper VSCode helpers
-  if (output.mimetype === "text/plain") {
-    const text =
-      typeof output.data === "object"
-        ? JSON.stringify(output.data)
-        : // oxlint-disable-next-line typescript-eslint/no-unnecessary-type-conversion
-          String(output.data);
-    if (!text) {
-      return null;
-    }
-
-    switch (output.channel) {
-      case "stdout":
-        return code.NotebookCellOutputItem.stdout(text);
-      case "stderr":
-        return code.NotebookCellOutputItem.stderr(text);
-      case "stdin":
-        return code.NotebookCellOutputItem.text(text, "text/plain");
-    }
-  }
-
-  // Handle traceback — emit as a structured error so VS Code's built-in
-  // notebook error renderer applies its red-bordered styling. We rewrite
-  // each frame: cell-temp paths become `Cell cell-<N>, line <M>`, and real
-  // file paths get an inline `<a href>` anchor so VS Code's webview
-  // opener turns them into clickable links.
-  if (output.mimetype === "application/vnd.marimo+traceback") {
-    const text =
-      typeof output.data === "object"
-        ? JSON.stringify(output.data)
-        : // oxlint-disable-next-line typescript-eslint/no-unnecessary-type-conversion
-          String(output.data);
-    if (!text) {
-      return null;
-    }
-    const cellIdToIndex = notebook
-      ? createCellIdToIndex(MarimoNotebookDocument.from(notebook))
-      : undefined;
-    return code.NotebookCellOutputItem.error(
-      parseTraceback(text, cellIdToIndex),
-    );
-  }
-
-  // Handle marimo errors
-  if (output.channel === "marimo-error" && Array.isArray(output.data)) {
-    // Convert marimo errors to VSCode Error objects
-    const cellIdMapper = notebook
-      ? createCellIdMapper(MarimoNotebookDocument.from(notebook))
-      : undefined;
-    const errors = output.data.map((error) => {
-      const errorMessage = prettyErrorMessage(error, cellIdMapper);
-      // If the error message contains HTML (links), use text/html mime type
-      if (errorMessage.includes("<a href=")) {
-        return code.NotebookCellOutputItem.text(errorMessage, "text/html");
-      }
-      return code.NotebookCellOutputItem.stderr(errorMessage);
-    });
-    return errors[0] || null;
-  }
-
-  if (isOutputEmpty(output)) {
-    return null;
-  }
-
-  // Default pass to our renderer
-  return code.NotebookCellOutputItem.json(
-    { cellId, state },
-    "application/vnd.marimo.ui+json",
-  );
-}
-
-function isOutputEmpty(output: OutputMessage | undefined | null): boolean {
-  if (output == null) {
-    return true;
-  }
-
-  if (output.data == null || output.data === "") {
-    return true;
-  }
-
-  return false;
 }

--- a/extension/src/kernel/CellExecutions.ts
+++ b/extension/src/kernel/CellExecutions.ts
@@ -3,6 +3,7 @@ import {
   Context,
   Effect,
   Equal,
+  Exit,
   Layer,
   MutableHashMap,
   Option,
@@ -59,6 +60,11 @@ interface DriveBinding {
 interface RunRecord {
   readonly entry: CellRunEntry;
   readonly drive: Option.Option<DriveBinding>;
+}
+
+interface SubmittedSource {
+  readonly token: symbol;
+  readonly source: string;
 }
 
 // MutableHashMap compares plain object keys by structure.
@@ -125,6 +131,10 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
       const code = yield* VsCode;
       const editorRegistry = yield* NotebookEditorRegistry;
       const records = MutableHashMap.empty<CellExecutionKey, RunRecord>();
+      const submittedSources = MutableHashMap.empty<
+        CellExecutionKey,
+        Array<SubmittedSource>
+      >();
       const revision = yield* SubscriptionRef.make(0);
 
       const emptyRecord = (cellId: NotebookCellId): RunRecord => ({
@@ -268,6 +278,18 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
             ),
         });
 
+      const takeSubmittedSource = (key: CellExecutionKey) => {
+        const pending = MutableHashMap.get(submittedSources, key);
+        if (Option.isNone(pending) || pending.value.length === 0) {
+          return undefined;
+        }
+        const [submitted, ...remaining] = pending.value;
+        if (remaining.length === 0)
+          MutableHashMap.remove(submittedSources, key);
+        else MutableHashMap.set(submittedSources, key, remaining);
+        return submitted?.source;
+      };
+
       return {
         isCellStale,
         recordExecution: (cell: MarimoNotebookCell) =>
@@ -281,6 +303,9 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
           Effect.gen(function* () {
             const key = cellExecutionKey(notebookId, cellId);
             const record = MutableHashMap.get(records, key);
+            yield* Effect.sync(() =>
+              MutableHashMap.remove(submittedSources, key),
+            );
             if (Option.isNone(record)) return;
 
             const result = step(record.value.entry, Op.Interrupt());
@@ -295,6 +320,50 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
               );
             }
           }),
+        submit: <A, E, R>(
+          notebookId: NotebookId,
+          cells: ReadonlyArray<{
+            readonly cellId: NotebookCellId;
+            readonly source: string;
+          }>,
+          send: Effect.Effect<A, E, R>,
+        ) => {
+          const token = Symbol("cell submission");
+          const register = Effect.sync(() => {
+            for (const { cellId, source } of cells) {
+              const key = cellExecutionKey(notebookId, cellId);
+              const pending = Option.getOrElse(
+                MutableHashMap.get(submittedSources, key),
+                () => [],
+              );
+              MutableHashMap.set(submittedSources, key, [
+                ...pending,
+                { token, source },
+              ]);
+            }
+          });
+          const rollback = Effect.sync(() => {
+            for (const { cellId } of cells) {
+              const key = cellExecutionKey(notebookId, cellId);
+              const pending = MutableHashMap.get(submittedSources, key);
+              if (Option.isNone(pending)) continue;
+              const remaining = pending.value.filter(
+                (submitted) => submitted.token !== token,
+              );
+              if (remaining.length === 0) {
+                MutableHashMap.remove(submittedSources, key);
+              } else {
+                MutableHashMap.set(submittedSources, key, remaining);
+              }
+            }
+          });
+          return register.pipe(
+            Effect.andThen(send),
+            Effect.onExit((exit) =>
+              Exit.isSuccess(exit) ? Effect.void : rollback,
+            ),
+          );
+        },
         get changes(): Stream.Stream<void> {
           return Stream.merge(
             Stream.map(SubscriptionRef.changes(revision), constVoid),
@@ -328,7 +397,7 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
           message: CellOperationNotification,
           options: {
             notebookId: NotebookId;
-            source: string;
+            source?: string;
             drive: Drive;
             renderOutput?: boolean;
           },
@@ -382,7 +451,11 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
               return;
             }
 
-            const result = step(record.entry, op.value, options.source);
+            const source =
+              op.value._tag === "Queue"
+                ? (takeSubmittedSource(key) ?? options.source)
+                : undefined;
+            const result = step(record.entry, op.value, source);
             const opened = openedRunIds(result.commands);
             yield* Effect.sync(() =>
               MutableHashMap.set(records, key, {

--- a/extension/src/kernel/NotebookControllers.ts
+++ b/extension/src/kernel/NotebookControllers.ts
@@ -36,6 +36,7 @@ import {
   PythonController,
 } from "./PythonController.ts";
 import { createSandboxController } from "./SandboxController.ts";
+import { VsCodeCellDrive } from "./VsCodeCellDrive.ts";
 
 export interface NotebookController extends RuntimeNotebookController {
   readonly selectedNotebookChanges: Stream.Stream<{
@@ -156,6 +157,7 @@ export const NotebookControllersLive = Layer.effectDiscard(
     );
   }),
 ).pipe(
+  Layer.provide(VsCodeCellDrive.layer),
   Layer.provide(Uv.layer),
   Layer.provide(OutputChannel.layer),
   Layer.provide(Config.layer),

--- a/extension/src/kernel/NotebookRuntime.ts
+++ b/extension/src/kernel/NotebookRuntime.ts
@@ -1101,7 +1101,7 @@ function syncCellIdentity(
     for (const cellId of removedCellIds) {
       if (addedCellIds.has(cellId)) continue;
 
-      yield* options.executions.forgetCell(event.notebook.id, cellId);
+      yield* options.executions.removeCell(event.notebook.id, cellId);
       yield* options.notebook.deleteCell({ cellId }).pipe(
         Effect.catchCause((cause) =>
           Effect.logWarning(

--- a/extension/src/kernel/NotebookRuntime.ts
+++ b/extension/src/kernel/NotebookRuntime.ts
@@ -46,6 +46,7 @@ import { PythonEnvInvalidation } from "../python/PythonEnvInvalidation.ts";
 import { Uv } from "../python/Uv.ts";
 import {
   extractCellIdFromCellMessage,
+  findNotebookCell,
   MarimoNotebookCell,
   MarimoNotebookDocument,
   type NotebookCellId,
@@ -56,7 +57,7 @@ import type {
   MarimoOperation,
   NotificationOf,
 } from "../types.ts";
-import { CellExecutions } from "./CellExecutions.ts";
+import { CellExecutions, type Drive } from "./CellExecutions.ts";
 import { resolveImageDataUri, saveImageToDisk } from "./imageResolver.ts";
 import {
   NotebookFileRootError,
@@ -82,9 +83,7 @@ type InnerRequest<K extends keyof MarimoClientService> =
 export interface NotebookController {
   readonly id: string;
   readonly executable?: string;
-  readonly createNotebookCellExecution: (
-    cell: MarimoNotebookCell,
-  ) => vscode.NotebookCellExecution;
+  readonly drive: (notebook: MarimoNotebookDocument) => Drive;
   readonly resolveExecutable: (
     notebook: MarimoNotebookDocument,
   ) => Effect.Effect<string, ExecutableResolutionError | UnsavedNotebookError>;
@@ -975,9 +974,20 @@ function processNotebookOperation(
         if (extractCellIdFromCellMessage(operation) === SCRATCH_CELL_ID) {
           break;
         }
+        const cellId = extractCellIdFromCellMessage(operation);
+        const cell = yield* findNotebookCell(notebook, cellId).pipe(
+          Effect.option,
+        );
+        if (Option.isNone(cell)) {
+          yield* Effect.logWarning(
+            "Notebook cell not found for cell operation",
+          ).pipe(Effect.annotateLogs({ cellId }));
+          break;
+        }
         yield* executions.handleOperation(operation, {
-          editor: editor.value,
-          controller: controller.value,
+          notebookId: notebook.id,
+          source: cell.value.document.getText(),
+          drive: controller.value.drive(notebook),
           renderOutput: options.renderCellOutput,
         });
         yield* forkForSession(
@@ -986,7 +996,7 @@ function processNotebookOperation(
         break;
       }
       case "interrupted":
-        yield* executions.handleInterrupt(editor.value);
+        yield* executions.handleInterrupt(notebook.id);
         break;
       case "missing-package-alert":
         yield* forkForSession(

--- a/extension/src/kernel/NotebookRuntime.ts
+++ b/extension/src/kernel/NotebookRuntime.ts
@@ -49,6 +49,7 @@ import {
   findNotebookCell,
   MarimoNotebookCell,
   MarimoNotebookDocument,
+  NotebookCellId as makeNotebookCellId,
   type NotebookCellId,
   type NotebookId,
 } from "../schemas/MarimoNotebookDocument.ts";
@@ -256,12 +257,22 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
               notebookId,
               executable,
             );
-            const result = yield* marimo.executeCells({
+            const send = marimo.executeCells({
               notebookUri: notebookId,
               executable,
               workingDirectory,
               inner: request,
             });
+            const result = yield* executions.submit(
+              notebookId,
+              request.cellIds.flatMap((cellId, index) => {
+                const source = request.codes[index];
+                return source === undefined
+                  ? []
+                  : [{ cellId: makeNotebookCellId(cellId), source }];
+              }),
+              send,
+            );
             runtimeSessions.set(notebookId, {
               executable,
               workingDirectory,
@@ -986,7 +997,6 @@ function processNotebookOperation(
         }
         yield* executions.handleOperation(operation, {
           notebookId: notebook.id,
-          source: cell.value.document.getText(),
           drive: controller.value.drive(notebook),
           renderOutput: options.renderCellOutput,
         });

--- a/extension/src/kernel/PythonController.ts
+++ b/extension/src/kernel/PythonController.ts
@@ -16,12 +16,11 @@ import { VsCode } from "../platform/VsCode.ts";
 import { EnvironmentValidator } from "../python/EnvironmentValidator.ts";
 import { findVenvPath } from "../python/findVenvPath.ts";
 import { Uv } from "../python/Uv.ts";
-import {
-  type MarimoNotebookCell,
-  MarimoNotebookDocument,
-} from "../schemas/MarimoNotebookDocument.ts";
+import { MarimoNotebookDocument } from "../schemas/MarimoNotebookDocument.ts";
+import type { Drive } from "./CellExecutions.ts";
 import { makeControllerSelectionChanges } from "./ControllerSelectionChanges.ts";
 import { NotebookRuntime } from "./NotebookRuntime.ts";
+import { VsCodeCellDrive } from "./VsCodeCellDrive.ts";
 
 const NotebookControllerId = Brand.nominal<NotebookControllerId>();
 export type NotebookControllerId = Brand.Branded<string, "ControllerId">;
@@ -34,6 +33,7 @@ export const createPythonController = Effect.fn("createPythonController")(
   }) {
     const uv = yield* Uv;
     const code = yield* VsCode;
+    const cellDrive = yield* VsCodeCellDrive;
     const config = yield* Config;
     const notebooks = yield* NotebookRuntime;
     const validator = yield* EnvironmentValidator;
@@ -246,6 +246,14 @@ export const createPythonController = Effect.fn("createPythonController")(
       controller,
       options.env.path,
       selectedNotebookChanges,
+      (notebook) =>
+        cellDrive.bind({
+          notebook,
+          controller: {
+            createNotebookCellExecution: (cell) =>
+              controller.createNotebookCellExecution(cell.rawNotebookCell),
+          },
+        }),
     );
   },
 );
@@ -253,6 +261,7 @@ export const createPythonController = Effect.fn("createPythonController")(
 export class PythonController {
   readonly _tag = "PythonController";
   #inner: Omit<vscode.NotebookController, "dispose">;
+  readonly drive: (notebook: MarimoNotebookDocument) => Drive;
   /** The python interpreter this controller's environment runs on. */
   executable: string;
   /**
@@ -271,10 +280,12 @@ export class PythonController {
       notebook: vscode.NotebookDocument;
       selected: boolean;
     }>,
+    drive: (notebook: MarimoNotebookDocument) => Drive,
   ) {
     this.#inner = inner;
     this.executable = executable;
     this.selectedNotebookChanges = selectedNotebookChanges;
+    this.drive = drive;
   }
   static getId(env: py.Environment) {
     return NotebookControllerId(`marimo-${env.path}`);
@@ -291,9 +302,6 @@ export class PythonController {
       this.#inner.description = description;
       return this;
     });
-  }
-  createNotebookCellExecution(cell: MarimoNotebookCell) {
-    return this.#inner.createNotebookCellExecution(cell.rawNotebookCell);
   }
   resolveExecutable(_notebook: MarimoNotebookDocument) {
     return Effect.succeed(this.executable);

--- a/extension/src/kernel/SandboxController.ts
+++ b/extension/src/kernel/SandboxController.ts
@@ -16,10 +16,7 @@ import { VsCode } from "../platform/VsCode.ts";
 import { getVenvPythonPath } from "../python/getVenvPythonPath.ts";
 import { PythonExtension } from "../python/PythonExtension.ts";
 import { Uv } from "../python/Uv.ts";
-import {
-  type MarimoNotebookCell,
-  MarimoNotebookDocument,
-} from "../schemas/MarimoNotebookDocument.ts";
+import { MarimoNotebookDocument } from "../schemas/MarimoNotebookDocument.ts";
 import { SemVerFromString } from "../schemas/SemVerFromString.ts";
 import { makeControllerSelectionChanges } from "./ControllerSelectionChanges.ts";
 import {
@@ -27,11 +24,13 @@ import {
   NotebookRuntime,
   UnsavedNotebookError,
 } from "./NotebookRuntime.ts";
+import { VsCodeCellDrive } from "./VsCodeCellDrive.ts";
 
 export const createSandboxController = Effect.fn("createSandboxController")(
   function* () {
     const uv = yield* Uv;
     const code = yield* VsCode;
+    const cellDrive = yield* VsCodeCellDrive;
     const marimo = yield* MarimoClient;
     const notebooks = yield* NotebookRuntime;
     const python = yield* PythonExtension;
@@ -228,9 +227,14 @@ export const createSandboxController = Effect.fn("createSandboxController")(
                 }),
           ),
         ),
-      createNotebookCellExecution(cell: MarimoNotebookCell) {
-        return controller.createNotebookCellExecution(cell.rawNotebookCell);
-      },
+      drive: (notebook: MarimoNotebookDocument) =>
+        cellDrive.bind({
+          notebook,
+          controller: {
+            createNotebookCellExecution: (cell) =>
+              controller.createNotebookCellExecution(cell.rawNotebookCell),
+          },
+        }),
       selectedNotebookChanges,
       updateNotebookAffinity(
         notebook: vscode.NotebookDocument,

--- a/extension/src/kernel/VsCodeCellDrive.ts
+++ b/extension/src/kernel/VsCodeCellDrive.ts
@@ -1,0 +1,219 @@
+import { Cause, Context, Data, Effect, Layer, Option } from "effect";
+import type * as vscode from "vscode";
+
+import { acquireDisposable } from "../lib/acquireDisposable.ts";
+import { VsCode } from "../platform/VsCode.ts";
+import {
+  findNotebookCell,
+  type MarimoNotebookCell,
+  MarimoNotebookDocument,
+  type NotebookCellId,
+} from "../schemas/MarimoNotebookDocument.ts";
+import type { CellRuntimeState } from "../types.ts";
+import type { CellRef, Drive } from "./CellExecutions.ts";
+import { CellOutputProjection } from "./CellOutputProjection.ts";
+import { CellCommand, type RunId } from "./CellRunReducer.ts";
+import {
+  buildKeyedCellOutputs,
+  cellTracebackFrame,
+  diagnosticMessage,
+} from "./VsCodeCellOutputs.ts";
+
+interface CellController {
+  readonly createNotebookCellExecution: (
+    cell: MarimoNotebookCell,
+  ) => vscode.NotebookCellExecution;
+}
+
+export interface VsCodeDriveBinding {
+  readonly notebook: MarimoNotebookDocument;
+  readonly controller: CellController;
+}
+
+class InvalidCellError extends Data.TaggedError("InvalidCellError")<{
+  readonly cellId: NotebookCellId;
+  readonly cause: unknown;
+}> {}
+
+interface PresentedRun {
+  readonly execution: vscode.NotebookCellExecution;
+  readonly projection: CellOutputProjection;
+  readonly notebook: vscode.NotebookDocument;
+}
+
+const resourceKey = (cell: CellRef, runId: RunId): string =>
+  JSON.stringify([cell.notebookId, cell.cellId, runId]);
+
+/** Owns VS Code's live execution handles behind the {@link Drive} seam. */
+export class VsCodeCellDrive extends Context.Service<VsCodeCellDrive>()(
+  "VsCodeCellDrive",
+  {
+    make: Effect.gen(function* () {
+      const code = yield* VsCode;
+      const resources = new Map<string, PresentedRun>();
+      const errorDiagnostics = yield* acquireDisposable(() =>
+        code.languages.createDiagnosticCollection("marimo-runtime"),
+      );
+
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => {
+          for (const resource of resources.values()) {
+            try {
+              resource.execution.end(false);
+            } catch {
+              // The execution was already ended by a concurrent notification.
+            }
+          }
+          resources.clear();
+        }),
+      );
+
+      const withResource = (
+        cell: CellRef,
+        runId: RunId,
+        apply: (resource: PresentedRun) => Effect.Effect<void>,
+      ) => {
+        const resource = resources.get(resourceKey(cell, runId));
+        return resource === undefined
+          ? Effect.logDebug("No live VS Code execution for cell run").pipe(
+              Effect.annotateLogs({ ...cell, runId }),
+            )
+          : apply(resource);
+      };
+
+      const resolveCell = (cell: CellRef, binding: VsCodeDriveBinding) =>
+        Effect.gen(function* () {
+          if (binding.notebook.id !== cell.notebookId) {
+            return yield* new InvalidCellError({
+              cellId: cell.cellId,
+              cause: new Error("Drive is bound to another notebook"),
+            });
+          }
+          return yield* findNotebookCell(binding.notebook, cell.cellId);
+        });
+
+      const renderOutputs = (
+        cell: CellRef,
+        runId: RunId,
+        state: CellRuntimeState,
+        final: boolean,
+      ) =>
+        withResource(cell, runId, ({ notebook, projection }) => {
+          const outputs = buildKeyedCellOutputs(
+            cell.cellId,
+            state,
+            code,
+            notebook,
+          );
+          return Effect.tryPromise(() =>
+            final ? projection.commit(outputs) : projection.project(outputs),
+          ).pipe(
+            Effect.catchCause((cause) =>
+              Effect.logWarning("Failed to update cell output").pipe(
+                Effect.annotateLogs({ cause, ...cell, runId }),
+              ),
+            ),
+          );
+        });
+
+      const setDiagnostic = (
+        cell: CellRef,
+        binding: VsCodeDriveBinding,
+        state: Option.Option<CellRuntimeState>,
+      ) =>
+        resolveCell(cell, binding).pipe(
+          Effect.flatMap((notebookCell) =>
+            Effect.sync(() => {
+              const { document } = notebookCell;
+              if (Option.isNone(state)) {
+                errorDiagnostics.delete(document.uri);
+                return;
+              }
+              const frame =
+                state.value.output?.channel === "marimo-error"
+                  ? cellTracebackFrame(state.value, cell.cellId)
+                  : undefined;
+              if (frame === undefined) {
+                errorDiagnostics.delete(document.uri);
+                return;
+              }
+              const line = Math.min(
+                Math.max(frame.line - 1, 0),
+                Math.max(document.lineCount - 1, 0),
+              );
+              const diagnostic = new code.Diagnostic(
+                document.lineAt(line).range,
+                diagnosticMessage(state.value),
+                code.DiagnosticSeverity.Error,
+              );
+              diagnostic.source = "marimo";
+              errorDiagnostics.set(document.uri, [diagnostic]);
+            }),
+          ),
+        );
+
+      const apply = (
+        cell: CellRef,
+        binding: VsCodeDriveBinding,
+        command: CellCommand,
+      ) =>
+        CellCommand.$match(command, {
+          OpenRun: ({ runId }) =>
+            Effect.gen(function* () {
+              const notebookCell = yield* resolveCell(cell, binding);
+              const execution = yield* Effect.try({
+                try: () =>
+                  binding.controller.createNotebookCellExecution(notebookCell),
+                catch: (cause) =>
+                  new InvalidCellError({ cellId: cell.cellId, cause }),
+              });
+              resources.set(resourceKey(cell, runId), {
+                execution,
+                projection: new CellOutputProjection(execution),
+                notebook: binding.notebook.rawNotebookDocument,
+              });
+            }),
+          StartRun: ({ runId, at }) =>
+            withResource(cell, runId, ({ execution }) =>
+              Effect.sync(() => execution.start(at)),
+            ),
+          RenderOutputs: ({ runId, state, final }) =>
+            renderOutputs(cell, runId, state, final),
+          CloseRun: ({ runId, success, at }) =>
+            withResource(cell, runId, ({ execution }) =>
+              Effect.gen(function* () {
+                yield* Effect.try(() => execution.end(success, at)).pipe(
+                  Effect.ignore,
+                );
+                resources.delete(resourceKey(cell, runId));
+              }),
+            ),
+          SetDiagnostic: ({ state }) => setDiagnostic(cell, binding, state),
+        }).pipe(
+          Effect.catchTag("NotebookCellNotFoundError", () =>
+            Effect.logWarning("Notebook cell not found for command").pipe(
+              Effect.annotateLogs({ ...cell, command: command._tag }),
+            ),
+          ),
+          Effect.catchTag("InvalidCellError", (error) =>
+            Effect.logWarning("Cell is no longer valid; skipping command").pipe(
+              Effect.annotateLogs({
+                cause: Cause.fail(error.cause),
+                ...cell,
+                command: command._tag,
+              }),
+            ),
+          ),
+        );
+
+      return {
+        bind:
+          (binding: VsCodeDriveBinding): Drive =>
+          (cell, command) =>
+            apply(cell, binding, command),
+      };
+    }),
+  },
+) {
+  static readonly layer = Layer.effect(this, this.make);
+}

--- a/extension/src/kernel/VsCodeCellOutputs.ts
+++ b/extension/src/kernel/VsCodeCellOutputs.ts
@@ -105,6 +105,10 @@ export function buildKeyedCellOutputs(
           stdinItems.push(item);
           break;
         case "media":
+          // Items in one NotebookCellOutput are alternate MIME
+          // representations. Keep the full console state in the rich marimo
+          // item so its renderer preserves the ordering of text and media;
+          // native stdout remains the fallback representation.
           stdoutItems.push(item);
           break;
         case "output":

--- a/extension/src/kernel/VsCodeCellOutputs.ts
+++ b/extension/src/kernel/VsCodeCellOutputs.ts
@@ -1,0 +1,330 @@
+import { createCellRuntimeState } from "@marimo-team/frontend/unstable_internal/core/cells/types.ts";
+import type {
+  CellOutput,
+  OutputMessage,
+} from "@marimo-team/frontend/unstable_internal/core/kernel/messages.ts";
+import { Context, Option, Array as EffectArray } from "effect";
+import type * as vscode from "vscode";
+
+import { logUnreachable } from "../assert.ts";
+import { SCRATCH_CELL_ID } from "../constants.ts";
+import { prettyErrorMessage } from "../lib/errors.ts";
+import {
+  extractCellFrames,
+  parseTraceback,
+  type TracebackCellFrame,
+} from "../lib/tracebacks.ts";
+import { VsCode } from "../platform/VsCode.ts";
+import {
+  type NotebookCellId,
+  MarimoNotebookDocument,
+} from "../schemas/MarimoNotebookDocument.ts";
+import {
+  type CellOperationNotification,
+  type CellRuntimeState,
+  createCellNavigationLink,
+} from "../types.ts";
+import type { KeyedCellOutput } from "./CellOutputProjection.ts";
+import { transitionCell } from "./CellRunReducer.ts";
+
+type VsCodeService = Context.Service.Shape<typeof VsCode>;
+
+/** Convert scratch-cell notifications to one VS Code output. */
+export function scratchCellNotificationsToVsCodeOutput(
+  notifications:
+    | CellOperationNotification
+    | ReadonlyArray<CellOperationNotification>,
+  code: VsCodeService,
+) {
+  const arr = EffectArray.ensure(notifications);
+  const outputs = buildCellOutputs(
+    SCRATCH_CELL_ID,
+    arr.reduce(transitionCell, createCellRuntimeState()),
+    code,
+  );
+  const items = outputs.flatMap((output) => output.items);
+  return items.length === 0
+    ? Option.none<vscode.NotebookCellOutput>()
+    : Option.some(new code.NotebookCellOutput(items));
+}
+
+/** Build VS Code cell outputs grouped by their logical output channel. */
+export function buildCellOutputs(
+  cellId: NotebookCellId,
+  state: CellRuntimeState,
+  code: VsCodeService,
+  notebook?: vscode.NotebookDocument,
+): vscode.NotebookCellOutput[] {
+  return buildKeyedCellOutputs(cellId, state, code, notebook).map(
+    (keyed) => keyed.output,
+  );
+}
+
+/**
+ * Build outputs with stable keys used by {@link CellOutputProjection}.
+ * Console streams arrive before the main result, matching Jupyter ordering.
+ */
+export function buildKeyedCellOutputs(
+  cellId: NotebookCellId,
+  state: CellRuntimeState,
+  code: VsCodeService,
+  notebook?: vscode.NotebookDocument,
+): KeyedCellOutput[] {
+  const outputs: KeyedCellOutput[] = [];
+  const stdoutItems: vscode.NotebookCellOutputItem[] = [];
+  const stderrItems: vscode.NotebookCellOutputItem[] = [];
+  const stdinItems: vscode.NotebookCellOutputItem[] = [];
+  const errorItems: vscode.NotebookCellOutputItem[] = [];
+  const outputItems: vscode.NotebookCellOutputItem[] = [];
+  const tracebackItems: vscode.NotebookCellOutputItem[] = [];
+
+  if (state.consoleOutputs) {
+    for (const output of state.consoleOutputs) {
+      const item = buildOutputItem(
+        output,
+        cellId,
+        { ...state, output: null },
+        code,
+        notebook,
+      );
+      if (!item) continue;
+
+      if (output.mimetype === TRACEBACK_MIME) {
+        tracebackItems.push(item);
+        continue;
+      }
+
+      switch (output.channel) {
+        case "stdout":
+          stdoutItems.push(item);
+          break;
+        case "stderr":
+          stderrItems.push(item);
+          break;
+        case "stdin":
+          stdinItems.push(item);
+          break;
+        case "media":
+          stdoutItems.push(item);
+          break;
+        case "output":
+        case "marimo-error":
+        case "pdb":
+          break;
+        default:
+          logUnreachable(output.channel);
+      }
+    }
+  }
+
+  if (state.output && !isOutputEmpty(state.output)) {
+    const item = buildOutputItem(
+      state.output,
+      cellId,
+      { ...state, consoleOutputs: [] },
+      code,
+      notebook,
+    );
+    if (item) {
+      if (state.output.channel === "marimo-error") {
+        errorItems.push(item);
+      } else {
+        outputItems.push(item);
+      }
+    }
+  }
+
+  if (stdoutItems.length > 0) {
+    outputs.push({
+      key: "stdout",
+      output: new code.NotebookCellOutput(stdoutItems, { channel: "stdout" }),
+    });
+  }
+  if (stderrItems.length > 0) {
+    outputs.push({
+      key: "stderr",
+      output: new code.NotebookCellOutput(stderrItems, { channel: "stderr" }),
+    });
+  }
+
+  const errorShown = errorItems.length > 0 && !shouldSuppressMarimoError(state);
+  let mainSlotTaken = false;
+  if (errorShown) {
+    outputs.push({
+      key: "main",
+      output: new code.NotebookCellOutput(errorItems, {
+        channel: "marimo-error",
+      }),
+    });
+    mainSlotTaken = true;
+  } else if (outputItems.length > 0) {
+    outputs.push({
+      key: "main",
+      output: new code.NotebookCellOutput(outputItems),
+    });
+    mainSlotTaken = true;
+  }
+
+  tracebackItems.forEach((tracebackItem, index) => {
+    const key = !mainSlotTaken && index === 0 ? "main" : `traceback:${index}`;
+    if (key === "main") mainSlotTaken = true;
+    outputs.push({
+      key,
+      output: new code.NotebookCellOutput([tracebackItem], {
+        channel: "stderr",
+      }),
+    });
+  });
+
+  if (stdinItems.length > 0) {
+    outputs.push({
+      key: "stdin",
+      output: new code.NotebookCellOutput(stdinItems, { channel: "stdin" }),
+    });
+  }
+
+  return outputs;
+}
+
+const TRACEBACK_MIME = "application/vnd.marimo+traceback";
+
+function hasTraceback(state: CellRuntimeState): boolean {
+  if (state.output?.mimetype === TRACEBACK_MIME) return true;
+  return (state.consoleOutputs ?? []).some(
+    (output) => output?.mimetype === TRACEBACK_MIME,
+  );
+}
+
+export function cellTracebackFrame(
+  state: CellRuntimeState,
+  cellId: NotebookCellId,
+): TracebackCellFrame | undefined {
+  const traceback = (state.consoleOutputs ?? []).find(
+    (output) => output?.mimetype === TRACEBACK_MIME,
+  );
+  if (!traceback) return undefined;
+  const text =
+    typeof traceback.data === "object"
+      ? JSON.stringify(traceback.data)
+      : traceback.data;
+  return extractCellFrames(text)
+    .filter((frame) => frame.cellId === cellId)
+    .at(-1);
+}
+
+export function diagnosticMessage(state: CellRuntimeState): string {
+  const data = state.output?.data;
+  return Array.isArray(data) && data.length > 0
+    ? prettyErrorMessage(data[0])
+    : "Cell execution failed";
+}
+
+function shouldSuppressMarimoError(state: CellRuntimeState): boolean {
+  const output = state.output;
+  if (
+    !output ||
+    output.channel !== "marimo-error" ||
+    !Array.isArray(output.data)
+  ) {
+    return false;
+  }
+  const everyRedundant = output.data.every((error) => {
+    if (error == null || typeof error !== "object") return false;
+    if (!("type" in error) || error.type !== "exception") return false;
+    return !("raising_cell" in error) || !error.raising_cell;
+  });
+  return everyRedundant && hasTraceback(state);
+}
+
+function createCellIdMapper(
+  notebook: MarimoNotebookDocument,
+): (cellId: NotebookCellId) => string | undefined {
+  return (cellId) => {
+    const cellIndex = notebook.getCells().findIndex((cell) =>
+      Option.match(cell.id, {
+        onSome: (id) => id === cellId,
+        onNone: () => false,
+      }),
+    );
+    return cellIndex === -1
+      ? undefined
+      : createCellNavigationLink(cellId, cellIndex + 1);
+  };
+}
+
+function createCellIdToIndex(
+  notebook: MarimoNotebookDocument,
+): (cellId: string) => number | undefined {
+  return (cellId) => {
+    const cellIndex = notebook.getCells().findIndex((cell) =>
+      Option.match(cell.id, {
+        onSome: (id) => id === cellId,
+        onNone: () => false,
+      }),
+    );
+    return cellIndex === -1 ? undefined : cellIndex;
+  };
+}
+
+function buildOutputItem(
+  output: CellOutput,
+  cellId: NotebookCellId,
+  state: CellRuntimeState,
+  code: VsCodeService,
+  notebook?: vscode.NotebookDocument,
+): vscode.NotebookCellOutputItem | null {
+  if (output.mimetype === "text/plain") {
+    const text =
+      typeof output.data === "object"
+        ? JSON.stringify(output.data)
+        : // oxlint-disable-next-line typescript-eslint/no-unnecessary-type-conversion
+          String(output.data);
+    if (!text) return null;
+    switch (output.channel) {
+      case "stdout":
+        return code.NotebookCellOutputItem.stdout(text);
+      case "stderr":
+        return code.NotebookCellOutputItem.stderr(text);
+      case "stdin":
+        return code.NotebookCellOutputItem.text(text, "text/plain");
+    }
+  }
+
+  if (output.mimetype === TRACEBACK_MIME) {
+    const text =
+      typeof output.data === "object"
+        ? JSON.stringify(output.data)
+        : // oxlint-disable-next-line typescript-eslint/no-unnecessary-type-conversion
+          String(output.data);
+    if (!text) return null;
+    const cellIdToIndex = notebook
+      ? createCellIdToIndex(MarimoNotebookDocument.from(notebook))
+      : undefined;
+    return code.NotebookCellOutputItem.error(
+      parseTraceback(text, cellIdToIndex),
+    );
+  }
+
+  if (output.channel === "marimo-error" && Array.isArray(output.data)) {
+    const cellIdMapper = notebook
+      ? createCellIdMapper(MarimoNotebookDocument.from(notebook))
+      : undefined;
+    const errors = output.data.map((error) => {
+      const message = prettyErrorMessage(error, cellIdMapper);
+      return message.includes("<a href=")
+        ? code.NotebookCellOutputItem.text(message, "text/html")
+        : code.NotebookCellOutputItem.stderr(message);
+    });
+    return errors[0] || null;
+  }
+
+  if (isOutputEmpty(output)) return null;
+  return code.NotebookCellOutputItem.json(
+    { cellId, state },
+    "application/vnd.marimo.ui+json",
+  );
+}
+
+function isOutputEmpty(output: OutputMessage | undefined | null): boolean {
+  return output == null || output.data == null || output.data === "";
+}

--- a/extension/src/kernel/__tests__/CellExecutions.test.ts
+++ b/extension/src/kernel/__tests__/CellExecutions.test.ts
@@ -1662,6 +1662,98 @@ it.effect(
 );
 
 it.effect(
+  "accepts the submitted source when the cell changes before queued",
+  Effect.fn(function* () {
+    const cellData = {
+      kind: 1,
+      value: "x = 1",
+      languageId: "python",
+      metadata: MarimoNotebookCell.createMetadata({
+        marimoRuntime: { stableId: "cell-1" },
+      }),
+    };
+    const editor = TestVsCode.makeNotebookEditor("/test/notebook_mo.py", {
+      data: { cells: [cellData] },
+    });
+    const ctx = yield* withTestCtx({ initialDocuments: [editor.notebook] });
+
+    yield* Effect.gen(function* () {
+      const executions = yield* CellExecutions;
+      const cell = MarimoNotebookDocument.from(editor.notebook).cellAt(0);
+      const cellId = Option.getOrThrow(cell.id);
+      const drive: Drive = () => Effect.void;
+
+      yield* executions.submit(
+        cell.notebook.id,
+        [{ cellId, source: "x = 1" }],
+        Effect.gen(function* () {
+          cellData.value = "x = 2";
+          yield* executions.handleOperation(
+            {
+              op: "cell-op",
+              cell_id: cellId,
+              status: "queued",
+              run_id: "run-1",
+            },
+            { notebookId: cell.notebook.id, drive },
+          );
+        }),
+      );
+
+      expect(yield* executions.isCellStale(cell)).toBe(true);
+    }).pipe(Effect.provide(ctx.layer));
+  }),
+);
+
+it.effect(
+  "rolls back submitted sources when transport fails",
+  Effect.fn(function* () {
+    const cellData = {
+      kind: 1,
+      value: "x = 2",
+      languageId: "python",
+      metadata: MarimoNotebookCell.createMetadata({
+        marimoRuntime: { stableId: "cell-1" },
+      }),
+    };
+    const editor = TestVsCode.makeNotebookEditor("/test/notebook_mo.py", {
+      data: { cells: [cellData] },
+    });
+    const ctx = yield* withTestCtx({ initialDocuments: [editor.notebook] });
+
+    yield* Effect.gen(function* () {
+      const executions = yield* CellExecutions;
+      const cell = MarimoNotebookDocument.from(editor.notebook).cellAt(0);
+      const cellId = Option.getOrThrow(cell.id);
+      const drive: Drive = () => Effect.void;
+
+      yield* executions
+        .submit(
+          cell.notebook.id,
+          [{ cellId, source: "x = 1" }],
+          Effect.fail("transport failed"),
+        )
+        .pipe(Effect.flip);
+      yield* executions.submit(
+        cell.notebook.id,
+        [{ cellId, source: "x = 2" }],
+        executions.handleOperation(
+          {
+            op: "cell-op",
+            cell_id: cellId,
+            status: "queued",
+            run_id: "run-1",
+          },
+          { notebookId: cell.notebook.id, drive },
+        ),
+      );
+
+      expect(yield* executions.isCellStale(cell)).toBe(false);
+    }).pipe(Effect.provide(ctx.layer));
+  }),
+);
+
+it.effect(
   "clears stale state when cell is queued for execution",
   Effect.fn(function* () {
     const ctx = yield* withTestCtx();

--- a/extension/src/kernel/__tests__/CellExecutions.test.ts
+++ b/extension/src/kernel/__tests__/CellExecutions.test.ts
@@ -1170,6 +1170,54 @@ it.effect(
 );
 
 it.effect(
+  "closes an active run when its cell is removed",
+  Effect.fn(function* () {
+    const editor = TestVsCode.makeNotebookEditor("/test/notebook_mo.py", {
+      data: {
+        cells: [
+          {
+            kind: 1,
+            value: "x = 1",
+            languageId: "python",
+            metadata: MarimoNotebookCell.createMetadata({
+              marimoRuntime: { stableId: "cell-1" },
+            }),
+          },
+        ],
+      },
+    });
+    const ctx = yield* withTestCtx({ initialDocuments: [editor.notebook] });
+
+    yield* Effect.gen(function* () {
+      const executions = yield* CellExecutions;
+      const cell = MarimoNotebookDocument.from(editor.notebook).cellAt(0);
+      const cellId = Option.getOrThrow(cell.id);
+      const commands: string[] = [];
+      const drive: Drive = (_cell, command) =>
+        Effect.sync(() => commands.push(command._tag));
+
+      yield* executions.handleOperation(
+        {
+          op: "cell-op",
+          cell_id: cellId,
+          status: "queued",
+          run_id: "run-1",
+        },
+        {
+          notebookId: cell.notebook.id,
+          source: cell.document.getText(),
+          drive,
+        },
+      );
+      yield* executions.removeCell(cell.notebook.id, cellId);
+      yield* executions.removeCell(cell.notebook.id, cellId);
+
+      expect(commands).toEqual(["SetDiagnostic", "OpenRun", "CloseRun"]);
+    }).pipe(Effect.provide(ctx.layer));
+  }),
+);
+
+it.effect(
   "keeps commands on the Drive that opened their run",
   Effect.fn(function* () {
     const editor = TestVsCode.makeNotebookEditor("/test/notebook_mo.py", {

--- a/extension/src/kernel/__tests__/CellExecutions.test.ts
+++ b/extension/src/kernel/__tests__/CellExecutions.test.ts
@@ -1063,7 +1063,7 @@ describe("buildCellOutputs", () => {
   );
 
   it.effect(
-    "handles media channel with stdout in console outputs",
+    "offers native stdout and rich media as alternate MIME representations",
     Effect.fn(function* () {
       const ctx = yield* withTestCtx();
       const state: CellRuntimeState = {
@@ -1089,8 +1089,22 @@ describe("buildCellOutputs", () => {
         return buildCellOutputs(CELL_ID, state, code);
       }).pipe(Effect.provide(ctx.layer));
 
-      // Both stdout and media should be in the stdout channel
-      expect(normalizeOutputsForSnapshot(outputs)).toMatchSnapshot();
+      expect(outputs).toHaveLength(1);
+      const output = outputs.at(0);
+      if (output === undefined) throw new Error("Expected stdout output");
+      expect(output.metadata).toEqual({ channel: "stdout" });
+      expect(output.items.map((item) => item.mime)).toEqual([
+        "application/vnd.code.notebook.stdout",
+        "application/vnd.marimo.ui+json",
+      ]);
+
+      const richItem = output.items.at(1);
+      if (richItem === undefined) throw new Error("Expected rich MIME item");
+      expect(JSON.parse(new TextDecoder().decode(richItem.data))).toMatchObject(
+        {
+          state: { consoleOutputs: state.consoleOutputs },
+        },
+      );
     }),
   );
 });

--- a/extension/src/kernel/__tests__/CellExecutions.test.ts
+++ b/extension/src/kernel/__tests__/CellExecutions.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "@effect/vitest";
 import { createCellRuntimeState } from "@marimo-team/frontend/unstable_internal/core/cells/types.ts";
-import { Effect, Layer, Option, Stream } from "effect";
+import { Effect, Layer, Option } from "effect";
 import { TestClock } from "effect/testing";
 import type * as vscode from "vscode";
 
@@ -12,11 +12,12 @@ import {
 } from "../../__mocks__/TestVsCode.ts";
 import { makeTestNotebookRuntime } from "../../__tests__/__utils__/TestMarimoClient.ts";
 import { NOTEBOOK_TYPE } from "../../constants.ts";
+import { CellExecutions, type Drive } from "../../kernel/CellExecutions.ts";
 import {
-  buildCellOutputs,
-  CellExecutions,
-} from "../../kernel/CellExecutions.ts";
-import { PythonController } from "../../kernel/PythonController.ts";
+  VsCodeCellDrive,
+  type VsCodeDriveBinding,
+} from "../../kernel/VsCodeCellDrive.ts";
+import { buildCellOutputs } from "../../kernel/VsCodeCellOutputs.ts";
 import {
   cellId,
   UNSAFE_castForNegativeTest,
@@ -39,6 +40,7 @@ const withTestCtx = Effect.fn(function* (
   const vscode = yield* TestVsCode.make(options);
   const layer = Layer.empty.pipe(
     Layer.merge(CellExecutions.layer),
+    Layer.merge(VsCodeCellDrive.layer),
     Layer.provide(TestNotebookRuntime),
     Layer.provide(TestTelemetryLive),
     Layer.provideMerge(vscode.layer),
@@ -47,6 +49,21 @@ const withTestCtx = Effect.fn(function* (
 });
 
 const CELL_ID = cellId("test-cell-id");
+
+const acceptCell = (
+  executions: CellExecutions["Service"],
+  host: VsCodeCellDrive["Service"],
+  cell: MarimoNotebookCell,
+  message: CellOperationNotification,
+  controller: VsCodeDriveBinding["controller"],
+  renderOutput?: boolean,
+) =>
+  executions.handleOperation(message, {
+    notebookId: cell.notebook.id,
+    source: cell.document.getText(),
+    drive: host.bind({ notebook: cell.notebook, controller }),
+    renderOutput,
+  });
 
 // Convert Uint8Array data to strings for readable snapshots
 function normalizeOutputsForSnapshot(
@@ -1104,6 +1121,7 @@ it.effect(
 
     yield* Effect.gen(function* () {
       const executions = yield* CellExecutions;
+      const host = yield* VsCodeCellDrive;
       const code = yield* VsCode;
       const vscodeController = yield* code.notebooks.createNotebookController(
         "test-controller",
@@ -1126,14 +1144,20 @@ it.effect(
         run_id: "shared-run",
       };
 
-      yield* executions.handleOperation(message, {
-        editor: firstEditor,
+      yield* acceptCell(
+        executions,
+        host,
+        MarimoNotebookDocument.from(firstEditor.notebook).cellAt(0),
+        message,
         controller,
-      });
-      yield* executions.handleOperation(message, {
-        editor: secondEditor,
+      );
+      yield* acceptCell(
+        executions,
+        host,
+        MarimoNotebookDocument.from(secondEditor.notebook).cellAt(0),
+        message,
         controller,
-      });
+      );
 
       expect(createdFor.toSorted((a, b) => a.localeCompare(b))).toEqual(
         [
@@ -1141,6 +1165,83 @@ it.effect(
           MarimoNotebookDocument.from(secondEditor.notebook).id,
         ].toSorted((a, b) => a.localeCompare(b)),
       );
+    }).pipe(Effect.provide(ctx.layer));
+  }),
+);
+
+it.effect(
+  "keeps commands on the Drive that opened their run",
+  Effect.fn(function* () {
+    const editor = TestVsCode.makeNotebookEditor("/test/notebook_mo.py", {
+      data: {
+        cells: [
+          {
+            kind: 1,
+            value: "x = 1",
+            languageId: "python",
+            metadata: MarimoNotebookCell.createMetadata({
+              marimoRuntime: { stableId: "cell-1" },
+            }),
+          },
+        ],
+      },
+    });
+    const ctx = yield* withTestCtx({ initialDocuments: [editor.notebook] });
+
+    yield* Effect.gen(function* () {
+      const executions = yield* CellExecutions;
+      const cell = MarimoNotebookDocument.from(editor.notebook).cellAt(0);
+      const cellId = Option.getOrThrow(cell.id);
+      const events: string[] = [];
+      const namedDrive =
+        (name: string): Drive =>
+        (_cell, command) =>
+          Effect.sync(() => {
+            if ("runId" in command) {
+              events.push(`${name}:${command._tag}:${command.runId}`);
+            }
+          });
+      const first = namedDrive("first");
+      const second = namedDrive("second");
+      const accept = (message: CellOperationNotification, drive: Drive) =>
+        executions.handleOperation(message, {
+          notebookId: cell.notebook.id,
+          source: cell.document.getText(),
+          drive,
+        });
+
+      yield* accept(
+        {
+          op: "cell-op",
+          cell_id: cellId,
+          status: "queued",
+          run_id: "run-1",
+        },
+        first,
+      );
+      yield* accept(
+        {
+          op: "cell-op",
+          cell_id: cellId,
+          status: "queued",
+          run_id: "run-2",
+        },
+        second,
+      );
+      // Even if a later operation arrives with another current Drive, the
+      // active run remains bound to the Drive that opened it.
+      yield* accept(
+        { op: "cell-op", cell_id: cellId, status: "running" },
+        first,
+      );
+
+      expect(events).toEqual([
+        "first:OpenRun:run-1",
+        "first:CloseRun:run-1",
+        "second:OpenRun:run-2",
+        "second:StartRun:run-2",
+        "second:RenderOutputs:run-2",
+      ]);
     }).pipe(Effect.provide(ctx.layer));
   }),
 );
@@ -1169,6 +1270,7 @@ it.effect(
 
     yield* Effect.gen(function* () {
       const executions = yield* CellExecutions;
+      const host = yield* VsCodeCellDrive;
       const notebook = MarimoNotebookDocument.from(editor.notebook);
       const cell = notebook.cellAt(0);
       const cid = Option.getOrThrow(cell.id);
@@ -1200,16 +1302,22 @@ it.effect(
         },
       };
 
-      yield* executions.handleOperation(
+      yield* acceptCell(
+        executions,
+        host,
+        cell,
         {
           op: "cell-op",
           cell_id: cid,
           status: "queued",
           run_id: "run",
         },
-        { editor, controller },
+        controller,
       );
-      yield* executions.handleOperation(
+      yield* acceptCell(
+        executions,
+        host,
+        cell,
         {
           op: "cell-op",
           cell_id: cid,
@@ -1221,12 +1329,16 @@ it.effect(
             timestamp: 0,
           },
         },
-        { editor, controller, renderOutput: false },
+        controller,
+        false,
       );
 
       expect(projectionCalls).toEqual([]);
 
-      yield* executions.handleOperation(
+      yield* acceptCell(
+        executions,
+        host,
+        cell,
         {
           op: "cell-op",
           cell_id: cid,
@@ -1238,7 +1350,8 @@ it.effect(
             timestamp: 1,
           },
         },
-        { editor, controller, renderOutput: true },
+        controller,
+        true,
       );
 
       expect(projectionCalls).toEqual(["clear", "append"]);
@@ -1270,6 +1383,7 @@ it.effect(
 
     yield* Effect.gen(function* () {
       const executions = yield* CellExecutions;
+      const host = yield* VsCodeCellDrive;
       const notebook = MarimoNotebookDocument.from(editor.notebook);
       const cell = notebook.cellAt(0);
       const cid = Option.getOrThrow(cell.id);
@@ -1296,16 +1410,22 @@ it.effect(
         },
       };
 
-      yield* executions.handleOperation(
+      yield* acceptCell(
+        executions,
+        host,
+        cell,
         {
           op: "cell-op",
           cell_id: cid,
           status: "queued",
           run_id: "run-2",
         },
-        { editor, controller },
+        controller,
       );
-      yield* executions.handleOperation(
+      yield* acceptCell(
+        executions,
+        host,
+        cell,
         {
           op: "cell-op",
           cell_id: cid,
@@ -1313,12 +1433,16 @@ it.effect(
           run_id: "run-1",
           timestamp: 1,
         },
-        { editor, controller, renderOutput: false },
+        controller,
+        false,
       );
 
       expect(starts).toEqual([]);
 
-      yield* executions.handleOperation(
+      yield* acceptCell(
+        executions,
+        host,
+        cell,
         {
           op: "cell-op",
           cell_id: cid,
@@ -1326,7 +1450,8 @@ it.effect(
           run_id: "run-2",
           timestamp: 2,
         },
-        { editor, controller, renderOutput: false },
+        controller,
+        false,
       );
 
       expect(starts).toEqual([2_000]);
@@ -1362,26 +1487,11 @@ it.effect(
       const cell = notebook.cellAt(0);
       const cid = Option.getOrThrow(cell.id);
       let created = 0;
-      const controller = {
-        createNotebookCellExecution(): vscode.NotebookCellExecution {
-          created += 1;
-          return {
-            cell: cell.rawNotebookCell,
-            executionOrder: undefined,
-            token: {
-              isCancellationRequested: false,
-              onCancellationRequested: () => ({ dispose() {} }),
-            },
-            start() {},
-            end() {},
-            async clearOutput() {},
-            async appendOutput() {},
-            async appendOutputItems() {},
-            async replaceOutput() {},
-            async replaceOutputItems() {},
-          };
-        },
-      };
+      const drive: Drive = (_cell, command) =>
+        Effect.sync(() => {
+          if (command._tag === "OpenRun") created += 1;
+        });
+      const options = { notebookId: cell.notebook.id, drive };
 
       yield* executions.handleOperation(
         {
@@ -1390,7 +1500,7 @@ it.effect(
           status: "queued",
           run_id: "run-1",
         },
-        { editor, controller },
+        options,
       );
       yield* executions.handleOperation(
         {
@@ -1400,7 +1510,7 @@ it.effect(
           run_id: "run-1",
           timestamp: 1,
         },
-        { editor, controller },
+        options,
       );
       expect(created).toBe(1);
 
@@ -1416,7 +1526,7 @@ it.effect(
             data: [{ type: "syntax", msg: "late error" }],
           },
         },
-        { editor, controller },
+        options,
       );
 
       expect(created).toBe(1);
@@ -1449,6 +1559,7 @@ it.effect(
 
     yield* Effect.gen(function* () {
       const executions = yield* CellExecutions;
+      const host = yield* VsCodeCellDrive;
       const code = yield* VsCode;
 
       const notebook = MarimoNotebookDocument.from(editor.notebook);
@@ -1475,13 +1586,9 @@ it.effect(
         stale_inputs: true,
       };
 
-      yield* executions.handleOperation(message, {
-        editor,
-        controller: new PythonController(
-          controller,
-          "test-controller",
-          Stream.never,
-        ),
+      yield* acceptCell(executions, host, cell, message, {
+        createNotebookCellExecution: (value) =>
+          controller.createNotebookCellExecution(value.rawNotebookCell),
       });
 
       // Check that CellExecutions tracked the cell as stale
@@ -1513,6 +1620,7 @@ it.effect(
 
     yield* Effect.gen(function* () {
       const executions = yield* CellExecutions;
+      const host = yield* VsCodeCellDrive;
 
       // Create a test notebook with a stale cell
       const cellData = {
@@ -1567,13 +1675,9 @@ it.effect(
         run_id: "test-run-id",
       };
 
-      yield* executions.handleOperation(message, {
-        editor,
-        controller: new PythonController(
-          controller,
-          "test-controller",
-          Stream.never,
-        ),
+      yield* acceptCell(executions, host, cell, message, {
+        createNotebookCellExecution: (value) =>
+          controller.createNotebookCellExecution(value.rawNotebookCell),
       });
 
       // Check that the cell's stale state was cleared
@@ -1593,6 +1697,7 @@ it.effect(
 
     yield* Effect.gen(function* () {
       const executions = yield* CellExecutions;
+      const host = yield* VsCodeCellDrive;
 
       const cellData = {
         kind: 1, // Code
@@ -1640,13 +1745,9 @@ it.effect(
         run_id: null,
       };
 
-      yield* executions.handleOperation(message, {
-        editor,
-        controller: new PythonController(
-          controller,
-          "test-controller",
-          Stream.never,
-        ),
+      yield* acceptCell(executions, host, cell, message, {
+        createNotebookCellExecution: (value) =>
+          controller.createNotebookCellExecution(value.rawNotebookCell),
       });
 
       // Stale state preserved because we bail before recordExecution
@@ -1660,27 +1761,15 @@ it.effect(
 );
 
 /**
- * Creates a PythonController whose `createNotebookCellExecution` throws,
+ * Creates a controller whose `createNotebookCellExecution` throws,
  * simulating VS Code's "invalid cell" error when a cell is deleted.
  */
-function makeThrowingController(): PythonController {
-  const inner: Omit<vscode.NotebookController, "dispose"> = {
-    id: "throwing-controller",
-    notebookType: NOTEBOOK_TYPE,
-    label: "throwing-controller",
-    supportedLanguages: undefined,
-    description: undefined,
-    detail: undefined,
-    supportsExecutionOrder: undefined,
-    executeHandler: () => {},
-    interruptHandler: undefined,
-    onDidChangeSelectedNotebooks: () => ({ dispose() {} }),
-    updateNotebookAffinity() {},
+function makeThrowingController(): VsCodeDriveBinding["controller"] {
+  return {
     createNotebookCellExecution() {
       throw new Error("invalid cell");
     },
   };
-  return new PythonController(inner, "/usr/bin/python3", Stream.never);
 }
 
 it.effect(
@@ -1708,6 +1797,7 @@ it.effect(
 
     yield* Effect.gen(function* () {
       const executions = yield* CellExecutions;
+      const host = yield* VsCodeCellDrive;
 
       const notebook = MarimoNotebookDocument.from(editor.notebook);
       const cell = notebook.cellAt(0);
@@ -1726,10 +1816,7 @@ it.effect(
         run_id: "test-run-id",
       };
 
-      yield* executions.handleOperation(message, {
-        editor,
-        controller,
-      });
+      yield* acceptCell(executions, host, cell, message, controller);
 
       // If we get here, the error was handled gracefully
       expect(true).toBe(true);
@@ -1762,6 +1849,7 @@ it.effect(
 
     yield* Effect.gen(function* () {
       const executions = yield* CellExecutions;
+      const host = yield* VsCodeCellDrive;
 
       const notebook = MarimoNotebookDocument.from(editor.notebook);
       const cell = notebook.cellAt(0);
@@ -1787,10 +1875,7 @@ it.effect(
         },
       };
 
-      yield* executions.handleOperation(message, {
-        editor,
-        controller,
-      });
+      yield* acceptCell(executions, host, cell, message, controller);
 
       // If we get here, the error was handled gracefully
       expect(true).toBe(true);

--- a/extension/src/kernel/__tests__/CellExecutions.test.ts
+++ b/extension/src/kernel/__tests__/CellExecutions.test.ts
@@ -1768,6 +1768,111 @@ it.effect(
 );
 
 it.effect(
+  "drops submitted sources when execution is interrupted before queued",
+  Effect.fn(function* () {
+    const cellData = {
+      kind: 1,
+      value: "x = 2",
+      languageId: "python",
+      metadata: MarimoNotebookCell.createMetadata({
+        marimoRuntime: { stableId: "cell-1" },
+      }),
+    };
+    const editor = TestVsCode.makeNotebookEditor("/test/notebook_mo.py", {
+      data: { cells: [cellData] },
+    });
+    const ctx = yield* withTestCtx({ initialDocuments: [editor.notebook] });
+
+    yield* Effect.gen(function* () {
+      const executions = yield* CellExecutions;
+      const cell = MarimoNotebookDocument.from(editor.notebook).cellAt(0);
+      const cellId = Option.getOrThrow(cell.id);
+      const drive: Drive = () => Effect.void;
+
+      yield* executions.submit(
+        cell.notebook.id,
+        [{ cellId, source: "x = 1" }],
+        Effect.void,
+      );
+      yield* executions.handleInterrupt(cell.notebook.id);
+      yield* executions.submit(
+        cell.notebook.id,
+        [{ cellId, source: "x = 2" }],
+        executions.handleOperation(
+          {
+            op: "cell-op",
+            cell_id: cellId,
+            status: "queued",
+            run_id: "run-1",
+          },
+          { notebookId: cell.notebook.id, drive },
+        ),
+      );
+
+      expect(yield* executions.isCellStale(cell)).toBe(false);
+    }).pipe(Effect.provide(ctx.layer));
+  }),
+);
+
+it.effect(
+  "drops submitted sources when compilation fails before queued",
+  Effect.fn(function* () {
+    const cellData = {
+      kind: 1,
+      value: "x = 2",
+      languageId: "python",
+      metadata: MarimoNotebookCell.createMetadata({
+        marimoRuntime: { stableId: "cell-1" },
+      }),
+    };
+    const editor = TestVsCode.makeNotebookEditor("/test/notebook_mo.py", {
+      data: { cells: [cellData] },
+    });
+    const ctx = yield* withTestCtx({ initialDocuments: [editor.notebook] });
+
+    yield* Effect.gen(function* () {
+      const executions = yield* CellExecutions;
+      const cell = MarimoNotebookDocument.from(editor.notebook).cellAt(0);
+      const cellId = Option.getOrThrow(cell.id);
+      const drive: Drive = () => Effect.void;
+
+      yield* executions.submit(
+        cell.notebook.id,
+        [{ cellId, source: "x = 1" }],
+        executions.handleOperation(
+          {
+            op: "cell-op",
+            cell_id: cellId,
+            status: "idle",
+            output: {
+              mimetype: "application/vnd.marimo+error",
+              channel: "marimo-error",
+              data: [{ type: "syntax", msg: "invalid syntax" }],
+            },
+          },
+          { notebookId: cell.notebook.id, drive },
+        ),
+      );
+      yield* executions.submit(
+        cell.notebook.id,
+        [{ cellId, source: "x = 2" }],
+        executions.handleOperation(
+          {
+            op: "cell-op",
+            cell_id: cellId,
+            status: "queued",
+            run_id: "run-1",
+          },
+          { notebookId: cell.notebook.id, drive },
+        ),
+      );
+
+      expect(yield* executions.isCellStale(cell)).toBe(false);
+    }).pipe(Effect.provide(ctx.layer));
+  }),
+);
+
+it.effect(
   "clears stale state when cell is queued for execution",
   Effect.fn(function* () {
     const ctx = yield* withTestCtx();

--- a/extension/src/kernel/__tests__/NotebookRuntime.test.ts
+++ b/extension/src/kernel/__tests__/NotebookRuntime.test.ts
@@ -220,9 +220,7 @@ it.effect(
     const { layer } = yield* makeTestLayer();
     const controller: NotebookController = {
       id: "marimo-/usr/bin/python",
-      createNotebookCellExecution() {
-        throw new Error("not used");
-      },
+      drive: () => () => Effect.void,
       resolveExecutable: () => Effect.succeed("/usr/bin/python"),
     };
 
@@ -245,9 +243,7 @@ it.effect(
     const editor = TestVsCode.makeNotebookEditor("/test/notebook_mo.py");
     const controller: NotebookController = {
       id: "marimo-/usr/bin/python",
-      createNotebookCellExecution() {
-        throw new Error("not used");
-      },
+      drive: () => () => Effect.void,
       resolveExecutable: () => Effect.succeed("/usr/bin/python"),
     };
 
@@ -370,9 +366,7 @@ it.effect(
     const id = notebookId(editor.notebook.uri.toString());
     const controller: NotebookController = {
       id: "marimo-/usr/bin/python",
-      createNotebookCellExecution() {
-        throw new Error("not used");
-      },
+      drive: () => () => Effect.void,
       resolveExecutable: () => Effect.succeed("/usr/bin/python"),
     };
 

--- a/extension/src/kernel/__tests__/NotebookRuntimeOperations.test.ts
+++ b/extension/src/kernel/__tests__/NotebookRuntimeOperations.test.ts
@@ -30,6 +30,7 @@ import {
   processRuntimeOperations,
 } from "../../kernel/NotebookRuntime.ts";
 import { PythonController } from "../../kernel/PythonController.ts";
+import { VsCodeCellDrive } from "../../kernel/VsCodeCellDrive.ts";
 import {
   cellId,
   notebookId,
@@ -92,6 +93,9 @@ const withTestCtx = Effect.fn(function* () {
         inputRequested.open.pipe(Effect.andThen(Queue.take(inputQueue))),
     },
   });
+  const cellDrive = yield* VsCodeCellDrive.make.pipe(
+    Effect.provide(vscode.layer),
+  );
 
   const mockController = yield* Effect.gen(function* () {
     const code = yield* VsCode;
@@ -100,7 +104,19 @@ const withTestCtx = Effect.fn(function* () {
       NOTEBOOK_TYPE,
       "Test Controller",
     );
-    return new PythonController(controller, "/usr/bin/python3", Stream.never);
+    return new PythonController(
+      controller,
+      "/usr/bin/python3",
+      Stream.never,
+      (document) =>
+        cellDrive.bind({
+          notebook: document,
+          controller: {
+            createNotebookCellExecution: (cell) =>
+              controller.createNotebookCellExecution(cell.rawNotebookCell),
+          },
+        }),
+    );
   }).pipe(Effect.provide(vscode.layer));
 
   const layer = Layer.empty.pipe(

--- a/extension/src/kernel/__tests__/__snapshots__/CellExecutions.test.ts.snap
+++ b/extension/src/kernel/__tests__/__snapshots__/CellExecutions.test.ts.snap
@@ -102,27 +102,6 @@ exports[`buildCellOutputs > handles media channel in console outputs 1`] = `
 ]
 `;
 
-exports[`buildCellOutputs > handles media channel with stdout in console outputs 1`] = `
-[
-  {
-    "items": [
-      {
-        "data": "Text output
-",
-        "mime": "application/vnd.code.notebook.stdout",
-      },
-      {
-        "data": "{"cellId":"test-cell-id","state":{"outline":null,"output":null,"consoleOutputs":[{"mimetype":"text/plain","channel":"stdout","data":"Text output\\n","timestamp":0},{"mimetype":"image/png","channel":"media","data":"imagedata","timestamp":1}],"status":"idle","staleInputs":false,"interrupted":false,"errored":false,"stopped":false,"runElapsedTimeMs":null,"runStartTimestamp":null,"lastRunStartTimestamp":null,"debuggerActive":false}}",
-        "mime": "application/vnd.marimo.ui+json",
-      },
-    ],
-    "metadata": {
-      "channel": "stdout",
-    },
-  },
-]
-`;
-
 exports[`buildCellOutputs > handles mix of empty and non-empty console outputs 1`] = `
 [
   {

--- a/extension/src/kernel/__tests__/operations.test.ts
+++ b/extension/src/kernel/__tests__/operations.test.ts
@@ -24,9 +24,7 @@ const alert: NotificationOf<"missing-package-alert"> = {
 // script-install path and reaches the prompt without touching the filesystem.
 const controller: NotebookController = {
   id: "test-controller",
-  createNotebookCellExecution() {
-    throw new Error("not implemented");
-  },
+  drive: () => () => Effect.void,
   resolveExecutable: () => Effect.die("not implemented"),
 };
 

--- a/extension/src/panel/packages/__tests__/PackagesService.test.ts
+++ b/extension/src/panel/packages/__tests__/PackagesService.test.ts
@@ -84,15 +84,18 @@ const makePythonController = Effect.fn(function* (executable: string) {
     NOTEBOOK_TYPE,
     "Test Python",
   );
-  return new PythonController(controller, executable, Stream.never);
+  return new PythonController(
+    controller,
+    executable,
+    Stream.never,
+    () => () => Effect.void,
+  );
 });
 
 function makeNonPythonController(): NotebookController {
   return {
     id: "test-sandbox-controller",
-    createNotebookCellExecution() {
-      throw new Error("Not used by PackagesService tests");
-    },
+    drive: () => () => Effect.void,
     resolveExecutable: () => Effect.succeed("/unused"),
   };
 }

--- a/extension/src/platform/Api.ts
+++ b/extension/src/platform/Api.ts
@@ -17,8 +17,8 @@ import {
 } from "effect";
 import type * as vscode from "vscode";
 
-import { scratchCellNotificationsToVsCodeOutput } from "../kernel/CellExecutions.ts";
 import { NotebookRuntime } from "../kernel/NotebookRuntime.ts";
+import { scratchCellNotificationsToVsCodeOutput } from "../kernel/VsCodeCellOutputs.ts";
 import { MarimoNotebookDocument } from "../schemas/MarimoNotebookDocument.ts";
 import { VsCode } from "./VsCode.ts";
 

--- a/extension/src/schemas/MarimoNotebookDocument.ts
+++ b/extension/src/schemas/MarimoNotebookDocument.ts
@@ -18,7 +18,7 @@ const NotebookId = Brand.nominal<NotebookId>();
 // (openapi codegen types, not Effect Brand). No runtime check — callers pass
 // strings originating from the LSP's typed responses.
 // oxlint-disable-next-line typescript/no-unsafe-type-assertion
-const NotebookCellId = (id: string) => id as CellId;
+export const NotebookCellId = (id: string) => id as CellId;
 // oxlint-disable-next-line typescript/no-unsafe-type-assertion
 const VariableName = (name: string) => name as VariableName;
 


### PR DESCRIPTION
`CellExecutions` emits commands through one effectful capability.

```ts
type Drive = (
  cell: CellRef,
  command: CellCommand,
) => Effect.Effect<void>;
```

`VsCodeCellDrive` owns `NotebookCellExecution`, output projection, and runtime diagnostics. Controllers expose `drive(notebook)`; no VS Code execution handle crosses into `CellExecutions`.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
