### PR TITLE
Own background work by document session

### DIFF
--- a/extension/src/__tests__/__utils__/TestNotebookDocumentSession.ts
+++ b/extension/src/__tests__/__utils__/TestNotebookDocumentSession.ts
@@ -1,4 +1,4 @@
-import { Effect } from "effect";
+import { Scope } from "effect";
 import type * as vscode from "vscode";
 
 import { type NotebookDocumentSession } from "../../notebook/NotebookDocumentSessions.ts";
@@ -12,6 +12,6 @@ export function makeTestNotebookDocumentSession(
     id: makeNotebookDocumentSessionId(),
     notebookId: MarimoNotebookDocument.from(document).id,
     document,
-    ended: Effect.never,
+    scope: Scope.makeUnsafe(),
   };
 }

--- a/extension/src/kernel/CellExecutions.ts
+++ b/extension/src/kernel/CellExecutions.ts
@@ -158,7 +158,6 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
       const code = yield* VsCode;
       const editorRegistry = yield* NotebookEditorRegistry;
       const documentSessions = yield* NotebookDocumentSessions;
-      const serviceScope = yield* Effect.scope;
       const notebooks = new Map<NotebookId, NotebookEntry>();
       const opening = Semaphore.makeUnsafe(1);
       const allStaleCells = yield* SubscriptionRef.make(
@@ -662,19 +661,22 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
             const entry: NotebookEntry = { session, ...made };
             notebooks.set(notebookId, entry);
 
-            yield* session.ended.pipe(
-              Effect.andThen(
-                Effect.suspend(() => {
-                  if (notebooks.get(notebookId)?.session !== session) {
-                    return Effect.void;
-                  }
-                  notebooks.delete(notebookId);
-                  return made.close;
-                }),
-              ),
-              Effect.forkIn(serviceScope),
+            yield* documentSessions.addFinalizer(
+              session,
+              Effect.suspend(() => {
+                if (notebooks.get(notebookId)?.session !== session) {
+                  return Effect.void;
+                }
+                notebooks.delete(notebookId);
+                return made.close;
+              }),
             );
             if (displaced !== undefined) yield* displaced.close;
+            if (documentSessions.current(notebookId) !== session) {
+              return yield* new NotebookDocumentSessionEndedError({
+                notebookId,
+              });
+            }
             return made.executions;
           }),
         );

--- a/extension/src/kernel/NotebookExecutor.ts
+++ b/extension/src/kernel/NotebookExecutor.ts
@@ -1,4 +1,14 @@
-import { Cause, Deferred, Effect, Fiber, Queue, type Scope } from "effect";
+import {
+  Cause,
+  Data,
+  Deferred,
+  Effect,
+  Exit,
+  Fiber,
+  Predicate,
+  Queue,
+  type Scope,
+} from "effect";
 
 import type { NotebookId } from "../schemas/MarimoNotebookDocument.ts";
 
@@ -17,13 +27,30 @@ interface Actor<R> {
   readonly worker: Fiber.Fiber<void>;
 }
 
+/** The scope that owned an admitted notebook command closed before it ended. */
+export class NotebookExecutionScopeClosedError extends Data.TaggedError(
+  "NotebookExecutionScopeClosedError",
+)<{ readonly notebookId: NotebookId }> {}
+
 /** Runs admitted work in FIFO order, independently for each notebook. */
 export interface NotebookExecutor<R> {
   readonly submit: <A, E>(
     notebookId: NotebookId,
     effect: Effect.Effect<A, E, R>,
   ) => Effect.Effect<A, E>;
+  /** Like `submit`, but interrupts queued or running work when `scope` closes. */
+  readonly submitIn: <A, E>(
+    scope: Scope.Scope,
+    notebookId: NotebookId,
+    effect: Effect.Effect<A, E, R>,
+  ) => Effect.Effect<A, E | NotebookExecutionScopeClosedError>;
   readonly post: (
+    notebookId: NotebookId,
+    effect: Effect.Effect<void, never, R>,
+  ) => Effect.Effect<void>;
+  /** Like `post`, but interrupts queued or running work when `scope` closes. */
+  readonly postIn: (
+    scope: Scope.Scope,
     notebookId: NotebookId,
     effect: Effect.Effect<void, never, R>,
   ) => Effect.Effect<void>;
@@ -149,7 +176,36 @@ export function makeNotebookExecutor<R>(): Effect.Effect<
         ),
       );
 
-      const submit = <A, E>(
+      const inScope = <A, E, R2>(
+        effect: Effect.Effect<A, E, R2>,
+        scope: Scope.Scope,
+        notebookId: NotebookId,
+      ): Effect.Effect<A, E | NotebookExecutionScopeClosedError, R2> =>
+        Effect.gen(function* () {
+          if (Predicate.isTagged(scope.state, "Closed")) {
+            return yield* new NotebookExecutionScopeClosedError({
+              notebookId,
+            });
+          }
+          const fiber = yield* Effect.forkIn(effect, scope, {
+            startImmediately: true,
+          });
+          const exit = yield* Fiber.await(fiber).pipe(
+            Effect.onInterrupt(() => Fiber.interrupt(fiber)),
+          );
+          if (
+            Predicate.isTagged(scope.state, "Closed") &&
+            Exit.isFailure(exit) &&
+            Cause.hasInterruptsOnly(exit.cause)
+          ) {
+            return yield* new NotebookExecutionScopeClosedError({
+              notebookId,
+            });
+          }
+          return yield* exit;
+        });
+
+      const submitWork = <A, E>(
         notebookId: NotebookId,
         effect: Effect.Effect<A, E, R>,
       ): Effect.Effect<A, E> =>
@@ -173,7 +229,18 @@ export function makeNotebookExecutor<R>(): Effect.Effect<
           }),
         );
 
-      const post: NotebookExecutor<R>["post"] = (notebookId, effect) =>
+      const submit: NotebookExecutor<R>["submit"] = (notebookId, effect) =>
+        submitWork(notebookId, effect);
+      const submitIn: NotebookExecutor<R>["submitIn"] = (
+        scope,
+        notebookId,
+        effect,
+      ) => submitWork(notebookId, inScope(effect, scope, notebookId));
+
+      const postWork = (
+        notebookId: NotebookId,
+        effect: Effect.Effect<void, never, R>,
+      ) =>
         Effect.uninterruptible(
           Effect.gen(function* () {
             const admitted = yield* Queue.offer(ingress, {
@@ -184,6 +251,22 @@ export function makeNotebookExecutor<R>(): Effect.Effect<
             if (!admitted) return yield* Effect.interrupt;
             return undefined;
           }),
+        );
+      const post: NotebookExecutor<R>["post"] = (notebookId, effect) =>
+        postWork(notebookId, effect);
+      const postIn: NotebookExecutor<R>["postIn"] = (
+        scope,
+        notebookId,
+        effect,
+      ) =>
+        postWork(
+          notebookId,
+          inScope(effect, scope, notebookId).pipe(
+            Effect.catchTag(
+              "NotebookExecutionScopeClosedError",
+              () => Effect.void,
+            ),
+          ),
         );
 
       // Routed through ingress like any work so it runs after everything
@@ -204,7 +287,7 @@ export function makeNotebookExecutor<R>(): Effect.Effect<
           }).pipe(Effect.asVoid),
         );
 
-      return { submit, post, retire };
+      return { submit, submitIn, post, postIn, retire };
     }),
   );
 }

--- a/extension/src/kernel/NotebookRuntime.ts
+++ b/extension/src/kernel/NotebookRuntime.ts
@@ -370,9 +370,10 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
         controller: Ref.Ref<Option.Option<NotebookController>>,
       ): NotebookDocumentHandle => ({
         executeCells: (request, executable) =>
-          runInNotebook(
-            session.notebookId,
-            Effect.raceFirst(
+          executor
+            .submitIn(
+              session.scope,
+              session.notebookId,
               Effect.gen(function* () {
                 const notebookId = session.notebookId;
                 const notebook = MarimoNotebookDocument.from(session.document);
@@ -415,17 +416,16 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
                   ),
                 ),
               ),
-              session.ended.pipe(
-                Effect.andThen(
-                  Effect.fail(
-                    new NoActiveKernelError({
-                      notebookUri: session.notebookId,
-                    }),
-                  ),
+            )
+            .pipe(
+              Effect.catchTag("NotebookExecutionScopeClosedError", () =>
+                Effect.fail(
+                  new NoActiveKernelError({
+                    notebookUri: session.notebookId,
+                  }),
                 ),
               ),
             ),
-          ),
       });
 
       const makeHandle = (
@@ -687,17 +687,6 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
           ),
           Stream.runForEach((message) => {
             const run = Effect.gen(function* () {
-              // The session is captured when the operation enters the runtime,
-              // not when its per-notebook worker eventually processes it.
-              // This keeps queued operations from an old session out of a
-              // rapidly reopened notebook with the same URI.
-              if (
-                documentSessions.current(message.notebookUri) !==
-                message.session
-              ) {
-                return;
-              }
-
               // The kernel-session gate covers one race: sessionsChanged and
               // kernel notifications arrive on independent streams, so a
               // notification from a kernel replaced by restart can reach this
@@ -732,33 +721,30 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
                 "notification.type",
                 message.notification.op,
               );
-              yield* Effect.raceFirst(
-                processOperation(message, {
-                  forNotebook,
-                  respondToStdin,
-                  session: message.session,
-                }).pipe(
-                  Effect.catchTag(
-                    "NotebookDocumentSessionEndedError",
-                    () => Effect.void,
-                  ),
-                  Effect.catchCause(
-                    Effect.fn(function* (cause) {
-                      yield* Effect.logError(
-                        "Failed to process marimo operation",
-                      ).pipe(Effect.annotateLogs({ cause }));
-                      yield* Effect.forkChild(
-                        showErrorAndPromptLogs(
-                          "Failed to process marimo operation.",
-                        ),
-                      );
-                    }),
-                  ),
-                  Effect.annotateLogs({
-                    "notification.type": message.notification.op,
+              yield* processOperation(message, {
+                forNotebook,
+                respondToStdin,
+                session: message.session,
+              }).pipe(
+                Effect.catchTag(
+                  "NotebookDocumentSessionEndedError",
+                  () => Effect.void,
+                ),
+                Effect.catchCause(
+                  Effect.fn(function* (cause) {
+                    yield* Effect.logError(
+                      "Failed to process marimo operation",
+                    ).pipe(Effect.annotateLogs({ cause }));
+                    yield* Effect.forkChild(
+                      showErrorAndPromptLogs(
+                        "Failed to process marimo operation.",
+                      ),
+                    );
                   }),
                 ),
-                message.session.ended,
+                Effect.annotateLogs({
+                  "notification.type": message.notification.op,
+                }),
               );
             }).pipe(
               Effect.catchCause(
@@ -775,7 +761,11 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
               ),
               Effect.withSpan("NotebookRuntime.processOperation"),
             );
-            return executor.post(message.notebookUri, run);
+            return executor.postIn(
+              message.session.scope,
+              message.notebookUri,
+              run,
+            );
           }),
         ),
       );
@@ -784,14 +774,10 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
           Stream.runForEach((message) => {
             const session = documentSessions.current(message.notebookUri);
             if (session === undefined) return Effect.void;
-            return executor.post(
+            return executor.postIn(
+              session.scope,
               message.notebookUri,
-              Effect.gen(function* () {
-                if (documentSessions.current(message.notebookUri) !== session) {
-                  return;
-                }
-                yield* variables.updateVariables(session, message.analysis);
-              }),
+              variables.updateVariables(session, message.analysis),
             );
           }),
         ),
@@ -1230,9 +1216,7 @@ function processNotebookOperation(
     });
 
     const forkForSession = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
-      Effect.forkDetach(
-        Effect.raceFirst(effect, options.session.ended).pipe(Effect.asVoid),
-      );
+      Effect.forkIn(effect, options.session.scope);
 
     if (operation.op === "cell-op") {
       if (extractCellIdFromCellMessage(operation) === SCRATCH_CELL_ID) return;

--- a/extension/src/kernel/__tests__/NotebookExecutor.test.ts
+++ b/extension/src/kernel/__tests__/NotebookExecutor.test.ts
@@ -1,8 +1,11 @@
-import { assert, describe, it } from "@effect/vitest";
-import { Effect, Exit, Fiber, Latch, Ref, Scope } from "effect";
+import { assert, describe, expect, it } from "@effect/vitest";
+import { Cause, Effect, Exit, Fiber, Latch, Ref, Scope } from "effect";
 
 import { notebookId } from "../../lib/__tests__/branded.ts";
-import { makeNotebookExecutor } from "../NotebookExecutor.ts";
+import {
+  makeNotebookExecutor,
+  NotebookExecutionScopeClosedError,
+} from "../NotebookExecutor.ts";
 
 describe("NotebookExecutor", () => {
   it.effect(
@@ -85,6 +88,69 @@ describe("NotebookExecutor", () => {
         executor.post(notebook, Effect.void),
       );
       assert.isTrue(Exit.hasInterrupts(postAfterClose));
+    }),
+  );
+
+  it.effect(
+    "interrupts work owned by a document scope without closing the executor",
+    Effect.fn(function* () {
+      const executor = yield* makeNotebookExecutor<never>();
+      const documentScope = yield* Scope.make();
+      const started = yield* Latch.make();
+      const bufferedStarted = yield* Ref.make(false);
+      const notebook = notebookId("notebook");
+
+      const active = yield* executor
+        .submitIn(
+          documentScope,
+          notebook,
+          started.open.pipe(Effect.andThen(Effect.never)),
+        )
+        .pipe(Effect.forkDetach);
+      yield* started.await;
+
+      const buffered = yield* executor
+        .submitIn(
+          documentScope,
+          notebook,
+          Ref.set(bufferedStarted, true).pipe(Effect.andThen(Effect.never)),
+        )
+        .pipe(Effect.forkDetach);
+      yield* Effect.yieldNow;
+
+      yield* Scope.close(documentScope, Exit.void);
+      const [activeExit, bufferedExit] = yield* Effect.all([
+        Fiber.await(active),
+        Fiber.await(buffered),
+      ]);
+
+      for (const exit of [activeExit, bufferedExit]) {
+        assert.isTrue(Exit.isFailure(exit));
+        if (!Exit.isFailure(exit)) continue;
+        const failure = exit.cause.reasons.find(Cause.isFailReason);
+        assert.instanceOf(failure?.error, NotebookExecutionScopeClosedError);
+        expect(failure?.error).toMatchObject({ notebookId: notebook });
+      }
+      assert.isFalse(yield* Ref.get(bufferedStarted));
+
+      const result = yield* executor.submit(notebook, Effect.succeed("done"));
+      assert.strictEqual(result, "done");
+    }),
+  );
+
+  it.effect(
+    "preserves self-interruption while the owning scope remains open",
+    Effect.fn(function* () {
+      const executor = yield* makeNotebookExecutor<never>();
+      const documentScope = yield* Scope.make();
+      const notebook = notebookId("notebook");
+
+      const submitted = yield* executor
+        .submitIn(documentScope, notebook, Effect.interrupt)
+        .pipe(Effect.forkDetach);
+
+      assert.isTrue(Exit.hasInterrupts(yield* Fiber.await(submitted)));
+      yield* Scope.close(documentScope, Exit.void);
     }),
   );
 

--- a/extension/src/notebook/NotebookDocumentSessions.ts
+++ b/extension/src/notebook/NotebookDocumentSessions.ts
@@ -1,4 +1,16 @@
-import { Context, Data, Deferred, Effect, Layer, PubSub, Stream } from "effect";
+import {
+  Context,
+  Data,
+  Effect,
+  Exit,
+  HashMap,
+  Layer,
+  Option,
+  PubSub,
+  Ref,
+  Scope,
+  Stream,
+} from "effect";
 import type * as vscode from "vscode";
 
 import { VsCode } from "../platform/VsCode.ts";
@@ -22,18 +34,16 @@ export interface NotebookDocumentSession {
   readonly id: NotebookDocumentSessionId;
   readonly notebookId: NotebookId;
   readonly document: vscode.NotebookDocument;
-  readonly ended: Effect.Effect<void>;
+  /** Lifetime of work and resources tied to this exact document opening. */
+  readonly scope: Scope.Scope;
 }
 
-export type NotebookDocumentSessionChange =
-  | {
-      readonly _tag: "Opened";
-      readonly session: NotebookDocumentSession;
-    }
-  | {
-      readonly _tag: "Ended";
-      readonly session: NotebookDocumentSession;
-    };
+export type NotebookDocumentSessionChange = Data.TaggedEnum<{
+  Opened: { readonly session: NotebookDocumentSession };
+  Ended: { readonly session: NotebookDocumentSession };
+}>;
+export const NotebookDocumentSessionChange =
+  Data.taggedEnum<NotebookDocumentSessionChange>();
 
 export class NotebookDocumentSessionEndedError extends Data.TaggedError(
   "NotebookDocumentSessionEndedError",
@@ -41,8 +51,14 @@ export class NotebookDocumentSessionEndedError extends Data.TaggedError(
 
 interface SessionEntry {
   readonly session: NotebookDocumentSession;
-  readonly end: Deferred.Deferred<void>;
+  readonly scope: Scope.Closeable;
 }
+
+type InstallResult = Data.TaggedEnum<{
+  Existing: { readonly current: SessionEntry };
+  Installed: { readonly displaced: SessionEntry | undefined };
+}>;
+const InstallResult = Data.taggedEnum<InstallResult>();
 
 /** Tracks the current document session for each notebook URI. */
 export class NotebookDocumentSessions extends Context.Service<NotebookDocumentSessions>()(
@@ -50,87 +66,145 @@ export class NotebookDocumentSessions extends Context.Service<NotebookDocumentSe
   {
     make: Effect.gen(function* () {
       const code = yield* VsCode;
-      const sessions = new Map<NotebookId, SessionEntry>();
+      const serviceScope = yield* Effect.scope;
+      const sessions = yield* Ref.make(
+        HashMap.empty<NotebookId, SessionEntry>(),
+      );
       const changes = yield* PubSub.unbounded<NotebookDocumentSessionChange>();
 
-      const end = (entry: SessionEntry) => {
-        Deferred.doneUnsafe(entry.end, Effect.void);
-        const change: NotebookDocumentSessionChange = {
-          _tag: "Ended",
-          session: entry.session,
-        };
-        PubSub.publishUnsafe(changes, change);
-      };
+      const end = Effect.fn("NotebookDocumentSessions.end")(function* (
+        entry: SessionEntry,
+      ) {
+        yield* Scope.close(entry.scope, Exit.void);
+        yield* PubSub.publish(
+          changes,
+          NotebookDocumentSessionChange.Ended({
+            session: entry.session,
+          }),
+        );
+      });
 
-      const markOpen = (document: vscode.NotebookDocument) => {
-        // The lifecycle replay can deliver an opened event for a document
-        // that was since closed or replaced at the same URI; a closed
-        // document never starts a session.
-        if (document.isClosed) return undefined;
-        const notebook = MarimoNotebookDocument.tryFrom(document);
-        if (notebook._tag === "None") return undefined;
+      const markOpen = Effect.fn("NotebookDocumentSessions.markOpen")(
+        function* (document: vscode.NotebookDocument) {
+          // The lifecycle replay can deliver an opened event for a document
+          // that was since closed or replaced at the same URI; a closed
+          // document never starts a session.
+          if (document.isClosed) return undefined;
+          const notebook = MarimoNotebookDocument.tryFrom(document);
+          if (notebook._tag === "None") return undefined;
 
-        const existing = sessions.get(notebook.value.id);
-        if (existing?.session.document === document) return existing.session;
+          const scope = yield* Scope.fork(serviceScope, "parallel");
+          const session: NotebookDocumentSession = {
+            id: makeNotebookDocumentSessionId(),
+            notebookId: notebook.value.id,
+            document,
+            scope,
+          };
+          const candidate: SessionEntry = { session, scope };
+          const result = yield* Ref.modify(
+            sessions,
+            (
+              current,
+            ): readonly [
+              InstallResult,
+              HashMap.HashMap<NotebookId, SessionEntry>,
+            ] => {
+              const existing = HashMap.get(current, notebook.value.id);
+              if (
+                Option.isSome(existing) &&
+                existing.value.session.document === document
+              ) {
+                return [
+                  InstallResult.Existing({ current: existing.value }),
+                  current,
+                ];
+              }
+              return [
+                InstallResult.Installed({
+                  displaced: Option.getOrUndefined(existing),
+                }),
+                HashMap.set(current, notebook.value.id, candidate),
+              ];
+            },
+          );
 
-        const ended = Deferred.makeUnsafe<void>();
-        const session: NotebookDocumentSession = {
-          id: makeNotebookDocumentSessionId(),
-          notebookId: notebook.value.id,
-          document,
-          ended: Deferred.await(ended),
-        };
-        sessions.set(notebook.value.id, { session, end: ended });
+          if (InstallResult.$is("Existing")(result)) {
+            yield* Scope.close(scope, Exit.void);
+            return result.current.session;
+          }
 
-        if (existing) end(existing);
-        const change: NotebookDocumentSessionChange = {
-          _tag: "Opened",
-          session,
-        };
-        PubSub.publishUnsafe(changes, change);
-        return session;
-      };
+          if (result.displaced !== undefined) yield* end(result.displaced);
+          yield* PubSub.publish(
+            changes,
+            NotebookDocumentSessionChange.Opened({ session }),
+          );
+          return session;
+        },
+      );
 
-      const markClosed = (document: vscode.NotebookDocument) => {
-        const notebook = MarimoNotebookDocument.tryFrom(document);
-        if (notebook._tag === "None") return;
+      const markClosed = Effect.fn("NotebookDocumentSessions.markClosed")(
+        function* (document: vscode.NotebookDocument) {
+          const notebook = MarimoNotebookDocument.tryFrom(document);
+          if (notebook._tag === "None") return;
 
-        const current = sessions.get(notebook.value.id);
-        if (current?.session.document !== document) return;
-
-        sessions.delete(notebook.value.id);
-        end(current);
-      };
+          const removed = yield* Ref.modify(sessions, (current) => {
+            const entry = HashMap.get(current, notebook.value.id);
+            if (
+              Option.isNone(entry) ||
+              entry.value.session.document !== document
+            ) {
+              return [Option.none<SessionEntry>(), current];
+            }
+            return [entry, HashMap.remove(current, notebook.value.id)];
+          });
+          if (Option.isSome(removed)) yield* end(removed.value);
+        },
+      );
 
       const lifecycle = yield* code.workspace.subscribeNotebookLifecycle;
       const openDocuments = yield* code.workspace.getNotebookDocuments;
-      for (const document of openDocuments) markOpen(document);
+      yield* Effect.forEach(openDocuments, markOpen, { discard: true });
       yield* Effect.forkScoped(
         lifecycle.pipe(
           Stream.runForEach((event) =>
-            Effect.sync(() =>
-              event.type === "opened"
-                ? markOpen(event.document)
-                : markClosed(event.document),
-            ),
+            event.type === "opened"
+              ? markOpen(event.document)
+              : markClosed(event.document),
           ),
         ),
       );
 
       yield* Effect.addFinalizer(() =>
         Effect.gen(function* () {
-          for (const entry of sessions.values()) end(entry);
+          const current = yield* Ref.getAndSet(
+            sessions,
+            HashMap.empty<NotebookId, SessionEntry>(),
+          );
+          yield* Effect.forEach(HashMap.values(current), end, {
+            discard: true,
+          });
           yield* PubSub.shutdown(changes);
         }),
       );
 
       return {
-        current: (notebookId: NotebookId) => sessions.get(notebookId)?.session,
+        current: (notebookId: NotebookId) =>
+          Option.getOrUndefined(
+            HashMap.get(Ref.getUnsafe(sessions), notebookId),
+          )?.session,
         forDocument(document: vscode.NotebookDocument) {
           const notebook = MarimoNotebookDocument.tryFrom(document);
           if (notebook._tag === "None") return undefined;
-          const session = sessions.get(notebook.value.id)?.session;
+          const session = Option.getOrUndefined(
+            HashMap.get(Ref.getUnsafe(sessions), notebook.value.id),
+          )?.session;
           return session?.document === document ? session : undefined;
+        },
+        addFinalizer(
+          session: NotebookDocumentSession,
+          finalizer: Effect.Effect<unknown>,
+        ) {
+          return Scope.addFinalizer(session.scope, finalizer);
         },
         changes: Stream.fromPubSub(changes),
       } as const;

--- a/extension/src/notebook/__tests__/NotebookDocumentSessions.test.ts
+++ b/extension/src/notebook/__tests__/NotebookDocumentSessions.test.ts
@@ -1,5 +1,5 @@
 import { expect, it } from "@effect/vitest";
-import { Effect, Fiber, Layer } from "effect";
+import { Deferred, Effect, Layer } from "effect";
 
 import {
   createTestNotebookDocument,
@@ -27,9 +27,13 @@ it.effect(
       expect(firstSession?.document).toBe(first);
       if (firstSession === undefined) return;
 
-      const firstEnded = yield* Effect.forkChild(firstSession.ended);
+      const firstEnded = yield* Deferred.make<void>();
+      yield* sessions.addFinalizer(
+        firstSession,
+        Deferred.succeed(firstEnded, undefined),
+      );
       yield* vscode.openNotebook(replacement);
-      yield* Fiber.join(firstEnded);
+      yield* Deferred.await(firstEnded);
 
       const replacementSession = sessions.current(id);
       expect(replacementSession?.document).toBe(replacement);
@@ -41,11 +45,13 @@ it.effect(
       yield* Effect.yieldNow;
       expect(sessions.current(id)).toBe(replacementSession);
 
-      const replacementEnded = yield* Effect.forkChild(
-        replacementSession.ended,
+      const replacementEnded = yield* Deferred.make<void>();
+      yield* sessions.addFinalizer(
+        replacementSession,
+        Deferred.succeed(replacementEnded, undefined),
       );
       yield* vscode.closeNotebook(replacement);
-      yield* Fiber.join(replacementEnded);
+      yield* Deferred.await(replacementEnded);
       expect(sessions.current(id)).toBeUndefined();
     }).pipe(Effect.provide(layer));
   }),


### PR DESCRIPTION
`NotebookDocumentSession.ended` exposed lifetime, so callers had to arrange cleanup fibers themselves. Those independent races kept admission and resource ownership as separate concerns.

Each document opening now owns an Effect `Scope`. Scope-aware executor admission interrupts active work and rejects buffered work when that opening closes, while the shared per-notebook executor remains available to a replacement session at the same URI. Cell execution cleanup is a scope finalizer, making the registry the sole owner of document lifetime.