### PR TITLE
Make session ownership an Effect requirement

### DIFF
--- a/extension/src/__tests__/__utils__/TestMarimoClient.ts
+++ b/extension/src/__tests__/__utils__/TestMarimoClient.ts
@@ -69,56 +69,59 @@ export function makeTestNotebookRuntime(options: Options = {}) {
           yield* PubSub.unbounded<NotebookControllerSelection>();
         yield* Effect.addFinalizer(() => PubSub.shutdown(selections));
 
-        const forNotebook = (notebookId: NotebookId): NotebookHandle => {
-          const existing = handles.get(notebookId);
-          if (existing !== undefined) return existing;
-          const handle: NotebookHandle = {
-            id: notebookId,
-            getController: Effect.sync(() =>
-              Option.fromNullishOr(controllers.get(notebookId)),
-            ),
-            executeScratchpad: () => Stream.empty,
-            updateUIElements: (inner) =>
-              client.updateUiElement({
+        const forNotebook = (
+          notebookId: NotebookId,
+        ): Effect.Effect<NotebookHandle> =>
+          Effect.sync(() => {
+            const existing = handles.get(notebookId);
+            if (existing !== undefined) return existing;
+            const handle: NotebookHandle = {
+              id: notebookId,
+              getController: Effect.sync(() =>
+                Option.fromNullishOr(controllers.get(notebookId)),
+              ),
+              executeScratchpad: () => Stream.empty,
+              updateUIElements: (inner) =>
+                client.updateUiElement({
+                  notebookUri: notebookId,
+                  sessionId: TEST_KERNEL_SESSION_ID,
+                  inner,
+                }),
+              updateModel: (inner) =>
+                client.setModelValue({
+                  notebookUri: notebookId,
+                  sessionId: TEST_KERNEL_SESSION_ID,
+                  inner,
+                }),
+              invokeFunction: (inner) =>
+                client.invokeFunction({
+                  notebookUri: notebookId,
+                  sessionId: TEST_KERNEL_SESSION_ID,
+                  inner,
+                }),
+              deleteCell: (inner) =>
+                client.deleteCell({
+                  notebookUri: notebookId,
+                  sessionId: TEST_KERNEL_SESSION_ID,
+                  inner,
+                }),
+              interrupt: client.interrupt({
                 notebookUri: notebookId,
-                sessionId: TEST_KERNEL_SESSION_ID,
-                inner,
+                inner: { sessionId: TEST_KERNEL_SESSION_ID },
               }),
-            updateModel: (inner) =>
-              client.setModelValue({
-                notebookUri: notebookId,
-                sessionId: TEST_KERNEL_SESSION_ID,
-                inner,
-              }),
-            invokeFunction: (inner) =>
-              client.invokeFunction({
-                notebookUri: notebookId,
-                sessionId: TEST_KERNEL_SESSION_ID,
-                inner,
-              }),
-            deleteCell: (inner) =>
-              client.deleteCell({
-                notebookUri: notebookId,
-                sessionId: TEST_KERNEL_SESSION_ID,
-                inner,
-              }),
-            interrupt: client.interrupt({
-              notebookUri: notebookId,
-              inner: { sessionId: TEST_KERNEL_SESSION_ID },
-            }),
-            restart: client
-              .restartSession({
-                notebookUri: notebookId,
-                inner: { executable: "", workingDirectory: "" },
-              })
-              .pipe(Effect.as(undefined)),
-            close: client
-              .closeSession({ notebookUri: notebookId, inner: {} })
-              .pipe(Effect.asVoid),
-          };
-          handles.set(notebookId, handle);
-          return handle;
-        };
+              restart: client
+                .restartSession({
+                  notebookUri: notebookId,
+                  inner: { executable: "", workingDirectory: "" },
+                })
+                .pipe(Effect.as(undefined)),
+              close: client
+                .closeSession({ notebookUri: notebookId, inner: {} })
+                .pipe(Effect.asVoid),
+            };
+            handles.set(notebookId, handle);
+            return handle;
+          });
 
         const forDocument = (
           document: Parameters<typeof MarimoNotebookDocument.from>[0],

--- a/extension/src/commands/restartKernel.ts
+++ b/extension/src/commands/restartKernel.ts
@@ -40,7 +40,8 @@ const handler = Effect.fn("command.restartKernel")(function* (
     Effect.fn(function* (progress) {
       progress.report({ message: "Restarting session..." });
 
-      const succeeded = yield* runtime.forNotebook(notebook.id).restart.pipe(
+      const handle = yield* runtime.forNotebook(notebook.id);
+      const succeeded = yield* handle.restart.pipe(
         Effect.as(true),
         Effect.catchCause(
           Effect.fn(function* (cause) {

--- a/extension/src/commands/sessionCommands.ts
+++ b/extension/src/commands/sessionCommands.ts
@@ -38,7 +38,8 @@ export const restartSession = Effect.fn("command.restartSession")(function* ({
   notebookUri,
 }: SessionCommandTarget) {
   const runtime = yield* NotebookRuntime;
-  yield* runtime.forNotebook(notebookUri).restart.pipe(
+  const notebook = yield* runtime.forNotebook(notebookUri);
+  yield* notebook.restart.pipe(
     Effect.catchCause(
       Effect.fn(function* (cause) {
         yield* Effect.logError("Failed to restart kernel").pipe(
@@ -59,7 +60,8 @@ export const shutdownSession = Effect.fn("command.shutdownSession")(function* ({
   const session = yield* sessions.find(notebookUri);
   if (Option.isNone(session)) return;
 
-  yield* runtime.forNotebook(notebookUri).close;
+  const notebook = yield* runtime.forNotebook(notebookUri);
+  yield* notebook.close;
   const choice = yield* code.window.showInformationMessage(
     `Shut down kernel for ${session.value.filename ?? "notebook"}.`,
     { items: ["Restart"] },

--- a/extension/src/commands/updateActivePythonEnvironment.ts
+++ b/extension/src/commands/updateActivePythonEnvironment.ts
@@ -27,7 +27,8 @@ const handler = Effect.fn("command.updateActivePythonEnvironment")(function* (
 
   const { document: notebook, editor } = target.value;
 
-  const controller = yield* notebooks.forNotebook(notebook.id).getController;
+  const handle = yield* notebooks.forNotebook(notebook.id);
+  const controller = yield* handle.getController;
 
   if (Option.isNone(controller)) {
     yield* code.window.showInformationMessage(

--- a/extension/src/config/MarimoConfigurationService.ts
+++ b/extension/src/config/MarimoConfigurationService.ts
@@ -7,6 +7,7 @@ import {
   HashMap,
   Layer,
   Option,
+  Scope,
   Stream,
   SubscriptionRef,
 } from "effect";
@@ -109,13 +110,19 @@ export class MarimoConfigurationService extends Context.Service<MarimoConfigurat
           );
         });
 
-      yield* Effect.forkScoped(
-        documentSessions.changes.pipe(
-          Stream.runForEach((change) =>
-            change._tag === "Ended"
-              ? clearCache(change.session.notebookId, change.session)
-              : Effect.void,
-          ),
+      const registeredSessionCleanups = new WeakSet<NotebookDocumentSession>();
+      const registerSessionCleanup = Effect.fn(
+        "MarimoConfigurationService.registerSessionCleanup",
+      )((session: NotebookDocumentSession) =>
+        Effect.uninterruptible(
+          Effect.suspend(() => {
+            if (registeredSessionCleanups.has(session)) return Effect.void;
+            registeredSessionCleanups.add(session);
+            return Scope.addFinalizer(
+              session.scope,
+              clearCache(session.notebookId, session),
+            );
+          }),
         ),
       );
 
@@ -156,8 +163,13 @@ export class MarimoConfigurationService extends Context.Service<MarimoConfigurat
             }
 
             const key = keyFor(session);
+            yield* registerSessionCleanup(session);
             const config = yield* Cache.get(configurationCache, key);
-            yield* projectCurrent(key);
+            if (documentSessions.current(notebookUri) === session) {
+              yield* projectCurrent(key);
+            } else {
+              yield* clearCache(notebookUri, session);
+            }
             return config;
           });
         },
@@ -171,6 +183,9 @@ export class MarimoConfigurationService extends Context.Service<MarimoConfigurat
         ) {
           return Effect.gen(function* () {
             const session = documentSessions.current(notebookUri);
+            if (session !== undefined) {
+              yield* registerSessionCleanup(session);
+            }
             yield* Effect.logTrace("Updating configuration").pipe(
               Effect.annotateLogs({ notebookUri, config: partialConfig }),
             );

--- a/extension/src/features/RegisterLanguageModelTools.ts
+++ b/extension/src/features/RegisterLanguageModelTools.ts
@@ -144,8 +144,8 @@ export const RegisterLanguageModelToolsLive = Layer.effectDiscard(
         );
       }
 
-      const ops = yield* notebooks
-        .forNotebook(notebookId.value)
+      const notebook = yield* notebooks.forNotebook(notebookId.value);
+      const ops = yield* notebook
         .executeScratchpad(input.code)
         .pipe(Stream.runCollect);
 

--- a/extension/src/kernel/DebugAdapter.ts
+++ b/extension/src/kernel/DebugAdapter.ts
@@ -97,7 +97,6 @@ export class DebugAdapter extends Context.Service<DebugAdapter>()(
   {
     make: Effect.gen(function* () {
       const code = yield* VsCode;
-      const notebooks = yield* NotebookRuntime;
 
       const debugpyLibsPath = yield* resolveDebugpyPath(code);
 
@@ -208,11 +207,7 @@ export class DebugAdapter extends Context.Service<DebugAdapter>()(
 
             // Activate debugpy (idempotent — returns existing port if running).
             yield* Effect.logInfo("Activating debugpy in kernel");
-            const state = yield* activateDebugpy(
-              notebooks,
-              notebookUri,
-              debugpyLibsPath,
-            );
+            const state = yield* activateDebugpy(notebookUri, debugpyLibsPath);
             yield* Effect.logInfo("debugpy ready").pipe(
               Effect.annotateLogs({
                 port: state.port,
@@ -283,58 +278,57 @@ export class DebugAdapter extends Context.Service<DebugAdapter>()(
  * Activate debugpy in the kernel by running a scratchpad snippet
  * and parsing the port + tmpdir from stdout.
  */
-function activateDebugpy(
-  notebooks: NotebookRuntime["Service"],
+const activateDebugpy = Effect.fn("DebugAdapter.activateDebugpy")(function* (
   notebookUri: NotebookId,
   debugpyLibsPath: string,
 ) {
-  return Effect.gen(function* () {
-    const script = activationScript(debugpyLibsPath);
-    const ops = notebooks.forNotebook(notebookUri).executeScratchpad(script);
+  const notebooks = yield* NotebookRuntime;
+  const script = activationScript(debugpyLibsPath);
+  const notebook = yield* notebooks.forNotebook(notebookUri);
+  const ops = notebook.executeScratchpad(script);
 
-    // Collect all console outputs and find the JSON with port + tmpdir
-    let result: DebugpyState | undefined;
+  // Collect all console outputs and find the JSON with port + tmpdir
+  let result: DebugpyState | undefined;
 
-    yield* Stream.runForEach(ops, (op) =>
-      Effect.sync(() => {
-        if (result) return;
-        // SAFETY: `console` is an optional cell-op field whose shape isn't
-        // surfaced in the openapi-generated type for `CellOperationNotification`;
-        // the guards below validate each entry before use.
-        const consoleOutput = (op as { console?: unknown }).console;
-        if (!consoleOutput) return;
+  yield* Stream.runForEach(ops, (op) =>
+    Effect.sync(() => {
+      if (result) return;
+      // SAFETY: `console` is an optional cell-op field whose shape isn't
+      // surfaced in the openapi-generated type for `CellOperationNotification`;
+      // the guards below validate each entry before use.
+      const consoleOutput = (op as { console?: unknown }).console;
+      if (!consoleOutput) return;
 
-        const outputs = Array.isArray(consoleOutput)
-          ? consoleOutput
-          : [consoleOutput];
-        for (const output of outputs) {
-          if (
-            typeof output !== "object" ||
-            output === null ||
-            !("channel" in output) ||
-            !("data" in output)
-          ) {
-            continue;
-          }
-          if (output.channel === "stdout" && typeof output.data === "string") {
-            try {
-              const json: unknown = JSON.parse(output.data.trim());
-              const decoded = Schema.decodeUnknownOption(DebugpyState)(json);
-              if (Option.isSome(decoded)) {
-                result = decoded.value;
-              }
-            } catch {
-              // Not valid JSON, skip
+      const outputs = Array.isArray(consoleOutput)
+        ? consoleOutput
+        : [consoleOutput];
+      for (const output of outputs) {
+        if (
+          typeof output !== "object" ||
+          output === null ||
+          !("channel" in output) ||
+          !("data" in output)
+        ) {
+          continue;
+        }
+        if (output.channel === "stdout" && typeof output.data === "string") {
+          try {
+            const json: unknown = JSON.parse(output.data.trim());
+            const decoded = Schema.decodeUnknownOption(DebugpyState)(json);
+            if (Option.isSome(decoded)) {
+              result = decoded.value;
             }
+          } catch {
+            // Not valid JSON, skip
           }
         }
-      }),
-    );
+      }
+    }),
+  );
 
-    if (!result) {
-      return yield* new DebugpyActivationError({ reason: "no port received" });
-    }
+  if (!result) {
+    return yield* new DebugpyActivationError({ reason: "no port received" });
+  }
 
-    return result;
-  });
-}
+  return result;
+});

--- a/extension/src/kernel/NotebookControllers.ts
+++ b/extension/src/kernel/NotebookControllers.ts
@@ -330,8 +330,8 @@ const pruneStaleControllers = Effect.fn("pruneStaleControllers")(
     for (const rawDocument of documents) {
       const notebook = MarimoNotebookDocument.tryFrom(rawDocument);
       if (Option.isNone(notebook)) continue;
-      const controller = yield* notebooks.forNotebook(notebook.value.id)
-        .getController;
+      const handle = yield* notebooks.forNotebook(notebook.value.id);
+      const controller = yield* handle.getController;
       if (Option.isSome(controller)) {
         selectedControllerIds.add(controller.value.id);
       }

--- a/extension/src/kernel/NotebookExecutor.ts
+++ b/extension/src/kernel/NotebookExecutor.ts
@@ -10,6 +10,7 @@ import {
   Queue,
   type Scope,
 } from "effect";
+import type { TaggedEnum } from "effect/Data";
 
 import type { NotebookId } from "../schemas/MarimoNotebookDocument.ts";
 
@@ -27,6 +28,19 @@ interface Actor<R> {
   readonly queue: Queue.Queue<Work<R>, Cause.Done>;
 }
 
+type Ingress<R> = Data.TaggedEnum<{
+  Work: { readonly work: Work<R> };
+  Idle: {
+    readonly notebookId: NotebookId;
+    readonly actor: Actor<R>;
+    readonly retire: Deferred.Deferred<boolean>;
+  };
+}>;
+interface IngressDef extends TaggedEnum.WithGenerics<1> {
+  readonly taggedEnum: Ingress<this["A"]>;
+}
+const Ingress = Data.taggedEnum<IngressDef>();
+
 /** The scope that owned an admitted notebook command closed before it ended. */
 export class NotebookExecutionScopeClosedError extends Data.TaggedError(
   "NotebookExecutionScopeClosedError",
@@ -38,27 +52,20 @@ export interface NotebookExecutor<R> {
     notebookId: NotebookId,
     effect: Effect.Effect<A, E, R>,
   ) => Effect.Effect<A, E>;
-  /** Like `submit`, but interrupts queued or running work when `scope` closes. */
-  readonly submitIn: <A, E>(
-    scope: Scope.Scope,
+  /** Like `submit`, but owned by the `Scope` in the Effect environment. */
+  readonly submitScoped: <A, E>(
     notebookId: NotebookId,
     effect: Effect.Effect<A, E, R>,
-  ) => Effect.Effect<A, E | NotebookExecutionScopeClosedError>;
+  ) => Effect.Effect<A, E | NotebookExecutionScopeClosedError, Scope.Scope>;
   readonly post: (
     notebookId: NotebookId,
     effect: Effect.Effect<void, never, R>,
   ) => Effect.Effect<void>;
-  /** Like `post`, but interrupts queued or running work when `scope` closes. */
-  readonly postIn: (
-    scope: Scope.Scope,
+  /** Like `post`, but owned by the `Scope` in the Effect environment. */
+  readonly postScoped: (
     notebookId: NotebookId,
     effect: Effect.Effect<void, never, R>,
-  ) => Effect.Effect<void>;
-  /**
-   * Releases the notebook's worker after all previously admitted work has
-   * run. Later submissions for the same notebook start a fresh worker.
-   */
-  readonly retire: (notebookId: NotebookId) => Effect.Effect<void>;
+  ) => Effect.Effect<void, never, Scope.Scope>;
 }
 
 /** Makes a scoped executor that owns every successfully admitted effect. */
@@ -69,7 +76,7 @@ export function makeNotebookExecutor<R>(): Effect.Effect<
 > {
   return Effect.uninterruptible(
     Effect.gen(function* () {
-      const ingress = yield* Queue.unbounded<Work<R>, Cause.Done>();
+      const ingress = yield* Queue.unbounded<Ingress<R>, Cause.Done>();
       const actors = new Map<NotebookId, Actor<R>>();
       const fibers = yield* FiberSet.make<void, never>();
 
@@ -84,26 +91,38 @@ export function makeNotebookExecutor<R>(): Effect.Effect<
           yield* Queue.shutdown(actor.queue);
         });
 
-      const runWorker = (queue: Queue.Queue<Work<R>, Cause.Done>) =>
-        Effect.forever(
+      const runWorker = (notebookId: NotebookId, actor: Actor<R>) => {
+        const loop = (): Effect.Effect<void, Cause.Done, R> =>
           Effect.uninterruptibleMask((restore) =>
-            restore(Queue.take(queue)).pipe(
-              Effect.flatMap((work) =>
-                work
-                  .run(restore)
-                  .pipe(
-                    Effect.catchCause((cause) =>
-                      Cause.hasInterruptsOnly(cause)
-                        ? Effect.void
-                        : Effect.logError(
-                            "Notebook executor event failed",
-                          ).pipe(Effect.annotateLogs({ cause })),
-                    ),
+            Effect.gen(function* () {
+              const work = yield* restore(Queue.take(actor.queue));
+              yield* work
+                .run(restore)
+                .pipe(
+                  Effect.catchCause((cause) =>
+                    Cause.hasInterruptsOnly(cause)
+                      ? Effect.void
+                      : Effect.logError("Notebook executor event failed").pipe(
+                          Effect.annotateLogs({ cause }),
+                        ),
                   ),
-              ),
+                );
+
+              if ((yield* Queue.size(actor.queue)) > 0) return false;
+              const retire = yield* Deferred.make<boolean>();
+              const offered = yield* Queue.offer(
+                ingress,
+                Ingress.Idle({ notebookId, actor, retire }),
+              );
+              return offered ? yield* Deferred.await(retire) : true;
+            }),
+          ).pipe(
+            Effect.flatMap((retire) =>
+              retire ? Effect.void : Effect.suspend(loop),
             ),
-          ),
-        ).pipe(Effect.catchTag("Done", () => Effect.void));
+          );
+        return loop().pipe(Effect.catchTag("Done", () => Effect.void));
+      };
 
       const actorFor = (notebookId: NotebookId) =>
         Effect.gen(function* () {
@@ -115,7 +134,7 @@ export function makeNotebookExecutor<R>(): Effect.Effect<
           actors.set(notebookId, actor);
           yield* FiberSet.run(
             fibers,
-            runWorker(queue).pipe(
+            runWorker(notebookId, actor).pipe(
               Effect.ensuring(closeActor(notebookId, actor)),
             ),
           );
@@ -126,19 +145,29 @@ export function makeNotebookExecutor<R>(): Effect.Effect<
         fibers,
         Effect.forever(
           Queue.take(ingress).pipe(
-            Effect.flatMap((work) =>
-              Effect.gen(function* () {
-                const actor = yield* actorFor(work.notebookId);
-                if (!(yield* Queue.offer(actor.queue, work))) {
-                  // The actor retired between lookup and offer. Retirement
-                  // removes the map entry before ending the queue, so one
-                  // retry lands on a fresh actor.
-                  const fresh = yield* actorFor(work.notebookId);
-                  if (!(yield* Queue.offer(fresh.queue, work))) {
-                    yield* work.reject;
-                  }
-                }
-              }),
+            Effect.flatMap((message) =>
+              Ingress.$is("Work")(message)
+                ? Effect.gen(function* () {
+                    const { work } = message;
+                    const actor = yield* actorFor(work.notebookId);
+                    if (!(yield* Queue.offer(actor.queue, work))) {
+                      const fresh = yield* actorFor(work.notebookId);
+                      if (!(yield* Queue.offer(fresh.queue, work))) {
+                        yield* work.reject;
+                      }
+                    }
+                  })
+                : Effect.gen(function* () {
+                    const current = actors.get(message.notebookId);
+                    const shouldRetire =
+                      current !== message.actor ||
+                      (yield* Queue.size(message.actor.queue)) === 0;
+                    if (shouldRetire && current === message.actor) {
+                      actors.delete(message.notebookId);
+                      yield* Queue.end(message.actor.queue);
+                    }
+                    yield* Deferred.succeed(message.retire, shouldRetire);
+                  }),
             ),
           ),
         ).pipe(Effect.catchTag("Done", () => Effect.void)),
@@ -200,7 +229,7 @@ export function makeNotebookExecutor<R>(): Effect.Effect<
               reject: Deferred.interrupt(reply).pipe(Effect.asVoid),
             };
 
-            if (!(yield* Queue.offer(ingress, work))) {
+            if (!(yield* Queue.offer(ingress, Ingress.Work({ work })))) {
               yield* work.reject;
             }
 
@@ -212,11 +241,25 @@ export function makeNotebookExecutor<R>(): Effect.Effect<
 
       const submit: NotebookExecutor<R>["submit"] = (notebookId, effect) =>
         submitWork(notebookId, effect);
-      const submitIn: NotebookExecutor<R>["submitIn"] = (
-        scope,
+      const submitScoped: NotebookExecutor<R>["submitScoped"] = (
         notebookId,
         effect,
-      ) => submitWork(notebookId, inScope(effect, scope, notebookId));
+      ) =>
+        Effect.gen(function* () {
+          const scope = yield* Effect.scope;
+          const closed = yield* Deferred.make<void>();
+          yield* Effect.addFinalizer(() => Deferred.succeed(closed, undefined));
+          return yield* Effect.raceFirst(
+            submitWork(notebookId, inScope(effect, scope, notebookId)),
+            Deferred.await(closed).pipe(
+              Effect.andThen(
+                Effect.fail(
+                  new NotebookExecutionScopeClosedError({ notebookId }),
+                ),
+              ),
+            ),
+          );
+        });
 
       const postWork = (
         notebookId: NotebookId,
@@ -224,51 +267,40 @@ export function makeNotebookExecutor<R>(): Effect.Effect<
       ) =>
         Effect.uninterruptible(
           Effect.gen(function* () {
-            const admitted = yield* Queue.offer(ingress, {
-              notebookId,
-              run: (restore) => restore(effect),
-              reject: Effect.void,
-            });
+            const admitted = yield* Queue.offer(
+              ingress,
+              Ingress.Work({
+                work: {
+                  notebookId,
+                  run: (restore) => restore(effect),
+                  reject: Effect.void,
+                },
+              }),
+            );
             if (!admitted) return yield* Effect.interrupt;
             return undefined;
           }),
         );
       const post: NotebookExecutor<R>["post"] = (notebookId, effect) =>
         postWork(notebookId, effect);
-      const postIn: NotebookExecutor<R>["postIn"] = (
-        scope,
+      const postScoped: NotebookExecutor<R>["postScoped"] = (
         notebookId,
         effect,
       ) =>
-        postWork(
-          notebookId,
-          inScope(effect, scope, notebookId).pipe(
-            Effect.catchTag(
-              "NotebookExecutionScopeClosedError",
-              () => Effect.void,
-            ),
-          ),
-        );
-
-      // Routed through ingress like any work so it runs after everything
-      // admitted for the notebook before it. Draining the queue after end
-      // lets the worker finish those items and exit on Done.
-      const retire: NotebookExecutor<R>["retire"] = (notebookId) =>
-        Effect.uninterruptible(
-          Queue.offer(ingress, {
+        Effect.gen(function* () {
+          const scope = yield* Effect.scope;
+          yield* postWork(
             notebookId,
-            run: () =>
-              Effect.suspend(() => {
-                const actor = actors.get(notebookId);
-                if (actor === undefined) return Effect.void;
-                actors.delete(notebookId);
-                return Queue.end(actor.queue).pipe(Effect.asVoid);
-              }),
-            reject: Effect.void,
-          }).pipe(Effect.asVoid),
-        );
+            inScope(effect, scope, notebookId).pipe(
+              Effect.catchTag(
+                "NotebookExecutionScopeClosedError",
+                () => Effect.void,
+              ),
+            ),
+          );
+        });
 
-      return { submit, submitIn, post, postIn, retire };
+      return { submit, submitScoped, post, postScoped };
     }),
   );
 }

--- a/extension/src/kernel/NotebookExecutor.ts
+++ b/extension/src/kernel/NotebookExecutor.ts
@@ -8,7 +8,7 @@ import {
   FiberSet,
   Predicate,
   Queue,
-  type Scope,
+  Scope,
 } from "effect";
 import type { TaggedEnum } from "effect/Data";
 
@@ -247,8 +247,12 @@ export function makeNotebookExecutor<R>(): Effect.Effect<
       ) =>
         Effect.gen(function* () {
           const scope = yield* Effect.scope;
+          const watcherScope = yield* Scope.fork(scope);
           const closed = yield* Deferred.make<void>();
-          yield* Effect.addFinalizer(() => Deferred.succeed(closed, undefined));
+          yield* Scope.addFinalizer(
+            watcherScope,
+            Deferred.succeed(closed, undefined),
+          );
           return yield* Effect.raceFirst(
             submitWork(notebookId, inScope(effect, scope, notebookId)),
             Deferred.await(closed).pipe(
@@ -258,7 +262,7 @@ export function makeNotebookExecutor<R>(): Effect.Effect<
                 ),
               ),
             ),
-          );
+          ).pipe(Effect.ensuring(Scope.close(watcherScope, Exit.void)));
         });
 
       const postWork = (

--- a/extension/src/kernel/NotebookRuntime.ts
+++ b/extension/src/kernel/NotebookRuntime.ts
@@ -11,6 +11,7 @@ import {
   Ref,
   type SchemaError,
   Semaphore,
+  Scope,
   Stream,
   Array as EffectArray,
 } from "effect";
@@ -371,62 +372,73 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
         controller: Ref.Ref<Option.Option<NotebookController>>,
       ): NotebookDocumentHandle => ({
         executeCells: (request, executable) =>
-          executor
-            .submitIn(
-              session.scope,
-              session.notebookId,
-              Effect.gen(function* () {
-                const notebookId = session.notebookId;
-                const notebook = MarimoNotebookDocument.from(session.document);
-                const workingDirectory = yield* resolveWorkingDirectory(
-                  notebookId,
-                  executable,
-                  notebook,
-                );
-                const send = marimo.executeCells({
-                  notebookUri: notebookId,
-                  executable,
-                  workingDirectory,
-                  inner: request,
-                });
-                const notebookExecutions = yield* executions.open(session, {
-                  getDrive: Ref.get(controller).pipe(
-                    Effect.map(
-                      Option.map((selected) => selected.drive(notebook)),
+          registerDocumentSessionCleanup(session).pipe(
+            Effect.andThen(
+              executor
+                .submitScoped(
+                  session.notebookId,
+                  Effect.gen(function* () {
+                    const notebookId = session.notebookId;
+                    const notebook = MarimoNotebookDocument.from(
+                      session.document,
+                    );
+                    const workingDirectory = yield* resolveWorkingDirectory(
+                      notebookId,
+                      executable,
+                      notebook,
+                    );
+                    const send = marimo.executeCells({
+                      notebookUri: notebookId,
+                      executable,
+                      workingDirectory,
+                      inner: request,
+                    });
+                    const notebookExecutions = yield* executions.open(session, {
+                      getDrive: Ref.get(controller).pipe(
+                        Effect.map(
+                          Option.map((selected) => selected.drive(notebook)),
+                        ),
+                      ),
+                    });
+                    const result = yield* notebookExecutions.submit(
+                      request.cellIds.flatMap((cellId, index) => {
+                        const source = request.codes[index];
+                        return source === undefined
+                          ? []
+                          : [
+                              {
+                                cellId: makeNotebookCellId(cellId),
+                                source,
+                              },
+                            ];
+                      }),
+                      send,
+                    );
+                    yield* liveSessions.refresh();
+                    yield* reconcileKernelSession(notebookId);
+                    return result;
+                  }).pipe(
+                    Effect.catchTag("NotebookDocumentSessionEndedError", () =>
+                      Effect.fail(
+                        new NoActiveKernelError({
+                          notebookUri: session.notebookId,
+                        }),
+                      ),
                     ),
                   ),
-                });
-                const result = yield* notebookExecutions.submit(
-                  request.cellIds.flatMap((cellId, index) => {
-                    const source = request.codes[index];
-                    return source === undefined
-                      ? []
-                      : [{ cellId: makeNotebookCellId(cellId), source }];
-                  }),
-                  send,
-                );
-                yield* liveSessions.refresh();
-                yield* reconcileKernelSession(notebookId);
-                return result;
-              }).pipe(
-                Effect.catchTag("NotebookDocumentSessionEndedError", () =>
-                  Effect.fail(
-                    new NoActiveKernelError({
-                      notebookUri: session.notebookId,
-                    }),
+                )
+                .pipe(
+                  Scope.provide(session.scope),
+                  Effect.catchTag("NotebookExecutionScopeClosedError", () =>
+                    Effect.fail(
+                      new NoActiveKernelError({
+                        notebookUri: session.notebookId,
+                      }),
+                    ),
                   ),
                 ),
-              ),
-            )
-            .pipe(
-              Effect.catchTag("NotebookExecutionScopeClosedError", () =>
-                Effect.fail(
-                  new NoActiveKernelError({
-                    notebookUri: session.notebookId,
-                  }),
-                ),
-              ),
             ),
+          ),
       });
 
       const makeHandle = (
@@ -627,31 +639,32 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
           Stream.runForEach(updateKernelContext),
         ),
       );
-      yield* Effect.forkScoped(
-        documentSessions.changes.pipe(
-          Stream.filter((change) => change._tag === "Ended"),
-          Stream.runForEach(
-            Effect.fn("NotebookRuntime.releaseDocumentSession")(
-              function* (change) {
-                const { notebookId } = change.session;
-                yield* executor.post(
+      const registeredSessionCleanups = new WeakSet<NotebookDocumentSession>();
+      const registerDocumentSessionCleanup = Effect.fn(
+        "NotebookRuntime.registerDocumentSessionCleanup",
+      )((session: NotebookDocumentSession) =>
+        Effect.uninterruptible(
+          Effect.suspend(() => {
+            if (registeredSessionCleanups.has(session)) return Effect.void;
+            registeredSessionCleanups.add(session);
+            const { notebookId } = session;
+            return Scope.addFinalizer(
+              session.scope,
+              executor
+                .post(
                   notebookId,
                   Effect.gen(function* () {
                     const state = notebooks.get(notebookId);
-                    if (state?.session === change.session) {
+                    if (state?.session === session)
                       notebooks.delete(notebookId);
-                    }
-                    yield* variables.clearSession(change.session);
-                    yield* datasources.clearSession(change.session);
+                    yield* variables.clearSession(session);
+                    yield* datasources.clearSession(session);
                     yield* updateKernelContext();
                   }),
-                );
-                // Ingress order puts retirement after the cleanup above; a
-                // reopened notebook simply starts a fresh worker.
-                yield* executor.retire(notebookId);
-              },
-            ),
-          ),
+                )
+                .pipe(Effect.exit, Effect.asVoid),
+            );
+          }),
         ),
       );
       yield* Effect.forkScoped(
@@ -762,10 +775,12 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
               ),
               Effect.withSpan("NotebookRuntime.processOperation"),
             );
-            return executor.postIn(
-              message.session.scope,
-              message.notebookUri,
-              run,
+            return registerDocumentSessionCleanup(message.session).pipe(
+              Effect.andThen(
+                executor
+                  .postScoped(message.notebookUri, run)
+                  .pipe(Scope.provide(message.session.scope)),
+              ),
             );
           }),
         ),
@@ -775,10 +790,15 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
           Stream.runForEach((message) => {
             const session = documentSessions.current(message.notebookUri);
             if (session === undefined) return Effect.void;
-            return executor.postIn(
-              session.scope,
-              message.notebookUri,
-              variables.updateVariables(session, message.analysis),
+            return registerDocumentSessionCleanup(session).pipe(
+              Effect.andThen(
+                executor
+                  .postScoped(
+                    message.notebookUri,
+                    variables.updateVariables(session, message.analysis),
+                  )
+                  .pipe(Scope.provide(session.scope)),
+              ),
             );
           }),
         ),
@@ -889,6 +909,10 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
           controller: NotebookController,
         ) {
           return Effect.gen(function* () {
+            const session = documentSessions.current(notebookId);
+            if (session !== undefined) {
+              yield* registerDocumentSessionCleanup(session);
+            }
             yield* Effect.uninterruptible(
               Effect.gen(function* () {
                 yield* Ref.set(
@@ -975,6 +999,7 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
                 notebookUri: notebook.id,
               });
             }
+            yield* registerDocumentSessionCleanup(session);
             const state = stateForNotebook(session.notebookId);
             return makeDocumentHandle(session, state.controller);
           });

--- a/extension/src/kernel/NotebookRuntime.ts
+++ b/extension/src/kernel/NotebookRuntime.ts
@@ -176,7 +176,6 @@ export interface NotebookDocumentHandle {
 }
 
 interface NotebookState {
-  readonly session: NotebookDocumentSession | undefined;
   readonly handle: NotebookHandle;
   readonly controller: Ref.Ref<Option.Option<NotebookController>>;
 }
@@ -239,7 +238,7 @@ function isScratchpadOutput(
  * ```ts
  * const runtime = yield* NotebookRuntime;
  * const documentHandle = yield* runtime.forDocument(rawNotebook);
- * const notebook = runtime.forNotebook(notebookId);
+ * const notebook = yield* runtime.forNotebook(notebookId);
  *
  * yield* documentHandle.executeCells(request, executable);
  * yield* notebook.updateUIElements(update);
@@ -262,7 +261,10 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
       const liveSessions = yield* SessionsService;
       const documentSessions = yield* NotebookDocumentSessions;
       const operations = yield* PubSub.unbounded<SessionNotification>();
-      const notebooks = new Map<NotebookId, NotebookState>();
+      const notebookStates = new Map<
+        NotebookId | NotebookDocumentSession,
+        NotebookState
+      >();
       const kernelSessions = new Map<NotebookId, KernelSessionId>(
         (yield* liveSessions.get).map((session) => [
           session.notebookUri,
@@ -372,7 +374,7 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
         controller: Ref.Ref<Option.Option<NotebookController>>,
       ): NotebookDocumentHandle => ({
         executeCells: (request, executable) =>
-          registerDocumentSessionCleanup(session).pipe(
+          stateForDocumentSession(session).pipe(
             Effect.andThen(
               executor
                 .submitScoped(
@@ -591,34 +593,6 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
         ),
       });
 
-      const makeState = (notebookId: NotebookId): NotebookState => {
-        const controller = Ref.makeUnsafe<Option.Option<NotebookController>>(
-          Option.none(),
-        );
-        return {
-          session: documentSessions.current(notebookId),
-          controller,
-          handle: makeHandle(notebookId, controller, Semaphore.makeUnsafe(1)),
-        };
-      };
-
-      const stateForNotebook = (notebookId: NotebookId) => {
-        const existing = notebooks.get(notebookId);
-        if (
-          existing !== undefined &&
-          existing.session === documentSessions.current(notebookId)
-        ) {
-          return existing;
-        }
-
-        const state = makeState(notebookId);
-        notebooks.set(notebookId, state);
-        return state;
-      };
-
-      const forNotebook = (notebookId: NotebookId) =>
-        stateForNotebook(notebookId).handle;
-
       const updateKernelContext = Effect.fn(
         "NotebookRuntime.updateKernelContext",
       )(function* () {
@@ -639,34 +613,64 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
           Stream.runForEach(updateKernelContext),
         ),
       );
-      const registeredSessionCleanups = new WeakSet<NotebookDocumentSession>();
-      const registerDocumentSessionCleanup = Effect.fn(
-        "NotebookRuntime.registerDocumentSessionCleanup",
+      const makeState = (notebookId: NotebookId): NotebookState => {
+        const controller = Ref.makeUnsafe<Option.Option<NotebookController>>(
+          Option.none(),
+        );
+        return {
+          controller,
+          handle: makeHandle(notebookId, controller, Semaphore.makeUnsafe(1)),
+        };
+      };
+
+      const stateForDocumentSession = Effect.fn(
+        "NotebookRuntime.stateForDocumentSession",
       )((session: NotebookDocumentSession) =>
         Effect.uninterruptible(
           Effect.suspend(() => {
-            if (registeredSessionCleanups.has(session)) return Effect.void;
-            registeredSessionCleanups.add(session);
+            const existing = notebookStates.get(session);
+            if (existing !== undefined) return Effect.succeed(existing);
+
             const { notebookId } = session;
+            const state = makeState(notebookId);
+            notebookStates.delete(notebookId);
+            notebookStates.set(session, state);
             return Scope.addFinalizer(
               session.scope,
               executor
                 .post(
                   notebookId,
                   Effect.gen(function* () {
-                    const state = notebooks.get(notebookId);
-                    if (state?.session === session)
-                      notebooks.delete(notebookId);
+                    notebookStates.delete(session);
                     yield* variables.clearSession(session);
                     yield* datasources.clearSession(session);
                     yield* updateKernelContext();
                   }),
                 )
                 .pipe(Effect.exit, Effect.asVoid),
-            );
+            ).pipe(Effect.as(state));
           }),
         ),
       );
+
+      const stateForNotebook = Effect.fn("NotebookRuntime.stateForNotebook")(
+        (notebookId: NotebookId) =>
+          Effect.suspend(() => {
+            const session = documentSessions.current(notebookId);
+            if (session !== undefined) return stateForDocumentSession(session);
+
+            const existing = notebookStates.get(notebookId);
+            if (existing !== undefined) return Effect.succeed(existing);
+
+            const state = makeState(notebookId);
+            notebookStates.set(notebookId, state);
+            return Effect.succeed(state);
+          }),
+      );
+
+      const forNotebook = (notebookId: NotebookId) =>
+        stateForNotebook(notebookId).pipe(Effect.map((state) => state.handle));
+
       yield* Effect.forkScoped(
         liveSessions.changes.pipe(
           Stream.runForEach((snapshot) =>
@@ -700,54 +704,72 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
             }),
           ),
           Stream.runForEach((message) => {
-            const run = Effect.gen(function* () {
-              // The kernel-session gate covers one race: sessionsChanged and
-              // kernel notifications arrive on independent streams, so a
-              // notification from a kernel replaced by restart can reach this
-              // worker after the reconcile that installed the new session id.
-              // The server never emits a stale id after announcing its
-              // replacement on the wire; only this client-side reordering
-              // needs guarding. (File-backed close/reopen reuses the same
-              // kernel session, so no id change is involved there.)
-              if (
-                kernelSessions.get(message.notebookUri) !== message.sessionId
-              ) {
-                yield* liveSessions.refresh();
-                yield* reconcileKernelSession(message.notebookUri);
-              }
-              if (
-                kernelSessions.get(message.notebookUri) !== message.sessionId
-              ) {
-                yield* Effect.logDebug(
-                  "Ignored notification from an inactive kernel session",
-                ).pipe(
+            const run = (notebook: NotebookHandle) =>
+              Effect.gen(function* () {
+                // The kernel-session gate covers one race: sessionsChanged and
+                // kernel notifications arrive on independent streams, so a
+                // notification from a kernel replaced by restart can reach this
+                // worker after the reconcile that installed the new session id.
+                // The server never emits a stale id after announcing its
+                // replacement on the wire; only this client-side reordering
+                // needs guarding. (File-backed close/reopen reuses the same
+                // kernel session, so no id change is involved there.)
+                if (
+                  kernelSessions.get(message.notebookUri) !== message.sessionId
+                ) {
+                  yield* liveSessions.refresh();
+                  yield* reconcileKernelSession(message.notebookUri);
+                }
+                if (
+                  kernelSessions.get(message.notebookUri) !== message.sessionId
+                ) {
+                  yield* Effect.logDebug(
+                    "Ignored notification from an inactive kernel session",
+                  ).pipe(
+                    Effect.annotateLogs({
+                      notebookUri: message.notebookUri,
+                      sessionId: message.sessionId,
+                      notification: message.notification.op,
+                    }),
+                  );
+                  return;
+                }
+
+                yield* PubSub.publish(operations, message);
+                yield* Effect.annotateCurrentSpan(
+                  "notification.type",
+                  message.notification.op,
+                );
+                yield* processOperation(message, {
+                  notebook,
+                  respondToStdin,
+                  session: message.session,
+                }).pipe(
+                  Effect.catchTag(
+                    "NotebookDocumentSessionEndedError",
+                    () => Effect.void,
+                  ),
+                  Effect.catchCause(
+                    Effect.fn(function* (cause) {
+                      yield* Effect.logError(
+                        "Failed to process marimo operation",
+                      ).pipe(Effect.annotateLogs({ cause }));
+                      yield* Effect.forkChild(
+                        showErrorAndPromptLogs(
+                          "Failed to process marimo operation.",
+                        ),
+                      );
+                    }),
+                  ),
                   Effect.annotateLogs({
-                    notebookUri: message.notebookUri,
-                    sessionId: message.sessionId,
-                    notification: message.notification.op,
+                    "notification.type": message.notification.op,
                   }),
                 );
-                return;
-              }
-
-              yield* PubSub.publish(operations, message);
-              yield* Effect.annotateCurrentSpan(
-                "notification.type",
-                message.notification.op,
-              );
-              yield* processOperation(message, {
-                forNotebook,
-                respondToStdin,
-                session: message.session,
               }).pipe(
-                Effect.catchTag(
-                  "NotebookDocumentSessionEndedError",
-                  () => Effect.void,
-                ),
                 Effect.catchCause(
                   Effect.fn(function* (cause) {
                     yield* Effect.logError(
-                      "Failed to process marimo operation",
+                      "Failed to coordinate marimo operation",
                     ).pipe(Effect.annotateLogs({ cause }));
                     yield* Effect.forkChild(
                       showErrorAndPromptLogs(
@@ -756,29 +778,12 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
                     );
                   }),
                 ),
-                Effect.annotateLogs({
-                  "notification.type": message.notification.op,
-                }),
+                Effect.withSpan("NotebookRuntime.processOperation"),
               );
-            }).pipe(
-              Effect.catchCause(
-                Effect.fn(function* (cause) {
-                  yield* Effect.logError(
-                    "Failed to coordinate marimo operation",
-                  ).pipe(Effect.annotateLogs({ cause }));
-                  yield* Effect.forkChild(
-                    showErrorAndPromptLogs(
-                      "Failed to process marimo operation.",
-                    ),
-                  );
-                }),
-              ),
-              Effect.withSpan("NotebookRuntime.processOperation"),
-            );
-            return registerDocumentSessionCleanup(message.session).pipe(
-              Effect.andThen(
+            return stateForDocumentSession(message.session).pipe(
+              Effect.flatMap((state) =>
                 executor
-                  .postScoped(message.notebookUri, run)
+                  .postScoped(message.notebookUri, run(state.handle))
                   .pipe(Scope.provide(message.session.scope)),
               ),
             );
@@ -790,7 +795,7 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
           Stream.runForEach((message) => {
             const session = documentSessions.current(message.notebookUri);
             if (session === undefined) return Effect.void;
-            return registerDocumentSessionCleanup(session).pipe(
+            return stateForDocumentSession(session).pipe(
               Effect.andThen(
                 executor
                   .postScoped(
@@ -809,7 +814,7 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
           Stream.runForEach(({ editor, message }) =>
             Effect.gen(function* () {
               const notebook = MarimoNotebookDocument.from(editor.notebook);
-              const handle = forNotebook(notebook.id);
+              const handle = yield* forNotebook(notebook.id);
 
               switch (message.command) {
                 case "update-ui-element":
@@ -894,10 +899,13 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
             ),
           ),
           Stream.runForEach((event) =>
-            syncCellIdentity(event, {
-              code,
-              executions,
-              notebook: forNotebook(event.notebook.id),
+            Effect.gen(function* () {
+              const notebook = yield* forNotebook(event.notebook.id);
+              yield* syncCellIdentity(event, {
+                code,
+                executions,
+                notebook,
+              });
             }),
           ),
         ),
@@ -909,16 +917,10 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
           controller: NotebookController,
         ) {
           return Effect.gen(function* () {
-            const session = documentSessions.current(notebookId);
-            if (session !== undefined) {
-              yield* registerDocumentSessionCleanup(session);
-            }
             yield* Effect.uninterruptible(
               Effect.gen(function* () {
-                yield* Ref.set(
-                  stateForNotebook(notebookId).controller,
-                  Option.some(controller),
-                );
+                const state = yield* stateForNotebook(notebookId);
+                yield* Ref.set(state.controller, Option.some(controller));
                 yield* PubSub.publish(controllerSelections, {
                   notebookUri: notebookId,
                   controller,
@@ -986,7 +988,10 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
           const current = yield* liveSessions.get;
           yield* Effect.forEach(
             current,
-            (session) => forNotebook(session.notebookUri).close,
+            (session) =>
+              forNotebook(session.notebookUri).pipe(
+                Effect.andThen((handle) => handle.close),
+              ),
             { discard: true },
           );
         }),
@@ -999,8 +1004,7 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
                 notebookUri: notebook.id,
               });
             }
-            yield* registerDocumentSessionCleanup(session);
-            const state = stateForNotebook(session.notebookId);
+            const state = yield* stateForDocumentSession(session);
             return makeDocumentHandle(session, state.controller);
           });
         },
@@ -1088,7 +1092,7 @@ function isValueUpdateEcho(
 function processOperation(
   message: SessionNotification,
   options: {
-    forNotebook: (notebookId: NotebookId) => NotebookHandle;
+    readonly notebook: NotebookHandle;
     readonly respondToStdin: RespondToStdin;
     readonly session: NotebookDocumentSession;
   },
@@ -1219,7 +1223,7 @@ function processNotebookOperation(
     | NotificationOf<"send-ui-element-message">
     | NotificationOf<"model-lifecycle">,
   options: {
-    forNotebook: (notebookId: NotebookId) => NotebookHandle;
+    readonly notebook: NotebookHandle;
     readonly respondToStdin: RespondToStdin;
     readonly session: NotebookDocumentSession;
     readonly kernelSessionId: KernelSessionId | undefined;
@@ -1229,12 +1233,11 @@ function processNotebookOperation(
     const editors = yield* NotebookEditorRegistry;
     const renderer = yield* NotebookRenderer;
     const executions = yield* CellExecutions;
-    const notebookHandle = options.forNotebook(notebookUri);
     const sessionNotebook = MarimoNotebookDocument.from(
       options.session.document,
     );
     const notebookExecutions = yield* executions.open(options.session, {
-      getDrive: notebookHandle.getController.pipe(
+      getDrive: options.notebook.getController.pipe(
         Effect.map(
           Option.map((controller) => controller.drive(sessionNotebook)),
         ),
@@ -1286,7 +1289,7 @@ function processNotebookOperation(
     }
     if (editor.value.notebook !== options.session.document) return;
 
-    const controller = yield* notebookHandle.getController;
+    const controller = yield* options.notebook.getController;
     if (Option.isNone(controller)) {
       yield* Effect.logWarning("No active controller, skipping operation");
       return;

--- a/extension/src/kernel/PythonController.ts
+++ b/extension/src/kernel/PythonController.ts
@@ -214,7 +214,8 @@ export const createPythonController = Effect.fn("createPythonController")(
       runPromise(
         Effect.gen(function* () {
           const notebook = MarimoNotebookDocument.from(rawNotebook);
-          yield* notebooks.forNotebook(notebook.id).interrupt;
+          const handle = yield* notebooks.forNotebook(notebook.id);
+          yield* handle.interrupt;
         }).pipe(
           Effect.withSpan("PythonController.interrupt", {
             attributes: {

--- a/extension/src/kernel/SandboxController.ts
+++ b/extension/src/kernel/SandboxController.ts
@@ -186,7 +186,8 @@ export const createSandboxController = Effect.fn("createSandboxController")(
       runPromise(
         Effect.gen(function* () {
           const notebook = MarimoNotebookDocument.from(doc);
-          yield* notebooks.forNotebook(notebook.id).interrupt;
+          const handle = yield* notebooks.forNotebook(notebook.id);
+          yield* handle.interrupt;
         }).pipe(
           Effect.withSpan("SandboxController.interrupt", {
             attributes: {

--- a/extension/src/kernel/__tests__/NotebookControllers.test.ts
+++ b/extension/src/kernel/__tests__/NotebookControllers.test.ts
@@ -86,13 +86,10 @@ it.effect(
       const notebooks = yield* NotebookRuntime;
       const editor = TestVsCode.makeNotebookEditor("/test/notebook_mo.py");
 
-      expect(
-        Option.isNone(
-          yield* notebooks.forNotebook(
-            notebookId(editor.notebook.uri.toString()),
-          ).getController,
-        ),
-      ).toBe(true);
+      const initial = yield* notebooks.forNotebook(
+        notebookId(editor.notebook.uri.toString()),
+      );
+      expect(Option.isNone(yield* initial.getController)).toBe(true);
 
       // No drain before selecting: the controller's selection listener is
       // acquired in the same fiber turn as its creation, so an event fired
@@ -105,9 +102,10 @@ it.effect(
       );
       yield* TestClock.adjust("10 millis");
 
-      const selected = yield* notebooks.forNotebook(
+      const selectedNotebook = yield* notebooks.forNotebook(
         notebookId(editor.notebook.uri.toString()),
-      ).getController;
+      );
+      const selected = yield* selectedNotebook.getController;
       assert(Option.isSome(selected));
       expect(selected.value.id).toBe(`marimo-${executable}`);
     }).pipe(Effect.provide(ctx.layer));

--- a/extension/src/kernel/__tests__/NotebookExecutor.test.ts
+++ b/extension/src/kernel/__tests__/NotebookExecutor.test.ts
@@ -166,13 +166,35 @@ describe("NotebookExecutor", () => {
         const failure = exit.cause.reasons.find(Cause.isFailReason);
         assert.instanceOf(failure?.error, NotebookExecutionScopeClosedError);
       }
-      assert.isFalse(yield* Ref.get(queuedStarted));
 
       yield* releaseBlocker.open;
       assert.strictEqual(
         yield* executor.submit(notebook, Effect.succeed("done")),
         "done",
       );
+      assert.isFalse(yield* Ref.get(queuedStarted));
+    }),
+  );
+
+  it.effect(
+    "releases scope-close watchers after submissions finish",
+    Effect.fn(function* () {
+      const executor = yield* makeNotebookExecutor<never>();
+      const documentScope = yield* Scope.make();
+      const notebook = notebookId("notebook");
+
+      for (let index = 0; index < 100; index++) {
+        yield* executor
+          .submitScoped(notebook, Effect.void)
+          .pipe(Scope.provide(documentScope));
+      }
+
+      const finalizerCount =
+        documentScope.state._tag === "Open"
+          ? documentScope.state.finalizers.size
+          : 0;
+      assert.strictEqual(finalizerCount, 0);
+      yield* Scope.close(documentScope, Exit.void);
     }),
   );
 

--- a/extension/src/kernel/__tests__/NotebookExecutor.test.ts
+++ b/extension/src/kernel/__tests__/NotebookExecutor.test.ts
@@ -101,20 +101,17 @@ describe("NotebookExecutor", () => {
       const notebook = notebookId("notebook");
 
       const active = yield* executor
-        .submitIn(
-          documentScope,
-          notebook,
-          started.open.pipe(Effect.andThen(Effect.never)),
-        )
+        .submitScoped(notebook, started.open.pipe(Effect.andThen(Effect.never)))
+        .pipe(Scope.provide(documentScope))
         .pipe(Effect.forkDetach);
       yield* started.await;
 
       const buffered = yield* executor
-        .submitIn(
-          documentScope,
+        .submitScoped(
           notebook,
           Ref.set(bufferedStarted, true).pipe(Effect.andThen(Effect.never)),
         )
+        .pipe(Scope.provide(documentScope))
         .pipe(Effect.forkDetach);
       yield* Effect.yieldNow;
 
@@ -139,6 +136,47 @@ describe("NotebookExecutor", () => {
   );
 
   it.effect(
+    "rejects queued scoped work as soon as its scope closes",
+    Effect.fn(function* () {
+      const executor = yield* makeNotebookExecutor<never>();
+      const documentScope = yield* Scope.make();
+      const blockerStarted = yield* Latch.make();
+      const releaseBlocker = yield* Latch.make();
+      const queuedStarted = yield* Ref.make(false);
+      const notebook = notebookId("notebook");
+
+      yield* executor.post(
+        notebook,
+        blockerStarted.open.pipe(Effect.andThen(releaseBlocker.await)),
+      );
+      yield* blockerStarted.await;
+
+      const queued = yield* executor
+        .submitScoped(
+          notebook,
+          Ref.set(queuedStarted, true).pipe(Effect.andThen(Effect.never)),
+        )
+        .pipe(Scope.provide(documentScope), Effect.forkDetach);
+      yield* Effect.yieldNow;
+
+      yield* Scope.close(documentScope, Exit.void);
+      const exit = yield* Fiber.await(queued);
+      assert.isTrue(Exit.isFailure(exit));
+      if (Exit.isFailure(exit)) {
+        const failure = exit.cause.reasons.find(Cause.isFailReason);
+        assert.instanceOf(failure?.error, NotebookExecutionScopeClosedError);
+      }
+      assert.isFalse(yield* Ref.get(queuedStarted));
+
+      yield* releaseBlocker.open;
+      assert.strictEqual(
+        yield* executor.submit(notebook, Effect.succeed("done")),
+        "done",
+      );
+    }),
+  );
+
+  it.effect(
     "preserves self-interruption while the owning scope remains open",
     Effect.fn(function* () {
       const executor = yield* makeNotebookExecutor<never>();
@@ -146,8 +184,8 @@ describe("NotebookExecutor", () => {
       const notebook = notebookId("notebook");
 
       const submitted = yield* executor
-        .submitIn(documentScope, notebook, Effect.interrupt)
-        .pipe(Effect.forkDetach);
+        .submitScoped(notebook, Effect.interrupt)
+        .pipe(Scope.provide(documentScope), Effect.forkDetach);
 
       assert.isTrue(Exit.hasInterrupts(yield* Fiber.await(submitted)));
       yield* Scope.close(documentScope, Exit.void);
@@ -169,79 +207,23 @@ describe("NotebookExecutor", () => {
   );
 
   it.effect(
-    "interrupts a retired worker that is still draining",
-    Effect.fn(function* () {
-      const scope = yield* Scope.make();
-      const executor = yield* makeNotebookExecutor<never>().pipe(
-        Effect.provideService(Scope.Scope, scope),
-      );
-      const blockerStarted = yield* Latch.make();
-      const releaseBlocker = yield* Latch.make();
-      const routed = yield* Latch.make();
-      const trailingStarted = yield* Latch.make();
-      const bufferedStarted = yield* Ref.make(false);
-      const notebook = notebookId("notebook");
-
-      yield* executor.post(
-        notebook,
-        blockerStarted.open.pipe(Effect.andThen(releaseBlocker.await)),
-      );
-      yield* blockerStarted.await;
-
-      yield* executor.retire(notebook);
-      const trailing = yield* executor
-        .submit(
-          notebook,
-          trailingStarted.open.pipe(Effect.andThen(Effect.never)),
-        )
-        .pipe(Effect.forkDetach);
-      const buffered = yield* executor
-        .submit(
-          notebook,
-          Ref.set(bufferedStarted, true).pipe(Effect.andThen(Effect.never)),
-        )
-        .pipe(Effect.forkDetach);
-
-      // Work for another notebook proves the coordinator routed everything
-      // above while the first actor was still blocked. The retire marker will
-      // remove that actor from the lookup map before its trailing work runs.
-      yield* executor.post(notebookId("barrier"), routed.open);
-      yield* routed.await;
-      yield* releaseBlocker.open;
-      yield* trailingStarted.await;
-
-      yield* Scope.close(scope, Exit.void);
-      const [trailingExit, bufferedExit] = yield* Effect.all([
-        Fiber.await(trailing),
-        Fiber.await(buffered),
-      ]);
-
-      assert.isTrue(Exit.hasInterrupts(trailingExit));
-      assert.isTrue(Exit.hasInterrupts(bufferedExit));
-      assert.isFalse(yield* Ref.get(bufferedStarted));
-    }),
-  );
-
-  it.effect(
-    "retires a notebook after draining admitted work",
+    "preserves FIFO while idle workers retire",
     Effect.fn(function* () {
       const executor = yield* makeNotebookExecutor<never>();
       const order = yield* Ref.make<ReadonlyArray<string>>([]);
       const notebook = notebookId("notebook");
 
-      yield* executor.post(
-        notebook,
-        Ref.update(order, (events) => [...events, "before"]),
-      );
-      yield* executor.retire(notebook);
-      yield* executor.post(
-        notebook,
-        Ref.update(order, (events) => [...events, "after"]),
-      );
+      for (let index = 0; index < 100; index++) {
+        yield* executor.submit(
+          notebook,
+          Ref.update(order, (events) => [...events, String(index)]),
+        );
+      }
 
-      const result = yield* executor.submit(notebook, Effect.succeed("done"));
-      assert.strictEqual(result, "done");
-      assert.deepStrictEqual(yield* Ref.get(order), ["before", "after"]);
+      assert.deepStrictEqual(
+        yield* Ref.get(order),
+        Array.from({ length: 100 }, (_, index) => String(index)),
+      );
     }),
   );
 });

--- a/extension/src/kernel/__tests__/NotebookRuntime.test.ts
+++ b/extension/src/kernel/__tests__/NotebookRuntime.test.ts
@@ -115,8 +115,8 @@ it.effect(
       const id = notebookId(editor.notebook.uri.toString());
       yield* vscode.openNotebook(editor.notebook);
       yield* Effect.yieldNow;
-      const first = notebooks.forNotebook(id);
-      const second = notebooks.forNotebook(id);
+      const first = yield* notebooks.forNotebook(id);
+      const second = yield* notebooks.forNotebook(id);
       const document = yield* notebooks.forDocument(editor.notebook);
 
       expect(first).toBe(second);
@@ -202,8 +202,8 @@ it.effect(
         .pipe(Effect.forkChild);
       yield* Deferred.await(secondExecutionStarted);
 
-      const mutation = yield* runtime
-        .forNotebook(id)
+      const notebook = yield* runtime.forNotebook(id);
+      const mutation = yield* notebook
         .updateUIElements({ objectIds: [], values: [] })
         .pipe(Effect.forkChild);
       yield* Effect.yieldNow;
@@ -391,7 +391,8 @@ it.effect("tracks RuntimeSession until a successful kernel close", () =>
             { cellIds: [], codes: [] },
             "/python-two",
           );
-          yield* runtime.forNotebook(id).close;
+          const notebook = yield* runtime.forNotebook(id);
+          yield* notebook.close;
           expect(Option.isNone(yield* runtime.getRuntimeSession(id))).toBe(
             true,
           );
@@ -429,8 +430,8 @@ it.effect(
 
     yield* Effect.gen(function* () {
       const notebooks = yield* NotebookRuntime;
-      notebooks.forNotebook(notebook);
-      notebooks.forNotebook(notebookId("notebook-b"));
+      yield* notebooks.forNotebook(notebook);
+      yield* notebooks.forNotebook(notebookId("notebook-b"));
 
       const settledSubscriptions = yield* eventually(
         Effect.sync(() => subscriptions),
@@ -453,7 +454,7 @@ it.effect(
 
     yield* Effect.gen(function* () {
       const notebooks = yield* NotebookRuntime;
-      const handle = notebooks.forNotebook(notebook);
+      const handle = yield* notebooks.forNotebook(notebook);
 
       expect(Option.isNone(yield* handle.getController)).toBe(true);
       yield* notebooks.attachController(notebook, controller);
@@ -612,7 +613,9 @@ it.effect(
       // so the runtime must stop handing this one out. Re-resolve the handle
       // each attempt: one captured before the close reads the released state.
       const released = yield* eventually(
-        Effect.suspend(() => notebooks.forNotebook(id).getController),
+        notebooks
+          .forNotebook(id)
+          .pipe(Effect.flatMap((notebook) => notebook.getController)),
         Option.isNone,
       );
       expect(Option.isNone(released)).toBe(true);

--- a/extension/src/kernel/__tests__/NotebookRuntimeOperations.test.ts
+++ b/extension/src/kernel/__tests__/NotebookRuntimeOperations.test.ts
@@ -1101,10 +1101,10 @@ describe("NotebookRuntime state eviction", () => {
           sessionId: activeSessionId,
           notification: { op: "variables", variables: [] },
         });
-        yield* TestClock.adjust("10 millis");
-        expect(
-          Option.isSome(yield* variables.getVariables(ctx.notebookUri)),
-        ).toBe(true);
+        yield* variables.getVariables(ctx.notebookUri).pipe(
+          Effect.filterOrFail(Option.isSome, () => "variables not settled"),
+          Effect.eventually,
+        );
       }).pipe(Effect.provide(ctx.layer));
     }),
   );
@@ -1165,14 +1165,17 @@ describe("NotebookRuntime state eviction", () => {
         ).toBe(true);
 
         yield* ctx.vscode.closeNotebook(ctx.editor.notebook);
-        yield* TestClock.adjust("10 millis");
-
-        expect(
-          Option.isSome(yield* variables.getVariables(ctx.notebookUri)),
-        ).toBe(false);
-        expect(
-          Option.isSome(yield* datasources.getDatasets(ctx.notebookUri)),
-        ).toBe(false);
+        yield* Effect.all([
+          variables.getVariables(ctx.notebookUri),
+          datasources.getDatasets(ctx.notebookUri),
+        ]).pipe(
+          Effect.filterOrFail(
+            ([currentVariables, currentDatasets]) =>
+              Option.isNone(currentVariables) && Option.isNone(currentDatasets),
+            () => "runtime projections not evicted" as const,
+          ),
+          Effect.eventually,
+        );
 
         // Notifications already queued, or delivered late by the old kernel
         // session, must not recreate state after eviction.

--- a/extension/src/kernel/__tests__/NotebookRuntimeOperations.test.ts
+++ b/extension/src/kernel/__tests__/NotebookRuntimeOperations.test.ts
@@ -679,7 +679,8 @@ describe("NotebookRuntime stdin", () => {
         );
         yield* ctx.inputRequested.await;
 
-        yield* runtime.forNotebook(ctx.notebookUri).restart;
+        const notebook = yield* runtime.forNotebook(ctx.notebookUri);
+        yield* notebook.restart;
         yield* Queue.offer(ctx.inputQueue, Option.some("stale response"));
         yield* TestClock.adjust("1 millis");
 
@@ -700,7 +701,8 @@ describe("NotebookRuntime scratch stream", () => {
       const ctx = yield* withTestCtx();
 
       yield* Effect.gen(function* () {
-        const notebook = (yield* NotebookRuntime).forNotebook(ctx.notebookUri);
+        const runtime = yield* NotebookRuntime;
+        const notebook = yield* runtime.forNotebook(ctx.notebookUri);
         const first = yield* Effect.forkChild(
           notebook.executeScratchpad("print('first')").pipe(Stream.runDrain),
         );
@@ -796,16 +798,16 @@ describe("NotebookRuntime scratch stream", () => {
         yield* ctx.vscode.openNotebook(otherEditor.notebook);
         yield* TestClock.adjust("1 millis");
         yield* runtime.attachController(otherNotebook.id, ctx.mockController);
+        const firstNotebook = yield* runtime.forNotebook(ctx.notebookUri);
+        const secondNotebook = yield* runtime.forNotebook(otherNotebook.id);
 
         const first = yield* Effect.forkChild(
-          runtime
-            .forNotebook(ctx.notebookUri)
+          firstNotebook
             .executeScratchpad("print('first')")
             .pipe(Stream.runDrain),
         );
         const second = yield* Effect.forkChild(
-          runtime
-            .forNotebook(otherNotebook.id)
+          secondNotebook
             .executeScratchpad("print('second')")
             .pipe(Stream.runDrain),
         );
@@ -874,12 +876,10 @@ describe("NotebookRuntime scratch stream", () => {
         // Route cell-op notifications through processSessionOperation.
         yield* ctx.vscode.setActiveNotebookEditor(Option.some(ctx.editor));
         yield* TestClock.adjust("1 millis");
+        const notebook = yield* runtime.forNotebook(ctx.notebookUri);
 
         const streamFiber = yield* Effect.forkChild(
-          runtime
-            .forNotebook(ctx.notebookUri)
-            .executeScratchpad("print('hi')")
-            .pipe(Stream.runCollect),
+          notebook.executeScratchpad("print('hi')").pipe(Stream.runCollect),
         );
 
         // Wait for executeScratchpad to enqueue marimo.api with its generated
@@ -975,12 +975,10 @@ describe("NotebookRuntime scratch stream", () => {
 
         yield* ctx.vscode.setActiveNotebookEditor(Option.some(ctx.editor));
         yield* TestClock.adjust("1 millis");
+        const notebook = yield* runtime.forNotebook(ctx.notebookUri);
 
         const streamFiber = yield* Effect.forkChild(
-          runtime
-            .forNotebook(ctx.notebookUri)
-            .executeScratchpad("print('hi')")
-            .pipe(Stream.runCollect),
+          notebook.executeScratchpad("print('hi')").pipe(Stream.runCollect),
         );
 
         // Wait until executeScratchpad sends the command and arms the
@@ -1029,12 +1027,10 @@ describe("NotebookRuntime scratch stream", () => {
 
         yield* ctx.vscode.setActiveNotebookEditor(Option.some(ctx.editor));
         yield* TestClock.adjust("1 millis");
+        const notebook = yield* runtime.forNotebook(ctx.notebookUri);
 
         const streamFiber = yield* Effect.forkChild(
-          runtime
-            .forNotebook(ctx.notebookUri)
-            .executeScratchpad("print('hi')")
-            .pipe(Stream.runCollect),
+          notebook.executeScratchpad("print('hi')").pipe(Stream.runCollect),
         );
 
         // Wait until the command is recorded. Do not count scheduler

--- a/extension/src/notebook/NotebookDocumentSessions.ts
+++ b/extension/src/notebook/NotebookDocumentSessions.ts
@@ -6,7 +6,6 @@ import {
   HashMap,
   Layer,
   Option,
-  PubSub,
   Ref,
   Scope,
   Stream,
@@ -38,13 +37,6 @@ export interface NotebookDocumentSession {
   readonly scope: Scope.Scope;
 }
 
-export type NotebookDocumentSessionChange = Data.TaggedEnum<{
-  Opened: { readonly session: NotebookDocumentSession };
-  Ended: { readonly session: NotebookDocumentSession };
-}>;
-export const NotebookDocumentSessionChange =
-  Data.taggedEnum<NotebookDocumentSessionChange>();
-
 export class NotebookDocumentSessionEndedError extends Data.TaggedError(
   "NotebookDocumentSessionEndedError",
 )<{ readonly notebookId: NotebookId }> {}
@@ -70,18 +62,11 @@ export class NotebookDocumentSessions extends Context.Service<NotebookDocumentSe
       const sessions = yield* Ref.make(
         HashMap.empty<NotebookId, SessionEntry>(),
       );
-      const changes = yield* PubSub.unbounded<NotebookDocumentSessionChange>();
 
       const end = Effect.fn("NotebookDocumentSessions.end")(function* (
         entry: SessionEntry,
       ) {
         yield* Scope.close(entry.scope, Exit.void);
-        yield* PubSub.publish(
-          changes,
-          NotebookDocumentSessionChange.Ended({
-            session: entry.session,
-          }),
-        );
       });
 
       const markOpen = Effect.fn("NotebookDocumentSessions.markOpen")(
@@ -134,10 +119,6 @@ export class NotebookDocumentSessions extends Context.Service<NotebookDocumentSe
           }
 
           if (result.displaced !== undefined) yield* end(result.displaced);
-          yield* PubSub.publish(
-            changes,
-            NotebookDocumentSessionChange.Opened({ session }),
-          );
           return session;
         },
       );
@@ -183,7 +164,6 @@ export class NotebookDocumentSessions extends Context.Service<NotebookDocumentSe
           yield* Effect.forEach(HashMap.values(current), end, {
             discard: true,
           });
-          yield* PubSub.shutdown(changes);
         }),
       );
 
@@ -200,7 +180,6 @@ export class NotebookDocumentSessions extends Context.Service<NotebookDocumentSe
           )?.session;
           return session?.document === document ? session : undefined;
         },
-        changes: Stream.fromPubSub(changes),
       } as const;
     }),
   },

--- a/extension/src/panel/packages/PackagesService.ts
+++ b/extension/src/panel/packages/PackagesService.ts
@@ -99,9 +99,10 @@ export class PackagesService extends Context.Service<PackagesService>()(
             return null;
           }
 
-          const activeController = yield* notebooks.forNotebook(
+          const notebook = yield* notebooks.forNotebook(
             activeNotebook.value.id,
-          ).getController;
+          );
+          const activeController = yield* notebook.getController;
           if (Option.isNone(activeController)) {
             yield* Effect.logDebug(
               "No active controller; skipping dependency tree fetch",

--- a/extension/src/panel/packages/PackagesService.ts
+++ b/extension/src/panel/packages/PackagesService.ts
@@ -6,6 +6,7 @@ import {
   Layer,
   Option,
   Result,
+  Scope,
   Stream,
   SubscriptionRef,
 } from "effect";
@@ -260,13 +261,19 @@ export class PackagesService extends Context.Service<PackagesService>()(
           );
         });
 
-      yield* Effect.forkScoped(
-        documentSessions.changes.pipe(
-          Stream.runForEach((change) =>
-            change._tag === "Ended"
-              ? clearCache(change.session.notebookId, change.session)
-              : Effect.void,
-          ),
+      const registeredSessionCleanups = new WeakSet<NotebookDocumentSession>();
+      const registerSessionCleanup = Effect.fn(
+        "PackagesService.registerSessionCleanup",
+      )((session: NotebookDocumentSession) =>
+        Effect.uninterruptible(
+          Effect.suspend(() => {
+            if (registeredSessionCleanups.has(session)) return Effect.void;
+            registeredSessionCleanups.add(session);
+            return Scope.addFinalizer(
+              session.scope,
+              clearCache(session.notebookId, session),
+            );
+          }),
         ),
       );
 
@@ -296,6 +303,7 @@ export class PackagesService extends Context.Service<PackagesService>()(
             }
 
             const key = keyFor(session);
+            yield* registerSessionCleanup(session);
             const existing = yield* Cache.getSuccess(dependencyTreeCache, key);
             if (
               Option.isSome(existing) &&
@@ -313,7 +321,11 @@ export class PackagesService extends Context.Service<PackagesService>()(
             }
 
             const next = yield* Cache.get(dependencyTreeCache, key);
-            yield* projectCurrent(key);
+            if (documentSessions.current(notebookUri) === session) {
+              yield* projectCurrent(key);
+            } else {
+              yield* clearCache(notebookUri, session);
+            }
             return next?.tree ?? null;
           });
         },

--- a/extension/src/panel/sessions/SessionFileLifecycle.ts
+++ b/extension/src/panel/sessions/SessionFileLifecycle.ts
@@ -118,7 +118,10 @@ export const SessionFileLifecycleLive = Layer.effectDiscard(
                     deletedWhileOpen.add(session.notebookId);
                     continue;
                   }
-                  yield* runtime.forNotebook(session.notebookId).close;
+                  const notebook = yield* runtime.forNotebook(
+                    session.notebookId,
+                  );
+                  yield* notebook.close;
                 }
               }).pipe(Effect.ignore),
             { discard: true },
@@ -134,7 +137,8 @@ export const SessionFileLifecycleLive = Layer.effectDiscard(
             const uri = document.uri.toString();
             if (!deletedWhileOpen.delete(uri)) return;
             const notebookUri = yield* decodeNotebookId(uri);
-            yield* runtime.forNotebook(notebookUri).close;
+            const notebook = yield* runtime.forNotebook(notebookUri);
+            yield* notebook.close;
           }).pipe(Effect.ignore),
         ),
       ),

--- a/extension/src/platform/Api.ts
+++ b/extension/src/platform/Api.ts
@@ -97,9 +97,8 @@ export class Api extends Context.Service<Api>()("Api", {
 
       // Just check if we have a controller.
       // TODO: Have proper statuses?
-      const isKernelActive = Option.isSome(
-        yield* notebooks.forNotebook(doc.value.id).getController,
-      );
+      const notebook = yield* notebooks.forNotebook(doc.value.id);
+      const isKernelActive = Option.isSome(yield* notebook.getController);
 
       if (!isKernelActive) {
         yield* Effect.logWarning("Kernel not active for notebook").pipe(
@@ -123,8 +122,7 @@ export class Api extends Context.Service<Api>()("Api", {
             return Effect.sync(() => disposable?.dispose());
           });
 
-          return notebooks
-            .forNotebook(doc.value.id)
+          return notebook
             .executeScratchpad(cellCode)
             .pipe(
               Stream.filterMap(


### PR DESCRIPTION
`submitIn` and `postIn` accepted an owning scope as a value, leaving lifetime outside the effect type and coupling document shutdown to a separate changes stream and explicit worker retirement.

`submitScoped` and `postScoped` require `Scope.Scope` in their environment. Document consumers provide the session scope at admission and attach exact-session cleanup directly to it. Cleanup registration is idempotent and atomic with finalizer installation.

The executor retires idle actors through its coordinator, preserving per-notebook admission order without exposing retirement as a lifecycle command.