### PR TITLE
Own cell state by notebook

### DIFF
--- a/extension/src/commands/restartKernel.ts
+++ b/extension/src/commands/restartKernel.ts
@@ -1,7 +1,7 @@
 import { Effect, Option } from "effect";
 
 import { defineCommand } from "../commands.ts";
-import { CellExecutions } from "../kernel/CellExecutions.ts";
+import { CellExecutions, CellInput } from "../kernel/CellExecutions.ts";
 import { showErrorAndPromptLogs } from "../lib/showErrorAndPromptLogs.ts";
 import { SessionsService } from "../panel/sessions/SessionsService.ts";
 import { VsCode } from "../platform/VsCode.ts";
@@ -55,7 +55,9 @@ const handler = Effect.fn("command.restartKernel")(function* (
 
       if (!succeeded) return false;
 
-      yield* executions.handleInterrupt(notebook.id);
+      yield* executions.accept(
+        CellInput.Interrupted({ notebookId: notebook.id }),
+      );
 
       progress.report({ message: "Kernel restarted." });
       yield* Effect.sleep("500 millis");

--- a/extension/src/commands/runStale.ts
+++ b/extension/src/commands/runStale.ts
@@ -21,7 +21,16 @@ const handler = Effect.fn("command.runStale")(
 
     const staleCells = yield* Effect.filter(
       target.value.document.getCells(),
-      (cell) => executions.isCellStale(cell),
+      (cell) =>
+        Option.match(cell.id, {
+          onNone: () => Effect.succeed(false),
+          onSome: (cellId) =>
+            executions.isStale({
+              notebookId: cell.notebook.id,
+              cellId,
+              source: cell.document.getText(),
+            }),
+        }),
     );
 
     if (staleCells.length === 0) {

--- a/extension/src/commands/sessionCommands.ts
+++ b/extension/src/commands/sessionCommands.ts
@@ -1,7 +1,7 @@
 import { Effect, Option } from "effect";
 
 import { NOTEBOOK_TYPE } from "../constants.ts";
-import { CellExecutions } from "../kernel/CellExecutions.ts";
+import { CellExecutions, CellInput } from "../kernel/CellExecutions.ts";
 import { showErrorAndPromptLogs } from "../lib/showErrorAndPromptLogs.ts";
 import { SessionsService } from "../panel/sessions/SessionsService.ts";
 import { VsCode } from "../platform/VsCode.ts";
@@ -32,7 +32,7 @@ const endExecutions = Effect.fn("command.endSessionExecutions")(function* (
   notebookUri: NotebookId,
 ) {
   const executions = yield* CellExecutions;
-  yield* executions.handleInterrupt(notebookUri);
+  yield* executions.accept(CellInput.Interrupted({ notebookId: notebookUri }));
 });
 
 export const openSession = Effect.fn("command.openSession")(function* ({

--- a/extension/src/features/CellStatusBarProvider.ts
+++ b/extension/src/features/CellStatusBarProvider.ts
@@ -5,6 +5,7 @@ import enableCell from "../commands/enableCell.ts";
 import runStale from "../commands/runStale.ts";
 import { NOTEBOOK_TYPE, SETUP_CELL_NAME } from "../constants.ts";
 import { CellExecutions } from "../kernel/CellExecutions.ts";
+import { NotebookEditorRegistry } from "../notebook/NotebookEditorRegistry.ts";
 import { VsCode } from "../platform/VsCode.ts";
 import {
   MarimoNotebookCell,
@@ -22,6 +23,31 @@ export const CellStatusBarProviderLive = Layer.effectDiscard(
   Effect.gen(function* () {
     const code = yield* VsCode;
     const executions = yield* CellExecutions;
+    const editors = yield* NotebookEditorRegistry;
+
+    const isStale = (cell: MarimoNotebookCell) =>
+      Option.match(cell.id, {
+        onNone: () => Effect.succeed(false),
+        onSome: (cellId) =>
+          executions.isStale({
+            notebookId: cell.notebook.id,
+            cellId,
+            source: cell.document.getText(),
+          }),
+      });
+
+    const cellContentChanges: Stream.Stream<void> =
+      code.workspace.notebookDocumentChanges.pipe(
+        Stream.filter((event) => {
+          if (Option.isNone(MarimoNotebookDocument.tryFrom(event.notebook))) {
+            return false;
+          }
+          return event.cellChanges.some(
+            (change) => change.document !== undefined,
+          );
+        }),
+        Stream.map(() => undefined),
+      );
 
     // Stream that fires when metadata changes on any marimo notebook cell
     const metadataChanges: Stream.Stream<void> =
@@ -37,13 +63,47 @@ export const CellStatusBarProviderLive = Layer.effectDiscard(
         Stream.map(() => undefined),
       );
 
+    const updateStaleContext = Effect.fn(function* () {
+      const activeNotebook = yield* editors.getActiveNotebookUri;
+      const hasStaleCells = yield* Option.match(activeNotebook, {
+        onNone: () => Effect.succeed(false),
+        onSome: (notebookId) =>
+          Effect.gen(function* () {
+            const editor = yield* editors.getLastNotebookEditor(notebookId);
+            if (Option.isNone(editor)) return false;
+            const notebook = MarimoNotebookDocument.tryFrom(
+              editor.value.notebook,
+            );
+            if (Option.isNone(notebook)) return false;
+            for (const cell of notebook.value.getCells()) {
+              if (yield* isStale(cell)) return true;
+            }
+            return false;
+          }),
+      });
+      yield* code.commands.setContext(
+        "marimo.notebook.hasStaleCells",
+        hasStaleCells,
+      );
+    });
+
+    yield* Effect.forkScoped(
+      Stream.merge(
+        executions.changes,
+        Stream.merge(
+          cellContentChanges,
+          Stream.map(editors.streamActiveNotebookChanges, () => undefined),
+        ),
+      ).pipe(Stream.runForEach(updateStaleContext)),
+    );
+
     // Staleness provider — derived from CellExecutions records
     yield* code.notebooks.registerNotebookCellStatusBarItemProvider(
       NOTEBOOK_TYPE,
       {
         provideCellStatusBarItems(raw) {
           const cell = MarimoNotebookCell.from(raw);
-          return executions.isCellStale(cell).pipe(
+          return isStale(cell).pipe(
             Effect.map((stale) => {
               if (!stale) return [];
               const item = new code.NotebookCellStatusBarItem(
@@ -64,7 +124,10 @@ export const CellStatusBarProviderLive = Layer.effectDiscard(
             }),
           );
         },
-        changes: Stream.merge(executions.changes, metadataChanges),
+        changes: Stream.merge(
+          executions.changes,
+          Stream.merge(cellContentChanges, metadataChanges),
+        ),
       },
     );
 

--- a/extension/src/features/__tests__/CellStatusBarProvider.test.ts
+++ b/extension/src/features/__tests__/CellStatusBarProvider.test.ts
@@ -12,7 +12,9 @@ import { makeTestNotebookRuntime } from "../../__tests__/__utils__/TestMarimoCli
 import { commandId } from "../../commands.ts";
 import enableCell from "../../commands/enableCell.ts";
 import runStale from "../../commands/runStale.ts";
+import { makeCellHarness } from "../../kernel/__tests__/CellExecutionsHarness.ts";
 import { CellExecutions } from "../../kernel/CellExecutions.ts";
+import { NotebookEditorRegistry } from "../../notebook/NotebookEditorRegistry.ts";
 import { MarimoNotebookCell } from "../../schemas/MarimoNotebookDocument.ts";
 import type * as Api from "../../schemas/Models.gen.ts";
 import { CellStatusBarProviderLive } from "../CellStatusBarProvider.ts";
@@ -22,6 +24,7 @@ const withTestCtx = Effect.fn(function* () {
   const layer = Layer.empty.pipe(
     Layer.provideMerge(CellStatusBarProviderLive),
     Layer.provideMerge(CellExecutions.layer),
+    Layer.provide(NotebookEditorRegistry.layer),
     Layer.provideMerge(vscode.layer),
     Layer.provide(TestTelemetryLive),
     Layer.provide(makeTestNotebookRuntime()),
@@ -81,13 +84,14 @@ it.effect(
     const ctx = yield* withTestCtx();
     yield* Effect.gen(function* () {
       const executions = yield* CellExecutions;
+      const cells = makeCellHarness(executions);
       const cell = createMockCell(notebookUri, {
         marimo: { name: "test_cell" },
         marimoRuntime: { stableId: "cell-1" },
       });
 
       // Record execution — clears stale
-      yield* executions.recordExecution(MarimoNotebookCell.from(cell));
+      yield* cells.acceptSource(MarimoNotebookCell.from(cell));
 
       const providers = yield* ctx.vscode.getRegisteredStatusBarItemProviders();
       const items = yield* providers[0].provideCellStatusBarItems(cell);
@@ -102,14 +106,15 @@ it.effect(
     const ctx = yield* withTestCtx();
     yield* Effect.gen(function* () {
       const executions = yield* CellExecutions;
+      const cells = makeCellHarness(executions);
       const cell = createMockCell(notebookUri, {
         marimo: { name: "test_cell" },
         marimoRuntime: { stableId: "cell-1" },
       });
 
       // Execute then invalidate (simulates staleInputs from kernel)
-      yield* executions.recordExecution(MarimoNotebookCell.from(cell));
-      yield* executions.invalidateCell(MarimoNotebookCell.from(cell));
+      yield* cells.acceptSource(MarimoNotebookCell.from(cell));
+      yield* cells.markStale(MarimoNotebookCell.from(cell));
 
       const providers = yield* ctx.vscode.getRegisteredStatusBarItemProviders();
       const items = yield* providers[0].provideCellStatusBarItems(cell);
@@ -197,14 +202,15 @@ it.effect(
     const ctx = yield* withTestCtx();
     yield* Effect.gen(function* () {
       const executions = yield* CellExecutions;
+      const cells = makeCellHarness(executions);
       const cell = createMockCell(notebookUri, {
         marimo: { name: "my_cell" },
         marimoRuntime: { stableId: "cell-2" },
       });
 
       // Execute then invalidate → stale + shows name
-      yield* executions.recordExecution(MarimoNotebookCell.from(cell));
-      yield* executions.invalidateCell(MarimoNotebookCell.from(cell));
+      yield* cells.acceptSource(MarimoNotebookCell.from(cell));
+      yield* cells.markStale(MarimoNotebookCell.from(cell));
 
       const providers = yield* ctx.vscode.getRegisteredStatusBarItemProviders();
 

--- a/extension/src/kernel/CellExecutions.ts
+++ b/extension/src/kernel/CellExecutions.ts
@@ -53,7 +53,7 @@ export type CellInput = Data.TaggedEnum<{
   Operation: {
     readonly notebookId: NotebookId;
     readonly operation: CellOperationNotification;
-    readonly source?: string;
+    readonly source: string;
     readonly drive: Drive;
     readonly renderOutput?: boolean;
   };

--- a/extension/src/kernel/CellExecutions.ts
+++ b/extension/src/kernel/CellExecutions.ts
@@ -1,33 +1,29 @@
 import {
   Cause,
   Context,
+  Data,
   Effect,
   Equal,
   Exit,
   Layer,
   MutableHashMap,
   Option,
+  Semaphore,
   Stream,
   SubscriptionRef,
   Array as EffectArray,
 } from "effect";
-import { constVoid } from "effect/Function";
 
-import { NotebookEditorRegistry } from "../notebook/NotebookEditorRegistry.ts";
-import { VsCode } from "../platform/VsCode.ts";
-import {
-  extractCellIdFromCellMessage,
-  type MarimoNotebookCell,
-  MarimoNotebookDocument,
-  type NotebookCellId,
-  type NotebookId,
+import type {
+  NotebookCellId,
+  NotebookId,
 } from "../schemas/MarimoNotebookDocument.ts";
 import type { CellOperationNotification } from "../types.ts";
 import {
   AcceptedSource,
   CellCommand,
-  type CellRunEntry,
-  makeCellRunEntry,
+  type CellRunState,
+  makeCellRunState,
   Op,
   parseOp,
   RunId,
@@ -41,24 +37,45 @@ export interface CellRef {
   readonly cellId: NotebookCellId;
 }
 
+/** A cell snapshot used to ask whether its accepted source is stale. */
+export interface CellSnapshot extends CellRef {
+  readonly source: string;
+}
+
 /** Effectful capability supplied by a host adapter. */
 export type Drive = (
   cell: CellRef,
   command: CellCommand,
 ) => Effect.Effect<void>;
 
-interface CellExecutionKey {
-  readonly notebookId: NotebookId;
-  readonly cellId: NotebookCellId;
-}
+/** Facts accepted by the cell execution module. */
+export type CellInput = Data.TaggedEnum<{
+  Operation: {
+    readonly notebookId: NotebookId;
+    readonly operation: CellOperationNotification;
+    readonly source?: string;
+    readonly drive: Drive;
+    readonly renderOutput?: boolean;
+  };
+  Interrupted: { readonly notebookId: NotebookId };
+  CellsRemoved: {
+    readonly notebookId: NotebookId;
+    readonly cellIds: ReadonlyArray<NotebookCellId>;
+  };
+  Invalidated: { readonly notebookId: NotebookId };
+}>;
+export const CellInput = Data.taggedEnum<CellInput>();
+
+type OperationInput = Extract<CellInput, { readonly _tag: "Operation" }>;
 
 interface DriveBinding {
   readonly runId: RunId;
   readonly value: Drive;
 }
 
-interface RunRecord {
-  readonly entry: CellRunEntry;
+/** Everything owned for one cell. */
+interface CellRecord {
+  readonly run: CellRunState;
   readonly drive: Option.Option<DriveBinding>;
 }
 
@@ -67,13 +84,33 @@ interface SubmittedSource {
   readonly source: string;
 }
 
-// MutableHashMap compares plain object keys by structure.
-const cellExecutionKey = (
-  notebookId: NotebookId,
-  cellId: NotebookCellId,
-): CellExecutionKey => ({ notebookId, cellId });
+interface NotebookEntry {
+  readonly records: MutableHashMap.MutableHashMap<NotebookCellId, CellRecord>;
+  readonly submittedSources: MutableHashMap.MutableHashMap<
+    NotebookCellId,
+    Array<SubmittedSource>
+  >;
+  readonly serial: Semaphore.Semaphore;
+}
 
-const cellRef = (key: CellExecutionKey): CellRef => key;
+type Release = Data.TaggedEnum<{
+  Interrupted: {};
+  CellsRemoved: { readonly cellIds: ReadonlySet<NotebookCellId> };
+  Invalidated: {};
+  Finalized: {};
+}>;
+const Release = Data.taggedEnum<Release>();
+
+interface Work {
+  readonly cell: CellRef;
+  readonly command: CellCommand;
+  readonly drive: Option.Option<Drive>;
+}
+
+const cellRef = (notebookId: NotebookId, cellId: NotebookCellId): CellRef => ({
+  notebookId,
+  cellId,
+});
 
 const openedRunIds = (commands: ReadonlyArray<CellCommand>) => {
   const ids = new Set<RunId>();
@@ -87,7 +124,7 @@ const noOpenedRuns = new Set<RunId>();
 
 const resolveDriveBinding = (
   runId: RunId,
-  record: RunRecord,
+  record: CellRecord,
   current: Option.Option<Drive>,
   opened: ReadonlySet<RunId>,
 ): Option.Option<DriveBinding> =>
@@ -101,7 +138,7 @@ const resolveDriveBinding = (
 
 const driveFor = (
   command: CellCommand,
-  record: RunRecord,
+  record: CellRecord,
   current: Option.Option<Drive>,
   opened: ReadonlySet<RunId>,
 ): Option.Option<Drive> => {
@@ -120,168 +157,84 @@ const driveFor = (
 };
 
 const driveAfter = (
-  entry: CellRunEntry,
-  record: RunRecord,
+  run: CellRunState,
+  record: CellRecord,
   current: Option.Option<Drive>,
   opened: ReadonlySet<RunId>,
 ): Option.Option<DriveBinding> => {
-  if (entry.phase._tag !== "Queued" && entry.phase._tag !== "Running") {
+  if (run.phase._tag !== "Queued" && run.phase._tag !== "Running") {
     return Option.none();
   }
-  const runId = entry.phase.runId;
+  const runId = run.phase.runId;
   return resolveDriveBinding(runId, record, current, opened);
 };
 
 /**
  * Owns cell records and turns kernel operations into ordered host commands.
- * Host resources stay private to the supplied {@link Drive} adapter.
+ * Each notebook has one ordering lane; host resources stay behind {@link Drive}.
  */
 export class CellExecutions extends Context.Service<CellExecutions>()(
   "CellExecutions",
   {
     make: Effect.gen(function* () {
-      const code = yield* VsCode;
-      const editorRegistry = yield* NotebookEditorRegistry;
-      const records = MutableHashMap.empty<CellExecutionKey, RunRecord>();
-      const submittedSources = MutableHashMap.empty<
-        CellExecutionKey,
-        Array<SubmittedSource>
-      >();
+      const notebooks = new Map<NotebookId, NotebookEntry>();
       const revision = yield* SubscriptionRef.make(0);
 
-      const emptyRecord = (cellId: NotebookCellId): RunRecord => ({
-        entry: makeCellRunEntry(cellId),
+      const makeEntry = (): NotebookEntry => ({
+        records: MutableHashMap.empty(),
+        submittedSources: MutableHashMap.empty(),
+        serial: Semaphore.makeUnsafe(1),
+      });
+
+      const entryFor = (notebookId: NotebookId) => {
+        const existing = notebooks.get(notebookId);
+        if (existing !== undefined) return existing;
+        const entry = makeEntry();
+        notebooks.set(notebookId, entry);
+        return entry;
+      };
+
+      const emptyRecord = (cellId: NotebookCellId): CellRecord => ({
+        run: makeCellRunState(cellId),
         drive: Option.none(),
       });
 
-      const isCellStale = (cell: MarimoNotebookCell) => {
-        const cellId = cell.id;
-        if (Option.isNone(cellId)) return Effect.succeed(false);
-        const currentCode = cell.document.getText();
-        return Effect.sync(() =>
-          Option.match(
-            MutableHashMap.get(
-              records,
-              cellExecutionKey(cell.notebook.id, cellId.value),
-            ),
-            {
-              onNone: () => false,
-              onSome: ({ entry }) =>
-                AcceptedSource.$match(entry.acceptedSource, {
-                  Unknown: () => false,
-                  Invalidated: () => true,
-                  Accepted: ({ source }) => source !== currentCode,
-                }),
-            },
-          ),
-        );
-      };
-
-      const updateStaleContext = Effect.fn(function* () {
-        const activeNotebook = yield* editorRegistry.getActiveNotebookUri;
-        const hasStaleCells = yield* Option.match(activeNotebook, {
-          onNone: () => Effect.succeed(false),
-          onSome: (notebookId) =>
-            Effect.gen(function* () {
-              const editor =
-                yield* editorRegistry.getLastNotebookEditor(notebookId);
-              if (Option.isNone(editor)) return false;
-              const notebook = MarimoNotebookDocument.tryFrom(
-                editor.value.notebook,
-              );
-              if (Option.isNone(notebook)) return false;
-              for (const cell of notebook.value.getCells()) {
-                if (yield* isCellStale(cell)) return true;
-              }
-              return false;
-            }),
-        });
-        yield* code.commands.setContext(
-          "marimo.notebook.hasStaleCells",
-          hasStaleCells,
-        );
-      });
-
-      const contentChanges = code.workspace.notebookDocumentChanges.pipe(
-        Stream.filter((event) => {
-          if (Option.isNone(MarimoNotebookDocument.tryFrom(event.notebook))) {
-            return false;
-          }
-          return event.cellChanges.some(
-            (change) => change.document !== undefined,
-          );
-        }),
-      );
-
-      yield* Effect.forkScoped(
-        SubscriptionRef.changes(revision).pipe(
-          Stream.runForEach(updateStaleContext),
-        ),
-      );
-      yield* Effect.forkScoped(
-        editorRegistry.streamActiveNotebookChanges.pipe(
-          Stream.runForEach(updateStaleContext),
-        ),
-      );
-      yield* Effect.forkScoped(
-        contentChanges.pipe(
-          Stream.mapEffect(updateStaleContext),
-          Stream.runDrain,
-        ),
-      );
-
-      const updateAcceptedSource = (
-        cell: MarimoNotebookCell,
-        acceptedSource: AcceptedSource,
+      const takeSubmittedSource = (
+        entry: NotebookEntry,
+        cellId: NotebookCellId,
       ) => {
-        const cellId = cell.id;
-        if (Option.isNone(cellId)) return Effect.void;
-        const key = cellExecutionKey(cell.notebook.id, cellId.value);
-        return Effect.sync(() => {
-          const record = Option.getOrElse(
-            MutableHashMap.get(records, key),
-            () => emptyRecord(cellId.value),
-          );
-          if (Equal.equals(record.entry.acceptedSource, acceptedSource)) {
-            return false;
-          }
-          MutableHashMap.set(records, key, {
-            ...record,
-            entry: { ...record.entry, acceptedSource },
-          });
-          return true;
-        }).pipe(
-          Effect.flatMap((changed) =>
-            changed
-              ? SubscriptionRef.update(revision, (value) => value + 1)
-              : Effect.void,
-          ),
-        );
+        const pending = MutableHashMap.get(entry.submittedSources, cellId);
+        if (Option.isNone(pending) || pending.value.length === 0) {
+          return undefined;
+        }
+        const [submitted, ...remaining] = pending.value;
+        if (remaining.length === 0) {
+          MutableHashMap.remove(entry.submittedSources, cellId);
+        } else {
+          MutableHashMap.set(entry.submittedSources, cellId, remaining);
+        }
+        return submitted?.source;
       };
 
-      const run = (
-        key: CellExecutionKey,
-        command: CellCommand,
-        drive: Option.Option<Drive>,
-      ) =>
+      const drive = ({ cell, command, drive }: Work) =>
         Option.match(drive, {
           onNone: () =>
             Effect.logWarning("Cell run has no Drive; skipping command").pipe(
               Effect.annotateLogs({
-                ...key,
+                ...cell,
                 command: command._tag,
                 ...("runId" in command ? { runId: command.runId } : {}),
               }),
             ),
           onSome: (apply) =>
-            apply(cellRef(key), command).pipe(
+            apply(cell, command).pipe(
               Effect.catchCause((cause) =>
                 Cause.hasInterrupts(cause)
                   ? Effect.failCause(cause)
                   : Effect.logWarning("Failed to drive cell command").pipe(
                       Effect.annotateLogs({
                         cause,
-                        ...key,
+                        ...cell,
                         command: command._tag,
                         ...("runId" in command ? { runId: command.runId } : {}),
                       }),
@@ -290,152 +243,19 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
             ),
         });
 
-      const takeSubmittedSource = (key: CellExecutionKey) => {
-        const pending = MutableHashMap.get(submittedSources, key);
-        if (Option.isNone(pending) || pending.value.length === 0) {
-          return undefined;
-        }
-        const [submitted, ...remaining] = pending.value;
-        if (remaining.length === 0)
-          MutableHashMap.remove(submittedSources, key);
-        else MutableHashMap.set(submittedSources, key, remaining);
-        return submitted?.source;
-      };
-
-      const clearSubmittedSources = (notebookId: NotebookId) => {
-        const targets = EffectArray.fromIterable(submittedSources).filter(
-          ([key]) => key.notebookId === notebookId,
-        );
-        for (const [key] of targets) {
-          MutableHashMap.remove(submittedSources, key);
-        }
-      };
-
-      return {
-        isCellStale,
-        recordExecution: (cell: MarimoNotebookCell) =>
-          updateAcceptedSource(
-            cell,
-            AcceptedSource.Accepted({ source: cell.document.getText() }),
-          ),
-        invalidateCell: (cell: MarimoNotebookCell) =>
-          updateAcceptedSource(cell, AcceptedSource.Invalidated()),
-        removeCell: (notebookId: NotebookId, cellId: NotebookCellId) =>
+      const acceptOperation = (entry: NotebookEntry, input: OperationInput) =>
+        entry.serial.withPermit(
           Effect.gen(function* () {
-            const key = cellExecutionKey(notebookId, cellId);
-            const record = MutableHashMap.get(records, key);
-            yield* Effect.sync(() =>
-              MutableHashMap.remove(submittedSources, key),
-            );
-            if (Option.isNone(record)) return;
-
-            const result = step(record.value.entry, Op.Interrupt());
-            yield* Effect.sync(() => MutableHashMap.remove(records, key));
-            yield* SubscriptionRef.update(revision, (value) => value + 1);
-
-            for (const command of result.commands) {
-              yield* run(
-                key,
-                command,
-                driveFor(command, record.value, Option.none(), noOpenedRuns),
-              );
-            }
-          }),
-        submit: <A, E, R>(
-          notebookId: NotebookId,
-          cells: ReadonlyArray<{
-            readonly cellId: NotebookCellId;
-            readonly source: string;
-          }>,
-          send: Effect.Effect<A, E, R>,
-        ) => {
-          const token = Symbol("cell submission");
-          const register = Effect.sync(() => {
-            for (const { cellId, source } of cells) {
-              const key = cellExecutionKey(notebookId, cellId);
-              const pending = Option.getOrElse(
-                MutableHashMap.get(submittedSources, key),
-                () => [],
-              );
-              MutableHashMap.set(submittedSources, key, [
-                ...pending,
-                { token, source },
-              ]);
-            }
-          });
-          const rollback = Effect.sync(() => {
-            for (const { cellId } of cells) {
-              const key = cellExecutionKey(notebookId, cellId);
-              const pending = MutableHashMap.get(submittedSources, key);
-              if (Option.isNone(pending)) continue;
-              const remaining = pending.value.filter(
-                (submitted) => submitted.token !== token,
-              );
-              if (remaining.length === 0) {
-                MutableHashMap.remove(submittedSources, key);
-              } else {
-                MutableHashMap.set(submittedSources, key, remaining);
-              }
-            }
-          });
-          return register.pipe(
-            Effect.andThen(send),
-            Effect.onExit((exit) =>
-              Exit.isSuccess(exit) ? Effect.void : rollback,
-            ),
-          );
-        },
-        get changes(): Stream.Stream<void> {
-          return Stream.merge(
-            Stream.map(SubscriptionRef.changes(revision), constVoid),
-            Stream.map(contentChanges, constVoid),
-          );
-        },
-        handleInterrupt: (notebookId: NotebookId) =>
-          Effect.gen(function* () {
-            clearSubmittedSources(notebookId);
-            const targets = EffectArray.fromIterable(records).filter(
-              ([key]) => key.notebookId === notebookId,
-            );
-            for (const [key, record] of targets) {
-              const result = step(record.entry, Op.Interrupt());
-              yield* Effect.sync(() =>
-                MutableHashMap.set(records, key, {
-                  ...record,
-                  entry: result.entry,
-                  drive: Option.none(),
-                }),
-              );
-              for (const command of result.commands) {
-                yield* run(
-                  key,
-                  command,
-                  driveFor(command, record, Option.none(), noOpenedRuns),
-                );
-              }
-            }
-          }),
-        handleOperation: (
-          message: CellOperationNotification,
-          options: {
-            notebookId: NotebookId;
-            source?: string;
-            drive: Drive;
-            renderOutput?: boolean;
-          },
-        ) =>
-          Effect.gen(function* () {
-            const cellId = extractCellIdFromCellMessage(message);
-            const key = cellExecutionKey(options.notebookId, cellId);
+            const message = input.operation;
+            const cell = cellRef(input.notebookId, message.cell_id);
             const record = Option.getOrElse(
-              MutableHashMap.get(records, key),
-              () => emptyRecord(cellId),
+              MutableHashMap.get(entry.records, cell.cellId),
+              () => emptyRecord(cell.cellId),
             );
-
             const activeRunId =
-              record.entry.phase._tag === "Queued" ||
-              record.entry.phase._tag === "Running"
-                ? record.entry.phase.runId
+              record.run.phase._tag === "Queued" ||
+              record.run.phase._tag === "Running"
+                ? record.run.phase.runId
                 : undefined;
             const receivedRunId =
               typeof message.run_id === "string" && message.run_id.length > 0
@@ -458,47 +278,44 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
               return;
             }
 
-            const next = transitionCell(record.entry.state, message);
+            const next = transitionCell(record.run.state, message);
             const op = parseOp(next, message, RunId(crypto.randomUUID()));
+
             if (Option.isNone(op)) {
-              takeSubmittedSource(key);
+              takeSubmittedSource(entry, cell.cellId);
+              MutableHashMap.set(entry.records, cell.cellId, {
+                ...record,
+                run: { ...record.run, state: next },
+              });
               yield* Effect.logWarning(
                 "Queued cell-op missing run_id; cannot track execution",
-              ).pipe(Effect.annotateLogs({ cellId, status: message.status }));
-              yield* Effect.sync(() =>
-                MutableHashMap.set(records, key, {
-                  ...record,
-                  entry: { ...record.entry, state: next },
-                }),
-              );
+              ).pipe(Effect.annotateLogs({ ...cell, status: message.status }));
               return;
             }
 
             if (message.status === "idle" && activeRunId === undefined) {
-              takeSubmittedSource(key);
+              takeSubmittedSource(entry, cell.cellId);
             }
 
             const source =
               op.value._tag === "Queue"
-                ? (takeSubmittedSource(key) ?? options.source)
+                ? (takeSubmittedSource(entry, cell.cellId) ?? input.source)
                 : undefined;
-            const result = step(record.entry, op.value, source);
+            const result = step(record.run, op.value, source);
             const opened = openedRunIds(result.commands);
-            yield* Effect.sync(() =>
-              MutableHashMap.set(records, key, {
-                entry: result.entry,
-                drive: driveAfter(
-                  result.entry,
-                  record,
-                  Option.some(options.drive),
-                  opened,
-                ),
-              }),
-            );
+            MutableHashMap.set(entry.records, cell.cellId, {
+              run: result.entry,
+              drive: driveAfter(
+                result.entry,
+                record,
+                Option.some(input.drive),
+                opened,
+              ),
+            });
             if (
               !Equal.equals(
                 result.entry.acceptedSource,
-                record.entry.acceptedSource,
+                record.run.acceptedSource,
               )
             ) {
               yield* SubscriptionRef.update(revision, (value) => value + 1);
@@ -506,27 +323,211 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
 
             for (const command of result.commands) {
               if (
-                options.renderOutput === false &&
+                input.renderOutput === false &&
                 command._tag === "RenderOutputs"
               ) {
                 continue;
               }
-              yield* run(
-                key,
+              yield* drive({
+                cell,
                 command,
-                driveFor(command, record, Option.some(options.drive), opened),
-              );
+                drive: driveFor(
+                  command,
+                  record,
+                  Option.some(input.drive),
+                  opened,
+                ),
+              });
             }
-          }).pipe(
-            Effect.annotateLogs({
-              cellId: extractCellIdFromCellMessage(message),
+          }),
+        );
+
+      const release = (
+        notebookId: NotebookId,
+        entry: NotebookEntry,
+        reason: Release,
+      ) =>
+        entry.serial.withPermit(
+          Effect.gen(function* () {
+            const behavior = Release.$match(reason, {
+              Interrupted: () => ({
+                target: (_cellId: NotebookCellId) => true,
+                remove: false,
+                notify: false,
+              }),
+              CellsRemoved: ({ cellIds }) => ({
+                target: (cellId: NotebookCellId) => cellIds.has(cellId),
+                remove: true,
+                notify: true,
+              }),
+              Invalidated: () => ({
+                target: (_cellId: NotebookCellId) => true,
+                remove: true,
+                notify: true,
+              }),
+              Finalized: () => ({
+                target: (_cellId: NotebookCellId) => true,
+                remove: true,
+                notify: false,
+              }),
+            });
+            const work: Work[] = [];
+            let changed = false;
+
+            for (const [cellId, record] of EffectArray.fromIterable(
+              entry.records,
+            )) {
+              if (!behavior.target(cellId)) continue;
+              changed = true;
+              const cell = cellRef(notebookId, cellId);
+              const result = step(record.run, Op.Interrupt());
+              for (const command of result.commands) {
+                work.push({
+                  cell,
+                  command,
+                  drive: driveFor(command, record, Option.none(), noOpenedRuns),
+                });
+              }
+
+              if (behavior.remove) {
+                MutableHashMap.remove(entry.records, cellId);
+              } else {
+                MutableHashMap.set(entry.records, cellId, {
+                  run: result.entry,
+                  drive: Option.none(),
+                });
+              }
+            }
+
+            for (const [cellId] of EffectArray.fromIterable(
+              entry.submittedSources,
+            )) {
+              if (behavior.target(cellId)) {
+                MutableHashMap.remove(entry.submittedSources, cellId);
+              }
+            }
+
+            if (changed && behavior.notify) {
+              yield* SubscriptionRef.update(revision, (value) => value + 1);
+            }
+            yield* Effect.forEach(work, drive, { discard: true });
+          }),
+        );
+
+      yield* Effect.addFinalizer(() =>
+        Effect.forEach(
+          Array.from(notebooks),
+          ([notebookId, entry]) =>
+            release(notebookId, entry, Release.Finalized()),
+          { discard: true },
+        ),
+      );
+
+      const withEntry = (
+        notebookId: NotebookId,
+        use: (entry: NotebookEntry) => Effect.Effect<void>,
+      ) => {
+        const entry = notebooks.get(notebookId);
+        return entry === undefined ? Effect.void : use(entry);
+      };
+
+      return {
+        isStale: (cell: CellSnapshot) =>
+          Effect.sync(() => {
+            const entry = notebooks.get(cell.notebookId);
+            if (entry === undefined) return false;
+            return Option.match(
+              MutableHashMap.get(entry.records, cell.cellId),
+              {
+                onNone: () => false,
+                onSome: ({ run }) =>
+                  AcceptedSource.$match(run.acceptedSource, {
+                    Unknown: () => false,
+                    Invalidated: () => true,
+                    Accepted: ({ source }) => source !== cell.source,
+                  }),
+              },
+            );
+          }),
+        get changes(): Stream.Stream<void> {
+          return Stream.map(SubscriptionRef.changes(revision), () => undefined);
+        },
+        submit: <A, E, R>(
+          notebookId: NotebookId,
+          cells: ReadonlyArray<{
+            readonly cellId: NotebookCellId;
+            readonly source: string;
+          }>,
+          send: Effect.Effect<A, E, R>,
+        ) => {
+          const entry = entryFor(notebookId);
+          const token = Symbol("cell submission");
+          const register = entry.serial.withPermit(
+            Effect.sync(() => {
+              for (const { cellId, source } of cells) {
+                const pending = Option.getOrElse(
+                  MutableHashMap.get(entry.submittedSources, cellId),
+                  () => [],
+                );
+                MutableHashMap.set(entry.submittedSources, cellId, [
+                  ...pending,
+                  { token, source },
+                ]);
+              }
+            }),
+          );
+          const rollback = entry.serial.withPermit(
+            Effect.sync(() => {
+              for (const { cellId } of cells) {
+                const pending = MutableHashMap.get(
+                  entry.submittedSources,
+                  cellId,
+                );
+                if (Option.isNone(pending)) continue;
+                const remaining = pending.value.filter(
+                  (submitted) => submitted.token !== token,
+                );
+                if (remaining.length === 0) {
+                  MutableHashMap.remove(entry.submittedSources, cellId);
+                } else {
+                  MutableHashMap.set(entry.submittedSources, cellId, remaining);
+                }
+              }
+            }),
+          );
+          return register.pipe(
+            Effect.andThen(send),
+            Effect.onExit((exit) =>
+              Exit.isSuccess(exit) ? Effect.void : rollback,
+            ),
+          );
+        },
+        accept: (input: CellInput) =>
+          Effect.suspend(() =>
+            CellInput.$match(input, {
+              Operation: (operation) =>
+                acceptOperation(entryFor(operation.notebookId), operation),
+              Interrupted: ({ notebookId }) =>
+                withEntry(notebookId, (entry) =>
+                  release(notebookId, entry, Release.Interrupted()),
+                ),
+              CellsRemoved: ({ notebookId, cellIds }) =>
+                withEntry(notebookId, (entry) =>
+                  release(
+                    notebookId,
+                    entry,
+                    Release.CellsRemoved({ cellIds: new Set(cellIds) }),
+                  ),
+                ),
+              Invalidated: ({ notebookId }) =>
+                withEntry(notebookId, (entry) =>
+                  release(notebookId, entry, Release.Invalidated()),
+                ),
             }),
           ),
       };
     }),
   },
 ) {
-  static readonly layer = Layer.effect(this, this.make).pipe(
-    Layer.provide([NotebookEditorRegistry.layer]),
-  );
+  static readonly layer = Layer.effect(this, this.make);
 }

--- a/extension/src/kernel/CellRunReducer.ts
+++ b/extension/src/kernel/CellRunReducer.ts
@@ -74,14 +74,14 @@ export type CellCommand = Data.TaggedEnum<{
 export const CellCommand = Data.taggedEnum<CellCommand>();
 
 /** Pure, vscode-free per-cell reducer state. */
-export interface CellRunEntry {
+export interface CellRunState {
   readonly id: NotebookCellId;
   readonly state: CellRuntimeState;
   readonly phase: RunPhase;
   readonly acceptedSource: AcceptedSource;
 }
 
-export function makeCellRunEntry(id: NotebookCellId): CellRunEntry {
+export function makeCellRunState(id: NotebookCellId): CellRunState {
   return {
     id,
     state: createCellRuntimeState(),
@@ -152,11 +152,11 @@ const isError = (state: CellRuntimeState): boolean =>
  * The one place that decides what a cell-op *means*.
  */
 export function step(
-  entry: CellRunEntry,
+  entry: CellRunState,
   op: Op,
   source?: string,
 ): {
-  readonly entry: CellRunEntry;
+  readonly entry: CellRunState;
   readonly commands: ReadonlyArray<CellCommand>;
 } {
   return Op.$match(op, {

--- a/extension/src/kernel/NotebookRuntime.ts
+++ b/extension/src/kernel/NotebookRuntime.ts
@@ -58,7 +58,7 @@ import type {
   MarimoOperation,
   NotificationOf,
 } from "../types.ts";
-import { CellExecutions, type Drive } from "./CellExecutions.ts";
+import { CellExecutions, CellInput, type Drive } from "./CellExecutions.ts";
 import { resolveImageDataUri, saveImageToDisk } from "./imageResolver.ts";
 import {
   NotebookFileRootError,
@@ -441,6 +441,7 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
         code,
         Effect.fn("NotebookRuntime.releaseNotebook")(function* (notebookId) {
           notebooks.delete(notebookId);
+          yield* executions.accept(CellInput.Invalidated({ notebookId }));
           yield* variables.clearNotebook(notebookId);
           yield* datasources.clearNotebook(notebookId);
           yield* updateKernelContext();
@@ -995,18 +996,23 @@ function processNotebookOperation(
           ).pipe(Effect.annotateLogs({ cellId }));
           break;
         }
-        yield* executions.handleOperation(operation, {
-          notebookId: notebook.id,
-          drive: controller.value.drive(notebook),
-          renderOutput: options.renderCellOutput,
-        });
+        yield* executions.accept(
+          CellInput.Operation({
+            notebookId: notebook.id,
+            operation,
+            drive: controller.value.drive(notebook),
+            renderOutput: options.renderCellOutput,
+          }),
+        );
         yield* forkForSession(
           handleStdinPrompt(operation, options.forNotebook(notebookUri)),
         );
         break;
       }
       case "interrupted":
-        yield* executions.handleInterrupt(notebook.id);
+        yield* executions.accept(
+          CellInput.Interrupted({ notebookId: notebook.id }),
+        );
         break;
       case "missing-package-alert":
         yield* forkForSession(
@@ -1108,10 +1114,17 @@ function syncCellIdentity(
       yield* options.code.workspace.applyEdit(edit);
     }
 
-    for (const cellId of removedCellIds) {
-      if (addedCellIds.has(cellId)) continue;
+    const removed = [...removedCellIds].filter(
+      (cellId) => !addedCellIds.has(cellId),
+    );
+    yield* options.executions.accept(
+      CellInput.CellsRemoved({
+        notebookId: event.notebook.id,
+        cellIds: removed,
+      }),
+    );
 
-      yield* options.executions.removeCell(event.notebook.id, cellId);
+    for (const cellId of removed) {
       yield* options.notebook.deleteCell({ cellId }).pipe(
         Effect.catchCause((cause) =>
           Effect.logWarning(

--- a/extension/src/kernel/NotebookRuntime.ts
+++ b/extension/src/kernel/NotebookRuntime.ts
@@ -1000,6 +1000,7 @@ function processNotebookOperation(
           CellInput.Operation({
             notebookId: notebook.id,
             operation,
+            source: cell.value.document.getText(),
             drive: controller.value.drive(notebook),
             renderOutput: options.renderCellOutput,
           }),

--- a/extension/src/kernel/__tests__/CellExecutions.test.ts
+++ b/extension/src/kernel/__tests__/CellExecutions.test.ts
@@ -1726,6 +1726,7 @@ it.effect(
                 status: "queued",
                 run_id: "run-1",
               },
+              source: cell.document.getText(),
               drive,
             }),
           );
@@ -1784,6 +1785,7 @@ it.effect(
               status: "queued",
               run_id: "run-1",
             },
+            source: cell.document.getText(),
             drive,
           }),
         ),

--- a/extension/src/kernel/__tests__/CellExecutions.test.ts
+++ b/extension/src/kernel/__tests__/CellExecutions.test.ts
@@ -12,7 +12,12 @@ import {
 } from "../../__mocks__/TestVsCode.ts";
 import { makeTestNotebookRuntime } from "../../__tests__/__utils__/TestMarimoClient.ts";
 import { NOTEBOOK_TYPE } from "../../constants.ts";
-import { CellExecutions, type Drive } from "../../kernel/CellExecutions.ts";
+import { makeCellHarness } from "../../kernel/__tests__/CellExecutionsHarness.ts";
+import {
+  CellExecutions,
+  CellInput,
+  type Drive,
+} from "../../kernel/CellExecutions.ts";
 import {
   VsCodeCellDrive,
   type VsCodeDriveBinding,
@@ -58,12 +63,15 @@ const acceptCell = (
   controller: VsCodeDriveBinding["controller"],
   renderOutput?: boolean,
 ) =>
-  executions.handleOperation(message, {
-    notebookId: cell.notebook.id,
-    source: cell.document.getText(),
-    drive: host.bind({ notebook: cell.notebook, controller }),
-    renderOutput,
-  });
+  executions.accept(
+    CellInput.Operation({
+      notebookId: cell.notebook.id,
+      operation: message,
+      source: cell.document.getText(),
+      drive: host.bind({ notebook: cell.notebook, controller }),
+      renderOutput,
+    }),
+  );
 
 // Convert Uint8Array data to strings for readable snapshots
 function normalizeOutputsForSnapshot(
@@ -1210,21 +1218,31 @@ it.effect(
       const drive: Drive = (_cell, command) =>
         Effect.sync(() => commands.push(command._tag));
 
-      yield* executions.handleOperation(
-        {
-          op: "cell-op",
-          cell_id: cellId,
-          status: "queued",
-          run_id: "run-1",
-        },
-        {
+      yield* executions.accept(
+        CellInput.Operation({
           notebookId: cell.notebook.id,
+          operation: {
+            op: "cell-op",
+            cell_id: cellId,
+            status: "queued",
+            run_id: "run-1",
+          },
           source: cell.document.getText(),
           drive,
-        },
+        }),
       );
-      yield* executions.removeCell(cell.notebook.id, cellId);
-      yield* executions.removeCell(cell.notebook.id, cellId);
+      yield* executions.accept(
+        CellInput.CellsRemoved({
+          notebookId: cell.notebook.id,
+          cellIds: [cellId],
+        }),
+      );
+      yield* executions.accept(
+        CellInput.CellsRemoved({
+          notebookId: cell.notebook.id,
+          cellIds: [cellId],
+        }),
+      );
 
       expect(commands).toEqual(["SetDiagnostic", "OpenRun", "CloseRun"]);
     }).pipe(Effect.provide(ctx.layer));
@@ -1266,11 +1284,14 @@ it.effect(
       const first = namedDrive("first");
       const second = namedDrive("second");
       const accept = (message: CellOperationNotification, drive: Drive) =>
-        executions.handleOperation(message, {
-          notebookId: cell.notebook.id,
-          source: cell.document.getText(),
-          drive,
-        });
+        executions.accept(
+          CellInput.Operation({
+            notebookId: cell.notebook.id,
+            operation: message,
+            source: cell.document.getText(),
+            drive,
+          }),
+        );
 
       yield* accept(
         {
@@ -1553,43 +1574,42 @@ it.effect(
         Effect.sync(() => {
           if (command._tag === "OpenRun") created += 1;
         });
-      const options = { notebookId: cell.notebook.id, drive };
+      const accept = (operation: CellOperationNotification) =>
+        executions.accept(
+          CellInput.Operation({
+            notebookId: cell.notebook.id,
+            operation,
+            source: cell.document.getText(),
+            drive,
+          }),
+        );
 
-      yield* executions.handleOperation(
-        {
-          op: "cell-op",
-          cell_id: cid,
-          status: "queued",
-          run_id: "run-1",
-        },
-        options,
-      );
-      yield* executions.handleOperation(
-        {
-          op: "cell-op",
-          cell_id: cid,
-          status: "idle",
-          run_id: "run-1",
-          timestamp: 1,
-        },
-        options,
-      );
+      yield* accept({
+        op: "cell-op",
+        cell_id: cid,
+        status: "queued",
+        run_id: "run-1",
+      });
+      yield* accept({
+        op: "cell-op",
+        cell_id: cid,
+        status: "idle",
+        run_id: "run-1",
+        timestamp: 1,
+      });
       expect(created).toBe(1);
 
-      yield* executions.handleOperation(
-        {
-          op: "cell-op",
-          cell_id: cid,
-          status: "idle",
-          run_id: "run-1",
-          output: {
-            mimetype: "application/vnd.marimo+error",
-            channel: "marimo-error",
-            data: [{ type: "syntax", msg: "late error" }],
-          },
+      yield* accept({
+        op: "cell-op",
+        cell_id: cid,
+        status: "idle",
+        run_id: "run-1",
+        output: {
+          mimetype: "application/vnd.marimo+error",
+          channel: "marimo-error",
+          data: [{ type: "syntax", msg: "late error" }],
         },
-        options,
-      );
+      });
 
       expect(created).toBe(1);
     }).pipe(Effect.provide(ctx.layer));
@@ -1621,6 +1641,7 @@ it.effect(
 
     yield* Effect.gen(function* () {
       const executions = yield* CellExecutions;
+      const cells = makeCellHarness(executions);
       const host = yield* VsCodeCellDrive;
       const code = yield* VsCode;
 
@@ -1655,21 +1676,15 @@ it.effect(
 
       // Check that CellExecutions tracked the cell as stale
       expect(
-        yield* executions.isCellStale(
-          MarimoNotebookCell.from(cell.rawNotebookCell),
-        ),
+        yield* cells.isStale(MarimoNotebookCell.from(cell.rawNotebookCell)),
       ).toBe(true);
 
       // Record execution to clear stale
-      yield* executions.recordExecution(
-        MarimoNotebookCell.from(cell.rawNotebookCell),
-      );
+      yield* cells.acceptSource(MarimoNotebookCell.from(cell.rawNotebookCell));
 
       // Check that the cell is no longer stale
       expect(
-        yield* executions.isCellStale(
-          MarimoNotebookCell.from(cell.rawNotebookCell),
-        ),
+        yield* cells.isStale(MarimoNotebookCell.from(cell.rawNotebookCell)),
       ).toBe(false);
     }).pipe(Effect.provide(ctx.layer));
   }),
@@ -1702,19 +1717,28 @@ it.effect(
         [{ cellId, source: "x = 1" }],
         Effect.gen(function* () {
           cellData.value = "x = 2";
-          yield* executions.handleOperation(
-            {
-              op: "cell-op",
-              cell_id: cellId,
-              status: "queued",
-              run_id: "run-1",
-            },
-            { notebookId: cell.notebook.id, drive },
+          yield* executions.accept(
+            CellInput.Operation({
+              notebookId: cell.notebook.id,
+              operation: {
+                op: "cell-op",
+                cell_id: cellId,
+                status: "queued",
+                run_id: "run-1",
+              },
+              drive,
+            }),
           );
         }),
       );
 
-      expect(yield* executions.isCellStale(cell)).toBe(true);
+      expect(
+        yield* executions.isStale({
+          notebookId: cell.notebook.id,
+          cellId,
+          source: cell.document.getText(),
+        }),
+      ).toBe(true);
     }).pipe(Effect.provide(ctx.layer));
   }),
 );
@@ -1751,18 +1775,27 @@ it.effect(
       yield* executions.submit(
         cell.notebook.id,
         [{ cellId, source: "x = 2" }],
-        executions.handleOperation(
-          {
-            op: "cell-op",
-            cell_id: cellId,
-            status: "queued",
-            run_id: "run-1",
-          },
-          { notebookId: cell.notebook.id, drive },
+        executions.accept(
+          CellInput.Operation({
+            notebookId: cell.notebook.id,
+            operation: {
+              op: "cell-op",
+              cell_id: cellId,
+              status: "queued",
+              run_id: "run-1",
+            },
+            drive,
+          }),
         ),
       );
 
-      expect(yield* executions.isCellStale(cell)).toBe(false);
+      expect(
+        yield* executions.isStale({
+          notebookId: cell.notebook.id,
+          cellId,
+          source: cell.document.getText(),
+        }),
+      ).toBe(false);
     }).pipe(Effect.provide(ctx.layer));
   }),
 );
@@ -1794,22 +1827,34 @@ it.effect(
         [{ cellId, source: "x = 1" }],
         Effect.void,
       );
-      yield* executions.handleInterrupt(cell.notebook.id);
+      yield* executions.accept(
+        CellInput.Interrupted({ notebookId: cell.notebook.id }),
+      );
       yield* executions.submit(
         cell.notebook.id,
         [{ cellId, source: "x = 2" }],
-        executions.handleOperation(
-          {
-            op: "cell-op",
-            cell_id: cellId,
-            status: "queued",
-            run_id: "run-1",
-          },
-          { notebookId: cell.notebook.id, drive },
+        executions.accept(
+          CellInput.Operation({
+            notebookId: cell.notebook.id,
+            source: cell.document.getText(),
+            drive,
+            operation: {
+              op: "cell-op",
+              cell_id: cellId,
+              status: "queued",
+              run_id: "run-1",
+            },
+          }),
         ),
       );
 
-      expect(yield* executions.isCellStale(cell)).toBe(false);
+      expect(
+        yield* executions.isStale({
+          notebookId: cell.notebook.id,
+          cellId,
+          source: cell.document.getText(),
+        }),
+      ).toBe(false);
     }).pipe(Effect.provide(ctx.layer));
   }),
 );
@@ -1835,39 +1880,48 @@ it.effect(
       const cell = MarimoNotebookDocument.from(editor.notebook).cellAt(0);
       const cellId = Option.getOrThrow(cell.id);
       const drive: Drive = () => Effect.void;
+      const operation = (message: CellOperationNotification) =>
+        executions.accept(
+          CellInput.Operation({
+            notebookId: cell.notebook.id,
+            operation: message,
+            source: cell.document.getText(),
+            drive,
+          }),
+        );
 
       yield* executions.submit(
         cell.notebook.id,
         [{ cellId, source: "x = 1" }],
-        executions.handleOperation(
-          {
-            op: "cell-op",
-            cell_id: cellId,
-            status: "idle",
-            output: {
-              mimetype: "application/vnd.marimo+error",
-              channel: "marimo-error",
-              data: [{ type: "syntax", msg: "invalid syntax" }],
-            },
+        operation({
+          op: "cell-op",
+          cell_id: cellId,
+          status: "idle",
+          output: {
+            mimetype: "application/vnd.marimo+error",
+            channel: "marimo-error",
+            data: [{ type: "syntax", msg: "invalid syntax" }],
           },
-          { notebookId: cell.notebook.id, drive },
-        ),
+        }),
       );
       yield* executions.submit(
         cell.notebook.id,
         [{ cellId, source: "x = 2" }],
-        executions.handleOperation(
-          {
-            op: "cell-op",
-            cell_id: cellId,
-            status: "queued",
-            run_id: "run-1",
-          },
-          { notebookId: cell.notebook.id, drive },
-        ),
+        operation({
+          op: "cell-op",
+          cell_id: cellId,
+          status: "queued",
+          run_id: "run-1",
+        }),
       );
 
-      expect(yield* executions.isCellStale(cell)).toBe(false);
+      expect(
+        yield* executions.isStale({
+          notebookId: cell.notebook.id,
+          cellId,
+          source: cell.document.getText(),
+        }),
+      ).toBe(false);
     }).pipe(Effect.provide(ctx.layer));
   }),
 );
@@ -1879,6 +1933,7 @@ it.effect(
 
     yield* Effect.gen(function* () {
       const executions = yield* CellExecutions;
+      const cells = makeCellHarness(executions);
       const host = yield* VsCodeCellDrive;
 
       // Create a test notebook with a stale cell
@@ -1908,15 +1963,11 @@ it.effect(
       yield* TestClock.adjust("10 millis");
 
       // First, invalidate the cell in CellExecutions
-      yield* executions.invalidateCell(
-        MarimoNotebookCell.from(cell.rawNotebookCell),
-      );
+      yield* cells.markStale(MarimoNotebookCell.from(cell.rawNotebookCell));
 
       // Verify cell is tracked as stale
       expect(
-        yield* executions.isCellStale(
-          MarimoNotebookCell.from(cell.rawNotebookCell),
-        ),
+        yield* cells.isStale(MarimoNotebookCell.from(cell.rawNotebookCell)),
       ).toBe(true);
 
       // Create a mock controller
@@ -1941,9 +1992,7 @@ it.effect(
 
       // Check that the cell's stale state was cleared
       expect(
-        yield* executions.isCellStale(
-          MarimoNotebookCell.from(cell.rawNotebookCell),
-        ),
+        yield* cells.isStale(MarimoNotebookCell.from(cell.rawNotebookCell)),
       ).toBe(false);
     }).pipe(Effect.provide(ctx.layer));
   }),
@@ -1956,6 +2005,7 @@ it.effect(
 
     yield* Effect.gen(function* () {
       const executions = yield* CellExecutions;
+      const cells = makeCellHarness(executions);
       const host = yield* VsCodeCellDrive;
 
       const cellData = {
@@ -1980,14 +2030,10 @@ it.effect(
       yield* ctx.vscode.setActiveNotebookEditor(Option.some(editor));
       yield* TestClock.adjust("10 millis");
 
-      // Mark the cell stale so we can prove the bail happens before recordExecution
-      yield* executions.invalidateCell(
-        MarimoNotebookCell.from(cell.rawNotebookCell),
-      );
+      // Mark the cell stale so we can prove the rejected ack changes nothing.
+      yield* cells.markStale(MarimoNotebookCell.from(cell.rawNotebookCell));
       expect(
-        yield* executions.isCellStale(
-          MarimoNotebookCell.from(cell.rawNotebookCell),
-        ),
+        yield* cells.isStale(MarimoNotebookCell.from(cell.rawNotebookCell)),
       ).toBe(true);
 
       const controller = yield* code.notebooks.createNotebookController(
@@ -2009,11 +2055,9 @@ it.effect(
           controller.createNotebookCellExecution(value.rawNotebookCell),
       });
 
-      // Stale state preserved because we bail before recordExecution
+      // Stale state is preserved because the queued ack is rejected.
       expect(
-        yield* executions.isCellStale(
-          MarimoNotebookCell.from(cell.rawNotebookCell),
-        ),
+        yield* cells.isStale(MarimoNotebookCell.from(cell.rawNotebookCell)),
       ).toBe(true);
     }).pipe(Effect.provide(ctx.layer));
   }),

--- a/extension/src/kernel/__tests__/CellExecutionsHarness.ts
+++ b/extension/src/kernel/__tests__/CellExecutionsHarness.ts
@@ -1,0 +1,48 @@
+import { Effect, Option } from "effect";
+
+import type { MarimoNotebookCell } from "../../schemas/MarimoNotebookDocument.ts";
+import type { CellOperationNotification } from "../../types.ts";
+import { CellExecutions, CellInput, type Drive } from "../CellExecutions.ts";
+
+const noDrive: Drive = () => Effect.void;
+
+export function makeCellHarness(executions: CellExecutions["Service"]) {
+  let nextRunId = 0;
+
+  const accept = (
+    cell: MarimoNotebookCell,
+    operation: Omit<CellOperationNotification, "op" | "cell_id">,
+    drive: Drive = noDrive,
+  ) => {
+    const cellId = Option.getOrThrow(cell.id);
+    return executions.accept(
+      CellInput.Operation({
+        notebookId: cell.notebook.id,
+        operation: { op: "cell-op", cell_id: cellId, ...operation },
+        source: cell.document.getText(),
+        drive,
+      }),
+    );
+  };
+
+  return {
+    accept,
+    acceptSource: (cell: MarimoNotebookCell) =>
+      accept(cell, {
+        status: "queued",
+        run_id: `test-run-${nextRunId++}`,
+      }),
+    markStale: (cell: MarimoNotebookCell) =>
+      accept(cell, { stale_inputs: true }),
+    isStale: (cell: MarimoNotebookCell) =>
+      Option.match(cell.id, {
+        onNone: () => Effect.succeed(false),
+        onSome: (cellId) =>
+          executions.isStale({
+            notebookId: cell.notebook.id,
+            cellId,
+            source: cell.document.getText(),
+          }),
+      }),
+  };
+}

--- a/extension/src/kernel/__tests__/CellExecutionsLifecycle.test.ts
+++ b/extension/src/kernel/__tests__/CellExecutionsLifecycle.test.ts
@@ -26,6 +26,46 @@ const acceptRun = (
   );
 
 describe("CellExecutions lifecycle", () => {
+  it.effect("accepts the current source for a cascaded queued run", () =>
+    Effect.gen(function* () {
+      const executions = yield* CellExecutions;
+      const notebook = notebookId("notebook");
+      const cell = cellId("cell");
+      const drive: Drive = () => Effect.void;
+
+      yield* acceptRun(executions, notebook, cell, "run-1", drive);
+      expect(
+        yield* executions.isStale({
+          notebookId: notebook,
+          cellId: cell,
+          source: "x = 2",
+        }),
+      ).toBe(true);
+
+      yield* executions.accept(
+        CellInput.Operation({
+          notebookId: notebook,
+          operation: {
+            op: "cell-op",
+            cell_id: cell,
+            status: "queued",
+            run_id: "run-2",
+          },
+          source: "x = 2",
+          drive,
+        }),
+      );
+
+      expect(
+        yield* executions.isStale({
+          notebookId: notebook,
+          cellId: cell,
+          source: "x = 2",
+        }),
+      ).toBe(false);
+    }).pipe(Effect.provide(CellExecutions.layer)),
+  );
+
   it.effect("removes a cell record and closes its active run", () =>
     Effect.gen(function* () {
       const executions = yield* CellExecutions;

--- a/extension/src/kernel/__tests__/CellExecutionsLifecycle.test.ts
+++ b/extension/src/kernel/__tests__/CellExecutionsLifecycle.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Fiber, Latch } from "effect";
+
+import { cellId, notebookId } from "../../lib/__tests__/branded.ts";
+import { CellExecutions, CellInput, type Drive } from "../CellExecutions.ts";
+
+const acceptRun = (
+  executions: CellExecutions["Service"],
+  notebook: ReturnType<typeof notebookId>,
+  cell: ReturnType<typeof cellId>,
+  runId: string,
+  drive: Drive,
+) =>
+  executions.accept(
+    CellInput.Operation({
+      notebookId: notebook,
+      operation: {
+        op: "cell-op",
+        cell_id: cell,
+        status: "queued",
+        run_id: runId,
+      },
+      source: "x = 1",
+      drive,
+    }),
+  );
+
+describe("CellExecutions lifecycle", () => {
+  it.effect("removes a cell record and closes its active run", () =>
+    Effect.gen(function* () {
+      const executions = yield* CellExecutions;
+      const notebook = notebookId("notebook");
+      const cell = cellId("cell");
+      const events: string[] = [];
+      const drive: Drive = (_cell, command) =>
+        Effect.sync(() => {
+          if ("runId" in command) {
+            events.push(`${command._tag}:${command.runId}`);
+          }
+        });
+
+      yield* acceptRun(executions, notebook, cell, "run", drive);
+      yield* executions.accept(
+        CellInput.Operation({
+          notebookId: notebook,
+          operation: { op: "cell-op", cell_id: cell, stale_inputs: true },
+          source: "x = 1",
+          drive,
+        }),
+      );
+      expect(
+        yield* executions.isStale({
+          notebookId: notebook,
+          cellId: cell,
+          source: "x = 1",
+        }),
+      ).toBe(true);
+
+      yield* executions.accept(
+        CellInput.CellsRemoved({ notebookId: notebook, cellIds: [cell] }),
+      );
+
+      expect(events).toContain("CloseRun:run");
+      expect(
+        yield* executions.isStale({
+          notebookId: notebook,
+          cellId: cell,
+          source: "x = 1",
+        }),
+      ).toBe(false);
+    }).pipe(Effect.provide(CellExecutions.layer)),
+  );
+
+  it.effect(
+    "orders a reopened notebook after cleanup without blocking another notebook",
+    () =>
+      Effect.gen(function* () {
+        const executions = yield* CellExecutions;
+        const firstNotebook = notebookId("first-notebook");
+        const secondNotebook = notebookId("second-notebook");
+        const firstCell = cellId("first-cell");
+        const secondCell = cellId("second-cell");
+        const closeStarted = yield* Latch.make();
+        const releaseClose = yield* Latch.make();
+        const events: string[] = [];
+        const drive =
+          (name: string): Drive =>
+          (_cell, command) =>
+            Effect.gen(function* () {
+              if ("runId" in command) {
+                events.push(`${name}:${command._tag}:${command.runId}`);
+              }
+              if (command._tag === "CloseRun" && command.runId === "run-1") {
+                yield* closeStarted.open;
+                yield* releaseClose.await;
+              }
+            });
+
+        yield* acceptRun(
+          executions,
+          firstNotebook,
+          firstCell,
+          "run-1",
+          drive("first"),
+        );
+        const cleanup = yield* executions
+          .accept(CellInput.Invalidated({ notebookId: firstNotebook }))
+          .pipe(Effect.forkChild);
+        yield* closeStarted.await;
+
+        const reopen = yield* acceptRun(
+          executions,
+          firstNotebook,
+          firstCell,
+          "run-2",
+          drive("reopened"),
+        ).pipe(Effect.forkChild);
+        yield* acceptRun(
+          executions,
+          secondNotebook,
+          secondCell,
+          "run-b",
+          drive("second"),
+        );
+
+        expect(events).toContain("second:OpenRun:run-b");
+        expect(events).not.toContain("reopened:OpenRun:run-2");
+
+        yield* releaseClose.open;
+        yield* Fiber.join(cleanup);
+        yield* Fiber.join(reopen);
+        expect(events).toContain("reopened:OpenRun:run-2");
+      }).pipe(Effect.provide(CellExecutions.layer)),
+  );
+});

--- a/extension/src/kernel/__tests__/CellRunReducer.test.ts
+++ b/extension/src/kernel/__tests__/CellRunReducer.test.ts
@@ -6,7 +6,7 @@ import type { CellRuntimeState } from "../../types.ts";
 import {
   AcceptedSource,
   CellCommand,
-  type CellRunEntry,
+  type CellRunState,
   Op,
   RunId,
   RunPhase,
@@ -17,7 +17,7 @@ const ID = cellId("cell-1");
 const RUN = RunId("run-1");
 const EPHEMERAL_RUN = RunId("ephemeral-run");
 
-const entry = (phase: RunPhase): CellRunEntry => ({
+const entry = (phase: RunPhase): CellRunState => ({
   id: ID,
   state: createCellRuntimeState(),
   phase,

--- a/extension/src/kernel/__tests__/CellStaleness.test.ts
+++ b/extension/src/kernel/__tests__/CellStaleness.test.ts
@@ -7,17 +7,22 @@ import {
   createTestNotebookDocument,
   TestVsCode,
 } from "../../__mocks__/TestVsCode.ts";
+import { CellStatusBarProviderLive } from "../../features/CellStatusBarProvider.ts";
 import { CellExecutions } from "../../kernel/CellExecutions.ts";
+import { NotebookEditorRegistry } from "../../notebook/NotebookEditorRegistry.ts";
 import { VsCode } from "../../platform/VsCode.ts";
 import {
   MarimoNotebookCell,
   MarimoNotebookDocument,
 } from "../../schemas/MarimoNotebookDocument.ts";
+import { makeCellHarness } from "./CellExecutionsHarness.ts";
 
 const withTestCtx = Effect.fn(function* () {
   const vscode = yield* TestVsCode.make();
   const layer = Layer.empty.pipe(
-    Layer.merge(CellExecutions.layer),
+    Layer.provideMerge(CellStatusBarProviderLive),
+    Layer.provideMerge(CellExecutions.layer),
+    Layer.provide(NotebookEditorRegistry.layer),
     Layer.provideMerge(vscode.layer),
     Layer.provide(TestTelemetryLive),
   );
@@ -85,6 +90,7 @@ describe("CellExecutions staleness", () => {
       yield* Effect.gen(function* () {
         const code = yield* VsCode;
         const executions = yield* CellExecutions;
+        const cells = makeCellHarness(executions);
 
         const cellData0 = new code.NotebookCellData(
           code.NotebookCellKind.Code,
@@ -107,14 +113,14 @@ describe("CellExecutions staleness", () => {
         const cell = notebook.cellAt(0);
 
         // Execute the cell, then invalidate (simulates staleInputs)
-        yield* executions.recordExecution(cell);
+        yield* cells.acceptSource(cell);
         yield* TestClock.adjust("10 millis");
 
         // Clear previous context updates
         yield* Ref.update(ctx.vscode.executions, () => []);
 
         // Invalidate → cell becomes stale → hasStaleCells should be true
-        yield* executions.invalidateCell(cell);
+        yield* cells.markStale(cell);
         yield* TestClock.adjust("10 millis");
       }).pipe(Effect.provide(ctx.layer));
 
@@ -135,6 +141,7 @@ describe("CellExecutions staleness", () => {
       yield* Effect.gen(function* () {
         const code = yield* VsCode;
         const executions = yield* CellExecutions;
+        const cells = makeCellHarness(executions);
 
         // Cell B, depends on a slow cell A elsewhere. Starts with original code.
         const cellDataB = new code.NotebookCellData(
@@ -159,9 +166,9 @@ describe("CellExecutions staleness", () => {
 
         // 1. B is queued as a reactive descendant of slow cell A — the kernel
         //    acks "queued" for B with the original code.
-        yield* executions.recordExecution(cellB);
+        yield* cells.acceptSource(cellB);
         yield* TestClock.adjust("10 millis");
-        expect(yield* executions.isCellStale(cellB)).toBe(false);
+        expect(yield* cells.isStale(cellB)).toBe(false);
 
         // 2. User edits B while it is still queued waiting for A to finish.
         //    The document text changes; fire a notebookChange so derivations run.
@@ -183,16 +190,16 @@ describe("CellExecutions staleness", () => {
         yield* TestClock.adjust("10 millis");
 
         // Editor code now differs from what the kernel last ran → stale.
-        expect(yield* executions.isCellStale(cellB)).toBe(true);
+        expect(yield* cells.isStale(cellB)).toBe(true);
 
         // 3. User presses Ctrl+Enter on B. Extension sends a new run request
-        //    with the new code; kernel acks "queued" → recordExecution fires.
-        yield* executions.recordExecution(cellB);
+        //    with the new code; the kernel's queued ack accepts the new source.
+        yield* cells.acceptSource(cellB);
         yield* TestClock.adjust("10 millis");
 
         // 4. Stale should clear immediately — regardless of whether the kernel
         //    happens to run B once more with the old code under the hood.
-        expect(yield* executions.isCellStale(cellB)).toBe(false);
+        expect(yield* cells.isStale(cellB)).toBe(false);
       }).pipe(Effect.provide(ctx.layer));
     }),
   );
@@ -205,6 +212,7 @@ describe("CellExecutions staleness", () => {
       yield* Effect.gen(function* () {
         const code = yield* VsCode;
         const executions = yield* CellExecutions;
+        const cells = makeCellHarness(executions);
 
         const cellData = new code.NotebookCellData(
           code.NotebookCellKind.Code,
@@ -222,19 +230,20 @@ describe("CellExecutions staleness", () => {
         yield* TestClock.adjust("10 millis");
 
         const cell = MarimoNotebookDocument.from(editor.notebook).cellAt(0);
-        expect(yield* executions.isCellStale(cell)).toBe(false);
+        expect(yield* cells.isStale(cell)).toBe(false);
       }).pipe(Effect.provide(ctx.layer));
     }),
   );
 
   it.effect(
-    "re-executing after invalidateCell clears stale",
+    "re-executing after invalidation clears stale",
     Effect.fn(function* () {
       const ctx = yield* withTestCtx();
 
       yield* Effect.gen(function* () {
         const code = yield* VsCode;
         const executions = yield* CellExecutions;
+        const cells = makeCellHarness(executions);
 
         const cellData = new code.NotebookCellData(
           code.NotebookCellKind.Code,
@@ -253,14 +262,14 @@ describe("CellExecutions staleness", () => {
 
         const cell = MarimoNotebookDocument.from(editor.notebook).cellAt(0);
 
-        yield* executions.recordExecution(cell);
-        yield* executions.invalidateCell(cell);
+        yield* cells.acceptSource(cell);
+        yield* cells.markStale(cell);
         yield* TestClock.adjust("10 millis");
-        expect(yield* executions.isCellStale(cell)).toBe(true);
+        expect(yield* cells.isStale(cell)).toBe(true);
 
-        yield* executions.recordExecution(cell);
+        yield* cells.acceptSource(cell);
         yield* TestClock.adjust("10 millis");
-        expect(yield* executions.isCellStale(cell)).toBe(false);
+        expect(yield* cells.isStale(cell)).toBe(false);
       }).pipe(Effect.provide(ctx.layer));
     }),
   );
@@ -273,6 +282,7 @@ describe("CellExecutions staleness", () => {
       yield* Effect.gen(function* () {
         const code = yield* VsCode;
         const executions = yield* CellExecutions;
+        const cells = makeCellHarness(executions);
 
         const cellData = new code.NotebookCellData(
           code.NotebookCellKind.Code,
@@ -291,7 +301,7 @@ describe("CellExecutions staleness", () => {
 
         const cell = MarimoNotebookDocument.from(editor.notebook).cellAt(0);
 
-        yield* executions.recordExecution(cell);
+        yield* cells.acceptSource(cell);
         yield* TestClock.adjust("10 millis");
 
         // Edit away — cell becomes stale.
@@ -311,7 +321,7 @@ describe("CellExecutions staleness", () => {
           contentChanges: [],
         });
         yield* TestClock.adjust("10 millis");
-        expect(yield* executions.isCellStale(cell)).toBe(true);
+        expect(yield* cells.isStale(cell)).toBe(true);
 
         // Undo back to the executed text — stale clears without re-running.
         cellData.value = "x = 1";
@@ -330,7 +340,7 @@ describe("CellExecutions staleness", () => {
           contentChanges: [],
         });
         yield* TestClock.adjust("10 millis");
-        expect(yield* executions.isCellStale(cell)).toBe(false);
+        expect(yield* cells.isStale(cell)).toBe(false);
       }).pipe(Effect.provide(ctx.layer));
     }),
   );
@@ -343,6 +353,7 @@ describe("CellExecutions staleness", () => {
       yield* Effect.gen(function* () {
         const code = yield* VsCode;
         const executions = yield* CellExecutions;
+        const cells = makeCellHarness(executions);
 
         const cellDataA = new code.NotebookCellData(
           code.NotebookCellKind.Code,
@@ -371,8 +382,8 @@ describe("CellExecutions staleness", () => {
         const cellA = notebook.cellAt(0);
         const cellB = notebook.cellAt(1);
 
-        yield* executions.recordExecution(cellA);
-        yield* executions.recordExecution(cellB);
+        yield* cells.acceptSource(cellA);
+        yield* cells.acceptSource(cellB);
         yield* TestClock.adjust("10 millis");
 
         // Edit A only; B must remain not-stale.
@@ -393,13 +404,13 @@ describe("CellExecutions staleness", () => {
         });
         yield* TestClock.adjust("10 millis");
 
-        expect(yield* executions.isCellStale(cellA)).toBe(true);
-        expect(yield* executions.isCellStale(cellB)).toBe(false);
+        expect(yield* cells.isStale(cellA)).toBe(true);
+        expect(yield* cells.isStale(cellB)).toBe(false);
 
         // Invalidating A must also not touch B.
-        yield* executions.invalidateCell(cellA);
+        yield* cells.markStale(cellA);
         yield* TestClock.adjust("10 millis");
-        expect(yield* executions.isCellStale(cellB)).toBe(false);
+        expect(yield* cells.isStale(cellB)).toBe(false);
       }).pipe(Effect.provide(ctx.layer));
     }),
   );
@@ -426,6 +437,7 @@ describe("CellExecutions staleness", () => {
       yield* Effect.gen(function* () {
         const code = yield* VsCode;
         const executions = yield* CellExecutions;
+        const cells = makeCellHarness(executions);
 
         const cellData = new code.NotebookCellData(
           code.NotebookCellKind.Code,
@@ -446,12 +458,12 @@ describe("CellExecutions staleness", () => {
         const cell = MarimoNotebookDocument.from(editor.notebook).cellAt(0);
 
         // Start from a clean slate, then record the initial execution.
-        yield* executions.recordExecution(cell);
+        yield* cells.acceptSource(cell);
         yield* TestClock.adjust("10 millis");
         yield* Ref.update(ctx.vscode.executions, () => []);
 
         // Invalidate → stale → context must flip to true.
-        yield* executions.invalidateCell(cell);
+        yield* cells.markStale(cell);
         yield* TestClock.adjust("10 millis");
         expect(
           hasStaleCellsContextValues(yield* Ref.get(ctx.vscode.executions)).at(
@@ -460,7 +472,7 @@ describe("CellExecutions staleness", () => {
         ).toBe(true);
 
         // Re-execute → stale clears → context must flip back to false.
-        yield* executions.recordExecution(cell);
+        yield* cells.acceptSource(cell);
         yield* TestClock.adjust("10 millis");
         expect(
           hasStaleCellsContextValues(yield* Ref.get(ctx.vscode.executions)).at(
@@ -479,6 +491,7 @@ describe("CellExecutions staleness", () => {
       yield* Effect.gen(function* () {
         const code = yield* VsCode;
         const executions = yield* CellExecutions;
+        const cells = makeCellHarness(executions);
 
         const cellData0 = new code.NotebookCellData(
           code.NotebookCellKind.Code,
@@ -500,8 +513,8 @@ describe("CellExecutions staleness", () => {
         const notebook = MarimoNotebookDocument.from(editor.notebook);
         const cell0 = notebook.cellAt(0);
 
-        // Simulate execution: recordExecution stores content as "last executed"
-        yield* executions.recordExecution(cell0);
+        // A queued ack stores the source accepted by the kernel.
+        yield* cells.acceptSource(cell0);
         yield* TestClock.adjust("10 millis");
 
         // Clear previous executions to check fresh state
@@ -527,7 +540,7 @@ describe("CellExecutions staleness", () => {
         yield* TestClock.adjust("10 millis");
 
         // Should NOT be stale since content matches last executed
-        expect(yield* executions.isCellStale(cell0)).toBe(false);
+        expect(yield* cells.isStale(cell0)).toBe(false);
 
         // The hasStaleCells context should NOT have been set to true
         const commandExecutions = yield* Ref.get(ctx.vscode.executions);


### PR DESCRIPTION
One input interface now owns operations and lifecycle changes.

```ts
type CellInput = Data.TaggedEnum<{
  Operation: { notebookId; operation; source; drive; renderOutput? };
  Interrupted: { notebookId };
  CellsRemoved: { notebookId; cellIds };
  Invalidated: { notebookId };
}>;

interface CellRecord {
  readonly run: CellRunState;
  readonly drive: Option.Option<DriveBinding>;
}
```

Each notebook has one record map and one ordering lane. This removes `recordExecution`, `invalidateCell`, `forgetCell`, `handleOperation`, and `handleInterrupt` as separate concepts; accepted source and cleanup now flow through `accept`.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
