### PR TITLE
Prune unused extension helpers

### DIFF
--- a/extension/src/lsp/__tests__/converters.test.ts
+++ b/extension/src/lsp/__tests__/converters.test.ts
@@ -34,7 +34,6 @@ import {
   toLspDiagnosticSeverity,
   toLspFoldingRangeKind,
   toLspInlayHint,
-  toLspPosition,
   toLspRange,
   toSelectionRange,
   toSignatureHelp,
@@ -1354,21 +1353,6 @@ describe("toCodeAction", () => {
 // ---------------------------------------------------------------------------
 // Trivial LSP-side converters
 // ---------------------------------------------------------------------------
-
-describe("toLspPosition", () => {
-  it.effect(
-    "extracts line and character",
-    Effect.fn(function* () {
-      const code = yield* withVsCode;
-      expect(toLspPosition(new code.Position(3, 7))).toMatchInlineSnapshot(`
-      	{
-      	  "character": 7,
-      	  "line": 3,
-      	}
-      `);
-    }),
-  );
-});
 
 describe("toLspRange", () => {
   it.effect(

--- a/extension/src/lsp/converters.ts
+++ b/extension/src/lsp/converters.ts
@@ -95,10 +95,6 @@ export function toVsCodeDiagnosticSeverity(
   }
 }
 
-export function toLspPosition(pos: vscode.Position): lsp.Position {
-  return { line: pos.line, character: pos.character };
-}
-
 export function toLspRange(range: vscode.Range): lsp.Range {
   return {
     start: { line: range.start.line, character: range.start.character },

--- a/extension/src/python/ProjectDependencyTarget.ts
+++ b/extension/src/python/ProjectDependencyTarget.ts
@@ -21,20 +21,12 @@ export type ProjectDependencyInspection = {
 };
 
 /**
- * Find every pyproject location in which a package is declared directly.
+ * Read and index the nearest pyproject once for a package-install batch.
  *
  * uv only updates the dependency field selected by `--group` / `--optional`;
  * an unqualified `uv add` always targets `project.dependencies`. Inspecting the
  * existing declarations lets us preserve the user's chosen location.
  */
-export function findProjectDependencyTargets(
-  directory: string,
-  requirement: string,
-): ReadonlyArray<ProjectDependencyTarget> {
-  return inspectProjectDependencies(directory).findTargets(requirement);
-}
-
-/** Read and index the nearest pyproject once for a package-install batch. */
 export function inspectProjectDependencies(
   directory: string,
 ): ProjectDependencyInspection {

--- a/extension/src/python/__tests__/ProjectDependencyTarget.test.ts
+++ b/extension/src/python/__tests__/ProjectDependencyTarget.test.ts
@@ -4,10 +4,7 @@ import * as NodePath from "node:path";
 
 import { describe, expect, it } from "vite-plus/test";
 
-import {
-  findProjectDependencyTargets,
-  inspectProjectDependencies,
-} from "../ProjectDependencyTarget.ts";
+import { inspectProjectDependencies } from "../ProjectDependencyTarget.ts";
 
 function withProject(content: string, test: (directory: string) => void) {
   using tmp = NodeFs.mkdtempDisposableSync(
@@ -17,7 +14,10 @@ function withProject(content: string, test: (directory: string) => void) {
   test(tmp.path);
 }
 
-describe("findProjectDependencyTargets", () => {
+const findTargets = (directory: string, requirement: string) =>
+  inspectProjectDependencies(directory).findTargets(requirement);
+
+describe("inspectProjectDependencies", () => {
   it("finds production, optional, and arbitrary dependency groups", () => {
     withProject(
       `
@@ -32,14 +32,12 @@ dev = ["marimo>=0.12"]
 docs = ["marimo>=0.13"]
 `,
       (directory) => {
-        expect(findProjectDependencyTargets(directory, "marimo>=0.20")).toEqual(
-          [
-            { _tag: "Production" },
-            { _tag: "Optional", name: "notebooks" },
-            { _tag: "Group", name: "dev" },
-            { _tag: "Group", name: "docs" },
-          ],
-        );
+        expect(findTargets(directory, "marimo>=0.20")).toEqual([
+          { _tag: "Production" },
+          { _tag: "Optional", name: "notebooks" },
+          { _tag: "Group", name: "dev" },
+          { _tag: "Group", name: "docs" },
+        ]);
       },
     );
   });
@@ -55,7 +53,7 @@ dev = [{ include-group = "notebooks" }]
 notebooks = ["marimo>=0.10"]
 `,
       (directory) => {
-        expect(findProjectDependencyTargets(directory, "marimo")).toEqual([
+        expect(findTargets(directory, "marimo")).toEqual([
           { _tag: "Group", name: "notebooks" },
         ]);
       },
@@ -72,7 +70,7 @@ dependencies = []
 dev-dependencies = ["marimo>=0.10"]
 `,
       (directory) => {
-        expect(findProjectDependencyTargets(directory, "marimo")).toEqual([
+        expect(findTargets(directory, "marimo")).toEqual([
           { _tag: "Group", name: "dev" },
         ]);
       },
@@ -92,7 +90,7 @@ dev = ["marimo>=0.10"]
 dev-dependencies = ["marimo>=0.10"]
 `,
       (directory) => {
-        expect(findProjectDependencyTargets(directory, "marimo")).toEqual([
+        expect(findTargets(directory, "marimo")).toEqual([
           { _tag: "Group", name: "dev" },
         ]);
       },
@@ -156,9 +154,9 @@ dependencies = []
 dev = ["My.Package_Name>=1"]
 `,
       (directory) => {
-        expect(
-          findProjectDependencyTargets(directory, "my-package-name>=2"),
-        ).toEqual([{ _tag: "Group", name: "dev" }]);
+        expect(findTargets(directory, "my-package-name>=2")).toEqual([
+          { _tag: "Group", name: "dev" },
+        ]);
       },
     );
   });
@@ -175,7 +173,7 @@ test = ["marimo"]
       (directory) => {
         const venv = NodePath.join(directory, ".venv", "nested");
         NodeFs.mkdirSync(venv, { recursive: true });
-        expect(findProjectDependencyTargets(venv, "marimo")).toEqual([
+        expect(findTargets(venv, "marimo")).toEqual([
           { _tag: "Group", name: "test" },
         ]);
       },
@@ -186,12 +184,12 @@ test = ["marimo"]
     using tmp = NodeFs.mkdtempDisposableSync(
       NodePath.join(NodeOs.tmpdir(), "marimo-project-target-"),
     );
-    expect(findProjectDependencyTargets(tmp.path, "marimo")).toEqual([]);
+    expect(findTargets(tmp.path, "marimo")).toEqual([]);
   });
 
   it("rejects malformed TOML", () => {
     withProject("[project\ndependencies = []", (directory) => {
-      expect(() => findProjectDependencyTargets(directory, "marimo")).toThrow();
+      expect(() => findTargets(directory, "marimo")).toThrow();
     });
   });
 });

--- a/extension/src/schemas/Models.gen.ts
+++ b/extension/src/schemas/Models.gen.ts
@@ -422,54 +422,6 @@ export const SetDisplayThemeRequest = Schema.Struct({
 export type SetDisplayThemeRequest = typeof SetDisplayThemeRequest.Type;
 
 /**
- * Wraps a marimo command with its target notebook context.
- *
- * Associates any marimo command/request with the specific notebook
- * it should operate on, enabling proper routing in multi-notebook
- * environments.
- */
-export const NotebookCommand = <S extends Schema.Top>(inner: S) =>
-  Schema.Struct({
-    notebookUri: NotebookIdFromString,
-    inner,
-  });
-
-/**
- * A command addressed to one exact live kernel.
- */
-export const KernelCommand = <S extends Schema.Top>(inner: S) =>
-  Schema.Struct({
-    notebookUri: NotebookIdFromString,
-    inner,
-    sessionId: KernelSessionIdFromString,
-  });
-
-/**
- * A notebook command that is further routed to a specific runtime/session.
- */
-export const SessionCommand = <S extends Schema.Top>(inner: S) =>
-  Schema.Struct({
-    notebookUri: NotebookIdFromString,
-    inner,
-    executable: Schema.String,
-    workingDirectory: Schema.String,
-  });
-
-/**
- * A notebook command that describes its python environment via a `PackageSource`.
- *
- * Distinct from `SessionCommand`: package endpoints don't talk to a live
- * marimo kernel — they shell out to `uv` — and sandbox notebooks have no
- * pre-resolved python executable for the client to send.
- */
-export const PackageCommand = <S extends Schema.Top>(inner: S) =>
-  Schema.Struct({
-    notebookUri: NotebookIdFromString,
-    inner,
-    source: PackageSource,
-  });
-
-/**
  * Serializable HTTP request representation.
  *
  * Mimics Starlette/FastAPI Request but is pickle-able and contains only a safe

--- a/extension/src/schemas/__tests__/Models.gen.test.ts
+++ b/extension/src/schemas/__tests__/Models.gen.test.ts
@@ -3,13 +3,13 @@ import { Effect, Result, Schema } from "effect";
 
 import {
   CellMetadata,
+  ExecuteCellsPayload,
   ExecuteScratchRequest,
+  GetPackageListPayload,
   makeApiClient,
   NotebookDocument,
   NotebookDocumentMetadata,
-  PackageCommand,
   PackageSource,
-  SessionCommand,
   VenvSource,
 } from "../Models.gen.ts";
 
@@ -86,24 +86,22 @@ describe("Models.gen (msgspec → Effect Schema codegen)", () => {
     expect(Result.isFailure(missingCode)).toBe(true);
   });
 
-  it("composes generic command wrappers around an inner schema", () => {
-    const command = PackageCommand(Schema.Struct({ query: Schema.String }));
-    const decoded = Schema.decodeUnknownSync(command)({
+  it("decodes a generated package command payload", () => {
+    const decoded = Schema.decodeUnknownSync(GetPackageListPayload)({
       notebookUri: "file:///nb.py",
       source: { kind: "script" },
-      inner: { query: "polars" },
+      inner: {},
     });
-    expect(decoded.inner.query).toBe("polars");
+    expect(decoded.inner).toEqual({});
     expect(decoded.source).toEqual({ kind: "script" });
   });
 
-  it("requires workingDirectory for session commands", () => {
-    const command = SessionCommand(Schema.Struct({ code: Schema.String }));
+  it("requires workingDirectory for generated session command payloads", () => {
     expect(() =>
-      Schema.decodeUnknownSync(command)({
+      Schema.decodeUnknownSync(ExecuteCellsPayload)({
         notebookUri: "file:///nb.py",
         executable: "/usr/bin/python",
-        inner: { code: "print(1)" },
+        inner: { cellIds: ["cell-1"], codes: ["print(1)"] },
       }),
     ).toThrow();
   });

--- a/scripts/codegen/effect_schemas.py
+++ b/scripts/codegen/effect_schemas.py
@@ -69,14 +69,6 @@ export type NotebookId = typeof NotebookIdFromString.Type;
 _StructLike = mi.StructType | mi.DataclassType | mi.TypedDictType
 """IR nodes with a `cls` and `fields` that emit as `Schema.Struct`."""
 
-
-class _Inner(msgspec.Struct):
-    """Placeholder substituted for generic type parameters.
-
-    Fields typed as `_Inner` are emitted as the TS generic parameter `inner`.
-    """
-
-
 # (exported name, type) pairs. The emitter topologically orders dependencies.
 CONCRETE: list[tuple[str, type | object]] = [
     ("PackageSource", models.PackageSource),
@@ -99,17 +91,6 @@ CONCRETE: list[tuple[str, type | object]] = [
     ("UpdateConfigurationRequest", models.UpdateConfigurationRequest),
     ("SetDisplayThemeRequest", models.SetDisplayThemeRequest),
 ]
-
-# Generic wrappers become TS functions of the `inner` schema. Parameterized
-# with the `_Inner` placeholder so msgspec resolves the type variable to a
-# marker the emitter can recognize.
-GENERIC: list[tuple[type, type]] = [
-    (models.NotebookCommand, models.NotebookCommand[_Inner]),
-    (models.KernelCommand, models.KernelCommand[_Inner]),
-    (models.SessionCommand, models.SessionCommand[_Inner]),
-    (models.PackageCommand, models.PackageCommand[_Inner]),
-]
-
 
 def _ts_string(value: str) -> str:
     return json.dumps(value)
@@ -271,8 +252,6 @@ class Emitter:
     def struct_ref(self, t: _StructLike) -> str:
         """Emit a struct/dataclass/TypedDict definition (once); return its name."""
         cls = t.cls
-        if cls is _Inner:
-            return "inner"
         if cls in self.emitted:
             name = self.emitted[cls]
             if cls in self.in_flight:
@@ -455,18 +434,6 @@ class Emitter:
             f"export type {name} = typeof {name}.Type;\n"
         )
 
-    def emit_generic(self, cls: type, parameterized: type) -> None:
-        info = mi.type_info(parameterized)
-        if not isinstance(info, mi.StructType):
-            msg = f"expected a struct, got {type(info).__name__}"
-            raise TypeError(msg)
-        fields = self.fields_src(info, indent="    ")
-        self.definitions.append(
-            f"{_jsdoc(cls.__doc__)}"
-            f"export const {cls.__name__} = <S extends Schema.Top>(inner: S) =>\n"
-            f"  Schema.Struct({{\n{fields}  }});\n"
-        )
-
     def emit_api_method(self, method: ApiMethod) -> tuple[str, str]:
         """Emit the payload schema for one registry entry.
 
@@ -523,8 +490,6 @@ def generate() -> str:
     emitter = Emitter()
     for name, t in CONCRETE:
         emitter.emit_named(name, t)
-    for cls, parameterized in GENERIC:
-        emitter.emit_generic(cls, parameterized)
     api = [emitter.emit_api_method(method) for method in API_METHODS]
     members = "\n".join(
         f"  | {{ readonly method: {_ts_string(method.name)}; "

--- a/scripts/codegen/effect_schemas.py
+++ b/scripts/codegen/effect_schemas.py
@@ -92,6 +92,7 @@ CONCRETE: list[tuple[str, type | object]] = [
     ("SetDisplayThemeRequest", models.SetDisplayThemeRequest),
 ]
 
+
 def _ts_string(value: str) -> str:
     return json.dumps(value)
 


### PR DESCRIPTION
Generated API payloads already inline their concrete command shapes. Removing the unused generic-emission path keeps codegen focused on schemas the client actually consumes.