### PR TITLE
Handle managed ty installation failures

### DIFF
--- a/extension/builtin-command-catalog.json
+++ b/extension/builtin-command-catalog.json
@@ -5,5 +5,6 @@
   "outline.focus": { "discoverable": true },
   "vscode.openWith": { "discoverable": false },
   "workbench.action.openSettings": { "discoverable": true },
-  "workbench.action.reloadWindow": { "discoverable": true }
+  "workbench.action.reloadWindow": { "discoverable": true },
+  "workbench.extensions.installExtension": { "discoverable": true }
 }

--- a/extension/src/commands.ts
+++ b/extension/src/commands.ts
@@ -225,6 +225,10 @@ export interface VscodeCommandMap {
     readonly args: [];
     readonly result: void;
   };
+  readonly "workbench.extensions.installExtension": {
+    readonly args: [extensionId: string];
+    readonly result: void;
+  };
 }
 
 export const VscodeBuiltinCommandCatalog = builtinCommandCatalog;

--- a/extension/src/lsp/TyLanguageServer.ts
+++ b/extension/src/lsp/TyLanguageServer.ts
@@ -5,6 +5,7 @@ import {
   Context,
   Data,
   Effect,
+  Exit,
   Layer,
   Option,
   Ref,
@@ -18,20 +19,48 @@ import {
   companionExtensionConfiguredPath,
   resolveBinary,
   userConfiguredPath,
+  validateBinary,
 } from "../lib/binaryResolution.ts";
+import { getExtensionVersion } from "../lib/getExtensionVersion.ts";
 import { showErrorAndPromptLogs } from "../lib/showErrorAndPromptLogs.ts";
 import { VariablesService } from "../panel/variables/VariablesService.ts";
 import { OutputChannel } from "../platform/OutputChannel.ts";
-import { ExtensionContext } from "../platform/Storage.ts";
+import { ExtensionContext, Storage } from "../platform/Storage.ts";
 import { VsCode } from "../platform/VsCode.ts";
 import { PythonEnvInvalidation } from "../python/PythonEnvInvalidation.ts";
 import { PythonExtension } from "../python/PythonExtension.ts";
-import { Uv } from "../python/Uv.ts";
+import { resolvePlatformBinaryName, Uv } from "../python/Uv.ts";
 import { Telemetry } from "../telemetry/Telemetry.ts";
 import { connectMarimoNotebookLspClient } from "./connect.ts";
+import {
+  clearManagedInstallFailure,
+  getManagedInstallFailure,
+  matchesManagedInstallFailure,
+  setManagedInstallFailure,
+} from "./managedInstallFailure.ts";
 
 const TY_SERVER = { name: "ty", version: "0.0.63" } as const;
 const TY_EXTENSION_ID = "astral-sh.ty";
+const INSTALL_TY_EXTENSION = "Install ty Extension";
+const OPEN_UV_LOGS = "Open uv Logs";
+const RELOAD_WINDOW = "Reload Window";
+
+export class ManagedTyInstallPreviouslyFailed extends Data.TaggedError(
+  "ManagedTyInstallPreviouslyFailed",
+)<{
+  readonly extensionVersion: string;
+  readonly serverVersion: string;
+  readonly details: string;
+}> {
+  format(): string {
+    return [
+      this.details,
+      "Managed installation will be retried after the marimo extension is updated.",
+      "To recover now, install the official ty extension (astral-sh.ty) or configure marimo.ty.path, then reload VS Code.",
+      "For full installation output, open the marimo (uv) output channel.",
+    ].join("\n");
+  }
+}
 
 export const TyLanguageServerStatus = Data.taggedEnum<TyLanguageServerStatus>();
 
@@ -67,6 +96,10 @@ export class TyLanguageServer extends Context.Service<TyLanguageServer>()(
       const envInvalidation = yield* PythonEnvInvalidation;
       const telemetry = yield* Effect.serviceOption(Telemetry);
       const code = yield* VsCode;
+      const uv = yield* Uv;
+      const notifyInstallFailure = yield* makeTyInstallFailureNotifier(
+        uv.channel,
+      );
 
       const statusRef = yield* Ref.make<TyLanguageServerStatus>(
         TyLanguageServerStatus.Starting(),
@@ -205,12 +238,50 @@ export class TyLanguageServer extends Context.Service<TyLanguageServer>()(
           }).pipe(Effect.scoped);
 
           // Run the server in a loop: start → invalidation → restart.
-          // On failure, the error propagates to catchCause and stops.
+          // Installation failures get a dedicated recovery path; other
+          // failures propagate to catchCause and stop the loop.
           yield* Effect.forever(serverCycle).pipe(
+            Effect.catchTag("ManagedTyInstallPreviouslyFailed", (error) =>
+              Effect.gen(function* () {
+                const message = error.format();
+                yield* Ref.set(
+                  statusRef,
+                  TyLanguageServerStatus.Failed({
+                    message,
+                    cause: Cause.fail(error),
+                  }),
+                );
+                yield* Effect.logWarning(message).pipe(
+                  Effect.annotateLogs({
+                    server: TY_SERVER.name,
+                    version: TY_SERVER.version,
+                  }),
+                );
+              }),
+            ),
+            Effect.catchTag("LanguageServerInstallError", (error) =>
+              Effect.gen(function* () {
+                const message = error.message;
+                yield* Ref.set(
+                  statusRef,
+                  TyLanguageServerStatus.Failed({
+                    message,
+                    cause: Cause.fail(error),
+                  }),
+                );
+                yield* Effect.logError(message).pipe(
+                  Effect.annotateLogs({
+                    server: TY_SERVER.name,
+                    version: TY_SERVER.version,
+                  }),
+                );
+                yield* notifyInstallFailure;
+              }),
+            ),
             Effect.catchCause((cause) =>
               Effect.gen(function* () {
                 if (Cause.hasInterruptsOnly(cause)) return;
-                const message = "Failed to start language server";
+                const message = "Failed to start ty language server";
                 yield* Ref.set(
                   statusRef,
                   TyLanguageServerStatus.Failed({ message, cause }),
@@ -242,6 +313,7 @@ export class TyLanguageServer extends Context.Service<TyLanguageServer>()(
       OutputChannel.layer,
       VariablesService.layer,
       PythonEnvInvalidation.layer,
+      Storage.layer,
     ]),
   );
 }
@@ -257,8 +329,15 @@ const resolveTyBinary = Effect.fn(function* () {
   const config = yield* Config;
   const uv = yield* Uv;
   const context = yield* ExtensionContext;
+  const extensionVersion = yield* getExtensionVersion();
 
   const tyExtension = code.extensions.getExtension(TY_EXTENSION_ID);
+  const targetPath = NodePath.resolve(context.globalStorageUri.fsPath, "libs");
+  const managedBinaryPath = NodePath.resolve(
+    targetPath,
+    "bin",
+    resolvePlatformBinaryName(TY_SERVER.name),
+  );
 
   const tyExtConfiguredPath = Effect.gen(function* () {
     const tyExtConfig = yield* code.workspace.getConfiguration("ty");
@@ -268,7 +347,7 @@ const resolveTyBinary = Effect.fn(function* () {
     );
   });
 
-  return yield* resolveBinary(
+  const resolved = yield* resolveBinary(
     TY_SERVER.name,
     [
       userConfiguredPath("ty", TY_SERVER.version, config.ty.path),
@@ -284,23 +363,113 @@ const resolveTyBinary = Effect.fn(function* () {
         TY_EXTENSION_ID,
         tyExtension,
       ),
+      {
+        label: "existing managed installation",
+        resolve: validateBinary(managedBinaryPath, TY_SERVER.version).pipe(
+          Effect.map(Option.map((path) => BinarySource.UvInstalled({ path }))),
+        ),
+      },
     ],
     {
       label: "uv install",
       resolve: Effect.gen(function* () {
-        const targetPath = NodePath.resolve(
-          context.globalStorageUri.fsPath,
-          "libs",
-        );
-        const binaryPath = yield* uv.ensureLanguageServerBinaryInstalled(
-          TY_SERVER,
-          {
-            targetPath,
-          },
-        );
+        const previousFailure =
+          yield* getPreviousInstallFailure(extensionVersion);
+        if (Option.isSome(previousFailure)) {
+          return yield* new ManagedTyInstallPreviouslyFailed({
+            extensionVersion: previousFailure.value.extensionVersion,
+            serverVersion: previousFailure.value.serverVersion,
+            details: previousFailure.value.details,
+          });
+        }
+
+        const binaryPath = yield* uv
+          .ensureLanguageServerBinaryInstalled(TY_SERVER, { targetPath })
+          .pipe(
+            Effect.tapError((error) =>
+              rememberInstallFailure(extensionVersion, error.message),
+            ),
+          );
         return Option.some(BinarySource.UvInstalled({ path: binaryPath }));
       }),
     },
+  );
+
+  yield* clearManagedInstallFailure(TY_SERVER.name).pipe(Effect.ignore);
+  return resolved;
+});
+
+const getPreviousInstallFailure = Effect.fn(function* (
+  extensionVersion: Option.Option<string>,
+) {
+  if (Option.isNone(extensionVersion)) return Option.none();
+
+  const failure = yield* getManagedInstallFailure(TY_SERVER.name).pipe(
+    Effect.orElseSucceed(() => Option.none()),
+  );
+  return matchesManagedInstallFailure(failure, {
+    extensionVersion: extensionVersion.value,
+    serverVersion: TY_SERVER.version,
+  })
+    ? failure
+    : Option.none();
+});
+
+const rememberInstallFailure = Effect.fn(function* (
+  extensionVersion: Option.Option<string>,
+  details: string,
+) {
+  if (Option.isNone(extensionVersion)) return;
+
+  yield* setManagedInstallFailure(TY_SERVER.name, {
+    extensionVersion: extensionVersion.value,
+    serverVersion: TY_SERVER.version,
+    details,
+  }).pipe(Effect.ignore);
+});
+
+export const makeTyInstallFailureNotifier = Effect.fn(
+  "TyLanguageServer.makeTyInstallFailureNotifier",
+)(function* (channel: { readonly name: string; show(): void }) {
+  const code = yield* VsCode;
+
+  return yield* Effect.cached(
+    Effect.gen(function* () {
+      const selection = yield* code.window.showWarningMessage(
+        "marimo couldn't install ty. Install the official ty extension to enable Python completions and diagnostics in marimo notebooks.",
+        { items: [INSTALL_TY_EXTENSION, OPEN_UV_LOGS] },
+      );
+      if (Option.isNone(selection)) return;
+
+      if (selection.value === OPEN_UV_LOGS) {
+        channel.show();
+        return;
+      }
+
+      const install = yield* Effect.exit(
+        code.commands.executeVSCode(
+          "workbench.extensions.installExtension",
+          TY_EXTENSION_ID,
+        ),
+      );
+      if (Exit.isFailure(install)) {
+        yield* Effect.logError("Failed to install the ty extension").pipe(
+          Effect.annotateLogs({ cause: install.cause }),
+        );
+        yield* code.window.showErrorMessage(
+          "VS Code couldn't install the ty extension. Search for @id:astral-sh.ty in the Extensions view.",
+        );
+        return;
+      }
+
+      const reload = yield* code.window.showInformationMessage(
+        "Reload VS Code to finish enabling the ty extension in marimo notebooks.",
+        { items: [RELOAD_WINDOW] },
+      );
+      if (Option.contains(reload, RELOAD_WINDOW)) {
+        yield* code.commands.executeVSCode("workbench.action.reloadWindow");
+      }
+    }),
   );
 });
 

--- a/extension/src/lsp/__tests__/TyLanguageServer.test.ts
+++ b/extension/src/lsp/__tests__/TyLanguageServer.test.ts
@@ -1,0 +1,136 @@
+import { expect, it } from "@effect/vitest";
+import { Effect, Option, Ref } from "effect";
+import type * as vscode from "vscode";
+
+import { TestVsCode } from "../../__mocks__/TestVsCode.ts";
+import {
+  makeTyInstallFailureNotifier,
+  ManagedTyInstallPreviouslyFailed,
+} from "../TyLanguageServer.ts";
+
+const selectedItem = <T extends string>(
+  options: vscode.MessageOptions & { items?: readonly T[] },
+  item: string,
+) => Option.fromNullishOr(options.items?.find((value) => value === item));
+
+it("keeps recovery instructions in persisted failure diagnostics", () => {
+  const error = new ManagedTyInstallPreviouslyFailed({
+    extensionVersion: "0.16.2",
+    serverVersion: "0.0.63",
+    details: "Failed to install ty@0.0.63",
+  });
+
+  expect(error.format()).toBe(
+    [
+      "Failed to install ty@0.0.63",
+      "Managed installation will be retried after the marimo extension is updated.",
+      "To recover now, install the official ty extension (astral-sh.ty) or configure marimo.ty.path, then reload VS Code.",
+      "For full installation output, open the marimo (uv) output channel.",
+    ].join("\n"),
+  );
+});
+
+it.effect(
+  "shows the managed installation warning once and can open uv logs",
+  Effect.fn(function* () {
+    const prompts = yield* Ref.make(0);
+    let channelShows = 0;
+    const vscode = yield* TestVsCode.make({
+      window: {
+        showWarningMessage: <T extends string>(
+          _message: string,
+          options: vscode.MessageOptions & { items?: readonly T[] } = {},
+        ) =>
+          Ref.update(prompts, (count) => count + 1).pipe(
+            Effect.as(selectedItem(options, "Open uv Logs")),
+          ),
+      },
+    });
+    const notify = yield* makeTyInstallFailureNotifier({
+      name: "marimo (uv)",
+      show: () => {
+        channelShows += 1;
+      },
+    }).pipe(Effect.provide(vscode.layer));
+
+    yield* Effect.all([notify, notify], { concurrency: "unbounded" });
+
+    expect(yield* Ref.get(prompts)).toBe(1);
+    expect(channelShows).toBe(1);
+  }),
+);
+
+it.effect(
+  "installs the companion extension and reloads when selected",
+  Effect.fn(function* () {
+    const vscode = yield* TestVsCode.make({
+      window: {
+        showWarningMessage: <T extends string>(
+          _message: string,
+          options: vscode.MessageOptions & { items?: readonly T[] } = {},
+        ) => Effect.succeed(selectedItem(options, "Install ty Extension")),
+        showInformationMessage: <T extends string>(
+          _message: string,
+          options: vscode.MessageOptions & { items?: readonly T[] } = {},
+        ) => Effect.succeed(selectedItem(options, "Reload Window")),
+      },
+    });
+    const notify = yield* makeTyInstallFailureNotifier({
+      name: "marimo (uv)",
+      show() {},
+    }).pipe(Effect.provide(vscode.layer));
+
+    yield* notify;
+
+    expect(yield* Ref.get(vscode.executions)).toEqual([
+      {
+        command: "workbench.extensions.installExtension",
+        args: ["astral-sh.ty"],
+      },
+      { command: "workbench.action.reloadWindow", args: [] },
+    ]);
+  }),
+);
+
+it.effect(
+  "reports a companion extension installation failure without prompting to reload",
+  Effect.fn(function* () {
+    const installAttempts = yield* Ref.make(0);
+    const errorMessages = yield* Ref.make<ReadonlyArray<string>>([]);
+    const reloadPrompts = yield* Ref.make(0);
+    const vscode = yield* TestVsCode.make({
+      window: {
+        showWarningMessage: <T extends string>(
+          _message: string,
+          options: vscode.MessageOptions & { items?: readonly T[] } = {},
+        ) => Effect.succeed(selectedItem(options, "Install ty Extension")),
+        showInformationMessage: () =>
+          Ref.update(reloadPrompts, (count) => count + 1).pipe(
+            Effect.as(Option.none()),
+          ),
+        showErrorMessage: (message) =>
+          Ref.update(errorMessages, (messages) => [...messages, message]).pipe(
+            Effect.as(Option.none()),
+          ),
+      },
+      commands: {
+        executeVSCode: () =>
+          Ref.update(installAttempts, (count) => count + 1).pipe(
+            Effect.andThen(Effect.die(new Error("command rejected"))),
+          ),
+      },
+    });
+    const notify = yield* makeTyInstallFailureNotifier({
+      name: "marimo (uv)",
+      show() {},
+    }).pipe(Effect.provide(vscode.layer));
+
+    yield* notify;
+
+    expect(yield* Ref.get(installAttempts)).toBe(1);
+    expect(yield* Ref.get(reloadPrompts)).toBe(0);
+    expect(yield* Ref.get(errorMessages)).toEqual([
+      "VS Code couldn't install the ty extension. Search for @id:astral-sh.ty in the Extensions view.",
+    ]);
+  }),
+);

--- a/extension/src/lsp/__tests__/managedInstallFailure.test.ts
+++ b/extension/src/lsp/__tests__/managedInstallFailure.test.ts
@@ -1,0 +1,76 @@
+import { expect, it } from "@effect/vitest";
+import { Effect, Layer, Option } from "effect";
+
+import { Memento } from "../../__mocks__/TestExtensionContext.ts";
+import { Uri } from "../../__mocks__/TestVsCode.ts";
+import { ExtensionContext, Storage } from "../../platform/Storage.ts";
+import {
+  clearManagedInstallFailure,
+  getManagedInstallFailure,
+  matchesManagedInstallFailure,
+  setManagedInstallFailure,
+} from "../managedInstallFailure.ts";
+
+const makeStorageLayer = () =>
+  Storage.layer.pipe(
+    Layer.provide(
+      Layer.succeed(ExtensionContext, {
+        globalState: new Memento(),
+        workspaceState: new Memento(),
+        extensionUri: Uri.parse("file:///test/extension/path", true),
+        globalStorageUri: Uri.parse(
+          "file:///test/extension/global-storage",
+          true,
+        ),
+      }),
+    ),
+  );
+
+it.effect(
+  "persists and clears a managed installation failure",
+  Effect.fn(function* () {
+    const layer = makeStorageLayer();
+    const failure = {
+      extensionVersion: "0.16.2",
+      serverVersion: "0.0.63",
+      details: "certificate validation failed",
+    };
+
+    yield* Effect.gen(function* () {
+      yield* setManagedInstallFailure("ty", failure);
+      expect(yield* getManagedInstallFailure("ty")).toEqual(
+        Option.some(failure),
+      );
+
+      yield* clearManagedInstallFailure("ty");
+      expect(Option.isNone(yield* getManagedInstallFailure("ty"))).toBe(true);
+    }).pipe(Effect.provide(layer));
+  }),
+);
+
+it("matches only the current extension and server versions", () => {
+  const failure = Option.some({
+    extensionVersion: "0.16.2",
+    serverVersion: "0.0.63",
+    details: "certificate validation failed",
+  });
+
+  expect(
+    matchesManagedInstallFailure(failure, {
+      extensionVersion: "0.16.2",
+      serverVersion: "0.0.63",
+    }),
+  ).toBe(true);
+  expect(
+    matchesManagedInstallFailure(failure, {
+      extensionVersion: "0.16.3",
+      serverVersion: "0.0.63",
+    }),
+  ).toBe(false);
+  expect(
+    matchesManagedInstallFailure(failure, {
+      extensionVersion: "0.16.2",
+      serverVersion: "0.0.64",
+    }),
+  ).toBe(false);
+});

--- a/extension/src/lsp/managedInstallFailure.ts
+++ b/extension/src/lsp/managedInstallFailure.ts
@@ -1,0 +1,49 @@
+import { Effect, Option, Schema } from "effect";
+
+import { createStorageKey, Storage } from "../platform/Storage.ts";
+
+const ManagedInstallFailure = Schema.Struct({
+  extensionVersion: Schema.String,
+  serverVersion: Schema.String,
+  details: Schema.String,
+});
+
+export type ManagedInstallFailure = typeof ManagedInstallFailure.Type;
+
+const storageKey = (serverName: string) =>
+  createStorageKey(
+    `languageServer.${serverName}.installFailure`,
+    ManagedInstallFailure,
+  );
+
+export const getManagedInstallFailure = Effect.fn("ManagedInstallFailure.get")(
+  function* (serverName: string) {
+    const storage = yield* Storage;
+    return yield* storage.global.get(storageKey(serverName));
+  },
+);
+
+export const setManagedInstallFailure = Effect.fn("ManagedInstallFailure.set")(
+  function* (serverName: string, failure: ManagedInstallFailure) {
+    const storage = yield* Storage;
+    yield* storage.global.set(storageKey(serverName), failure);
+  },
+);
+
+export const clearManagedInstallFailure = Effect.fn(
+  "ManagedInstallFailure.clear",
+)(function* (serverName: string) {
+  const storage = yield* Storage;
+  yield* storage.global.delete(storageKey(serverName));
+});
+
+export function matchesManagedInstallFailure(
+  failure: Option.Option<ManagedInstallFailure>,
+  current: Pick<ManagedInstallFailure, "extensionVersion" | "serverVersion">,
+): failure is Option.Some<ManagedInstallFailure> {
+  return (
+    Option.isSome(failure) &&
+    failure.value.extensionVersion === current.extensionVersion &&
+    failure.value.serverVersion === current.serverVersion
+  );
+}

--- a/extension/src/python/Uv.ts
+++ b/extension/src/python/Uv.ts
@@ -168,9 +168,12 @@ export class LanguageServerInstallError extends Data.TaggedError(
   readonly targetPath: string;
   readonly attempts: ReadonlyArray<LanguageServerInstallAttempt>;
 }> {
+  override readonly message = this.format();
+
   format(): string {
     const lines = [
       `Failed to install ${this.server.name}@${this.server.version}`,
+      `Target: ${this.targetPath}`,
     ];
     for (const attempt of this.attempts) {
       const errorMsg =

--- a/extension/src/python/__tests__/UvErrors.test.ts
+++ b/extension/src/python/__tests__/UvErrors.test.ts
@@ -1,0 +1,29 @@
+import { expect, it } from "@effect/vitest";
+import { ChildProcess } from "effect/unstable/process";
+
+import { LanguageServerInstallError, UvUnknownError } from "../Uv.ts";
+
+it("includes uv stderr in language-server installation diagnostics", () => {
+  const error = new LanguageServerInstallError({
+    server: { name: "ty", version: "0.0.63" },
+    targetPath: "/managed/libs",
+    attempts: [
+      {
+        strategy: "default",
+        error: new UvUnknownError({
+          command: ChildProcess.make("uv", ["pip", "install", "ty"]),
+          stderr: "certificate validation failed for the configured proxy",
+        }),
+      },
+    ],
+  });
+
+  expect(error.format()).toBe(
+    [
+      "Failed to install ty@0.0.63",
+      "Target: /managed/libs",
+      "  [default] exit code unknown: certificate validation failed for the configured proxy",
+    ].join("\n"),
+  );
+  expect(error.message).toBe(error.format());
+});


### PR DESCRIPTION
The managed fallback retried a known-failing uv install on every VS Code activation and hid uv stderr behind a generic startup error.

Record completed failures for the current extension and ty versions. Configured, companion, and existing managed binaries still take precedence, so installing ty another way can recover on the next activation. Updating marimo or the requested ty version makes the managed fallback eligible again.

Surface formatted attempt details in diagnostics and offer the full uv logs or the official ty extension as recovery paths.

Closes #766.