### PR TITLE
Replace WASM kernel multiprocessing with subprocess IPC

### DIFF
--- a/extension/resources/wasm/kernel.py
+++ b/extension/resources/wasm/kernel.py
@@ -136,12 +136,13 @@ class _Bridge:
     ) -> str:
         """Read the readiness line without allowing startup to hang forever."""
         assert self._process is not None
-        assert self._process.stdout is not None
+        stdout = self._process.stdout
+        assert stdout is not None
         result: queue.Queue[str | Exception] = queue.Queue(maxsize=1)
 
         def read_ready() -> None:
             try:
-                ready = self._process.stdout.readline().decode(errors="replace").strip()
+                ready = stdout.readline().decode(errors="replace").strip()
                 result.put(ready)
             except Exception as error:  # noqa: BLE001
                 result.put(error)

--- a/extension/resources/wasm/kernel.py
+++ b/extension/resources/wasm/kernel.py
@@ -2,8 +2,15 @@
 
 """Run a marimo kernel behind the WASM language server's stdio protocol.
 
-This script runs in the notebook's selected Python. It adapts Node's opaque
-stdin and stdout bytes to marimo's normal edit-mode kernel manager.
+This script runs in the notebook's selected Python. It owns marimo IPC and
+ZeroMQ; Node only brokers its opaque stdin and stdout bytes.
+
+The kernel is launched with ``subprocess``, the same path as the native
+language server. ``multiprocessing`` spawn is deliberately avoided: on
+Windows it starts children with dangling standard handle values, which later
+alias live pipes inside the kernel and stall anything that touches a
+standard stream -- cell subprocesses (marimo-lsp#734) and the CRT
+initialization of extension-module DLLs during imports (marimo-lsp#763).
 """
 
 from __future__ import annotations
@@ -11,16 +18,18 @@ from __future__ import annotations
 import atexit
 import contextlib
 import os
+import queue
+import signal
+import subprocess
 import sys
 import threading
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import marimo._ipc as ipc
 import msgspec
-from marimo._config.manager import MarimoConfigReader
-from marimo._session.managers.kernel import KernelManagerImpl
-from marimo._session.managers.queue import QueueManagerImpl
-from marimo._session.model import SessionMode
+from marimo._runtime.commands import StopKernelCommand
+from marimo._session.managers import IPCQueueManagerImpl
 from protocol import (
     HEADER_SIZE,
     MAX_FRAME_SIZE,
@@ -30,6 +39,7 @@ from protocol import (
     FromBridge,
     Input,
     Interrupt,
+    Log,
     Operation,
     Ready,
     Start,
@@ -39,58 +49,11 @@ from protocol import (
 )
 
 if TYPE_CHECKING:
-    from marimo._config.config import MarimoConfig
     from marimo._messaging.types import KernelMessage
 
 _write_lock = threading.Lock()
 _decoder = msgspec.json.Decoder(ToBridge)
-
-
-def _bind_std_handles_to_nul() -> None:
-    """Point this process's Win32 standard handles at the NUL device.
-
-    ``multiprocessing`` spawns children on Windows with ``bInheritHandles=FALSE``
-    and no ``STARTUPINFO``, so the kernel process inherits this bridge's
-    standard handle *values* without the handles themselves. Those dangling
-    numbers end up aliasing whatever unrelated objects reuse them inside the
-    kernel — multiprocessing pipes among them. ``subprocess`` forwards
-    ``GetStdHandle(...)`` results to every child it launches, so a notebook
-    cell's ``subprocess.run(...)`` hands its child an aliased pipe as stdin and
-    the child hangs at startup behind that pipe's pending reads until the next
-    control message happens to complete them (marimo-lsp#734). Rebinding the
-    slots to NUL gives cell subprocesses real, inert handles; streams a cell
-    doesn't redirect land in NUL, matching a windowless host.
-    """
-    import ctypes  # noqa: PLC0415 - Windows-only, in the hook that needs it.
-    import msvcrt  # noqa: PLC0415
-
-    kernel32 = ctypes.windll.kernel32
-    for slot, flags in (
-        (-10, os.O_RDONLY),  # STD_INPUT_HANDLE
-        (-11, os.O_WRONLY),  # STD_OUTPUT_HANDLE
-        (-12, os.O_WRONLY),  # STD_ERROR_HANDLE
-    ):
-        # Deliberately left open for the life of the process.
-        fd = os.open(os.devnull, flags)
-        if not kernel32.SetStdHandle(slot, msvcrt.get_osfhandle(fd)):
-            raise ctypes.WinError()
-
-
-# multiprocessing re-imports this script in every spawned child before running
-# its target, which is the only hook we get into the kernel process itself.
-if sys.platform == "win32" and __name__ == "__mp_main__":
-    _bind_std_handles_to_nul()
-
-
-class _StaticConfigManager(MarimoConfigReader):
-    """Expose the launch-time user config through marimo's manager API."""
-
-    def __init__(self, config: MarimoConfig) -> None:
-        self._user_config = config
-
-    def get_config(self, *, hide_secrets: bool = True) -> MarimoConfig:
-        del hide_secrets
-        return self._user_config
+KERNEL_READY_TIMEOUT = 10.0
 
 
 def _read_frame() -> ToBridge | None:
@@ -116,52 +79,109 @@ def _write_frame(message: FromBridge) -> None:
 
 
 class _Bridge:
-    """Own marimo's edit-mode kernel manager and its stdio adapter."""
+    """Own one native kernel subprocess and its marimo IPC queues."""
 
     def __init__(self) -> None:
-        self._queues: QueueManagerImpl | None = None
-        self._manager: KernelManagerImpl | None = None
-        self._operation_thread: threading.Thread | None = None
+        self._queues: IPCQueueManagerImpl | None = None
+        self._ipc_queues: ipc.QueueManager | None = None
+        self._process: subprocess.Popen[bytes] | None = None
         self._closed = False
 
     def start(self, message: Start) -> None:
-        """Start a regular marimo edit-mode kernel subprocess."""
+        """Create IPC queues and start the kernel subprocess."""
         working_directory = message.working_directory
         path = Path(working_directory)
         if not path.is_absolute() or not path.is_dir():
             msg = f"Invalid kernel working directory: {working_directory}"
             raise ValueError(msg)
 
-        args = message.kernel_args
-        self._queues = QueueManagerImpl(use_multiprocessing=True)
-        self._manager = KernelManagerImpl(
-            queue_manager=self._queues,
-            mode=SessionMode.EDIT,
-            configs=args.configs,
-            app_metadata=args.app_metadata,
-            config_manager=_StaticConfigManager(args.user_config),
-            virtual_file_storage=None,
-            redirect_console_to_browser=args.redirect_console_to_browser,
+        ipc_queues, connection_info = ipc.QueueManager.create()
+        self._ipc_queues = ipc_queues
+        self._queues = IPCQueueManagerImpl.from_ipc(ipc_queues)
+
+        kernel_args = msgspec.structs.replace(
+            message.kernel_args,
+            connection_info=connection_info,
+            parent_pid=os.getpid(),
         )
-        self._manager.start_kernel()
-        self._operation_thread = threading.Thread(
-            target=self._forward_operations,
-            name="kernel-operation-forwarder",
-            daemon=True,
+
+        # Piped standard streams make CreateProcess hand the kernel real
+        # handles, so its fds 0-2 are valid from birth.
+        self._process = subprocess.Popen(
+            [sys.executable, "-m", "marimo._ipc.launch_kernel"],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=working_directory,
         )
-        self._operation_thread.start()
+        assert self._process.stdin is not None
+        self._process.stdin.write(kernel_args.encode_json())
+        self._process.stdin.flush()
+        self._process.stdin.close()
+
+        # Drain stderr before waiting for readiness so a noisy child cannot
+        # fill its pipe and deadlock startup.
+        threading.Thread(target=self._forward_stderr, daemon=True).start()
+        ready = self._wait_for_kernel_ready()
+        if ready != "KERNEL_READY":
+            msg = f"Expected KERNEL_READY, received {ready!r}"
+            raise RuntimeError(msg)
+
+        threading.Thread(target=self._forward_operations, daemon=True).start()
         _write_frame(Ready())
 
-    def _forward_operations(self) -> None:
-        assert self._manager is not None
-        connection = self._manager.kernel_connection
+    def _wait_for_kernel_ready(
+        self,
+        timeout: float = KERNEL_READY_TIMEOUT,
+    ) -> str:
+        """Read the readiness line without allowing startup to hang forever."""
+        assert self._process is not None
+        assert self._process.stdout is not None
+        result: queue.Queue[str | Exception] = queue.Queue(maxsize=1)
+
+        def read_ready() -> None:
+            try:
+                ready = self._process.stdout.readline().decode(errors="replace").strip()
+                result.put(ready)
+            except Exception as error:  # noqa: BLE001
+                result.put(error)
+
+        threading.Thread(target=read_ready, daemon=True).start()
         try:
-            while True:
-                message: KernelMessage = connection.recv()
-                _write_frame(Operation(message=msgspec.Raw(message)))
-        except (EOFError, OSError):
-            if not self._closed:
-                _write_frame(Error(message="Kernel connection closed unexpectedly"))
+            ready = result.get(timeout=timeout)
+        except queue.Empty as error:
+            msg = f"Kernel did not become ready within {timeout:g} seconds"
+            raise TimeoutError(msg) from error
+        if isinstance(ready, Exception):
+            raise ready
+        return ready
+
+    def _forward_operations(self) -> None:
+        assert self._queues is not None
+        stream_queue = self._queues.stream_queue
+        if stream_queue is None:
+            return
+        while not self._closed:
+            try:
+                message: KernelMessage | None = stream_queue.get(timeout=0.1)
+            except queue.Empty:
+                continue
+            if message is None:
+                return
+            _write_frame(Operation(message=msgspec.Raw(message)))
+
+    def _forward_stderr(self) -> None:
+        """Relay kernel stderr as logs and report an unexpected exit."""
+        process = self._process
+        if process is None or process.stderr is None:
+            return
+        for line in process.stderr:
+            _write_frame(Log(message=line.decode(errors="replace").rstrip()))
+        code = process.wait()
+        if not self._closed:
+            _write_frame(
+                Error(message=f"Kernel process exited unexpectedly (code={code})")
+            )
 
     def handle(self, message: ToBridge) -> bool:
         """Apply one command and return whether to keep reading."""
@@ -182,21 +202,41 @@ class _Bridge:
         return True
 
     def interrupt(self) -> None:
-        """Interrupt the kernel subprocess."""
-        if self._closed or self._manager is None:
+        """Interrupt the running kernel."""
+        if self._process is None or self._process.poll() is not None:
             return
-        self._manager.interrupt_kernel()
+        assert self._queues is not None
+        interrupt_queue = self._queues.win32_interrupt_queue
+        if sys.platform == "win32" and interrupt_queue is not None:
+            interrupt_queue.put_nowait(True)  # noqa: FBT003
+        else:
+            os.kill(self._process.pid, signal.SIGINT)
 
     def close(self) -> None:
-        """Stop the kernel exactly once."""
+        """Stop the kernel exactly once and release its queues."""
         if self._closed:
             return
         self._closed = True
-        if self._manager is not None:
+        # Only ask a live kernel to stop: with no connected peer, the zmq
+        # send would block instead of being dropped.
+        if (
+            self._queues is not None
+            and self._process is not None
+            and self._process.poll() is None
+        ):
             with contextlib.suppress(Exception):
-                self._manager.close_kernel()
-        if self._operation_thread is not None:
-            self._operation_thread.join(timeout=1)
+                self._queues.put_control_request(StopKernelCommand())
+        if self._process is not None and self._process.poll() is None:
+            try:
+                self._process.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                self._process.terminate()
+                try:
+                    self._process.wait(timeout=2)
+                except subprocess.TimeoutExpired:
+                    self._process.kill()
+        if self._ipc_queues is not None:
+            self._ipc_queues.close_queues()
 
 
 def _read_start_frame() -> Start:

--- a/extension/resources/wasm/kernel.py
+++ b/extension/resources/wasm/kernel.py
@@ -16,6 +16,7 @@ initialization of extension-module DLLs during imports (marimo-lsp#763).
 from __future__ import annotations
 
 import atexit
+import collections
 import contextlib
 import os
 import queue
@@ -85,6 +86,9 @@ class _Bridge:
         self._queues: IPCQueueManagerImpl | None = None
         self._ipc_queues: ipc.QueueManager | None = None
         self._process: subprocess.Popen[bytes] | None = None
+        self._stderr_tail: collections.deque[str] = collections.deque(maxlen=20)
+        self._stderr_lock = threading.Lock()
+        self._kernel_ready = False
         self._closed = False
 
     def start(self, message: Start) -> None:
@@ -107,17 +111,18 @@ class _Bridge:
 
         # Piped standard streams make CreateProcess hand the kernel real
         # handles, so its fds 0-2 are valid from birth.
-        self._process = subprocess.Popen(
+        process = subprocess.Popen(
             [sys.executable, "-m", "marimo._ipc.launch_kernel"],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             cwd=working_directory,
         )
-        assert self._process.stdin is not None
-        self._process.stdin.write(kernel_args.encode_json())
-        self._process.stdin.flush()
-        self._process.stdin.close()
+        self._process = process
+        assert process.stdin is not None
+        process.stdin.write(kernel_args.encode_json())
+        process.stdin.flush()
+        process.stdin.close()
 
         # Drain stderr before waiting for readiness so a noisy child cannot
         # fill its pipe and deadlock startup.
@@ -125,10 +130,22 @@ class _Bridge:
         ready = self._wait_for_kernel_ready()
         if ready != "KERNEL_READY":
             msg = f"Expected KERNEL_READY, received {ready!r}"
-            raise RuntimeError(msg)
+            raise RuntimeError(self._with_stderr_tail(msg))
+        self._kernel_ready = True
 
+        # Failures before this point are reported by start() alone. Exits
+        # after it are reported by this watcher alone, which cannot exist
+        # during startup.
+        threading.Thread(target=self._watch_kernel_exit, daemon=True).start()
         threading.Thread(target=self._forward_operations, daemon=True).start()
         _write_frame(Ready())
+
+    def _with_stderr_tail(self, message: str) -> str:
+        with self._stderr_lock:
+            tail = "\n".join(self._stderr_tail)
+        if tail:
+            return f"{message}\nKernel stderr:\n{tail}"
+        return message
 
     def _wait_for_kernel_ready(
         self,
@@ -172,13 +189,20 @@ class _Bridge:
             _write_frame(Operation(message=msgspec.Raw(message)))
 
     def _forward_stderr(self) -> None:
-        """Relay kernel stderr as logs and report an unexpected exit."""
+        """Relay kernel stderr lines as logs."""
         process = self._process
         if process is None or process.stderr is None:
             return
         for line in process.stderr:
-            _write_frame(Log(message=line.decode(errors="replace").rstrip()))
-        code = process.wait()
+            text = line.decode(errors="replace").rstrip()
+            with self._stderr_lock:
+                self._stderr_tail.append(text)
+            _write_frame(Log(message=text))
+
+    def _watch_kernel_exit(self) -> None:
+        """Report a kernel that exits after it became ready."""
+        assert self._process is not None
+        code = self._process.wait()
         if not self._closed:
             _write_frame(
                 Error(message=f"Kernel process exited unexpectedly (code={code})")
@@ -218,24 +242,22 @@ class _Bridge:
         if self._closed:
             return
         self._closed = True
-        # Only ask a live kernel to stop: with no connected peer, the zmq
-        # send would block instead of being dropped.
-        if (
-            self._queues is not None
-            and self._process is not None
-            and self._process.poll() is None
-        ):
-            with contextlib.suppress(Exception):
-                self._queues.put_control_request(StopKernelCommand())
-        if self._process is not None and self._process.poll() is None:
-            try:
-                self._process.wait(timeout=2)
-            except subprocess.TimeoutExpired:
-                self._process.terminate()
+        process = self._process
+        if process is not None and process.poll() is None:
+            # Only ask a ready kernel to stop. Before readiness the control
+            # socket may have no connected peer, and the zmq send would block
+            # instead of being dropped.
+            if self._queues is not None and self._kernel_ready:
+                with contextlib.suppress(Exception):
+                    self._queues.put_control_request(StopKernelCommand())
+                    with contextlib.suppress(subprocess.TimeoutExpired):
+                        process.wait(timeout=2)
+            if process.poll() is None:
+                process.terminate()
                 try:
-                    self._process.wait(timeout=2)
+                    process.wait(timeout=2)
                 except subprocess.TimeoutExpired:
-                    self._process.kill()
+                    process.kill()
         if self._ipc_queues is not None:
             self._ipc_queues.close_queues()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,11 @@ build-backend = "uv_build"
 minimum-kernel-version = "0.23.3"
 
 [tool.ty.src]
-exclude = ["extension/**"]
+exclude = ["extension/tutorials/**"]
+
+[tool.ty.environment]
+# Resolves the WASM kernel bridge's flat `protocol` import.
+extra-paths = ["extension/resources/wasm"]
 
 [tool.ruff]
 extend-exclude = ["vscode/*", "extension/tutorials/*"]

--- a/tests/test_wasm_bridge.py
+++ b/tests/test_wasm_bridge.py
@@ -6,6 +6,7 @@ import importlib.util
 import io
 import json
 import logging
+import os
 import queue
 import subprocess
 import sys
@@ -15,7 +16,7 @@ import time
 from pathlib import Path
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
-from unittest.mock import ANY, Mock
+from unittest.mock import Mock
 
 import pytest
 from marimo._ast.app_config import _AppConfig
@@ -57,64 +58,75 @@ def _load_bridge_module(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
     return module
 
 
-def test_interrupt_delegates_to_marimo_kernel_manager(
+def test_windows_interrupt_uses_positional_queue_value(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     bridge_module = _load_bridge_module(monkeypatch)
     bridge = bridge_module._Bridge()
-    bridge._manager = Mock()
+    bridge._process = Mock(pid=42)
+    bridge._process.poll.return_value = None
+    bridge._queues = Mock()
+    interrupt_queue = bridge._queues.win32_interrupt_queue
+    monkeypatch.setattr(sys, "platform", "win32")
 
     bridge.interrupt()
 
-    bridge._manager.interrupt_kernel.assert_called_once_with()
+    interrupt_queue.put_nowait.assert_called_once_with(True)  # noqa: FBT003
 
 
-def test_bridge_uses_normal_edit_mode_multiprocessing_manager(
+def test_kernel_readiness_has_a_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    bridge_module = _load_bridge_module(monkeypatch)
+    bridge = bridge_module._Bridge()
+    release_reader = threading.Event()
+    bridge._process = Mock()
+    bridge._process.stdout.readline.side_effect = lambda: (
+        release_reader.wait(),
+        b"KERNEL_READY\n",
+    )[1]
+
+    with pytest.raises(TimeoutError, match="did not become ready"):
+        bridge._wait_for_kernel_ready(timeout=0.01)
+
+    release_reader.set()
+
+
+def test_bridge_launches_kernel_subprocess_over_marimo_ipc(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
+    """The kernel is a plain subprocess with piped standard streams.
+
+    Pinning the launch path guards against reintroducing multiprocessing
+    spawn, whose dangling standard handle values hang cell subprocesses
+    (marimo-lsp#734) and DLL initialization during imports (marimo-lsp#763)
+    on Windows.
+    """
     bridge_module = _load_bridge_module(monkeypatch)
-    queues = Mock()
-    manager = Mock()
-    manager.kernel_connection.recv.side_effect = EOFError
-    queue_manager = Mock(return_value=queues)
-    kernel_manager = Mock(return_value=manager)
+    process = Mock()
+    process.stdout.readline.return_value = b"KERNEL_READY\n"
+    process.stderr = None
+    popen = Mock(return_value=process)
     write_frame = Mock()
-    monkeypatch.setattr(bridge_module, "QueueManagerImpl", queue_manager)
-    monkeypatch.setattr(bridge_module, "KernelManagerImpl", kernel_manager)
+    monkeypatch.setattr(bridge_module.subprocess, "Popen", popen)
     monkeypatch.setattr(bridge_module, "_write_frame", write_frame)
     bridge = bridge_module._Bridge()
-    args = SimpleNamespace(
-        configs={},
-        app_metadata=Mock(),
-        user_config=Mock(),
-        redirect_console_to_browser=True,
-    )
 
-    bridge.start(
-        SimpleNamespace(
-            working_directory=str(tmp_path),
-            kernel_args=args,
-        )
-    )
-    assert bridge._operation_thread is not None
-    bridge._operation_thread.join(timeout=1)
+    try:
+        bridge.start(_start_frame(tmp_path))
 
-    queue_manager.assert_called_once_with(use_multiprocessing=True)
-    kernel_manager.assert_called_once_with(
-        queue_manager=queues,
-        mode=bridge_module.SessionMode.EDIT,
-        configs={},
-        app_metadata=args.app_metadata,
-        config_manager=ANY,
-        virtual_file_storage=None,
-        redirect_console_to_browser=True,
-    )
-    config_manager = kernel_manager.call_args.kwargs["config_manager"]
-    assert isinstance(config_manager, bridge_module._StaticConfigManager)
-    assert config_manager.get_config() is args.user_config
-    manager.start_kernel.assert_called_once_with()
-    write_frame.assert_any_call(bridge_module.Ready())
+        popen.assert_called_once()
+        command = popen.call_args.args[0]
+        assert command == [sys.executable, "-m", "marimo._ipc.launch_kernel"]
+        assert popen.call_args.kwargs["cwd"] == str(tmp_path)
+        assert popen.call_args.kwargs["stdin"] is bridge_module.subprocess.PIPE
+        assert popen.call_args.kwargs["stdout"] is bridge_module.subprocess.PIPE
+        assert popen.call_args.kwargs["stderr"] is bridge_module.subprocess.PIPE
+        sent = KernelLaunchArgs.decode_json(process.stdin.write.call_args.args[0])
+        assert sent.connection_info is not None
+        assert sent.parent_pid == os.getpid()
+        write_frame.assert_any_call(bridge_module.Ready())
+    finally:
+        bridge.close()
 
 
 class _BridgeProcess:
@@ -279,6 +291,36 @@ def test_cell_running_subprocess_completes_without_further_messages(
         received = bridge.wait_for(_is_completed_run, timeout=60)
 
         assert "cell finished sub-ok" in _console_text(received)
+    finally:
+        bridge.close()
+
+
+def test_kernel_stdin_reads_eof_instead_of_hanging(tmp_path: Path) -> None:
+    """The kernel's standard streams are real handles from birth.
+
+    Regression test for marimo-lsp#763: multiprocessing spawn left the
+    kernel's CRT fds 0-2 holding the bridge's dangling standard-handle
+    values, which later aliased live IPC pipes inside the kernel. Anything
+    touching a standard stream -- a cell subprocess, or the CRT
+    initialization of numpy's OpenBLAS DLL during ``import scipy`` -- then
+    blocked behind the aliased pipe's pending read until unrelated kernel
+    traffic arrived (minutes in VS Code). With a real, already-drained stdin
+    pipe, reading fd 0 returns EOF immediately.
+    """
+    bridge = _BridgeProcess(tmp_path)
+    try:
+        bridge.send(_start_frame(tmp_path))
+        bridge.wait_for(lambda m: isinstance(m, Ready), timeout=90)
+
+        code = "import os; print('stdin:', os.read(0, 1))"
+        bridge.send(
+            Control(
+                request=ExecuteCellsCommand(cell_ids=[CellId_t("c1")], codes=[code])
+            )
+        )
+        received = bridge.wait_for(_is_completed_run, timeout=60)
+
+        assert "stdin: b''" in _console_text(received)
     finally:
         bridge.close()
 

--- a/tests/test_wasm_bridge.py
+++ b/tests/test_wasm_bridge.py
@@ -74,6 +74,77 @@ def test_windows_interrupt_uses_positional_queue_value(
     interrupt_queue.put_nowait.assert_called_once_with(True)  # noqa: FBT003
 
 
+def test_watcher_reports_a_kernel_that_exits_after_readiness(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bridge_module = _load_bridge_module(monkeypatch)
+    write_frame = Mock()
+    monkeypatch.setattr(bridge_module, "_write_frame", write_frame)
+    bridge = bridge_module._Bridge()
+    bridge._process = Mock()
+    bridge._process.wait.return_value = 3
+
+    bridge._watch_kernel_exit()
+
+    error = write_frame.call_args.args[0]
+    assert isinstance(error, bridge_module.Error)
+    assert "code=3" in error.message
+
+
+def test_watcher_stays_quiet_once_the_bridge_is_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bridge_module = _load_bridge_module(monkeypatch)
+    write_frame = Mock()
+    monkeypatch.setattr(bridge_module, "_write_frame", write_frame)
+    bridge = bridge_module._Bridge()
+    bridge._process = Mock()
+    bridge._process.wait.return_value = 0
+    bridge._closed = True
+
+    bridge._watch_kernel_exit()
+
+    write_frame.assert_not_called()
+
+
+def test_close_terminates_an_unready_kernel_without_a_stop_command(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A kernel that never became ready has no connected control socket, so
+    the stop command would block. close() must go straight to terminate."""
+    bridge_module = _load_bridge_module(monkeypatch)
+    bridge = bridge_module._Bridge()
+    process = Mock()
+    process.poll.return_value = None
+    bridge._process = process
+    bridge._queues = Mock()
+    bridge._ipc_queues = Mock()
+
+    bridge.close()
+
+    bridge._queues.put_control_request.assert_not_called()
+    process.terminate.assert_called_once_with()
+    bridge._ipc_queues.close_queues.assert_called_once_with()
+
+
+def test_close_asks_a_ready_kernel_to_stop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bridge_module = _load_bridge_module(monkeypatch)
+    bridge = bridge_module._Bridge()
+    process = Mock()
+    process.poll.return_value = None
+    bridge._process = process
+    bridge._queues = Mock()
+    bridge._ipc_queues = Mock()
+    bridge._kernel_ready = True
+
+    bridge.close()
+
+    request = bridge._queues.put_control_request.call_args.args[0]
+    assert isinstance(request, bridge_module.StopKernelCommand)
+
+
 def test_kernel_readiness_has_a_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
     bridge_module = _load_bridge_module(monkeypatch)
     bridge = bridge_module._Bridge()


### PR DESCRIPTION
#725 moved the bridge from subprocess IPC to marimo's edit-mode multiprocessing to drop a redundant ZeroMQ transport. However, multiprocessing starts Windows children without standard handles, so the kernel's fds 0-2 keep dangling values that can alias its own IPC pipes. #739 fixed this for cell subprocesses by rebinding the Win32 slots, but the CRT fd table still dangles. E.g., during `from scipy import stats`, OpenBLAS DLL initialization peeks fd 0 and blocks for minutes until unrelated kernel traffic arrives (#763).

These changes go back to the #719 approach. The bridge launches the kernel as a subprocess running `marimo._ipc.launch_kernel` with piped streams. The kernel gets real handles and the #739 hook is no longer needed.

Closes #763.