### PR TITLE
Keep error banners from blurring notebook outputs

### DIFF
--- a/extension/src/renderer/CellOutput.tsx
+++ b/extension/src/renderer/CellOutput.tsx
@@ -9,6 +9,7 @@ import {
   TooltipProvider,
   useTheme,
 } from "./marimo-frontend.ts";
+import { suppressEmbeddedErrorDialog } from "./suppressEmbeddedErrorDialog.ts";
 import { useEventListener } from "./useEventListener.ts";
 
 interface CellOutputProps {
@@ -25,6 +26,7 @@ export function CellOutput({ cellId, state }: CellOutputProps) {
   const { target: hoveredImage, clear: clearHover } = useImageHover(container);
 
   useStopUnmodifiedInputKeys(container);
+  useEventListener(container, "click", suppressEmbeddedErrorDialog, true);
 
   return (
     <div

--- a/extension/src/renderer/__tests__/suppressEmbeddedErrorDialog.test.ts
+++ b/extension/src/renderer/__tests__/suppressEmbeddedErrorDialog.test.ts
@@ -1,0 +1,45 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { suppressEmbeddedErrorDialog } from "../suppressEmbeddedErrorDialog.ts";
+
+function dispatchClick(className: string) {
+  const output = document.createElement("div");
+  const host = document.createElement("marimo-mermaid");
+  const shadowRoot = host.attachShadow({ mode: "open" });
+  const banner = document.createElement("div");
+  const message = document.createElement("span");
+  const onBannerClick = vi.fn();
+
+  banner.className = className;
+  banner.appendChild(message);
+  shadowRoot.appendChild(banner);
+  output.appendChild(host);
+  output.addEventListener("click", suppressEmbeddedErrorDialog, {
+    capture: true,
+  });
+  banner.addEventListener("click", onBannerClick);
+
+  message.dispatchEvent(
+    new MouseEvent("click", { bubbles: true, composed: true }),
+  );
+  return onBannerClick;
+}
+
+describe("suppressEmbeddedErrorDialog", () => {
+  it("stops clicks inside marimo error banners", () => {
+    const onBannerClick = dispatchClick(
+      "cursor-pointer text-error border shadow-error",
+    );
+
+    expect(onBannerClick).not.toHaveBeenCalled();
+  });
+
+  it("does not stop unrelated clickable content", () => {
+    const onBannerClick = dispatchClick("cursor-pointer text-error border");
+
+    expect(onBannerClick).toHaveBeenCalledOnce();
+  });
+});

--- a/extension/src/renderer/styles.css
+++ b/extension/src/renderer/styles.css
@@ -59,6 +59,14 @@
 }
 
 /**
+ * The embedded renderer suppresses ErrorBanner's viewport-level dialog. Keep
+ * the banner's cursor consistent with its non-interactive behavior here.
+ */
+[data-vscode-output-container] .cursor-pointer.shadow-error {
+  cursor: default;
+}
+
+/**
  * Image toolbar: floating copy/save buttons shown on hover over images.
  */
 .image-toolbar {

--- a/extension/src/renderer/suppressEmbeddedErrorDialog.ts
+++ b/extension/src/renderer/suppressEmbeddedErrorDialog.ts
@@ -1,0 +1,34 @@
+interface ClickCaptureEvent {
+  readonly target: EventTarget | null;
+  composedPath(): EventTarget[];
+  stopPropagation(): void;
+}
+
+// ErrorBanner does not expose a semantic hook, so match its danger + clickable
+// style combination. The selector is scoped to CellOutput by the capture
+// handler and the corresponding renderer CSS rule.
+const ERROR_BANNER_SELECTOR = ".cursor-pointer.shadow-error";
+
+/**
+ * Prevent marimo's ErrorBanner from opening a viewport-level AlertDialog in an
+ * embedded cell output. Its fixed backdrop spans VS Code's shared renderer
+ * surface and can leave the dialog itself inaccessible.
+ *
+ * TODO(marimo-team/marimo-lsp#764): Remove this interception once marimo's
+ * ErrorBanner has embedded-safe error details that do not require a viewport
+ * dialog.
+ */
+export function suppressEmbeddedErrorDialog(event: ClickCaptureEvent): void {
+  // Plugins render in their own shadow roots. Outside that boundary, target is
+  // retargeted to the custom-element host; composedPath preserves the banner.
+  const clickedErrorBanner = event
+    .composedPath()
+    .some(
+      (target) =>
+        target instanceof Element && target.matches(ERROR_BANNER_SELECTOR),
+    );
+
+  if (clickedErrorBanner) {
+    event.stopPropagation();
+  }
+}


### PR DESCRIPTION
`ErrorBanner` opens a viewport-level dialog from inside one cell output. The fixed backdrop spans the shared VS Code renderer surface while the dialog content can remain inaccessible, leaving the notebook blurred until reload.

Capture clicks only for the current danger-banner style and retain normal interaction elsewhere. A future marimo change should provide embedded-safe error details so this class-based interception can be removed.

Closes #764.