### PR TITLE
Keep the WASM kernel bridge compatible with Python 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,6 +197,17 @@ jobs:
           uv run ruff format --check
           uv run ruff check
 
+  kernel-compatibility:
+    name: Python / Kernel compatibility floor
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+      - name: Import bridge with minimum Python and marimo
+        run: |
+          minimum_marimo="$(uv run --no-project --python 3.13 python -c 'from scripts.marimo_version import check; print(check().kernel_compatibility_floor)')"
+          uv run --no-project --python 3.10 --with "marimo==${minimum_marimo}" python tests/kernel_bridge_compatibility.py
+
   python-test:
     name: Python / Test / ${{ matrix.os }}
     strategy:

--- a/extension/resources/wasm/protocol.py
+++ b/extension/resources/wasm/protocol.py
@@ -7,7 +7,7 @@
 from __future__ import annotations
 
 import struct
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Generic, Literal, TypeAlias, TypeVar
 
 import marimo._ipc as ipc
 import msgspec
@@ -52,7 +52,7 @@ class Log(msgspec.Struct, tag="log", tag_field="type", rename="camel"):
     version: Literal[1] = VERSION
 
 
-type FromBridge = Ready | Operation | Error | Log
+FromBridge: TypeAlias = Ready | Operation | Error | Log
 
 
 class KernelLaunchArgs(ipc.KernelArgs):
@@ -99,7 +99,9 @@ class Close(msgspec.Struct, tag="close", tag_field="type", rename="camel"):
     version: Literal[1] = VERSION
 
 
-type ToBridge = Start | Control | Input | Interrupt | Close
+ToBridge: TypeAlias = Start | Control | Input | Interrupt | Close
+
+Message = TypeVar("Message")
 
 
 def encode(message: FromBridge | ToBridge) -> bytes:
@@ -119,7 +121,7 @@ def read_header(header: bytes | bytearray) -> int:
     return _HEADER.unpack(header)[0]
 
 
-class Decoder[Message]:
+class Decoder(Generic[Message]):
     """Decode length-prefixed messages across arbitrary byte chunks."""
 
     def __init__(self, message_type: TypeForm[Message]) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,12 @@ exclude = ["extension/**"]
 [tool.ruff]
 extend-exclude = ["vscode/*", "extension/tutorials/*"]
 
+[tool.ruff.per-file-target-version]
+# These files run in the notebook's selected Python, outside the bundled
+# Pyodide environment. Keep them compatible with marimo's Python floor.
+"extension/resources/wasm/*.py" = "py310"
+"src/marimo_lsp/wasm/protocol.py" = "py310"
+
 [tool.ruff.lint]
 pydocstyle = { convention = "numpy" }
 select = ["ALL"]

--- a/src/marimo_lsp/wasm/protocol.py
+++ b/src/marimo_lsp/wasm/protocol.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 import struct
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Generic, Literal, TypeAlias, TypeVar
 
 import marimo._ipc as ipc
 import msgspec
@@ -50,7 +50,7 @@ class Log(msgspec.Struct, tag="log", tag_field="type", rename="camel"):
     version: Literal[1] = VERSION
 
 
-type FromBridge = Ready | Operation | Error | Log
+FromBridge: TypeAlias = Ready | Operation | Error | Log
 
 
 class KernelLaunchArgs(ipc.KernelArgs):
@@ -97,7 +97,9 @@ class Close(msgspec.Struct, tag="close", tag_field="type", rename="camel"):
     version: Literal[1] = VERSION
 
 
-type ToBridge = Start | Control | Input | Interrupt | Close
+ToBridge: TypeAlias = Start | Control | Input | Interrupt | Close
+
+Message = TypeVar("Message")
 
 
 def encode(message: FromBridge | ToBridge) -> bytes:
@@ -117,7 +119,7 @@ def read_header(header: bytes | bytearray) -> int:
     return _HEADER.unpack(header)[0]
 
 
-class Decoder[Message]:
+class Decoder(Generic[Message]):
     """Decode length-prefixed messages across arbitrary byte chunks."""
 
     def __init__(self, message_type: TypeForm[Message]) -> None:

--- a/tests/kernel_bridge_compatibility.py
+++ b/tests/kernel_bridge_compatibility.py
@@ -1,0 +1,39 @@
+# Copyright 2026 Marimo. All rights reserved.
+
+"""Smoke-test the selected-Python kernel bridge in an isolated environment."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from importlib.metadata import version
+from pathlib import Path
+
+RESOURCE_DIRECTORY = Path(__file__).parents[1] / "extension" / "resources" / "wasm"
+KERNEL_SCRIPT = RESOURCE_DIRECTORY / "kernel.py"
+
+
+def main() -> None:
+    """Import the packaged bridge and all of its selected-Python dependencies."""
+    sys.path.insert(0, str(RESOURCE_DIRECTORY))
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "marimo_kernel_bridge_compatibility",
+            KERNEL_SCRIPT,
+        )
+        if spec is None or spec.loader is None:
+            msg = f"Could not load {KERNEL_SCRIPT}"
+            raise RuntimeError(msg)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+    finally:
+        sys.path.remove(str(RESOURCE_DIRECTORY))
+
+    sys.stdout.write(
+        f"Imported kernel bridge with Python {sys.version.split()[0]} "
+        f"and marimo {version('marimo')}\n"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
`kernel.py` runs in the notebook's selected Python, not the bundled Pyodide environment. Its protocol used PEP 695 syntax, so Python 3.10 and 3.11 rejected the bridge before the kernel could start despite marimo supporting Python 3.10.

These changes use portable typing syntax at this boundary and have Ruff check the bridge resources against Python 3.10. The rest of marimo-lsp keeps its Python 3.13 target.

CI reads the configured minimum kernel version and imports the packaged bridge under Python 3.10 with that marimo release, covering both syntax and private imports. 