### PR TITLE
Log unexpected protocol enum values

### DIFF
--- a/extension/src/lsp/__tests__/converters.test.ts
+++ b/extension/src/lsp/__tests__/converters.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "@effect/vitest";
 import { Effect } from "effect";
+import { vi } from "vite-plus/test";
 import * as lsp from "vscode-languageserver-protocol";
 
 import {
@@ -552,6 +553,23 @@ describe("toVsCodeDiagnosticSeverity", () => {
       	  "Warning": 1,
       	}
       `);
+    }),
+  );
+
+  it.effect(
+    "logs an unexpected runtime value without changing the fallback",
+    Effect.fn(function* () {
+      const code = yield* withVsCode;
+      const error = vi.spyOn(console, "error").mockImplementation(() => {});
+      try {
+        const unknown = UNSAFE_castForNegativeTest<lsp.DiagnosticSeverity>(99);
+        expect(toVsCodeDiagnosticSeverity(code, unknown)).toBe(99);
+        expect(error).toHaveBeenCalledWith(
+          "Entered unreachable code [Unknown LSP diagnostic severity]: 99",
+        );
+      } finally {
+        error.mockRestore();
+      }
     }),
   );
 });

--- a/extension/src/lsp/converters.ts
+++ b/extension/src/lsp/converters.ts
@@ -5,6 +5,7 @@
 import type * as vscode from "vscode";
 import * as lsp from "vscode-languageserver-protocol";
 
+import { logUnreachable } from "../assert.ts";
 import type { VsCode } from "../platform/VsCode.ts";
 
 /**
@@ -90,6 +91,7 @@ export function toVsCodeDiagnosticSeverity(
       return code.DiagnosticSeverity.Hint;
     default: {
       const _exhaustive: never = severity;
+      logUnreachable(_exhaustive, "Unknown LSP diagnostic severity");
       return _exhaustive;
     }
   }
@@ -121,6 +123,7 @@ export function toLspDiagnosticSeverity(
       return lsp.DiagnosticSeverity.Hint;
     default: {
       const _exhaustive: never = severity;
+      logUnreachable(_exhaustive, "Unknown VS Code diagnostic severity");
       return _exhaustive;
     }
   }
@@ -240,6 +243,7 @@ export function toCompletionItemKind(
       return code.CompletionItemKind.TypeParameter;
     default: {
       const _exhaustive: never = value;
+      logUnreachable(_exhaustive, "Unknown LSP completion item kind");
       return _exhaustive;
     }
   }
@@ -306,6 +310,7 @@ export function toLspCompletionItemKind(
       return lsp.CompletionItemKind.Text;
     default: {
       const _exhaustive: never = kind;
+      logUnreachable(_exhaustive, "Unknown VS Code completion item kind");
       return _exhaustive;
     }
   }
@@ -324,6 +329,7 @@ export function toLspCompletionTriggerKind(
       return lsp.CompletionTriggerKind.TriggerForIncompleteCompletions;
     default: {
       const _exhaustive: never = kind;
+      logUnreachable(_exhaustive, "Unknown VS Code completion trigger kind");
       return _exhaustive;
     }
   }
@@ -421,6 +427,7 @@ export function toSymbolKind(kind: lsp.SymbolKind): vscode.SymbolKind {
       return 25 satisfies vscode.SymbolKind.TypeParameter;
     default: {
       const _exhaustive: never = kind;
+      logUnreachable(_exhaustive, "Unknown LSP symbol kind");
       return _exhaustive;
     }
   }
@@ -465,6 +472,7 @@ export function toDocumentHighlightKind(
       return 2 satisfies typeof vscode.DocumentHighlightKind.Write;
     default: {
       const _exhaustive: never = kind;
+      logUnreachable(_exhaustive, "Unknown LSP document highlight kind");
       return _exhaustive;
     }
   }
@@ -831,6 +839,7 @@ export function toLspCodeActionTriggerKind(
       return lsp.CodeActionTriggerKind.Automatic;
     default: {
       const _exhaustive: never = kind;
+      logUnreachable(_exhaustive, "Unknown VS Code code action trigger kind");
       return _exhaustive;
     }
   }


### PR DESCRIPTION
The switches are exhaustive for the installed TypeScript definitions, but their values cross VS Code and LSP runtime boundaries. Preserve the existing fallback behavior while making version-skew values observable.