### PR TITLE
Remove unused Python LSP helpers

### DIFF
--- a/src/marimo_lsp/app_file_manager.py
+++ b/src/marimo_lsp/app_file_manager.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 import pathlib
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 from urllib.parse import unquote
 
 from lsprotocol.types import NotebookDocument
@@ -71,62 +71,6 @@ class LspAppFileManager:
     def move(self, notebook_uri: str) -> None:
         """Update the URI after the backing notebook is renamed."""
         self._notebook_uri = notebook_uri
-
-    @property
-    def is_notebook_named(self) -> bool:
-        """Check if the notebook has a name.
-
-        LSP notebooks always have a URI, so this always returns True.
-        """
-        return True
-
-    def save(self, request: object) -> str:
-        """Save is not supported in LSP."""
-        msg = "Save not supported in LSP mode. LSP handles file operations."
-        raise NotImplementedError(msg)
-
-    def rename(self, new_filename: str) -> None:
-        """Rename is not supported in LSP."""
-        msg = "Rename not supported in LSP mode. LSP handles file operations."
-        raise NotImplementedError(msg)
-
-    def save_app_config(self, config: dict[str, Any]) -> str:
-        """Save app config is not supported in LSP."""
-        msg = "Save app config not supported in LSP mode. LSP handles file operations."
-        raise NotImplementedError(msg)
-
-    def to_code(self) -> str:
-        """Export to Python code is not supported in LSP."""
-        msg = "Export not supported in LSP mode. Notebook serializer handles document."
-        raise NotImplementedError(msg)
-
-    def read_file(self) -> str:
-        """Read raw file content is not supported in LSP mode."""
-        msg = "Read raw file not supported in LSP mode. LSP handles file operations."
-        raise NotImplementedError(msg)
-
-    def reload(self) -> set[CellId_t]:
-        """Relad file is not supported in LSP mode."""
-        msg = "Reload file si not supported in LSP mode. LSP handles file operations."
-        raise NotImplementedError(msg)
-
-    def read_layout_config(self) -> object | None:
-        """Read layout configuration."""
-        return None
-
-    def read_css_file(self) -> str | None:
-        """Read CSS file content.
-
-        Custom CSS is not applicable in LSP.
-        """
-        return None
-
-    def read_html_head_file(self) -> str | None:
-        """Read HTML head file content.
-
-        Custom HTML is not applicable in LSP.
-        """
-        return None
 
 
 def find_notebook_document(

--- a/src/marimo_lsp/utils.py
+++ b/src/marimo_lsp/utils.py
@@ -13,7 +13,6 @@ from marimo._convert.common.format import (
     DEFAULT_MARKDOWN_PREFIX,
     markdown_to_marimo,
 )
-from marimo._types.ids import CellId_t
 
 from marimo_lsp.loggers import get_logger
 from marimo_lsp.models import (
@@ -90,12 +89,6 @@ def decode_notebook_document_metadata(
         return MarimoNotebookMetadata()
     envelope = msgspec.convert({"marimo": raw_dict["marimo"]}, NotebookDocumentMetadata)
     return envelope.marimo
-
-
-def get_stable_id(cell: lsp.NotebookCell) -> CellId_t | None:
-    """Get the stable ID of a marimo notebook cell."""
-    stable_id = decode_cell_metadata(cell).marimo_runtime.stable_id
-    return CellId_t(stable_id) if stable_id is not None else None
 
 
 def normalize_cell_code(

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -27,7 +27,6 @@ from marimo_lsp.models import (
 )
 from marimo_lsp.utils import (
     decode_cell_metadata,
-    get_stable_id,
     normalize_cell_code,
 )
 
@@ -366,38 +365,6 @@ class TestSnapshotVariables:
 
 class TestCellMetadataHelpers:
     """Unit tests for cell metadata helper functions."""
-
-    def test_get_stable_id_with_id(self) -> None:
-        """Test get_stable_id returns the stable ID when present."""
-        cell = lsp.NotebookCell(
-            kind=lsp.NotebookCellKind.Code,
-            document="file:///test.py#cell1",
-            metadata=_cell_metadata(stable_id="abc-123"),
-        )
-
-        stable_id = get_stable_id(cell)
-        assert stable_id == CellId_t("abc-123")
-
-    def test_get_stable_id_without_id(self) -> None:
-        """Test get_stable_id returns None when stable ID is missing."""
-        cell = lsp.NotebookCell(
-            kind=lsp.NotebookCellKind.Code,
-            document="file:///test.py#cell1",
-            metadata=_cell_metadata(),
-        )
-
-        stable_id = get_stable_id(cell)
-        assert stable_id is None
-
-    def test_get_stable_id_no_metadata(self) -> None:
-        """Test get_stable_id returns None when metadata is missing."""
-        cell = lsp.NotebookCell(
-            kind=lsp.NotebookCellKind.Code,
-            document="file:///test.py#cell1",
-        )
-
-        stable_id = get_stable_id(cell)
-        assert stable_id is None
 
     def test_decode_cell_metadata_complete(self) -> None:
         """Test decode_cell_metadata with all metadata."""


### PR DESCRIPTION
The custom session owns file operations through the notebook protocol and only consumes app, path, filename, and move from LspAppFileManager. Keeping the old filesystem-shaped stubs implied an interface the adapter no longer implements.