### PR TITLE
Keep notebook caches with their session owner

### DIFF
--- a/extension/src/config/MarimoConfigurationService.ts
+++ b/extension/src/config/MarimoConfigurationService.ts
@@ -25,6 +25,11 @@ type ConfigurationCacheKey = readonly [
   sessionId: NotebookDocumentSession["id"],
 ];
 
+const keyFor = (session: NotebookDocumentSession): ConfigurationCacheKey => [
+  session.notebookId,
+  session.id,
+];
+
 /**
  * Manages marimo configuration state across all notebooks.
  *
@@ -85,7 +90,7 @@ export class MarimoConfigurationService extends Context.Service<MarimoConfigurat
       ) =>
         Effect.gen(function* () {
           const keys: ReadonlyArray<ConfigurationCacheKey> = expectedSession
-            ? [[expectedSession.notebookId, expectedSession.id]]
+            ? [keyFor(expectedSession)]
             : Array.from(yield* Cache.keys(configurationCache)).filter(
                 ([cachedNotebookId]) => cachedNotebookId === notebookUri,
               );
@@ -134,10 +139,7 @@ export class MarimoConfigurationService extends Context.Service<MarimoConfigurat
             );
             return currentSession === undefined
               ? Option.none<MarimoConfig>()
-              : HashMap.get(projection, [
-                  currentSession.notebookId,
-                  currentSession.id,
-                ]);
+              : HashMap.get(projection, keyFor(currentSession));
           }),
           Stream.changes,
         );
@@ -153,7 +155,7 @@ export class MarimoConfigurationService extends Context.Service<MarimoConfigurat
               return yield* fetchConfiguration(notebookUri);
             }
 
-            const key: ConfigurationCacheKey = [session.notebookId, session.id];
+            const key = keyFor(session);
             const config = yield* Cache.get(configurationCache, key);
             yield* projectCurrent(key);
             return config;
@@ -185,10 +187,7 @@ export class MarimoConfigurationService extends Context.Service<MarimoConfigurat
               session !== undefined &&
               documentSessions.current(notebookUri) === session
             ) {
-              const key: ConfigurationCacheKey = [
-                session.notebookId,
-                session.id,
-              ];
+              const key = keyFor(session);
               yield* Cache.set(configurationCache, key, result);
               yield* projectCurrent(key);
             }

--- a/extension/src/config/MarimoConfigurationService.ts
+++ b/extension/src/config/MarimoConfigurationService.ts
@@ -1,6 +1,9 @@
 import {
+  Cache,
   Context,
+  Duration,
   Effect,
+  Exit,
   HashMap,
   Layer,
   Option,
@@ -17,12 +20,16 @@ import { NotebookEditorRegistry } from "../notebook/NotebookEditorRegistry.ts";
 import type { NotebookId } from "../schemas/MarimoNotebookDocument.ts";
 import type { MarimoConfig } from "../types.ts";
 
+type ConfigurationCacheKey = readonly [
+  notebookId: NotebookId,
+  sessionId: NotebookDocumentSession["id"],
+];
+
 /**
  * Manages marimo configuration state across all notebooks.
  *
- * Tracks configuration for each notebook using SubscriptionRef for reactive
- * state management. Configurations are fetched from the LSP server, updated
- * both locally and remotely, and evicted when the notebook closes.
+ * Caches configuration lookups by document session. A SubscriptionRef keeps a
+ * reactive projection of resolved values for stream consumers.
  */
 export class MarimoConfigurationService extends Context.Service<MarimoConfigurationService>()(
   "MarimoConfigurationService",
@@ -32,42 +39,70 @@ export class MarimoConfigurationService extends Context.Service<MarimoConfigurat
       const editorRegistry = yield* NotebookEditorRegistry;
       const documentSessions = yield* NotebookDocumentSessions;
 
-      // Track configurations: NotebookUri -> MarimoConfig
-      const configRef = yield* SubscriptionRef.make(
-        HashMap.empty<NotebookId, MarimoConfig>(),
+      const fetchConfiguration = (notebookUri: NotebookId) =>
+        Effect.gen(function* () {
+          yield* Effect.logTrace("Fetching configuration from LSP").pipe(
+            Effect.annotateLogs({ notebookUri }),
+          );
+          const result = yield* marimo.getConfiguration({
+            notebookUri,
+            inner: {},
+          });
+          yield* Effect.logTrace("Configuration fetched").pipe(
+            Effect.annotateLogs({ notebookUri }),
+          );
+          return result.config;
+        });
+
+      const configurationCache = yield* Cache.makeWith(
+        ([notebookUri]: ConfigurationCacheKey) =>
+          // Cache starts its lookup fiber before publishing the entry. Yield
+          // once so invalidation can always observe an in-flight request.
+          Effect.yieldNow.pipe(Effect.andThen(fetchConfiguration(notebookUri))),
+        {
+          capacity: Number.POSITIVE_INFINITY,
+          // Preserve the previous retry behavior for failed LSP requests.
+          timeToLive: (exit) =>
+            Exit.isSuccess(exit) ? Duration.infinity : Duration.zero,
+        },
       );
-      const cacheOwners = new Map<NotebookId, NotebookDocumentSession>();
-      const cacheGenerations = new Map<NotebookId, symbol>();
-      const generationFor = (notebookUri: NotebookId) => {
-        const existing = cacheGenerations.get(notebookUri);
-        if (existing !== undefined) return existing;
-        const generation = Symbol("configuration cache generation");
-        cacheGenerations.set(notebookUri, generation);
-        return generation;
-      };
+      const configProjection = yield* SubscriptionRef.make(
+        HashMap.empty<ConfigurationCacheKey, MarimoConfig>(),
+      );
+      const projectCurrent = (key: ConfigurationCacheKey) =>
+        Effect.gen(function* () {
+          const current = yield* Cache.getSuccess(configurationCache, key);
+          yield* SubscriptionRef.update(configProjection, (projection) =>
+            Option.match(current, {
+              onNone: () => HashMap.remove(projection, key),
+              onSome: (config) => HashMap.set(projection, key, config),
+            }),
+          );
+        });
       const clearCache = (
         notebookUri: NotebookId,
-        expectedOwner?: NotebookDocumentSession,
+        expectedSession?: NotebookDocumentSession,
       ) =>
-        SubscriptionRef.update(configRef, (map) => {
-          if (
-            expectedOwner !== undefined &&
-            cacheOwners.get(notebookUri) !== expectedOwner
-          ) {
-            return map;
+        Effect.gen(function* () {
+          const keys: ReadonlyArray<ConfigurationCacheKey> = expectedSession
+            ? [[expectedSession.notebookId, expectedSession.id]]
+            : Array.from(yield* Cache.keys(configurationCache)).filter(
+                ([cachedNotebookId]) => cachedNotebookId === notebookUri,
+              );
+          for (const key of keys) {
+            yield* Cache.invalidate(configurationCache, key);
           }
-          cacheOwners.delete(notebookUri);
-          // Deleting keeps the map bounded; an in-flight operation holding
-          // the old symbol fails the equality check either way.
-          cacheGenerations.delete(notebookUri);
-          return HashMap.remove(map, notebookUri);
-        }).pipe(
-          Effect.tap(() =>
-            Effect.logTrace("Cleared configuration cache").pipe(
-              Effect.annotateLogs({ notebookUri }),
-            ),
-          ),
-        );
+          yield* SubscriptionRef.update(configProjection, (projection) => {
+            let next = projection;
+            for (const key of keys) {
+              next = HashMap.remove(next, key);
+            }
+            return next;
+          });
+          yield* Effect.logTrace("Cleared configuration cache").pipe(
+            Effect.annotateLogs({ notebookUri }),
+          );
+        });
 
       yield* Effect.forkScoped(
         documentSessions.changes.pipe(
@@ -87,14 +122,22 @@ export class MarimoConfigurationService extends Context.Service<MarimoConfigurat
        */
       const streamActiveConfigChanges = () =>
         Stream.zipLatest(
-          SubscriptionRef.changes(configRef),
+          SubscriptionRef.changes(configProjection),
           editorRegistry.streamActiveNotebookChanges,
         ).pipe(
-          Stream.map(([map, activeNotebookUri]) => {
+          Stream.map(([projection, activeNotebookUri]) => {
             if (Option.isNone(activeNotebookUri)) {
               return Option.none<MarimoConfig>();
             }
-            return HashMap.get(map, activeNotebookUri.value);
+            const currentSession = documentSessions.current(
+              activeNotebookUri.value,
+            );
+            return currentSession === undefined
+              ? Option.none<MarimoConfig>()
+              : HashMap.get(projection, [
+                  currentSession.notebookId,
+                  currentSession.id,
+                ]);
           }),
           Stream.changes,
         );
@@ -106,48 +149,14 @@ export class MarimoConfigurationService extends Context.Service<MarimoConfigurat
         getConfig(notebookUri: NotebookId) {
           return Effect.gen(function* () {
             const session = documentSessions.current(notebookUri);
-            const generation = generationFor(notebookUri);
-            // First check if we have it cached
-            const map = yield* SubscriptionRef.get(configRef);
-            const cached = HashMap.get(map, notebookUri);
-
-            if (
-              session !== undefined &&
-              cacheOwners.get(notebookUri) === session &&
-              Option.isSome(cached)
-            ) {
-              return cached.value;
+            if (session === undefined) {
+              return yield* fetchConfiguration(notebookUri);
             }
 
-            // Fetch from LSP server
-            yield* Effect.logTrace("Fetching configuration from LSP").pipe(
-              Effect.annotateLogs({ notebookUri }),
-            );
-
-            const result = yield* marimo.getConfiguration({
-              notebookUri,
-              inner: {},
-            });
-
-            // A close may have invalidated this request while it was in
-            // flight. Return its result to the original caller, but never
-            // repopulate a cache belonging to a newer notebook session.
-            let cacheIsCurrent = false;
-            yield* SubscriptionRef.update(configRef, (map) => {
-              cacheIsCurrent =
-                session !== undefined &&
-                documentSessions.current(notebookUri) === session &&
-                cacheGenerations.get(notebookUri) === generation;
-              if (!cacheIsCurrent || session === undefined) return map;
-              cacheOwners.set(notebookUri, session);
-              return HashMap.set(map, notebookUri, result.config);
-            });
-
-            yield* Effect.logTrace("Configuration fetched").pipe(
-              Effect.annotateLogs({ notebookUri, cached: cacheIsCurrent }),
-            );
-
-            return result.config;
+            const key: ConfigurationCacheKey = [session.notebookId, session.id];
+            const config = yield* Cache.get(configurationCache, key);
+            yield* projectCurrent(key);
+            return config;
           });
         },
 
@@ -160,7 +169,6 @@ export class MarimoConfigurationService extends Context.Service<MarimoConfigurat
         ) {
           return Effect.gen(function* () {
             const session = documentSessions.current(notebookUri);
-            const generation = generationFor(notebookUri);
             yield* Effect.logTrace("Updating configuration").pipe(
               Effect.annotateLogs({ notebookUri, config: partialConfig }),
             );
@@ -173,17 +181,17 @@ export class MarimoConfigurationService extends Context.Service<MarimoConfigurat
               },
             });
 
-            yield* SubscriptionRef.update(configRef, (map) => {
-              if (
-                session === undefined ||
-                documentSessions.current(notebookUri) !== session ||
-                cacheGenerations.get(notebookUri) !== generation
-              ) {
-                return map;
-              }
-              cacheOwners.set(notebookUri, session);
-              return HashMap.set(map, notebookUri, result);
-            });
+            if (
+              session !== undefined &&
+              documentSessions.current(notebookUri) === session
+            ) {
+              const key: ConfigurationCacheKey = [
+                session.notebookId,
+                session.id,
+              ];
+              yield* Cache.set(configurationCache, key, result);
+              yield* projectCurrent(key);
+            }
 
             yield* Effect.logTrace("Configuration updated successfully").pipe(
               Effect.annotateLogs({ notebookUri }),

--- a/extension/src/config/__tests__/MarimoConfigurationService.test.ts
+++ b/extension/src/config/__tests__/MarimoConfigurationService.test.ts
@@ -177,6 +177,44 @@ describe("MarimoConfigurationService", () => {
   );
 
   it.effect(
+    "shares an in-flight configuration lookup",
+    Effect.fn(function* () {
+      const requestStarted = yield* Deferred.make<void>();
+      const releaseRequest = yield* Deferred.make<void>();
+      let requests = 0;
+      const ctx = yield* withTestCtx({
+        configStore: new Map([[NOTEBOOK_URI, AUTORUN_CONFIG]]),
+        beforeGetResponse: () =>
+          Effect.sync(() => {
+            requests += 1;
+          }).pipe(
+            Effect.andThen(Deferred.succeed(requestStarted, undefined)),
+            Effect.andThen(Deferred.await(releaseRequest)),
+          ),
+      });
+
+      yield* Effect.gen(function* () {
+        const service = yield* MarimoConfigurationService;
+        const lookups = yield* Effect.forkChild(
+          Effect.all(
+            [service.getConfig(NOTEBOOK_URI), service.getConfig(NOTEBOOK_URI)],
+            { concurrency: "unbounded" },
+          ),
+        );
+        yield* Deferred.await(requestStarted);
+        yield* TestClock.adjust("1 millis");
+
+        expect(requests).toBe(1);
+        yield* Deferred.succeed(releaseRequest, undefined);
+        expect(yield* Fiber.join(lookups)).toEqual([
+          AUTORUN_CONFIG,
+          AUTORUN_CONFIG,
+        ]);
+      }).pipe(Effect.provide(ctx.layer));
+    }),
+  );
+
+  it.effect(
     "should update configuration and cache",
     Effect.fn(function* () {
       const notebookUri = NOTEBOOK_URI;
@@ -291,6 +329,47 @@ describe("MarimoConfigurationService", () => {
           "autorun",
         );
         // The invalid response was not cached; this fetch reaches the server.
+        expect(
+          (yield* service.getConfig(NOTEBOOK_URI)).runtime?.on_cell_change,
+        ).toBe("lazy");
+      }).pipe(Effect.provide(ctx.layer));
+    }),
+  );
+
+  it.effect(
+    "does not restore configuration from a request invalidated by close",
+    Effect.fn(function* () {
+      const requestStarted = yield* Deferred.make<void>();
+      const releaseRequest = yield* Deferred.make<void>();
+      const ctx = yield* withTestCtx({
+        configStore: new Map([[NOTEBOOK_URI, AUTORUN_CONFIG]]),
+        beforeGetResponse: () =>
+          Deferred.succeed(requestStarted, undefined).pipe(
+            Effect.andThen(Deferred.await(releaseRequest)),
+          ),
+      });
+
+      yield* Effect.gen(function* () {
+        const service = yield* MarimoConfigurationService;
+        const document = ctx.initialDocuments[0];
+        assert(document !== undefined);
+        const pending = yield* Effect.forkChild(
+          service.getConfig(NOTEBOOK_URI),
+        );
+        yield* Deferred.await(requestStarted);
+
+        yield* ctx.vscode.closeNotebook(document);
+        yield* TestClock.adjust("1 millis");
+        yield* ctx.setConfig(NOTEBOOK_URI, LAZY_CONFIG);
+        yield* Deferred.succeed(releaseRequest, undefined);
+
+        expect((yield* Fiber.join(pending)).runtime?.on_cell_change).toBe(
+          "autorun",
+        );
+
+        const replacement = createTestNotebookDocument(Uri.parse(NOTEBOOK_URI));
+        yield* ctx.vscode.openNotebook(replacement);
+        yield* TestClock.adjust("1 millis");
         expect(
           (yield* service.getConfig(NOTEBOOK_URI)).runtime?.on_cell_change,
         ).toBe("lazy");

--- a/extension/src/panel/packages/PackagesService.ts
+++ b/extension/src/panel/packages/PackagesService.ts
@@ -1,9 +1,11 @@
 import {
+  Cache,
   Context,
   Effect,
   HashMap,
   Layer,
   Option,
+  Result,
   Stream,
   SubscriptionRef,
 } from "effect";
@@ -43,11 +45,21 @@ interface DependencyTreeState {
   error: string | null;
 }
 
+type DependencyTreeCacheKey = readonly [
+  notebookId: NotebookId,
+  sessionId: NotebookDocumentSession["id"],
+];
+
+const keyFor = (session: NotebookDocumentSession): DependencyTreeCacheKey => [
+  session.notebookId,
+  session.id,
+];
+
 /**
  * Manages dependency trees for notebooks.
  *
- * Stores dependency trees (NotebookUri -> DependencyTreeState) in a
- * SubscriptionRef for reactive state management.
+ * Caches dependency-tree lookups by document session. A SubscriptionRef keeps
+ * the loading and result projection consumed by the packages view.
  */
 export class PackagesService extends Context.Service<PackagesService>()(
   "PackagesService",
@@ -58,42 +70,195 @@ export class PackagesService extends Context.Service<PackagesService>()(
       const editors = yield* NotebookEditorRegistry;
       const documentSessions = yield* NotebookDocumentSessions;
 
-      // Track dependency trees: NotebookUri -> DependencyTreeState
-      const dependencyTreesRef = yield* SubscriptionRef.make(
-        HashMap.empty<NotebookId, DependencyTreeState>(),
+      const dependencyTreeProjection = yield* SubscriptionRef.make(
+        HashMap.empty<DependencyTreeCacheKey, DependencyTreeState>(),
       );
-      const cacheOwners = new Map<NotebookId, NotebookDocumentSession>();
-      const cacheGenerations = new Map<NotebookId, symbol>();
-      const generationFor = (notebookUri: NotebookId) => {
-        const existing = cacheGenerations.get(notebookUri);
-        if (existing !== undefined) return existing;
-        const generation = Symbol("package cache generation");
-        cacheGenerations.set(notebookUri, generation);
-        return generation;
-      };
+      const projectLoading = (key: DependencyTreeCacheKey) =>
+        SubscriptionRef.update(dependencyTreeProjection, (projection) =>
+          HashMap.set(projection, key, {
+            tree: null,
+            loading: true,
+            error: null,
+          }),
+        );
+
+      const loadDependencyTree = (
+        notebookUri: NotebookId,
+        key?: DependencyTreeCacheKey,
+      ) =>
+        Effect.gen(function* () {
+          // Get the active controller; its `target` describes how to ask
+          // the server about the env (`venv` with an executable, or `script`).
+          const activeNotebook = Option.flatMap(
+            yield* editors.getActiveNotebookEditor,
+            (editor) => MarimoNotebookDocument.tryFrom(editor.notebook),
+          );
+          if (Option.isNone(activeNotebook)) {
+            yield* Effect.logWarning("Could not find marimo-notebook editor");
+            return null;
+          }
+
+          const activeController = yield* notebooks.forNotebook(
+            activeNotebook.value.id,
+          ).getController;
+          if (Option.isNone(activeController)) {
+            yield* Effect.logDebug(
+              "No active controller; skipping dependency tree fetch",
+            ).pipe(Effect.annotateLogs({ notebookUri }));
+            return {
+              tree: null,
+              loading: false,
+              error: "No kernel selected",
+            } satisfies DependencyTreeState;
+          }
+
+          const source = controllerSource(activeController.value);
+          if (key !== undefined) yield* projectLoading(key);
+
+          return yield* marimo
+            .getDependencyTree({
+              notebookUri,
+              source,
+              inner: {},
+            })
+            .pipe(
+              Effect.tap((result) =>
+                Effect.logTrace("Fetched dependency tree").pipe(
+                  Effect.annotateLogs({ notebookUri, result }),
+                ),
+              ),
+              Effect.map(
+                (result): DependencyTreeState => ({
+                  tree: result.tree,
+                  loading: false,
+                  error: null,
+                }),
+              ),
+              Effect.catch((error) =>
+                Effect.gen(function* () {
+                  const errorMsg = String(error);
+
+                  // Script mode has no useful fallback — `uv tree --script`
+                  // is the only path that resolves PEP 723 metadata.
+                  if (source.kind === "script") {
+                    yield* Effect.logError(
+                      "Dependency tree failed for script mode",
+                    ).pipe(
+                      Effect.annotateLogs({ notebookUri, error: errorMsg }),
+                    );
+                    return {
+                      tree: null,
+                      loading: false,
+                      error: errorMsg,
+                    } satisfies DependencyTreeState;
+                  }
+
+                  yield* Effect.logWarning(
+                    "Dependency tree failed, falling back to package list",
+                  ).pipe(Effect.annotateLogs({ notebookUri, error: errorMsg }));
+
+                  // Venv fallback: fetch the flat package list (which the
+                  // server backs with `uv pip list -p <exe>`) and synthesize
+                  // a single-level tree from it.
+                  return yield* marimo
+                    .getPackageList({
+                      notebookUri,
+                      source,
+                      inner: {},
+                    })
+                    .pipe(
+                      Effect.map(
+                        (packageListRaw): DependencyTreeState => ({
+                          tree: {
+                            name: "installed-packages",
+                            version: null,
+                            tags: [],
+                            dependencies: packageListRaw.packages.map(
+                              (pkg) => ({
+                                name: pkg.name,
+                                version: pkg.version,
+                                tags: [],
+                                dependencies: [],
+                              }),
+                            ),
+                          },
+                          loading: false,
+                          error: null,
+                        }),
+                      ),
+                      Effect.catch((fallbackError) =>
+                        Effect.gen(function* () {
+                          const fallbackErrorMsg = String(fallbackError);
+                          yield* Effect.logError(
+                            "Package list fallback also failed",
+                          ).pipe(
+                            Effect.annotateLogs({
+                              notebookUri,
+                              error: fallbackErrorMsg,
+                            }),
+                          );
+                          return {
+                            tree: null,
+                            loading: false,
+                            error: `${errorMsg}; fallback also failed: ${fallbackErrorMsg}`,
+                          } satisfies DependencyTreeState;
+                        }),
+                      ),
+                    );
+                }),
+              ),
+            );
+        });
+
+      const dependencyTreeCache = yield* Cache.make({
+        capacity: Number.POSITIVE_INFINITY,
+        lookup: (key: DependencyTreeCacheKey) =>
+          // Cache starts its lookup fiber before publishing the entry. Yield
+          // once so invalidation can always observe an in-flight request.
+          Effect.yieldNow.pipe(Effect.andThen(loadDependencyTree(key[0], key))),
+      });
+      const projectCurrent = (key: DependencyTreeCacheKey) =>
+        Effect.gen(function* () {
+          const current = yield* Cache.getSuccess(dependencyTreeCache, key);
+          yield* SubscriptionRef.update(
+            dependencyTreeProjection,
+            (projection) =>
+              Option.match(current, {
+                onNone: () => HashMap.remove(projection, key),
+                onSome: (state) =>
+                  state === null
+                    ? HashMap.remove(projection, key)
+                    : HashMap.set(projection, key, state),
+              }),
+          );
+        });
       const clearCache = (
         notebookUri: NotebookId,
-        expectedOwner?: NotebookDocumentSession,
+        expectedSession?: NotebookDocumentSession,
       ) =>
-        SubscriptionRef.update(dependencyTreesRef, (map) => {
-          if (
-            expectedOwner !== undefined &&
-            cacheOwners.get(notebookUri) !== expectedOwner
-          ) {
-            return map;
+        Effect.gen(function* () {
+          const keys: ReadonlyArray<DependencyTreeCacheKey> = expectedSession
+            ? [keyFor(expectedSession)]
+            : Array.from(yield* Cache.keys(dependencyTreeCache)).filter(
+                ([cachedNotebookId]) => cachedNotebookId === notebookUri,
+              );
+          for (const key of keys) {
+            yield* Cache.invalidate(dependencyTreeCache, key);
           }
-          cacheOwners.delete(notebookUri);
-          // Deleting keeps the map bounded; an in-flight operation holding
-          // the old symbol fails the equality check either way.
-          cacheGenerations.delete(notebookUri);
-          return HashMap.remove(map, notebookUri);
-        }).pipe(
-          Effect.tap(() =>
-            Effect.logTrace("Cleared package data").pipe(
-              Effect.annotateLogs({ notebookUri }),
-            ),
-          ),
-        );
+          yield* SubscriptionRef.update(
+            dependencyTreeProjection,
+            (projection) =>
+              expectedSession === undefined
+                ? HashMap.filter(
+                    projection,
+                    (_, [cachedNotebookId]) => cachedNotebookId !== notebookUri,
+                  )
+                : HashMap.remove(projection, keyFor(expectedSession)),
+          );
+          yield* Effect.logTrace("Cleared package data").pipe(
+            Effect.annotateLogs({ notebookUri }),
+          );
+        });
 
       yield* Effect.forkScoped(
         documentSessions.changes.pipe(
@@ -110,222 +275,46 @@ export class PackagesService extends Context.Service<PackagesService>()(
          * Get dependency tree state for a notebook
          */
         getDependencyTree(notebookUri: NotebookId) {
-          // Eviction on session end is asynchronous; never serve an entry a
-          // previous document session cached.
-          return Effect.map(SubscriptionRef.get(dependencyTreesRef), (map) =>
-            HashMap.get(map, notebookUri).pipe(
-              Option.filter(() => {
-                const owner = cacheOwners.get(notebookUri);
-                return (
-                  owner !== undefined &&
-                  owner === documentSessions.current(notebookUri)
-                );
-              }),
-            ),
-          );
+          const session = documentSessions.current(notebookUri);
+          return session === undefined
+            ? Effect.succeed(Option.none<DependencyTreeState>())
+            : Effect.map(
+                SubscriptionRef.get(dependencyTreeProjection),
+                HashMap.get(keyFor(session)),
+              );
         },
 
         /**
          * Fetch dependency tree from the language server
-         * Caches the result in dependencyTreesRef and re-uses if already cached
+         * Re-uses successful results from dependencyTreeCache.
          */
         fetchDependencyTree(notebookUri: NotebookId) {
           return Effect.gen(function* () {
             const session = documentSessions.current(notebookUri);
-            const generation = generationFor(notebookUri);
-            const updateIfCurrent = (
-              update: (
-                map: HashMap.HashMap<NotebookId, DependencyTreeState>,
-              ) => HashMap.HashMap<NotebookId, DependencyTreeState>,
-            ) =>
-              SubscriptionRef.update(dependencyTreesRef, (map) => {
-                if (
-                  session === undefined ||
-                  documentSessions.current(notebookUri) !== session ||
-                  cacheGenerations.get(notebookUri) !== generation
-                ) {
-                  return map;
-                }
-                cacheOwners.set(notebookUri, session);
-                return update(map);
-              });
+            if (session === undefined) {
+              return (yield* loadDependencyTree(notebookUri))?.tree ?? null;
+            }
 
-            // Check if we already have a cached tree
-            const cached = yield* SubscriptionRef.get(dependencyTreesRef);
-            const existing = HashMap.get(cached, notebookUri);
-
-            // If we have a tree and it's not in error state, re-use it
+            const key = keyFor(session);
+            const existing = yield* Cache.getSuccess(dependencyTreeCache, key);
             if (
               Option.isSome(existing) &&
-              session !== undefined &&
-              cacheOwners.get(notebookUri) === session &&
-              existing.value.tree &&
-              !existing.value.error
+              existing.value !== null &&
+              existing.value.tree !== null &&
+              existing.value.error === null
             ) {
               yield* Effect.logTrace("Re-using cached dependency tree").pipe(
                 Effect.annotateLogs({ notebookUri }),
               );
               return existing.value.tree;
             }
-
-            // Get the active controller; its `target` describes how to ask
-            // the server about the env (`venv` with an executable, or `script`).
-            const activeNotebook = Option.flatMap(
-              yield* editors.getActiveNotebookEditor,
-              (editor) => MarimoNotebookDocument.tryFrom(editor.notebook),
-            );
-            if (Option.isNone(activeNotebook)) {
-              yield* Effect.logWarning("Could not find marimo-notebook editor");
-              return null;
+            if (Option.isSome(existing)) {
+              yield* Cache.invalidate(dependencyTreeCache, key);
             }
 
-            const activeController = yield* notebooks.forNotebook(
-              activeNotebook.value.id,
-            ).getController;
-            if (Option.isNone(activeController)) {
-              yield* updateIfCurrent((map) =>
-                HashMap.set(map, notebookUri, {
-                  tree: null,
-                  loading: false,
-                  error: "No kernel selected",
-                }),
-              );
-              yield* Effect.logDebug(
-                "No active controller; skipping dependency tree fetch",
-              ).pipe(Effect.annotateLogs({ notebookUri }));
-              return null;
-            }
-
-            const source = controllerSource(activeController.value);
-            yield* updateIfCurrent((map) =>
-              HashMap.set(
-                map,
-                notebookUri,
-                Option.match(HashMap.get(map, notebookUri), {
-                  onNone: () => ({
-                    tree: null,
-                    loading: true,
-                    error: null,
-                  }),
-                  onSome: (value) => ({ ...value, loading: true }),
-                }),
-              ),
-            );
-
-            // Fetch from language server
-            const next = yield* marimo
-              .getDependencyTree({
-                notebookUri,
-                source,
-                inner: {},
-              })
-              .pipe(
-                Effect.tap((result) =>
-                  Effect.logTrace("Fetched dependency tree").pipe(
-                    Effect.annotateLogs({ notebookUri, result }),
-                  ),
-                ),
-                Effect.map(
-                  (result): DependencyTreeState => ({
-                    tree: result.tree,
-                    loading: false,
-                    error: null,
-                  }),
-                ),
-                Effect.catch((error) =>
-                  Effect.gen(function* () {
-                    const errorMsg = String(error);
-
-                    // Script mode has no useful fallback — `uv tree --script`
-                    // is the only path that resolves PEP 723 metadata.
-                    if (source.kind === "script") {
-                      yield* Effect.logError(
-                        "Dependency tree failed for script mode",
-                      ).pipe(
-                        Effect.annotateLogs({ notebookUri, error: errorMsg }),
-                      );
-                      return {
-                        tree: null,
-                        loading: false,
-                        error: errorMsg,
-                      } satisfies DependencyTreeState;
-                    }
-
-                    yield* Effect.logWarning(
-                      "Dependency tree failed, falling back to package list",
-                    ).pipe(
-                      Effect.annotateLogs({ notebookUri, error: errorMsg }),
-                    );
-
-                    // Venv fallback: fetch the flat package list (which the
-                    // server backs with `uv pip list -p <exe>`) and synthesize
-                    // a single-level tree from it.
-                    return yield* marimo
-                      .getPackageList({
-                        notebookUri,
-                        source,
-                        inner: {},
-                      })
-                      .pipe(
-                        Effect.map(
-                          (packageListRaw): DependencyTreeState => ({
-                            tree: {
-                              name: "installed-packages",
-                              version: null,
-                              tags: [],
-                              dependencies: packageListRaw.packages.map(
-                                (pkg) => ({
-                                  name: pkg.name,
-                                  version: pkg.version,
-                                  tags: [],
-                                  dependencies: [],
-                                }),
-                              ),
-                            },
-                            loading: false,
-                            error: null,
-                          }),
-                        ),
-                        Effect.catch((fallbackError) =>
-                          Effect.gen(function* () {
-                            const fallbackErrorMsg = String(fallbackError);
-                            yield* Effect.logError(
-                              "Package list fallback also failed",
-                            ).pipe(
-                              Effect.annotateLogs({
-                                notebookUri,
-                                error: fallbackErrorMsg,
-                              }),
-                            );
-                            return {
-                              tree: null,
-                              loading: false,
-                              error: `${errorMsg}; fallback also failed: ${fallbackErrorMsg}`,
-                            } satisfies DependencyTreeState;
-                          }),
-                        ),
-                      );
-                  }),
-                ),
-              );
-
-            yield* updateIfCurrent((map) =>
-              HashMap.set(map, notebookUri, next),
-            );
-            if (
-              session !== undefined &&
-              documentSessions.current(notebookUri) === session &&
-              cacheGenerations.get(notebookUri) === generation
-            ) {
-              yield* Effect.logTrace("Cached dependency tree").pipe(
-                Effect.annotateLogs({
-                  notebookUri,
-                  hasTree: next.tree !== null,
-                }),
-              );
-            }
-
-            return next.tree;
+            const next = yield* Cache.get(dependencyTreeCache, key);
+            yield* projectCurrent(key);
+            return next?.tree ?? null;
           });
         },
 
@@ -339,8 +328,18 @@ export class PackagesService extends Context.Service<PackagesService>()(
          *
          * Emits the current value on subscription, then all subsequent changes.
          */
-        streamDependencyTreeChanges:
-          SubscriptionRef.changes(dependencyTreesRef),
+        streamDependencyTreeChanges: SubscriptionRef.changes(
+          dependencyTreeProjection,
+        ).pipe(
+          Stream.map((projection) =>
+            HashMap.filterMap(projection, (state, [notebookUri, sessionId]) =>
+              documentSessions.current(notebookUri)?.id === sessionId
+                ? Result.succeed(state)
+                : Result.failVoid,
+            ),
+          ),
+          Stream.changes,
+        ),
       };
     }),
   },

--- a/extension/src/panel/packages/PackagesService.ts
+++ b/extension/src/panel/packages/PackagesService.ts
@@ -213,7 +213,7 @@ export class PackagesService extends Context.Service<PackagesService>()(
             );
 
             // Fetch from language server
-            const rawResult = yield* marimo
+            const next = yield* marimo
               .getDependencyTree({
                 notebookUri,
                 source,
@@ -225,6 +225,13 @@ export class PackagesService extends Context.Service<PackagesService>()(
                     Effect.annotateLogs({ notebookUri, result }),
                   ),
                 ),
+                Effect.map(
+                  (result): DependencyTreeState => ({
+                    tree: result.tree,
+                    loading: false,
+                    error: null,
+                  }),
+                ),
                 Effect.catch((error) =>
                   Effect.gen(function* () {
                     const errorMsg = String(error);
@@ -232,19 +239,16 @@ export class PackagesService extends Context.Service<PackagesService>()(
                     // Script mode has no useful fallback — `uv tree --script`
                     // is the only path that resolves PEP 723 metadata.
                     if (source.kind === "script") {
-                      yield* updateIfCurrent((map) =>
-                        HashMap.set(map, notebookUri, {
-                          tree: null,
-                          loading: false,
-                          error: errorMsg,
-                        }),
-                      );
                       yield* Effect.logError(
                         "Dependency tree failed for script mode",
                       ).pipe(
                         Effect.annotateLogs({ notebookUri, error: errorMsg }),
                       );
-                      return { tree: null };
+                      return {
+                        tree: null,
+                        loading: false,
+                        error: errorMsg,
+                      } satisfies DependencyTreeState;
                     }
 
                     yield* Effect.logWarning(
@@ -256,23 +260,35 @@ export class PackagesService extends Context.Service<PackagesService>()(
                     // Venv fallback: fetch the flat package list (which the
                     // server backs with `uv pip list -p <exe>`) and synthesize
                     // a single-level tree from it.
-                    const packageListRaw = yield* marimo
+                    return yield* marimo
                       .getPackageList({
                         notebookUri,
                         source,
                         inner: {},
                       })
                       .pipe(
+                        Effect.map(
+                          (packageListRaw): DependencyTreeState => ({
+                            tree: {
+                              name: "installed-packages",
+                              version: null,
+                              tags: [],
+                              dependencies: packageListRaw.packages.map(
+                                (pkg) => ({
+                                  name: pkg.name,
+                                  version: pkg.version,
+                                  tags: [],
+                                  dependencies: [],
+                                }),
+                              ),
+                            },
+                            loading: false,
+                            error: null,
+                          }),
+                        ),
                         Effect.catch((fallbackError) =>
                           Effect.gen(function* () {
                             const fallbackErrorMsg = String(fallbackError);
-                            yield* updateIfCurrent((map) =>
-                              HashMap.set(map, notebookUri, {
-                                tree: null,
-                                loading: false,
-                                error: `${errorMsg}; fallback also failed: ${fallbackErrorMsg}`,
-                              }),
-                            );
                             yield* Effect.logError(
                               "Package list fallback also failed",
                             ).pipe(
@@ -281,34 +297,20 @@ export class PackagesService extends Context.Service<PackagesService>()(
                                 error: fallbackErrorMsg,
                               }),
                             );
-                            return { packages: [] };
+                            return {
+                              tree: null,
+                              loading: false,
+                              error: `${errorMsg}; fallback also failed: ${fallbackErrorMsg}`,
+                            } satisfies DependencyTreeState;
                           }),
                         ),
                       );
-
-                    const flatTree: DependencyTreeNode = {
-                      name: "installed-packages",
-                      version: null,
-                      tags: [],
-                      dependencies: packageListRaw.packages.map((pkg) => ({
-                        name: pkg.name,
-                        version: pkg.version,
-                        tags: [],
-                        dependencies: [],
-                      })),
-                    };
-
-                    return { tree: flatTree };
                   }),
                 ),
               );
 
             yield* updateIfCurrent((map) =>
-              HashMap.set(map, notebookUri, {
-                tree: rawResult.tree,
-                loading: false,
-                error: null,
-              }),
+              HashMap.set(map, notebookUri, next),
             );
             if (
               session !== undefined &&
@@ -318,12 +320,12 @@ export class PackagesService extends Context.Service<PackagesService>()(
               yield* Effect.logTrace("Cached dependency tree").pipe(
                 Effect.annotateLogs({
                   notebookUri,
-                  hasTree: rawResult.tree !== null,
+                  hasTree: next.tree !== null,
                 }),
               );
             }
 
-            return rawResult.tree;
+            return next.tree;
           });
         },
 

--- a/extension/src/panel/packages/__tests__/PackagesService.test.ts
+++ b/extension/src/panel/packages/__tests__/PackagesService.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "@effect/vitest";
-import { Deferred, Effect, Fiber, Layer, Option, Stream } from "effect";
+import { Deferred, Effect, Fiber, Layer, Option, Schema, Stream } from "effect";
 import { TestClock } from "effect/testing";
 
 import {
@@ -27,7 +27,7 @@ interface ExecutedCommand {
 const makeContext = Effect.fn(function* (options: {
   controller: Option.Option<NotebookController>;
   treeResponse?: unknown;
-  treeEffect?: Effect.Effect<unknown>;
+  treeEffect?: Effect.Effect<unknown, Schema.SchemaError>;
 }) {
   const document = createTestNotebookDocument(Uri.parse(NOTEBOOK_URI), {
     notebookType: "marimo-notebook",
@@ -186,6 +186,60 @@ describe("PackagesService", () => {
 
       expect(tree).toBeNull();
       expect(recorded).toEqual([]);
+    }),
+  );
+
+  it.effect(
+    "preserves a script dependency-tree failure in package state",
+    Effect.fn(function* () {
+      const failure = Schema.decodeUnknownEffect(Schema.Number)("not a number");
+      const error = yield* Effect.flip(failure);
+      const { layer } = yield* makeContext({
+        controller: Option.some(makeNonPythonController()),
+        treeEffect: failure,
+      });
+
+      yield* Effect.gen(function* () {
+        const svc = yield* PackagesService;
+
+        expect(yield* svc.fetchDependencyTree(NOTEBOOK_URI)).toBeNull();
+        expect(
+          Option.getOrThrow(yield* svc.getDependencyTree(NOTEBOOK_URI)),
+        ).toEqual({
+          tree: null,
+          loading: false,
+          error: String(error),
+        });
+      }).pipe(Effect.provide(layer));
+    }),
+  );
+
+  it.effect(
+    "preserves dependency-tree and package-list failures in package state",
+    Effect.fn(function* () {
+      const failure = Schema.decodeUnknownEffect(Schema.Number)("not a number");
+      const error = yield* Effect.flip(failure);
+      const vscode = yield* TestVsCode.make();
+      const controller = yield* makePythonController(
+        "/home/user/.venv/bin/python",
+      ).pipe(Effect.scoped, Effect.provide(vscode.layer));
+      const { layer } = yield* makeContext({
+        controller: Option.some(controller),
+        treeEffect: failure,
+      });
+
+      yield* Effect.gen(function* () {
+        const svc = yield* PackagesService;
+
+        expect(yield* svc.fetchDependencyTree(NOTEBOOK_URI)).toBeNull();
+        expect(
+          Option.getOrThrow(yield* svc.getDependencyTree(NOTEBOOK_URI)),
+        ).toEqual({
+          tree: null,
+          loading: false,
+          error: `${String(error)}; fallback also failed: ${String(error)}`,
+        });
+      }).pipe(Effect.provide(layer));
     }),
   );
 

--- a/extension/src/panel/packages/__tests__/PackagesService.test.ts
+++ b/extension/src/panel/packages/__tests__/PackagesService.test.ts
@@ -134,6 +134,46 @@ describe("PackagesService", () => {
   );
 
   it.effect(
+    "shares an in-flight dependency tree lookup",
+    Effect.fn(function* () {
+      const requestStarted = yield* Deferred.make<void>();
+      const releaseRequest = yield* Deferred.make<void>();
+      const tree = {
+        name: "<root>",
+        version: null,
+        tags: [],
+        dependencies: [],
+      };
+      const { layer, recorded } = yield* makeContext({
+        controller: Option.some(makeNonPythonController()),
+        treeEffect: Deferred.succeed(requestStarted, undefined).pipe(
+          Effect.andThen(Deferred.await(releaseRequest)),
+          Effect.as({ tree }),
+        ),
+      });
+
+      yield* Effect.gen(function* () {
+        const svc = yield* PackagesService;
+        const lookups = yield* Effect.forkChild(
+          Effect.all(
+            [
+              svc.fetchDependencyTree(NOTEBOOK_URI),
+              svc.fetchDependencyTree(NOTEBOOK_URI),
+            ],
+            { concurrency: "unbounded" },
+          ),
+        );
+        yield* Deferred.await(requestStarted);
+        yield* TestClock.adjust("1 millis");
+
+        expect(recorded).toHaveLength(1);
+        yield* Deferred.succeed(releaseRequest, undefined);
+        expect(yield* Fiber.join(lookups)).toEqual([tree, tree]);
+      }).pipe(Effect.provide(layer));
+    }),
+  );
+
+  it.effect(
     "fetchDependencyTree sends `source: venv` with the executable for a python controller",
     Effect.fn(function* () {
       const vscode = yield* TestVsCode.make();


### PR DESCRIPTION
Configuration and dependency lookups each kept a `SubscriptionRef` value map alongside separate owner and generation maps. That split reimplemented cache misses, in-flight ownership, invalidation, and late-response checks in both services.

Each service now gives `Effect.Cache` a document-session key:

```ts
type CacheKey = readonly [
  notebookId: NotebookId,
  sessionId: NotebookDocumentSession["id"],
];

const cache = yield* Cache.make({
  capacity: Number.POSITIVE_INFINITY,
  lookup: ([notebookId]: CacheKey) => load(notebookId),
});

yield* Cache.get(cache, keyFor(session));
yield* Cache.invalidate(cache, keyFor(session));
```

Cache shares concurrent lookups and owns reusable results and invalidation. `SubscriptionRef` remains only as the reactive projection required by configuration and package streams. Closing or replacing a document invalidates its exact session key, so an older caller can finish without repopulating current state.