### PR TITLE
Centralize LSP notification streams

### DIFF
--- a/extension/src/lsp/MarimoClient.ts
+++ b/extension/src/lsp/MarimoClient.ts
@@ -124,61 +124,62 @@ export function makeMarimoCommands<Error>(transport: MarimoTransport<Error>) {
   };
 }
 
-export const makeKernelNotificationStream = Effect.fn(function* (
-  register: (handler: (message: unknown) => void) => {
+interface NotificationChannel<A> {
+  readonly decode: (message: unknown) => Option.Option<A>;
+  readonly ignoredMessage: string;
+  readonly register: (handler: (message: unknown) => void) => {
     readonly dispose: () => void;
-  },
-) {
-  const notifications = yield* PubSub.unbounded<KernelNotification>();
-  const runSync = Effect.runSyncWith(yield* Effect.context());
-  yield* Effect.addFinalizer(() => PubSub.shutdown(notifications));
+  };
+}
 
-  // vscode-languageclient stores one notification handler per method, so
-  // register once and fan out to every consumer.
-  yield* acquireDisposable(() =>
-    register((message) => {
-      const decoded = decodeKernelNotification(message);
-      if (Option.isNone(decoded)) {
-        runSync(
-          Effect.logWarning("Ignored invalid kernel notification").pipe(
-            Effect.annotateLogs(describeIgnored(message)),
-          ),
-        );
-        return;
-      }
-      runSync(PubSub.publish(notifications, decoded.value));
-    }),
-  );
+function makeNotificationStream<A>({
+  decode,
+  ignoredMessage,
+  register,
+}: NotificationChannel<A>) {
+  return Effect.gen(function* () {
+    const notifications = yield* PubSub.unbounded<A>();
+    const runFork = Effect.runForkWith(yield* Effect.context());
+    yield* Effect.addFinalizer(() => PubSub.shutdown(notifications));
 
-  return Stream.fromPubSub(notifications);
-});
+    // vscode-languageclient stores one notification handler per method, so
+    // register once and fan out to every consumer.
+    yield* acquireDisposable(() =>
+      register((message) => {
+        const decoded = decode(message);
+        if (Option.isNone(decoded)) {
+          runFork(
+            Effect.logWarning(ignoredMessage).pipe(
+              Effect.annotateLogs(describeIgnored(message)),
+            ),
+          );
+          return;
+        }
+        PubSub.publishUnsafe(notifications, decoded.value);
+      }),
+    );
 
-export const makeDocumentAnalysisStream = Effect.fn(function* (
-  register: (handler: (message: unknown) => void) => {
-    readonly dispose: () => void;
-  },
-) {
-  const analyses = yield* PubSub.unbounded<DocumentAnalysis>();
-  const runSync = Effect.runSyncWith(yield* Effect.context());
-  yield* Effect.addFinalizer(() => PubSub.shutdown(analyses));
+    return Stream.fromPubSub(notifications);
+  });
+}
 
-  yield* acquireDisposable(() =>
-    register((message) => {
-      const decoded = decodeDocumentAnalysis(message);
-      if (Option.isNone(decoded)) {
-        runSync(
-          Effect.logWarning("Ignored invalid document analysis").pipe(
-            Effect.annotateLogs(describeIgnored(message)),
-          ),
-        );
-        return;
-      }
-      runSync(PubSub.publish(analyses, decoded.value));
-    }),
-  );
+export const makeKernelNotificationStream = (
+  register: NotificationChannel<KernelNotification>["register"],
+) =>
+  makeNotificationStream({
+    decode: decodeKernelNotification,
+    ignoredMessage: "Ignored invalid kernel notification",
+    register,
+  });
 
-  return Stream.fromPubSub(analyses);
-});
+export const makeDocumentAnalysisStream = (
+  register: NotificationChannel<DocumentAnalysis>["register"],
+) =>
+  makeNotificationStream({
+    decode: decodeDocumentAnalysis,
+    ignoredMessage: "Ignored invalid document analysis",
+    register,
+  });
 
 /**
  * Communication with marimo-lsp.

--- a/extension/src/lsp/__tests__/MarimoClient.test.ts
+++ b/extension/src/lsp/__tests__/MarimoClient.test.ts
@@ -442,6 +442,23 @@ it.effect(
 );
 
 it.effect(
+  "disposes the transport notification handler with its scope",
+  Effect.fn(function* () {
+    let disposals = 0;
+
+    yield* Effect.scoped(
+      makeKernelNotificationStream(() => ({
+        dispose() {
+          disposals += 1;
+        },
+      })).pipe(Effect.asVoid),
+    );
+
+    expect(disposals).toBe(1);
+  }),
+);
+
+it.effect(
   "decodes document analysis on its own channel",
   Effect.fn(function* () {
     let notify: ((message: unknown) => void) | undefined;


### PR DESCRIPTION
`MarimoClient` built kernel and document-analysis notification streams with two copies of the same scoped registration, decoding, invalid-message logging, and PubSub setup. Both callbacks also crossed into the Effect runtime for every valid notification just to publish to an unbounded queue.

These changes add an internal broadcaster that now owns registration and disposal for both channels. 