### PR TITLE
Own background work by document session

### DIFF
--- a/extension/src/__tests__/__utils__/TestNotebookDocumentSession.ts
+++ b/extension/src/__tests__/__utils__/TestNotebookDocumentSession.ts
@@ -1,4 +1,4 @@
-import { Effect } from "effect";
+import { Effect, Scope } from "effect";
 import type * as vscode from "vscode";
 
 import { type NotebookDocumentSession } from "../../notebook/NotebookDocumentSessions.ts";
@@ -13,5 +13,6 @@ export function makeTestNotebookDocumentSession(
     notebookId: MarimoNotebookDocument.from(document).id,
     document,
     ended: Effect.never,
+    scope: Scope.makeUnsafe(),
   };
 }

--- a/extension/src/__tests__/__utils__/TestNotebookDocumentSession.ts
+++ b/extension/src/__tests__/__utils__/TestNotebookDocumentSession.ts
@@ -1,4 +1,4 @@
-import { Effect, Scope } from "effect";
+import { Scope } from "effect";
 import type * as vscode from "vscode";
 
 import { type NotebookDocumentSession } from "../../notebook/NotebookDocumentSessions.ts";
@@ -12,7 +12,6 @@ export function makeTestNotebookDocumentSession(
     id: makeNotebookDocumentSessionId(),
     notebookId: MarimoNotebookDocument.from(document).id,
     document,
-    ended: Effect.never,
     scope: Scope.makeUnsafe(),
   };
 }

--- a/extension/src/kernel/CellExecutions.ts
+++ b/extension/src/kernel/CellExecutions.ts
@@ -122,7 +122,6 @@ interface CellSource {
 interface NotebookEntry {
   readonly session: NotebookDocumentSession;
   readonly executions: NotebookExecutions;
-  readonly close: Effect.Effect<void>;
   readonly updateSources: (
     sources: ReadonlyArray<CellSource>,
   ) => Effect.Effect<void>;
@@ -158,7 +157,6 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
       const code = yield* VsCode;
       const editorRegistry = yield* NotebookEditorRegistry;
       const documentSessions = yield* NotebookDocumentSessions;
-      const serviceScope = yield* Effect.scope;
       const notebooks = new Map<NotebookId, NotebookEntry>();
       const opening = Semaphore.makeUnsafe(1);
       const allStaleCells = yield* SubscriptionRef.make(
@@ -237,10 +235,9 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
       );
 
       const makeNotebook = Effect.fn("CellExecutions.makeNotebook")(function* (
-        session: NotebookDocumentSession,
+        notebook: MarimoNotebookDocument,
         binding: NotebookExecutionBinding,
       ) {
-        const notebook = MarimoNotebookDocument.from(session.document);
         const notebookId = notebook.id;
         const records = new Map<NotebookCellId, CellRecord>();
         const submittedSources = new Map<
@@ -257,7 +254,8 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
           HashSet.empty<NotebookCellId>(),
         );
         const ordering = Semaphore.makeUnsafe(1);
-        const presentationScope = yield* Scope.fork(serviceScope);
+        const scope = yield* Effect.scope;
+        const presentationScope = yield* Scope.fork(scope);
         const presentation = yield* Queue.unbounded<Work, Cause.Done>();
         let closed = false;
 
@@ -620,11 +618,6 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
           ),
         );
         yield* Scope.addFinalizer(presentationScope, cleanup);
-        const close = Effect.uninterruptible(
-          cleanup.pipe(
-            Effect.andThen(Scope.close(presentationScope, Exit.void)),
-          ),
-        );
 
         const executions: NotebookExecutions = {
           apply,
@@ -637,7 +630,7 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
             changes: SubscriptionRef.changes(staleRef),
           },
         };
-        return { executions, close, updateSources } as const;
+        return { executions, updateSources } as const;
       });
 
       const open = Effect.fn("CellExecutions.open")(function (
@@ -656,34 +649,31 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
             const existing = notebooks.get(notebookId);
             if (existing?.session === session) return existing.executions;
 
-            const made = yield* makeNotebook(session, binding);
-            const displaced = notebooks.get(notebookId);
+            const notebook = MarimoNotebookDocument.from(session.document);
+            const made = yield* Effect.gen(function* () {
+              const made = yield* makeNotebook(notebook, binding);
+              yield* Effect.addFinalizer(() =>
+                Effect.sync(() => {
+                  if (notebooks.get(notebookId)?.session === session) {
+                    notebooks.delete(notebookId);
+                  }
+                }),
+              );
+              return made;
+            }).pipe(Scope.provide(session.scope));
+
+            if (documentSessions.current(notebookId) !== session) {
+              return yield* new NotebookDocumentSessionEndedError({
+                notebookId,
+              });
+            }
+
             const entry: NotebookEntry = { session, ...made };
             notebooks.set(notebookId, entry);
-
-            yield* session.ended.pipe(
-              Effect.andThen(
-                Effect.suspend(() => {
-                  if (notebooks.get(notebookId)?.session !== session) {
-                    return Effect.void;
-                  }
-                  notebooks.delete(notebookId);
-                  return made.close;
-                }),
-              ),
-              Effect.forkIn(serviceScope),
-            );
-            if (displaced !== undefined) yield* displaced.close;
             return made.executions;
           }),
         );
       });
-
-      yield* Effect.addFinalizer(() =>
-        Effect.forEach(notebooks.values(), (entry) => entry.close, {
-          discard: true,
-        }),
-      );
 
       return {
         open,

--- a/extension/src/kernel/CellExecutions.ts
+++ b/extension/src/kernel/CellExecutions.ts
@@ -433,21 +433,20 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
                 drive: Option.none<DriveBinding>(),
               };
               const next = transitionCell(record.run.state, wire);
+              const retainUncorrelatedState = Effect.sync(() => {
+                if (wire.status === "queued") takeSubmittedSource(cellId);
+                // Keep the kernel's state fold even for an op we cannot
+                // correlate to a run — only presentation is withheld.
+                // Late console appends from threads of a finished run
+                // land here, and the kernel remains the source of truth
+                // for cell state.
+                records.set(cellId, {
+                  ...record,
+                  run: { ...record.run, state: next },
+                });
+              });
               const op = yield* correlate(record, next, wire).pipe(
-                Effect.tapError(() =>
-                  Effect.sync(() => {
-                    if (wire.status === "queued") takeSubmittedSource(cellId);
-                    // Keep the kernel's state fold even for an op we cannot
-                    // correlate to a run — only presentation is withheld.
-                    // Late console appends from threads of a finished run
-                    // land here, and the kernel remains the source of truth
-                    // for cell state.
-                    records.set(cellId, {
-                      ...record,
-                      run: { ...record.run, state: next },
-                    });
-                  }),
-                ),
+                Effect.tapError(() => retainUncorrelatedState),
               );
               if (
                 wire.status === "idle" &&

--- a/extension/src/kernel/NotebookExecutor.ts
+++ b/extension/src/kernel/NotebookExecutor.ts
@@ -1,9 +1,12 @@
 import {
   Cause,
+  Data,
   Deferred,
   Effect,
+  Exit,
   Fiber,
   FiberSet,
+  Predicate,
   Queue,
   type Scope,
 } from "effect";
@@ -24,13 +27,30 @@ interface Actor<R> {
   readonly queue: Queue.Queue<Work<R>, Cause.Done>;
 }
 
+/** The scope that owned an admitted notebook command closed before it ended. */
+export class NotebookExecutionScopeClosedError extends Data.TaggedError(
+  "NotebookExecutionScopeClosedError",
+)<{ readonly notebookId: NotebookId }> {}
+
 /** Runs admitted work in FIFO order, independently for each notebook. */
 export interface NotebookExecutor<R> {
   readonly submit: <A, E>(
     notebookId: NotebookId,
     effect: Effect.Effect<A, E, R>,
   ) => Effect.Effect<A, E>;
+  /** Like `submit`, but interrupts queued or running work when `scope` closes. */
+  readonly submitIn: <A, E>(
+    scope: Scope.Scope,
+    notebookId: NotebookId,
+    effect: Effect.Effect<A, E, R>,
+  ) => Effect.Effect<A, E | NotebookExecutionScopeClosedError>;
   readonly post: (
+    notebookId: NotebookId,
+    effect: Effect.Effect<void, never, R>,
+  ) => Effect.Effect<void>;
+  /** Like `post`, but interrupts queued or running work when `scope` closes. */
+  readonly postIn: (
+    scope: Scope.Scope,
     notebookId: NotebookId,
     effect: Effect.Effect<void, never, R>,
   ) => Effect.Effect<void>;
@@ -137,7 +157,36 @@ export function makeNotebookExecutor<R>(): Effect.Effect<
         ),
       );
 
-      const submit = <A, E>(
+      const inScope = <A, E, R2>(
+        effect: Effect.Effect<A, E, R2>,
+        scope: Scope.Scope,
+        notebookId: NotebookId,
+      ): Effect.Effect<A, E | NotebookExecutionScopeClosedError, R2> =>
+        Effect.gen(function* () {
+          if (Predicate.isTagged(scope.state, "Closed")) {
+            return yield* new NotebookExecutionScopeClosedError({
+              notebookId,
+            });
+          }
+          const fiber = yield* Effect.forkIn(effect, scope, {
+            startImmediately: true,
+          });
+          const exit = yield* Fiber.await(fiber).pipe(
+            Effect.onInterrupt(() => Fiber.interrupt(fiber)),
+          );
+          if (
+            Predicate.isTagged(scope.state, "Closed") &&
+            Exit.isFailure(exit) &&
+            Cause.hasInterruptsOnly(exit.cause)
+          ) {
+            return yield* new NotebookExecutionScopeClosedError({
+              notebookId,
+            });
+          }
+          return yield* exit;
+        });
+
+      const submitWork = <A, E>(
         notebookId: NotebookId,
         effect: Effect.Effect<A, E, R>,
       ): Effect.Effect<A, E> =>
@@ -161,7 +210,18 @@ export function makeNotebookExecutor<R>(): Effect.Effect<
           }),
         );
 
-      const post: NotebookExecutor<R>["post"] = (notebookId, effect) =>
+      const submit: NotebookExecutor<R>["submit"] = (notebookId, effect) =>
+        submitWork(notebookId, effect);
+      const submitIn: NotebookExecutor<R>["submitIn"] = (
+        scope,
+        notebookId,
+        effect,
+      ) => submitWork(notebookId, inScope(effect, scope, notebookId));
+
+      const postWork = (
+        notebookId: NotebookId,
+        effect: Effect.Effect<void, never, R>,
+      ) =>
         Effect.uninterruptible(
           Effect.gen(function* () {
             const admitted = yield* Queue.offer(ingress, {
@@ -172,6 +232,22 @@ export function makeNotebookExecutor<R>(): Effect.Effect<
             if (!admitted) return yield* Effect.interrupt;
             return undefined;
           }),
+        );
+      const post: NotebookExecutor<R>["post"] = (notebookId, effect) =>
+        postWork(notebookId, effect);
+      const postIn: NotebookExecutor<R>["postIn"] = (
+        scope,
+        notebookId,
+        effect,
+      ) =>
+        postWork(
+          notebookId,
+          inScope(effect, scope, notebookId).pipe(
+            Effect.catchTag(
+              "NotebookExecutionScopeClosedError",
+              () => Effect.void,
+            ),
+          ),
         );
 
       // Routed through ingress like any work so it runs after everything
@@ -192,7 +268,7 @@ export function makeNotebookExecutor<R>(): Effect.Effect<
           }).pipe(Effect.asVoid),
         );
 
-      return { submit, post, retire };
+      return { submit, submitIn, post, postIn, retire };
     }),
   );
 }

--- a/extension/src/kernel/NotebookRuntime.ts
+++ b/extension/src/kernel/NotebookRuntime.ts
@@ -200,6 +200,7 @@ type RuntimeWorkRequirements =
   | Constants
   | DatasourcesService
   | NotebookEditorRegistry
+  | NotebookDocumentSessions
   | NotebookRenderer
   | OutputChannel
   | PythonEnvInvalidation
@@ -1231,9 +1232,7 @@ function processNotebookOperation(
     });
 
     const forkForSession = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
-      Effect.forkDetach(
-        Effect.raceFirst(effect, options.session.ended).pipe(Effect.asVoid),
-      );
+      Effect.forkIn(effect, options.session.scope).pipe(Effect.asVoid);
 
     if (operation.op === "cell-op") {
       if (extractCellIdFromCellMessage(operation) === SCRATCH_CELL_ID) return;

--- a/extension/src/kernel/NotebookRuntime.ts
+++ b/extension/src/kernel/NotebookRuntime.ts
@@ -371,9 +371,10 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
         controller: Ref.Ref<Option.Option<NotebookController>>,
       ): NotebookDocumentHandle => ({
         executeCells: (request, executable) =>
-          runInNotebook(
-            session.notebookId,
-            Effect.raceFirst(
+          executor
+            .submitIn(
+              session.scope,
+              session.notebookId,
               Effect.gen(function* () {
                 const notebookId = session.notebookId;
                 const notebook = MarimoNotebookDocument.from(session.document);
@@ -416,17 +417,16 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
                   ),
                 ),
               ),
-              session.ended.pipe(
-                Effect.andThen(
-                  Effect.fail(
-                    new NoActiveKernelError({
-                      notebookUri: session.notebookId,
-                    }),
-                  ),
+            )
+            .pipe(
+              Effect.catchTag("NotebookExecutionScopeClosedError", () =>
+                Effect.fail(
+                  new NoActiveKernelError({
+                    notebookUri: session.notebookId,
+                  }),
                 ),
               ),
             ),
-          ),
       });
 
       const makeHandle = (
@@ -688,17 +688,6 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
           ),
           Stream.runForEach((message) => {
             const run = Effect.gen(function* () {
-              // The session is captured when the operation enters the runtime,
-              // not when its per-notebook worker eventually processes it.
-              // This keeps queued operations from an old session out of a
-              // rapidly reopened notebook with the same URI.
-              if (
-                documentSessions.current(message.notebookUri) !==
-                message.session
-              ) {
-                return;
-              }
-
               // The kernel-session gate covers one race: sessionsChanged and
               // kernel notifications arrive on independent streams, so a
               // notification from a kernel replaced by restart can reach this
@@ -733,19 +722,15 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
                 "notification.type",
                 message.notification.op,
               );
-              yield* Effect.raceFirst(
-                processOperation(message, {
-                  forNotebook,
-                  respondToStdin,
-                  session: message.session,
-                }).pipe(
-                  Effect.catchTag(
-                    "NotebookDocumentSessionEndedError",
-                    () => Effect.void,
-                  ),
+              yield* processOperation(message, {
+                forNotebook,
+                respondToStdin,
+                session: message.session,
+              }).pipe(
+                Effect.catchTag(
+                  "NotebookDocumentSessionEndedError",
+                  () => Effect.void,
                 ),
-                message.session.ended,
-              ).pipe(
                 Effect.catchCause(
                   Effect.fn(function* (cause) {
                     yield* Effect.logError(
@@ -777,7 +762,11 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
               ),
               Effect.withSpan("NotebookRuntime.processOperation"),
             );
-            return executor.post(message.notebookUri, run);
+            return executor.postIn(
+              message.session.scope,
+              message.notebookUri,
+              run,
+            );
           }),
         ),
       );
@@ -786,14 +775,10 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
           Stream.runForEach((message) => {
             const session = documentSessions.current(message.notebookUri);
             if (session === undefined) return Effect.void;
-            return executor.post(
+            return executor.postIn(
+              session.scope,
               message.notebookUri,
-              Effect.gen(function* () {
-                if (documentSessions.current(message.notebookUri) !== session) {
-                  return;
-                }
-                yield* variables.updateVariables(session, message.analysis);
-              }),
+              variables.updateVariables(session, message.analysis),
             );
           }),
         ),

--- a/extension/src/kernel/NotebookRuntime.ts
+++ b/extension/src/kernel/NotebookRuntime.ts
@@ -742,23 +742,24 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
                     "NotebookDocumentSessionEndedError",
                     () => Effect.void,
                   ),
-                  Effect.catchCause(
-                    Effect.fn(function* (cause) {
-                      yield* Effect.logError(
-                        "Failed to process marimo operation",
-                      ).pipe(Effect.annotateLogs({ cause }));
-                      yield* Effect.forkChild(
-                        showErrorAndPromptLogs(
-                          "Failed to process marimo operation.",
-                        ),
-                      );
-                    }),
-                  ),
-                  Effect.annotateLogs({
-                    "notification.type": message.notification.op,
-                  }),
                 ),
                 message.session.ended,
+              ).pipe(
+                Effect.catchCause(
+                  Effect.fn(function* (cause) {
+                    yield* Effect.logError(
+                      "Failed to process marimo operation",
+                    ).pipe(Effect.annotateLogs({ cause }));
+                    yield* Effect.forkChild(
+                      showErrorAndPromptLogs(
+                        "Failed to process marimo operation.",
+                      ),
+                    );
+                  }),
+                ),
+                Effect.annotateLogs({
+                  "notification.type": message.notification.op,
+                }),
               );
             }).pipe(
               Effect.catchCause(

--- a/extension/src/kernel/__tests__/NotebookExecutor.test.ts
+++ b/extension/src/kernel/__tests__/NotebookExecutor.test.ts
@@ -1,8 +1,11 @@
-import { assert, describe, it } from "@effect/vitest";
-import { Effect, Exit, Fiber, Latch, Ref, Scope } from "effect";
+import { assert, describe, expect, it } from "@effect/vitest";
+import { Cause, Effect, Exit, Fiber, Latch, Ref, Scope } from "effect";
 
 import { notebookId } from "../../lib/__tests__/branded.ts";
-import { makeNotebookExecutor } from "../NotebookExecutor.ts";
+import {
+  makeNotebookExecutor,
+  NotebookExecutionScopeClosedError,
+} from "../NotebookExecutor.ts";
 
 describe("NotebookExecutor", () => {
   it.effect(
@@ -85,6 +88,69 @@ describe("NotebookExecutor", () => {
         executor.post(notebook, Effect.void),
       );
       assert.isTrue(Exit.hasInterrupts(postAfterClose));
+    }),
+  );
+
+  it.effect(
+    "interrupts work owned by a document scope without closing the executor",
+    Effect.fn(function* () {
+      const executor = yield* makeNotebookExecutor<never>();
+      const documentScope = yield* Scope.make();
+      const started = yield* Latch.make();
+      const bufferedStarted = yield* Ref.make(false);
+      const notebook = notebookId("notebook");
+
+      const active = yield* executor
+        .submitIn(
+          documentScope,
+          notebook,
+          started.open.pipe(Effect.andThen(Effect.never)),
+        )
+        .pipe(Effect.forkDetach);
+      yield* started.await;
+
+      const buffered = yield* executor
+        .submitIn(
+          documentScope,
+          notebook,
+          Ref.set(bufferedStarted, true).pipe(Effect.andThen(Effect.never)),
+        )
+        .pipe(Effect.forkDetach);
+      yield* Effect.yieldNow;
+
+      yield* Scope.close(documentScope, Exit.void);
+      const [activeExit, bufferedExit] = yield* Effect.all([
+        Fiber.await(active),
+        Fiber.await(buffered),
+      ]);
+
+      for (const exit of [activeExit, bufferedExit]) {
+        assert.isTrue(Exit.isFailure(exit));
+        if (!Exit.isFailure(exit)) continue;
+        const failure = exit.cause.reasons.find(Cause.isFailReason);
+        assert.instanceOf(failure?.error, NotebookExecutionScopeClosedError);
+        expect(failure?.error).toMatchObject({ notebookId: notebook });
+      }
+      assert.isFalse(yield* Ref.get(bufferedStarted));
+
+      const result = yield* executor.submit(notebook, Effect.succeed("done"));
+      assert.strictEqual(result, "done");
+    }),
+  );
+
+  it.effect(
+    "preserves self-interruption while the owning scope remains open",
+    Effect.fn(function* () {
+      const executor = yield* makeNotebookExecutor<never>();
+      const documentScope = yield* Scope.make();
+      const notebook = notebookId("notebook");
+
+      const submitted = yield* executor
+        .submitIn(documentScope, notebook, Effect.interrupt)
+        .pipe(Effect.forkDetach);
+
+      assert.isTrue(Exit.hasInterrupts(yield* Fiber.await(submitted)));
+      yield* Scope.close(documentScope, Exit.void);
     }),
   );
 

--- a/extension/src/kernel/__tests__/NotebookRuntimeOperations.test.ts
+++ b/extension/src/kernel/__tests__/NotebookRuntimeOperations.test.ts
@@ -2,6 +2,7 @@ import * as NodePath from "node:path";
 
 import { assert, describe, expect, it } from "@effect/vitest";
 import {
+  Deferred,
   Effect,
   Fiber,
   Latch,
@@ -62,6 +63,9 @@ const REPLACEMENT_SESSION_ID = kernelSessionId(
 
 const withTestCtx = Effect.fn(function* (
   activeSessionId: KernelSessionId = ACTIVE_SESSION_ID,
+  workspace: {
+    readonly applyEdit?: () => Effect.Effect<boolean>;
+  } = {},
 ) {
   // Controllable showInputBox via Queue
   const inputQueue = yield* Queue.unbounded<Option.Option<string>>();
@@ -71,6 +75,7 @@ const withTestCtx = Effect.fn(function* (
   const executions = yield* SubscriptionRef.make<ReadonlyArray<MarimoApiCall>>(
     [],
   );
+  const errorMessages = yield* Ref.make<ReadonlyArray<string>>([]);
 
   // PubSub to push operations into NotebookRuntime
   const operationsPubSub = yield* PubSub.unbounded<KernelNotification>();
@@ -117,9 +122,14 @@ const withTestCtx = Effect.fn(function* (
 
   const vscode = yield* TestVsCode.make({
     initialDocuments: [editor.notebook],
+    workspace,
     window: {
       showInputBox: () =>
         inputRequested.open.pipe(Effect.andThen(Queue.take(inputQueue))),
+      showErrorMessage: (message) =>
+        Ref.update(errorMessages, (messages) => [...messages, message]).pipe(
+          Effect.as(Option.none()),
+        ),
     },
   });
   const cellDrive = yield* VsCodeCellDrive.make.pipe(
@@ -218,6 +228,7 @@ const withTestCtx = Effect.fn(function* (
     notebookUri,
     mockController,
     executions,
+    errorMessages,
     inputQueue,
     inputRequested,
     operationsPubSub,
@@ -358,6 +369,50 @@ describe("NotebookRuntime operation processing", () => {
       yield* secondProcessed.await;
 
       assert.deepStrictEqual(yield* Ref.get(processed), ["b-1", "a-1", "a-2"]);
+    }),
+  );
+
+  it.effect(
+    "does not report session cancellation as an operation failure",
+    Effect.fn(function* () {
+      const editStarted = yield* Deferred.make<void>();
+      const ctx = yield* withTestCtx(ACTIVE_SESSION_ID, {
+        applyEdit: () =>
+          Deferred.succeed(editStarted, undefined).pipe(
+            Effect.andThen(Effect.never),
+          ),
+      });
+
+      yield* Effect.gen(function* () {
+        yield* NotebookRuntime;
+        yield* ctx.vscode.setActiveNotebookEditor(Option.some(ctx.editor));
+        yield* TestClock.adjust("1 millis");
+
+        yield* PubSub.publish(ctx.operationsPubSub, {
+          notebookUri: ctx.notebookUri,
+          sessionId: ACTIVE_SESSION_ID,
+          notification: {
+            op: "notebook-document-transaction",
+            transaction: {
+              changes: [
+                {
+                  type: "set-code",
+                  cellId: cellId("cell-1"),
+                  code: "name = 'closed'",
+                },
+              ],
+              source: "code-mode",
+              version: 1,
+            },
+          },
+        });
+        yield* Deferred.await(editStarted);
+
+        yield* ctx.vscode.closeNotebook(ctx.editor.notebook);
+        yield* TestClock.adjust("1 millis");
+
+        expect(yield* Ref.get(ctx.errorMessages)).toEqual([]);
+      }).pipe(Effect.provide(ctx.layer));
     }),
   );
 });

--- a/extension/src/notebook/NotebookDocumentSessions.ts
+++ b/extension/src/notebook/NotebookDocumentSessions.ts
@@ -1,11 +1,13 @@
 import {
   Context,
   Data,
-  Deferred,
   Effect,
   Exit,
+  HashMap,
   Layer,
+  Option,
   PubSub,
+  Ref,
   Scope,
   Stream,
 } from "effect";
@@ -32,20 +34,16 @@ export interface NotebookDocumentSession {
   readonly id: NotebookDocumentSessionId;
   readonly notebookId: NotebookId;
   readonly document: vscode.NotebookDocument;
-  readonly ended: Effect.Effect<void>;
-  /** Lifetime of work owned by this opening of the document. */
+  /** Lifetime of work and resources tied to this exact document opening. */
   readonly scope: Scope.Scope;
 }
 
-export type NotebookDocumentSessionChange =
-  | {
-      readonly _tag: "Opened";
-      readonly session: NotebookDocumentSession;
-    }
-  | {
-      readonly _tag: "Ended";
-      readonly session: NotebookDocumentSession;
-    };
+export type NotebookDocumentSessionChange = Data.TaggedEnum<{
+  Opened: { readonly session: NotebookDocumentSession };
+  Ended: { readonly session: NotebookDocumentSession };
+}>;
+export const NotebookDocumentSessionChange =
+  Data.taggedEnum<NotebookDocumentSessionChange>();
 
 export class NotebookDocumentSessionEndedError extends Data.TaggedError(
   "NotebookDocumentSessionEndedError",
@@ -53,9 +51,14 @@ export class NotebookDocumentSessionEndedError extends Data.TaggedError(
 
 interface SessionEntry {
   readonly session: NotebookDocumentSession;
-  readonly end: Deferred.Deferred<void>;
   readonly scope: Scope.Closeable;
 }
+
+type InstallResult = Data.TaggedEnum<{
+  Existing: { readonly current: SessionEntry };
+  Installed: { readonly displaced: SessionEntry | undefined };
+}>;
+const InstallResult = Data.taggedEnum<InstallResult>();
 
 /** Tracks the current document session for each notebook URI. */
 export class NotebookDocumentSessions extends Context.Service<NotebookDocumentSessions>()(
@@ -64,62 +67,99 @@ export class NotebookDocumentSessions extends Context.Service<NotebookDocumentSe
     make: Effect.gen(function* () {
       const code = yield* VsCode;
       const serviceScope = yield* Effect.scope;
-      const sessions = new Map<NotebookId, SessionEntry>();
+      const sessions = yield* Ref.make(
+        HashMap.empty<NotebookId, SessionEntry>(),
+      );
       const changes = yield* PubSub.unbounded<NotebookDocumentSessionChange>();
 
-      const end = Effect.fn(function* (entry: SessionEntry) {
-        yield* Deferred.succeed(entry.end, undefined);
-        yield* Scope.close(entry.scope, Exit.void);
-        const change: NotebookDocumentSessionChange = {
-          _tag: "Ended",
-          session: entry.session,
-        };
-        yield* PubSub.publish(changes, change);
-      });
-
-      const markOpen = Effect.fn(function* (document: vscode.NotebookDocument) {
-        // The lifecycle replay can deliver an opened event for a document
-        // that was since closed or replaced at the same URI; a closed
-        // document never starts a session.
-        if (document.isClosed) return undefined;
-        const notebook = MarimoNotebookDocument.tryFrom(document);
-        if (notebook._tag === "None") return undefined;
-
-        const existing = sessions.get(notebook.value.id);
-        if (existing?.session.document === document) return existing.session;
-
-        const ended = yield* Deferred.make<void>();
-        const scope = yield* Scope.fork(serviceScope, "parallel");
-        const session: NotebookDocumentSession = {
-          id: makeNotebookDocumentSessionId(),
-          notebookId: notebook.value.id,
-          document,
-          ended: Deferred.await(ended),
-          scope,
-        };
-        sessions.set(notebook.value.id, { session, end: ended, scope });
-
-        if (existing) yield* end(existing);
-        const change: NotebookDocumentSessionChange = {
-          _tag: "Opened",
-          session,
-        };
-        yield* PubSub.publish(changes, change);
-        return session;
-      });
-
-      const markClosed = Effect.fn(function* (
-        document: vscode.NotebookDocument,
+      const end = Effect.fn("NotebookDocumentSessions.end")(function* (
+        entry: SessionEntry,
       ) {
-        const notebook = MarimoNotebookDocument.tryFrom(document);
-        if (notebook._tag === "None") return;
-
-        const current = sessions.get(notebook.value.id);
-        if (current?.session.document !== document) return;
-
-        sessions.delete(notebook.value.id);
-        yield* end(current);
+        yield* Scope.close(entry.scope, Exit.void);
+        yield* PubSub.publish(
+          changes,
+          NotebookDocumentSessionChange.Ended({
+            session: entry.session,
+          }),
+        );
       });
+
+      const markOpen = Effect.fn("NotebookDocumentSessions.markOpen")(
+        function* (document: vscode.NotebookDocument) {
+          // The lifecycle replay can deliver an opened event for a document
+          // that was since closed or replaced at the same URI; a closed
+          // document never starts a session.
+          if (document.isClosed) return undefined;
+          const notebook = MarimoNotebookDocument.tryFrom(document);
+          if (notebook._tag === "None") return undefined;
+
+          const scope = yield* Scope.fork(serviceScope, "parallel");
+          const session: NotebookDocumentSession = {
+            id: makeNotebookDocumentSessionId(),
+            notebookId: notebook.value.id,
+            document,
+            scope,
+          };
+          const candidate: SessionEntry = { session, scope };
+          const result = yield* Ref.modify(
+            sessions,
+            (
+              current,
+            ): readonly [
+              InstallResult,
+              HashMap.HashMap<NotebookId, SessionEntry>,
+            ] => {
+              const existing = HashMap.get(current, notebook.value.id);
+              if (
+                Option.isSome(existing) &&
+                existing.value.session.document === document
+              ) {
+                return [
+                  InstallResult.Existing({ current: existing.value }),
+                  current,
+                ];
+              }
+              return [
+                InstallResult.Installed({
+                  displaced: Option.getOrUndefined(existing),
+                }),
+                HashMap.set(current, notebook.value.id, candidate),
+              ];
+            },
+          );
+
+          if (InstallResult.$is("Existing")(result)) {
+            yield* Scope.close(scope, Exit.void);
+            return result.current.session;
+          }
+
+          if (result.displaced !== undefined) yield* end(result.displaced);
+          yield* PubSub.publish(
+            changes,
+            NotebookDocumentSessionChange.Opened({ session }),
+          );
+          return session;
+        },
+      );
+
+      const markClosed = Effect.fn("NotebookDocumentSessions.markClosed")(
+        function* (document: vscode.NotebookDocument) {
+          const notebook = MarimoNotebookDocument.tryFrom(document);
+          if (notebook._tag === "None") return;
+
+          const removed = yield* Ref.modify(sessions, (current) => {
+            const entry = HashMap.get(current, notebook.value.id);
+            if (
+              Option.isNone(entry) ||
+              entry.value.session.document !== document
+            ) {
+              return [Option.none<SessionEntry>(), current];
+            }
+            return [entry, HashMap.remove(current, notebook.value.id)];
+          });
+          if (Option.isSome(removed)) yield* end(removed.value);
+        },
+      );
 
       const lifecycle = yield* code.workspace.subscribeNotebookLifecycle;
       const openDocuments = yield* code.workspace.getNotebookDocuments;
@@ -136,17 +176,28 @@ export class NotebookDocumentSessions extends Context.Service<NotebookDocumentSe
 
       yield* Effect.addFinalizer(() =>
         Effect.gen(function* () {
-          yield* Effect.forEach(sessions.values(), end, { discard: true });
+          const current = yield* Ref.getAndSet(
+            sessions,
+            HashMap.empty<NotebookId, SessionEntry>(),
+          );
+          yield* Effect.forEach(HashMap.values(current), end, {
+            discard: true,
+          });
           yield* PubSub.shutdown(changes);
         }),
       );
 
       return {
-        current: (notebookId: NotebookId) => sessions.get(notebookId)?.session,
+        current: (notebookId: NotebookId) =>
+          Option.getOrUndefined(
+            HashMap.get(Ref.getUnsafe(sessions), notebookId),
+          )?.session,
         forDocument(document: vscode.NotebookDocument) {
           const notebook = MarimoNotebookDocument.tryFrom(document);
           if (notebook._tag === "None") return undefined;
-          const session = sessions.get(notebook.value.id)?.session;
+          const session = Option.getOrUndefined(
+            HashMap.get(Ref.getUnsafe(sessions), notebook.value.id),
+          )?.session;
           return session?.document === document ? session : undefined;
         },
         changes: Stream.fromPubSub(changes),

--- a/extension/src/notebook/NotebookDocumentSessions.ts
+++ b/extension/src/notebook/NotebookDocumentSessions.ts
@@ -1,4 +1,14 @@
-import { Context, Data, Deferred, Effect, Layer, PubSub, Stream } from "effect";
+import {
+  Context,
+  Data,
+  Deferred,
+  Effect,
+  Exit,
+  Layer,
+  PubSub,
+  Scope,
+  Stream,
+} from "effect";
 import type * as vscode from "vscode";
 
 import { VsCode } from "../platform/VsCode.ts";
@@ -23,6 +33,8 @@ export interface NotebookDocumentSession {
   readonly notebookId: NotebookId;
   readonly document: vscode.NotebookDocument;
   readonly ended: Effect.Effect<void>;
+  /** Lifetime of work owned by this opening of the document. */
+  readonly scope: Scope.Scope;
 }
 
 export type NotebookDocumentSessionChange =
@@ -42,6 +54,7 @@ export class NotebookDocumentSessionEndedError extends Data.TaggedError(
 interface SessionEntry {
   readonly session: NotebookDocumentSession;
   readonly end: Deferred.Deferred<void>;
+  readonly scope: Scope.Closeable;
 }
 
 /** Tracks the current document session for each notebook URI. */
@@ -50,19 +63,21 @@ export class NotebookDocumentSessions extends Context.Service<NotebookDocumentSe
   {
     make: Effect.gen(function* () {
       const code = yield* VsCode;
+      const serviceScope = yield* Effect.scope;
       const sessions = new Map<NotebookId, SessionEntry>();
       const changes = yield* PubSub.unbounded<NotebookDocumentSessionChange>();
 
-      const end = (entry: SessionEntry) => {
-        Deferred.doneUnsafe(entry.end, Effect.void);
+      const end = Effect.fn(function* (entry: SessionEntry) {
+        yield* Deferred.succeed(entry.end, undefined);
+        yield* Scope.close(entry.scope, Exit.void);
         const change: NotebookDocumentSessionChange = {
           _tag: "Ended",
           session: entry.session,
         };
-        PubSub.publishUnsafe(changes, change);
-      };
+        yield* PubSub.publish(changes, change);
+      });
 
-      const markOpen = (document: vscode.NotebookDocument) => {
+      const markOpen = Effect.fn(function* (document: vscode.NotebookDocument) {
         // The lifecycle replay can deliver an opened event for a document
         // that was since closed or replaced at the same URI; a closed
         // document never starts a session.
@@ -73,25 +88,29 @@ export class NotebookDocumentSessions extends Context.Service<NotebookDocumentSe
         const existing = sessions.get(notebook.value.id);
         if (existing?.session.document === document) return existing.session;
 
-        const ended = Deferred.makeUnsafe<void>();
+        const ended = yield* Deferred.make<void>();
+        const scope = yield* Scope.fork(serviceScope, "parallel");
         const session: NotebookDocumentSession = {
           id: makeNotebookDocumentSessionId(),
           notebookId: notebook.value.id,
           document,
           ended: Deferred.await(ended),
+          scope,
         };
-        sessions.set(notebook.value.id, { session, end: ended });
+        sessions.set(notebook.value.id, { session, end: ended, scope });
 
-        if (existing) end(existing);
+        if (existing) yield* end(existing);
         const change: NotebookDocumentSessionChange = {
           _tag: "Opened",
           session,
         };
-        PubSub.publishUnsafe(changes, change);
+        yield* PubSub.publish(changes, change);
         return session;
-      };
+      });
 
-      const markClosed = (document: vscode.NotebookDocument) => {
+      const markClosed = Effect.fn(function* (
+        document: vscode.NotebookDocument,
+      ) {
         const notebook = MarimoNotebookDocument.tryFrom(document);
         if (notebook._tag === "None") return;
 
@@ -99,27 +118,25 @@ export class NotebookDocumentSessions extends Context.Service<NotebookDocumentSe
         if (current?.session.document !== document) return;
 
         sessions.delete(notebook.value.id);
-        end(current);
-      };
+        yield* end(current);
+      });
 
       const lifecycle = yield* code.workspace.subscribeNotebookLifecycle;
       const openDocuments = yield* code.workspace.getNotebookDocuments;
-      for (const document of openDocuments) markOpen(document);
+      yield* Effect.forEach(openDocuments, markOpen, { discard: true });
       yield* Effect.forkScoped(
         lifecycle.pipe(
           Stream.runForEach((event) =>
-            Effect.sync(() =>
-              event.type === "opened"
-                ? markOpen(event.document)
-                : markClosed(event.document),
-            ),
+            event.type === "opened"
+              ? markOpen(event.document)
+              : markClosed(event.document),
           ),
         ),
       );
 
       yield* Effect.addFinalizer(() =>
         Effect.gen(function* () {
-          for (const entry of sessions.values()) end(entry);
+          yield* Effect.forEach(sessions.values(), end, { discard: true });
           yield* PubSub.shutdown(changes);
         }),
       );

--- a/extension/src/notebook/__tests__/NotebookDocumentSessions.test.ts
+++ b/extension/src/notebook/__tests__/NotebookDocumentSessions.test.ts
@@ -1,5 +1,5 @@
 import { expect, it } from "@effect/vitest";
-import { Deferred, Effect, Fiber, Layer, Option, Scope } from "effect";
+import { Deferred, Effect, Layer, Option, Scope } from "effect";
 
 import {
   createTestNotebookDocument,
@@ -27,9 +27,12 @@ it.effect(
       expect(firstSession?.document).toBe(first);
       if (firstSession === undefined) return;
 
-      const firstEnded = yield* Effect.forkChild(firstSession.ended);
+      const firstEnded = yield* Deferred.make<void>();
+      yield* Effect.addFinalizer(() =>
+        Deferred.succeed(firstEnded, undefined),
+      ).pipe(Scope.provide(firstSession.scope));
       yield* vscode.openNotebook(replacement);
-      yield* Fiber.join(firstEnded);
+      yield* Deferred.await(firstEnded);
 
       const replacementSession = sessions.current(id);
       expect(replacementSession?.document).toBe(replacement);
@@ -41,11 +44,12 @@ it.effect(
       yield* Effect.yieldNow;
       expect(sessions.current(id)).toBe(replacementSession);
 
-      const replacementEnded = yield* Effect.forkChild(
-        replacementSession.ended,
-      );
+      const replacementEnded = yield* Deferred.make<void>();
+      yield* Effect.addFinalizer(() =>
+        Deferred.succeed(replacementEnded, undefined),
+      ).pipe(Scope.provide(replacementSession.scope));
       yield* vscode.closeNotebook(replacement);
-      yield* Fiber.join(replacementEnded);
+      yield* Deferred.await(replacementEnded);
       expect(sessions.current(id)).toBeUndefined();
     }).pipe(Effect.provide(layer));
   }),

--- a/extension/src/notebook/__tests__/NotebookDocumentSessions.test.ts
+++ b/extension/src/notebook/__tests__/NotebookDocumentSessions.test.ts
@@ -1,5 +1,5 @@
 import { expect, it } from "@effect/vitest";
-import { Effect, Fiber, Layer } from "effect";
+import { Deferred, Effect, Fiber, Layer, Option, Scope } from "effect";
 
 import {
   createTestNotebookDocument,
@@ -74,6 +74,59 @@ it.effect(
       yield* vscode.openNotebook(replacement);
       yield* Effect.yieldNow;
       expect(sessions.current(id)?.document).toBe(replacement);
+    }).pipe(Effect.provide(layer));
+  }),
+);
+
+it.effect(
+  "a document session owns scoped work and finalizers",
+  Effect.fn(function* () {
+    const uri = Uri.parse("file:///test/notebook.py");
+    const id = notebookId(uri.toString());
+    const document = createTestNotebookDocument(uri);
+    const vscode = yield* TestVsCode.make({ initialDocuments: [document] });
+    const layer = NotebookDocumentSessions.layer.pipe(
+      Layer.provideMerge(vscode.layer),
+    );
+    const backgroundStarted = yield* Deferred.make<void>();
+    const backgroundStopped = yield* Deferred.make<void>();
+    const finalized = yield* Deferred.make<void>();
+    const lateFinalizer = yield* Deferred.make<void>();
+    const staleBackgroundStarted = yield* Deferred.make<void>();
+
+    yield* Effect.gen(function* () {
+      const sessions = yield* NotebookDocumentSessions;
+      const session = sessions.current(id);
+      expect(session).toBeDefined();
+      if (session === undefined) return;
+
+      yield* Effect.addFinalizer(() =>
+        Deferred.succeed(finalized, undefined),
+      ).pipe(Scope.provide(session.scope));
+      yield* Effect.forkIn(
+        Deferred.succeed(backgroundStarted, undefined).pipe(
+          Effect.andThen(Effect.never),
+          Effect.ensuring(Deferred.succeed(backgroundStopped, undefined)),
+        ),
+        session.scope,
+      );
+      yield* Deferred.await(backgroundStarted);
+
+      yield* vscode.closeNotebook(document);
+      yield* Deferred.await(backgroundStopped);
+      yield* Deferred.await(finalized);
+
+      yield* Effect.addFinalizer(() =>
+        Deferred.succeed(lateFinalizer, undefined),
+      ).pipe(Scope.provide(session.scope));
+      yield* Deferred.await(lateFinalizer);
+      yield* Effect.forkIn(
+        Deferred.succeed(staleBackgroundStarted, undefined),
+        session.scope,
+      );
+      expect(Option.isNone(yield* Deferred.poll(staleBackgroundStarted))).toBe(
+        true,
+      );
     }).pipe(Effect.provide(layer));
   }),
 );


### PR DESCRIPTION
Prompts and alerts previously used detached fibers. `CellExecutions` watched `session.ended` to call a returned close effect.

Each open document now owns an Effect `Scope`, and work acquired for that document uses the same scope.

```ts
const made = yield* makeNotebook(notebook, binding).pipe(
  Scope.provide(session.scope),
);

yield* Effect.forkIn(handlePrompt(...), session.scope);
```
