### PR TITLE
Name state modules by ownership

### DIFF
--- a/extension/src/commands/restartKernel.ts
+++ b/extension/src/commands/restartKernel.ts
@@ -3,7 +3,7 @@ import { Effect, Option } from "effect";
 import { defineCommand } from "../commands.ts";
 import { NotebookRuntime } from "../kernel/NotebookRuntime.ts";
 import { showErrorAndPromptLogs } from "../lib/showErrorAndPromptLogs.ts";
-import { SessionsService } from "../panel/sessions/SessionsService.ts";
+import { LiveSessions } from "../panel/sessions/LiveSessions.ts";
 import { VsCode } from "../platform/VsCode.ts";
 import type { NotebookTarget } from "./Invocation.ts";
 import { MarimoCommands } from "./MarimoCommands.ts";
@@ -12,7 +12,7 @@ const handler = Effect.fn("command.restartKernel")(function* (
   target: Option.Option<NotebookTarget>,
 ) {
   const code = yield* VsCode;
-  const sessions = yield* SessionsService;
+  const sessions = yield* LiveSessions;
   const runtime = yield* NotebookRuntime;
 
   if (Option.isNone(target)) {

--- a/extension/src/commands/restartLsp.ts
+++ b/extension/src/commands/restartLsp.ts
@@ -2,12 +2,12 @@ import { Effect } from "effect";
 
 import { defineCommand } from "../commands.ts";
 import { MarimoClient } from "../lsp/MarimoClient.ts";
-import { SessionsService } from "../panel/sessions/SessionsService.ts";
+import { LiveSessions } from "../panel/sessions/LiveSessions.ts";
 import { MarimoCommands } from "./MarimoCommands.ts";
 
 const handler = Effect.fn(function* () {
   const marimo = yield* MarimoClient;
-  const sessions = yield* SessionsService;
+  const sessions = yield* LiveSessions;
   yield* marimo.restart;
   yield* sessions
     .refresh()

--- a/extension/src/commands/sessionCommands.ts
+++ b/extension/src/commands/sessionCommands.ts
@@ -3,7 +3,7 @@ import { Effect, Option } from "effect";
 import { NOTEBOOK_TYPE } from "../constants.ts";
 import { NotebookRuntime } from "../kernel/NotebookRuntime.ts";
 import { showErrorAndPromptLogs } from "../lib/showErrorAndPromptLogs.ts";
-import { SessionsService } from "../panel/sessions/SessionsService.ts";
+import { LiveSessions } from "../panel/sessions/LiveSessions.ts";
 import { VsCode } from "../platform/VsCode.ts";
 import { type NotebookId } from "../schemas/MarimoNotebookDocument.ts";
 import type { SessionCommandTarget } from "./MarimoCommands.ts";
@@ -55,7 +55,7 @@ export const shutdownSession = Effect.fn("command.shutdownSession")(function* ({
   notebookUri,
 }: SessionCommandTarget) {
   const code = yield* VsCode;
-  const sessions = yield* SessionsService;
+  const sessions = yield* LiveSessions;
   const runtime = yield* NotebookRuntime;
   const session = yield* sessions.find(notebookUri);
   if (Option.isNone(session)) return;
@@ -79,7 +79,7 @@ export const shutdownSession = Effect.fn("command.shutdownSession")(function* ({
 export const shutdownAllSessions = Effect.fn("command.shutdownAllSessions")(
   function* () {
     const code = yield* VsCode;
-    const sessions = yield* SessionsService;
+    const sessions = yield* LiveSessions;
     const runtime = yield* NotebookRuntime;
     const live = yield* sessions.get;
     if (live.length === 0) return;

--- a/extension/src/features/CellMetadataBindings.ts
+++ b/extension/src/features/CellMetadataBindings.ts
@@ -1,7 +1,7 @@
 import { Effect, Layer, Option, Schema } from "effect";
 
 import { CellMetadataUIBindingService } from "../notebook/CellMetadataUIBindingService.ts";
-import { DatasourcesService } from "../panel/datasources/DatasourcesService.ts";
+import { NotebookDatasources } from "../panel/datasources/NotebookDatasources.ts";
 import { Constants } from "../platform/Constants.ts";
 import { VsCode } from "../platform/VsCode.ts";
 import {
@@ -49,7 +49,7 @@ export const CellMetadataBindingsLive = Layer.effectDiscard(
     const { LanguageId } = yield* Constants;
     const bindingService = yield* CellMetadataUIBindingService;
     const code = yield* VsCode;
-    const datasources = yield* DatasourcesService;
+    const datasources = yield* NotebookDatasources;
 
     /**
      * SQL dataframeName binding

--- a/extension/src/features/DebugLayer.ts
+++ b/extension/src/features/DebugLayer.ts
@@ -3,7 +3,7 @@ import { Effect, Layer } from "effect";
 import { CellExecutions } from "../kernel/CellExecutions.ts";
 import { NotebookRuntime } from "../kernel/NotebookRuntime.ts";
 import { NotebookEditorRegistry } from "../notebook/NotebookEditorRegistry.ts";
-import { VariablesService } from "../panel/variables/VariablesService.ts";
+import { NotebookVariables } from "../panel/variables/NotebookVariables.ts";
 
 declare global {
   // oxlint-disable-next-line eslint/no-var
@@ -24,7 +24,7 @@ export const DebugLayerLive = Layer.effectDiscard(
 
     globalThis.__marimoDebug = {
       cellExecutions: yield* CellExecutions,
-      variablesService: yield* VariablesService,
+      notebookVariables: yield* NotebookVariables,
       notebookEditorRegistry: yield* NotebookEditorRegistry,
       notebookRuntime: yield* NotebookRuntime,
     };

--- a/extension/src/features/Main.ts
+++ b/extension/src/features/Main.ts
@@ -16,14 +16,14 @@ import { NotebookEditorRegistry } from "../notebook/NotebookEditorRegistry.ts";
 import { NotebookRenderer } from "../notebook/NotebookRenderer.ts";
 import { NotebookSerializer } from "../notebook/NotebookSerializer.ts";
 import { NotebookSessionResources } from "../notebook/NotebookSessionResources.ts";
-import { DatasourcesService } from "../panel/datasources/DatasourcesService.ts";
 import { DatasourcesViewLive } from "../panel/datasources/DatasourcesView.ts";
+import { NotebookDatasources } from "../panel/datasources/NotebookDatasources.ts";
 import { PackagesViewLive } from "../panel/packages/PackagesView.ts";
+import { LiveSessions } from "../panel/sessions/LiveSessions.ts";
 import { SessionFileLifecycleLive } from "../panel/sessions/SessionFileLifecycle.ts";
-import { SessionsService } from "../panel/sessions/SessionsService.ts";
 import { SessionsViewLive } from "../panel/sessions/SessionsView.ts";
 import { TreeView } from "../panel/TreeView.ts";
-import { VariablesService } from "../panel/variables/VariablesService.ts";
+import { NotebookVariables } from "../panel/variables/NotebookVariables.ts";
 import { VariablesViewLive } from "../panel/variables/VariablesView.ts";
 import { Api, type MarimoApi } from "../platform/Api.ts";
 import { Constants } from "../platform/Constants.ts";
@@ -85,9 +85,9 @@ const MainLive = Layer.empty
     Layer.provide(NotebookRenderer.layer),
     Layer.provide(NotebookSerializer.layer),
     Layer.provide(CellExecutions.layer),
-    Layer.provide(VariablesService.layer),
-    Layer.provide(DatasourcesService.layer),
-    Layer.provideMerge(SessionsService.layer),
+    Layer.provide(NotebookVariables.layer),
+    Layer.provide(NotebookDatasources.layer),
+    Layer.provideMerge(LiveSessions.layer),
     Layer.provide(HealthService.layer),
     Layer.provide(CellMetadataUIBindingService.layer),
   )

--- a/extension/src/features/__tests__/CellMetadataBindings.test.ts
+++ b/extension/src/features/__tests__/CellMetadataBindings.test.ts
@@ -10,7 +10,7 @@ import {
 } from "../../__mocks__/TestVsCode.ts";
 import { makeTestMarimoClient } from "../../__tests__/__utils__/TestMarimoClient.ts";
 import { CellMetadataUIBindingService } from "../../notebook/CellMetadataUIBindingService.ts";
-import { DatasourcesService } from "../../panel/datasources/DatasourcesService.ts";
+import { NotebookDatasources } from "../../panel/datasources/NotebookDatasources.ts";
 import { Constants } from "../../platform/Constants.ts";
 import { MarimoNotebookCell } from "../../schemas/MarimoNotebookDocument.ts";
 import type * as Api from "../../schemas/Models.gen.ts";
@@ -24,7 +24,7 @@ const withTestCtx = Effect.gen(function* () {
   const layer = Layer.empty.pipe(
     Layer.provideMerge(CellMetadataBindingsLive),
     Layer.provide(CellMetadataUIBindingService.layer),
-    Layer.provide(DatasourcesService.layer),
+    Layer.provide(NotebookDatasources.layer),
     Layer.provide(makeTestMarimoClient()),
     Layer.provide(Constants.layer),
     Layer.provide(vscode.layer),

--- a/extension/src/kernel/NotebookRuntime.ts
+++ b/extension/src/kernel/NotebookRuntime.ts
@@ -33,9 +33,9 @@ import {
 } from "../notebook/NotebookDocumentSessions.ts";
 import { NotebookEditorRegistry } from "../notebook/NotebookEditorRegistry.ts";
 import { NotebookRenderer } from "../notebook/NotebookRenderer.ts";
-import { DatasourcesService } from "../panel/datasources/DatasourcesService.ts";
-import { SessionsService } from "../panel/sessions/SessionsService.ts";
-import { VariablesService } from "../panel/variables/VariablesService.ts";
+import { NotebookDatasources } from "../panel/datasources/NotebookDatasources.ts";
+import { LiveSessions } from "../panel/sessions/LiveSessions.ts";
+import { NotebookVariables } from "../panel/variables/NotebookVariables.ts";
 import { Constants } from "../platform/Constants.ts";
 import { OutputChannel } from "../platform/OutputChannel.ts";
 import { VsCode } from "../platform/VsCode.ts";
@@ -71,7 +71,7 @@ import { handleMissingPackageAlert } from "./operations.ts";
 type MarimoClientService = Context.Service.Shape<typeof MarimoClient>;
 type VsCodeService = Context.Service.Shape<typeof VsCode>;
 type CellExecutionsService = Context.Service.Shape<typeof CellExecutions>;
-type SessionsServiceShape = Context.Service.Shape<typeof SessionsService>;
+type LiveSessionsShape = Context.Service.Shape<typeof LiveSessions>;
 
 type InnerRequest<K extends keyof MarimoClientService> =
   MarimoClientService[K] extends (params: infer Params) => unknown
@@ -156,8 +156,8 @@ export interface NotebookHandle {
   readonly interrupt: WithNoActiveKernel<
     ReturnType<MarimoClientService["interrupt"]>
   >;
-  readonly restart: ReturnType<SessionsServiceShape["restart"]>;
-  readonly close: ReturnType<SessionsServiceShape["shutdown"]>;
+  readonly restart: ReturnType<LiveSessionsShape["restart"]>;
+  readonly close: ReturnType<LiveSessionsShape["shutdown"]>;
 }
 
 /** Operations scoped to one Notebook Document Session. */
@@ -198,14 +198,14 @@ type RuntimeWorkRequirements =
   | CellExecutions
   | Config
   | Constants
-  | DatasourcesService
+  | NotebookDatasources
   | NotebookEditorRegistry
   | NotebookDocumentSessions
   | NotebookRenderer
   | OutputChannel
   | PythonEnvInvalidation
   | Uv
-  | VariablesService
+  | NotebookVariables
   | VsCode;
 
 function hasRunId<T extends { run_id?: string | null }>(
@@ -256,9 +256,9 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
       const marimo = yield* MarimoClient;
       const renderer = yield* NotebookRenderer;
       const executions = yield* CellExecutions;
-      const variables = yield* VariablesService;
-      const datasources = yield* DatasourcesService;
-      const liveSessions = yield* SessionsService;
+      const variables = yield* NotebookVariables;
+      const datasources = yield* NotebookDatasources;
+      const liveSessions = yield* LiveSessions;
       const documentSessions = yield* NotebookDocumentSessions;
       const operations = yield* PubSub.unbounded<SessionNotification>();
       const notebookStates = new Map<
@@ -1066,13 +1066,13 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
       Config.layer,
       Constants.layer,
       OutputChannel.layer,
-      VariablesService.layer,
+      NotebookVariables.layer,
       NotebookRenderer.layer,
       CellExecutions.layer,
-      DatasourcesService.layer,
+      NotebookDatasources.layer,
       NotebookEditorRegistry.layer,
       PythonEnvInvalidation.layer,
-      SessionsService.layer,
+      LiveSessions.layer,
       NotebookDocumentSessions.layer,
     ]),
   );
@@ -1099,8 +1099,8 @@ function processOperation(
 ) {
   return Effect.gen(function* () {
     const { notebookUri, notification: operation, sessionId } = message;
-    const variables = yield* VariablesService;
-    const datasources = yield* DatasourcesService;
+    const variables = yield* NotebookVariables;
+    const datasources = yield* NotebookDatasources;
 
     switch (operation.op) {
       case "variables":

--- a/extension/src/kernel/__tests__/NotebookRuntimeOperations.test.ts
+++ b/extension/src/kernel/__tests__/NotebookRuntimeOperations.test.ts
@@ -36,8 +36,8 @@ import {
   notebookId,
   variableName,
 } from "../../lib/__tests__/branded.ts";
-import { DatasourcesService } from "../../panel/datasources/DatasourcesService.ts";
-import { VariablesService } from "../../panel/variables/VariablesService.ts";
+import { NotebookDatasources } from "../../panel/datasources/NotebookDatasources.ts";
+import { NotebookVariables } from "../../panel/variables/NotebookVariables.ts";
 import { VsCode } from "../../platform/VsCode.ts";
 import {
   MarimoNotebookCell,
@@ -162,8 +162,8 @@ const withTestCtx = Effect.fn(function* (
     Layer.provideMerge(NotebookRuntime.layer),
     // Merged out (not just provided) so tests can observe the same service
     // instances NotebookRuntime writes to.
-    Layer.provideMerge(VariablesService.layer),
-    Layer.provideMerge(DatasourcesService.layer),
+    Layer.provideMerge(NotebookVariables.layer),
+    Layer.provideMerge(NotebookDatasources.layer),
     Layer.provide(
       makeTestMarimoClient({
         execute(request) {
@@ -1079,7 +1079,7 @@ describe("NotebookRuntime state eviction", () => {
 
       yield* Effect.gen(function* () {
         yield* NotebookRuntime;
-        const variables = yield* VariablesService;
+        const variables = yield* NotebookVariables;
         yield* TestClock.adjust("1 millis");
 
         yield* PubSub.publish(ctx.operationsPubSub, {
@@ -1112,8 +1112,8 @@ describe("NotebookRuntime state eviction", () => {
 
       yield* Effect.gen(function* () {
         yield* NotebookRuntime;
-        const variables = yield* VariablesService;
-        const datasources = yield* DatasourcesService;
+        const variables = yield* NotebookVariables;
+        const datasources = yield* NotebookDatasources;
 
         // One scheduler drain so NotebookRuntime's forked operations pipeline
         // subscribes to the mock PubSub before we publish (forked fibers only

--- a/extension/src/lib/__tests__/getTopologicalCells.test.ts
+++ b/extension/src/lib/__tests__/getTopologicalCells.test.ts
@@ -8,7 +8,7 @@ import {
   type NotebookDocumentSession,
   NotebookDocumentSessions,
 } from "../../notebook/NotebookDocumentSessions.ts";
-import { VariablesService } from "../../panel/variables/VariablesService.ts";
+import { NotebookVariables } from "../../panel/variables/NotebookVariables.ts";
 import {
   MarimoNotebookCell,
   MarimoNotebookDocument,
@@ -68,7 +68,7 @@ const documentSessions = Layer.succeed(NotebookDocumentSessions, {
   active: Stream.empty,
 });
 const withTestLayer = () =>
-  Layer.effect(VariablesService, VariablesService.make).pipe(
+  Layer.effect(NotebookVariables, NotebookVariables.make).pipe(
     Layer.provide(documentSessions),
   );
 
@@ -122,7 +122,7 @@ describe("getTopologicalCells", () => {
         { stableId: "cell-a", code: "x = 1" }, // defines x
       ]);
 
-      const service = yield* VariablesService;
+      const service = yield* NotebookVariables;
 
       yield* service.updateVariables(
         sessionFor(doc),
@@ -150,7 +150,7 @@ describe("getTopologicalCells", () => {
         { stableId: "cell-a", code: "x = 1" }, // defines x
       ]);
 
-      const service = yield* VariablesService;
+      const service = yield* NotebookVariables;
 
       yield* service.updateVariables(
         sessionFor(doc),
@@ -205,7 +205,7 @@ describe("getTopologicalCells", () => {
       });
       const doc = MarimoNotebookDocument.from(raw);
 
-      const service = yield* VariablesService;
+      const service = yield* NotebookVariables;
 
       yield* service.updateVariables(
         sessionFor(doc),
@@ -232,7 +232,7 @@ describe("getTopologicalCells", () => {
         { stableId: "cell-c", code: "z = 3" },
       ]);
 
-      const service = yield* VariablesService;
+      const service = yield* NotebookVariables;
 
       // Each cell defines its own variable, no cross-cell dependencies
       yield* service.updateVariables(
@@ -266,7 +266,7 @@ describe("getTopologicalCells", () => {
         { stableId: "cell-a", code: "x = 1" },
       ]);
 
-      const service = yield* VariablesService;
+      const service = yield* NotebookVariables;
 
       yield* service.updateVariables(
         sessionFor(doc),

--- a/extension/src/lib/getTopologicalCells.ts
+++ b/extension/src/lib/getTopologicalCells.ts
@@ -2,7 +2,7 @@ import { Effect, Option } from "effect";
 import type * as vscode from "vscode";
 
 import { LanguageId } from "../constants.ts";
-import { VariablesService } from "../panel/variables/VariablesService.ts";
+import { NotebookVariables } from "../panel/variables/NotebookVariables.ts";
 import type { MarimoNotebookDocument } from "../schemas/MarimoNotebookDocument.ts";
 import type { NotebookCellId } from "../schemas/MarimoNotebookDocument.ts";
 import { getTopologicalCellIds } from "./getTopologicalCellIds.ts";
@@ -17,9 +17,9 @@ import { getTopologicalCellIds } from "./getTopologicalCellIds.ts";
  */
 export function getTopologicalCells(
   doc: MarimoNotebookDocument,
-): Effect.Effect<Array<vscode.NotebookCell>, never, VariablesService> {
+): Effect.Effect<Array<vscode.NotebookCell>, never, NotebookVariables> {
   return Effect.gen(function* () {
-    const variablesService = yield* VariablesService;
+    const notebookVariables = yield* NotebookVariables;
 
     // Filter to only Python cells - LSP server only understands Python
     const cells = doc
@@ -35,7 +35,7 @@ export function getTopologicalCells(
       return [];
     }
 
-    const variables = yield* variablesService.getVariables(doc.id);
+    const variables = yield* notebookVariables.getVariables(doc.id);
 
     // No variables yet - fall back to document order
     if (Option.isNone(variables)) {

--- a/extension/src/lsp/RuffLanguageServer.ts
+++ b/extension/src/lsp/RuffLanguageServer.ts
@@ -21,7 +21,7 @@ import {
   userConfiguredPath,
 } from "../lib/binaryResolution.ts";
 import { showErrorAndPromptLogs } from "../lib/showErrorAndPromptLogs.ts";
-import { VariablesService } from "../panel/variables/VariablesService.ts";
+import { NotebookVariables } from "../panel/variables/NotebookVariables.ts";
 import { OutputChannel } from "../platform/OutputChannel.ts";
 import { ExtensionContext } from "../platform/Storage.ts";
 import { VsCode } from "../platform/VsCode.ts";
@@ -173,7 +173,7 @@ export class RuffLanguageServer extends Context.Service<RuffLanguageServer>()(
       Uv.layer,
       Config.layer,
       OutputChannel.layer,
-      VariablesService.layer,
+      NotebookVariables.layer,
     ]),
   );
 }

--- a/extension/src/lsp/TyLanguageServer.ts
+++ b/extension/src/lsp/TyLanguageServer.ts
@@ -23,7 +23,7 @@ import {
 } from "../lib/binaryResolution.ts";
 import { getExtensionVersion } from "../lib/getExtensionVersion.ts";
 import { showErrorAndPromptLogs } from "../lib/showErrorAndPromptLogs.ts";
-import { VariablesService } from "../panel/variables/VariablesService.ts";
+import { NotebookVariables } from "../panel/variables/NotebookVariables.ts";
 import { OutputChannel } from "../platform/OutputChannel.ts";
 import { ExtensionContext, Storage } from "../platform/Storage.ts";
 import { VsCode } from "../platform/VsCode.ts";
@@ -311,7 +311,7 @@ export class TyLanguageServer extends Context.Service<TyLanguageServer>()(
       Uv.layer,
       Config.layer,
       OutputChannel.layer,
-      VariablesService.layer,
+      NotebookVariables.layer,
       PythonEnvInvalidation.layer,
       Storage.layer,
     ]),

--- a/extension/src/lsp/__tests__/client.integration.test.ts
+++ b/extension/src/lsp/__tests__/client.integration.test.ts
@@ -18,14 +18,14 @@ import {
   TestVsCode,
 } from "../../__mocks__/TestVsCode.ts";
 import { NotebookDocumentSessions } from "../../notebook/NotebookDocumentSessions.ts";
-import { VariablesService } from "../../panel/variables/VariablesService.ts";
+import { NotebookVariables } from "../../panel/variables/NotebookVariables.ts";
 import { VsCode } from "../../platform/VsCode.ts";
 import { MarimoNotebookDocument } from "../../schemas/MarimoNotebookDocument.ts";
 import { makeNotebookLspClient } from "../client.ts";
 
 const variablesLayer = Layer.effect(
-  VariablesService,
-  VariablesService.make,
+  NotebookVariables,
+  NotebookVariables.make,
 ).pipe(
   Layer.provide(
     Layer.succeed(NotebookDocumentSessions, {

--- a/extension/src/lsp/client.ts
+++ b/extension/src/lsp/client.ts
@@ -38,7 +38,7 @@ import * as lsp from "vscode-languageserver-protocol";
 
 import { NOTEBOOK_TYPE } from "../constants.ts";
 import { getTopologicalCells } from "../lib/getTopologicalCells.ts";
-import { VariablesService } from "../panel/variables/VariablesService.ts";
+import { NotebookVariables } from "../panel/variables/NotebookVariables.ts";
 import { MarimoNotebookDocument } from "../schemas/MarimoNotebookDocument.ts";
 import type { NotebookId } from "../schemas/MarimoNotebookDocument.ts";
 
@@ -713,7 +713,7 @@ export const makeNotebookLspClient = Effect.fn("makeNotebookLspClient")(
 
     // -- 5. State tracking ---------------------------------------------------
 
-    const variables = yield* VariablesService;
+    const variables = yield* NotebookVariables;
 
     const cellOrderRef = yield* Ref.make(
       HashMap.empty<NotebookId, Array<vscode.Uri>>(),

--- a/extension/src/panel/datasources/DatasourcesView.ts
+++ b/extension/src/panel/datasources/DatasourcesView.ts
@@ -9,8 +9,8 @@ import { TreeView } from "../TreeView.ts";
 import {
   type DatasourceDatabase,
   type DatasourceSchema,
-  DatasourcesService,
-} from "./DatasourcesService.ts";
+  NotebookDatasources,
+} from "./NotebookDatasources.ts";
 
 const IN_MEMORY_CONNECTION = "__in_memory";
 const IN_MEMORY_DATABASE = "default";
@@ -144,7 +144,7 @@ const itemId = (item: DatasourceTreeItem): string => {
 export const DatasourcesViewLive = Layer.effectDiscard(
   Effect.gen(function* () {
     const treeView = yield* TreeView;
-    const datasources = yield* DatasourcesService;
+    const datasources = yield* NotebookDatasources;
     const editors = yield* NotebookEditorRegistry;
     const documentSessions = yield* NotebookDocumentSessions;
 

--- a/extension/src/panel/datasources/NotebookDatasources.ts
+++ b/extension/src/panel/datasources/NotebookDatasources.ts
@@ -107,8 +107,8 @@ const EXPANSION_TIMEOUT = "30 seconds";
  * Uses SubscriptionRef for reactive state management.
  * Converts list-based data to Maps for efficient lookups.
  */
-export class DatasourcesService extends Context.Service<DatasourcesService>()(
-  "DatasourcesService",
+export class NotebookDatasources extends Context.Service<NotebookDatasources>()(
+  "NotebookDatasources",
   {
     make: Effect.gen(function* () {
       const marimo = yield* MarimoClient;
@@ -123,7 +123,7 @@ export class DatasourcesService extends Context.Service<DatasourcesService>()(
       const pendingByRequest = new Map<string, PendingExpansion>();
       const registeredSessionCleanups = new WeakSet<NotebookDocumentSession>();
 
-      const releaseSession = Effect.fn("DatasourcesService.releaseSession")(
+      const releaseSession = Effect.fn("NotebookDatasources.releaseSession")(
         function* (session: NotebookDocumentSession) {
           const notebookUri = session.notebookId;
           registeredSessionCleanups.delete(session);
@@ -150,7 +150,7 @@ export class DatasourcesService extends Context.Service<DatasourcesService>()(
       );
 
       const registerSessionCleanup = Effect.fn(
-        "DatasourcesService.registerSessionCleanup",
+        "NotebookDatasources.registerSessionCleanup",
       )((session: NotebookDocumentSession) =>
         Effect.suspend(() => {
           if (registeredSessionCleanups.has(session)) return Effect.void;

--- a/extension/src/panel/datasources/__tests__/NotebookDatasources.test.ts
+++ b/extension/src/panel/datasources/__tests__/NotebookDatasources.test.ts
@@ -35,7 +35,7 @@ import type {
   SqlTableListPreviewNotification,
 } from "../../../types.ts";
 import type { MarimoApiCall } from "../../../types.ts";
-import { DatasourcesService } from "../DatasourcesService.ts";
+import { NotebookDatasources } from "../NotebookDatasources.ts";
 
 const NOTEBOOK_URI = notebookId("file:///test/notebook.py");
 const KERNEL_SESSION_ID = kernelSessionId(
@@ -52,7 +52,7 @@ const makeLayer = (
     Effect.succeed(null),
   currentSession: () => NotebookDocumentSession = () => SESSION,
 ) =>
-  Layer.effect(DatasourcesService, DatasourcesService.make).pipe(
+  Layer.effect(NotebookDatasources, NotebookDatasources.make).pipe(
     Layer.provide([
       makeTestMarimoClient({ execute }),
       Layer.succeed(NotebookDocumentSessions, {
@@ -151,7 +151,7 @@ const connections = (
 });
 
 const getDatabase = Effect.fn(function* () {
-  const service = yield* DatasourcesService;
+  const service = yield* NotebookDatasources;
   const state = yield* service.getConnections(NOTEBOOK_URI);
   assert(Option.isSome(state));
   const database = state.value.connections
@@ -163,7 +163,7 @@ const getDatabase = Effect.fn(function* () {
 
 it.effect("preserves recursive schemas and deferred discovery", () =>
   Effect.gen(function* () {
-    const service = yield* DatasourcesService;
+    const service = yield* NotebookDatasources;
     yield* service.updateConnections(
       SESSION,
       KERNEL_SESSION_ID,
@@ -207,7 +207,7 @@ it.effect("isolates datasource state by document session", () => {
   );
 
   return Effect.gen(function* () {
-    const service = yield* DatasourcesService;
+    const service = yield* NotebookDatasources;
     yield* service.updateConnections(
       displaced,
       KERNEL_SESSION_ID,
@@ -256,7 +256,7 @@ it.effect(
     );
 
     return Effect.gen(function* () {
-      const service = yield* DatasourcesService;
+      const service = yield* NotebookDatasources;
       yield* service.updateConnections(
         SESSION,
         KERNEL_SESSION_ID,
@@ -295,7 +295,7 @@ it.effect(
 it.effect("merges child schemas at their parent path", () => {
   const { layer, nextCall } = makeRecordingLayer();
   return Effect.gen(function* () {
-    const service = yield* DatasourcesService;
+    const service = yield* NotebookDatasources;
     yield* service.updateConnections(
       SESSION,
       KERNEL_SESSION_ID,
@@ -337,7 +337,7 @@ it.effect("merges child schemas at their parent path", () => {
 it.effect("merges tables at a nested schema path", () => {
   const { layer, nextCall } = makeRecordingLayer();
   return Effect.gen(function* () {
-    const service = yield* DatasourcesService;
+    const service = yield* NotebookDatasources;
     yield* service.updateConnections(
       SESSION,
       KERNEL_SESSION_ID,
@@ -383,7 +383,7 @@ it.effect("merges tables at a nested schema path", () => {
 it.effect("does not resolve deferred state after an error", () => {
   const { layer, nextCall } = makeRecordingLayer();
   return Effect.gen(function* () {
-    const service = yield* DatasourcesService;
+    const service = yield* NotebookDatasources;
     yield* service.updateConnections(
       SESSION,
       KERNEL_SESSION_ID,
@@ -422,7 +422,7 @@ it.effect("does not resolve deferred state after an error", () => {
 
 it.effect("ignores uncorrelated expansion responses", () =>
   Effect.gen(function* () {
-    const service = yield* DatasourcesService;
+    const service = yield* NotebookDatasources;
     yield* service.updateConnections(
       SESSION,
       KERNEL_SESSION_ID,
@@ -459,7 +459,7 @@ it.effect("deduplicates concurrent schema expansion requests", () => {
   const { calls, layer, nextCall } = makeRecordingLayer();
 
   return Effect.gen(function* () {
-    const service = yield* DatasourcesService;
+    const service = yield* NotebookDatasources;
     yield* service.updateConnections(
       SESSION,
       KERNEL_SESSION_ID,
@@ -519,7 +519,7 @@ it.effect("interrupts an expansion send when its document session closes", () =>
     );
 
     yield* Effect.gen(function* () {
-      const service = yield* DatasourcesService;
+      const service = yield* NotebookDatasources;
       yield* service.updateConnections(
         session,
         KERNEL_SESSION_ID,
@@ -553,7 +553,7 @@ it.effect("detaches completed expansions from the session scope", () => {
   const { layer, nextCall } = makeRecordingLayer(() => session);
 
   return Effect.gen(function* () {
-    const service = yield* DatasourcesService;
+    const service = yield* NotebookDatasources;
     yield* service.updateConnections(
       session,
       KERNEL_SESSION_ID,
@@ -599,7 +599,7 @@ it.effect("retries nested table expansion after an error", () => {
   const { calls, layer, nextCall } = makeRecordingLayer();
 
   return Effect.gen(function* () {
-    const service = yield* DatasourcesService;
+    const service = yield* NotebookDatasources;
     yield* service.updateConnections(
       SESSION,
       KERNEL_SESSION_ID,
@@ -658,7 +658,7 @@ it.effect("shares one timeout deadline and retries after it expires", () => {
   const { calls, layer, nextCall } = makeRecordingLayer();
 
   return Effect.gen(function* () {
-    const service = yield* DatasourcesService;
+    const service = yield* NotebookDatasources;
     yield* service.updateConnections(
       SESSION,
       KERNEL_SESSION_ID,
@@ -675,7 +675,6 @@ it.effect("shares one timeout deadline and retries after it expires", () => {
     const joined = yield* Effect.forkChild(
       Effect.result(service.loadSchemas(SESSION, "warehouse", "analytics", [])),
     );
-
     yield* TestClock.adjust("10 seconds");
     expect((yield* Fiber.join(first))._tag).toBe("Failure");
     expect((yield* Fiber.join(joined))._tag).toBe("Failure");

--- a/extension/src/panel/sessions/LiveSessions.ts
+++ b/extension/src/panel/sessions/LiveSessions.ts
@@ -23,8 +23,8 @@ export type SessionViewItem = Omit<SessionInfo, "status"> & {
 };
 
 /** Authoritative live-session state shared by the tree and future renderers. */
-export class SessionsService extends Context.Service<SessionsService>()(
-  "SessionsService",
+export class LiveSessions extends Context.Service<LiveSessions>()(
+  "LiveSessions",
   {
     make: Effect.gen(function* () {
       const marimo = yield* MarimoClient;
@@ -32,15 +32,15 @@ export class SessionsService extends Context.Service<SessionsService>()(
         ReadonlyArray<SessionViewItem>
       >([]);
 
-      const applySnapshot = Effect.fn("SessionsService.applySnapshot")(
-        function* (snapshot: unknown) {
-          const decoded =
-            yield* Schema.decodeUnknownEffect(SessionsSnapshot)(snapshot);
-          yield* SubscriptionRef.set(sessions, decoded.sessions);
-        },
-      );
+      const applySnapshot = Effect.fn("LiveSessions.applySnapshot")(function* (
+        snapshot: unknown,
+      ) {
+        const decoded =
+          yield* Schema.decodeUnknownEffect(SessionsSnapshot)(snapshot);
+        yield* SubscriptionRef.set(sessions, decoded.sessions);
+      });
 
-      const refresh = Effect.fn("SessionsService.refresh")(function* () {
+      const refresh = Effect.fn("LiveSessions.refresh")(function* () {
         yield* applySnapshot(yield* marimo.listSessions({}));
       });
 
@@ -78,7 +78,7 @@ export class SessionsService extends Context.Service<SessionsService>()(
           ),
         );
 
-      const restart = Effect.fn("SessionsService.restart")(function* (
+      const restart = Effect.fn("LiveSessions.restart")(function* (
         notebookUri: NotebookId,
       ) {
         const current = yield* find(notebookUri);
@@ -126,14 +126,14 @@ export class SessionsService extends Context.Service<SessionsService>()(
         return undefined;
       });
 
-      const shutdown = Effect.fn("SessionsService.shutdown")(function* (
+      const shutdown = Effect.fn("LiveSessions.shutdown")(function* (
         notebookUri: NotebookId,
       ) {
         yield* marimo.closeSession({ notebookUri, inner: {} });
         yield* refresh();
       });
 
-      const move = Effect.fn("SessionsService.move")(function* (
+      const move = Effect.fn("LiveSessions.move")(function* (
         notebookUri: NotebookId,
         newNotebookUri: NotebookId,
       ) {
@@ -151,7 +151,7 @@ export class SessionsService extends Context.Service<SessionsService>()(
         refresh,
         restart,
         shutdown,
-        restore: Effect.fn("SessionsService.restore")(function* (
+        restore: Effect.fn("LiveSessions.restore")(function* (
           notebookUri: NotebookId,
           executable: string,
           workingDirectory: string,
@@ -166,7 +166,7 @@ export class SessionsService extends Context.Service<SessionsService>()(
           });
           yield* refresh();
         }),
-        shutdownAll: Effect.fn("SessionsService.shutdownAll")(function* () {
+        shutdownAll: Effect.fn("LiveSessions.shutdownAll")(function* () {
           yield* marimo.shutdownAllSessions({});
           yield* refresh();
         }),

--- a/extension/src/panel/sessions/SessionsView.ts
+++ b/extension/src/panel/sessions/SessionsView.ts
@@ -7,14 +7,14 @@ import shutdownSession from "../../commands/shutdownSession.ts";
 import { VsCode } from "../../platform/VsCode.ts";
 import { MarimoNotebookDocument } from "../../schemas/MarimoNotebookDocument.ts";
 import { type TreeItem, TreeView } from "../TreeView.ts";
-import { type SessionViewItem, SessionsService } from "./SessionsService.ts";
+import { type SessionViewItem, LiveSessions } from "./LiveSessions.ts";
 
 /** Native VS Code tree view for live marimo kernel sessions. */
 export const SessionsViewLive = Layer.effectDiscard(
   Effect.gen(function* () {
     const code = yield* VsCode;
     const treeView = yield* TreeView;
-    const sessions = yield* SessionsService;
+    const sessions = yield* LiveSessions;
     const provider = yield* treeView.createTreeDataProvider({
       viewId: "marimo-explorer-sessions",
       showCollapseAll: false,

--- a/extension/src/panel/sessions/__tests__/LiveSessions.test.ts
+++ b/extension/src/panel/sessions/__tests__/LiveSessions.test.ts
@@ -4,7 +4,7 @@ import { Effect, Layer, Result } from "effect";
 import { makeTestMarimoClient } from "../../../__tests__/__utils__/TestMarimoClient.ts";
 import { kernelSessionId, notebookId } from "../../../lib/__tests__/branded.ts";
 import type { MarimoApiCall } from "../../../types.ts";
-import { SessionNotFoundError, SessionsService } from "../SessionsService.ts";
+import { SessionNotFoundError, LiveSessions } from "../LiveSessions.ts";
 
 const NOTEBOOK_URI = notebookId("file:///workspace/notebook.py");
 const SESSION_ID = kernelSessionId("00000000-0000-4000-8000-000000000001");
@@ -24,7 +24,7 @@ const SNAPSHOT = {
 } as const;
 
 function makeLayer(recorded: MarimoApiCall[], snapshot: unknown = SNAPSHOT) {
-  return SessionsService.layer.pipe(
+  return LiveSessions.layer.pipe(
     Layer.provide(
       makeTestMarimoClient({
         execute: (request) =>
@@ -43,7 +43,7 @@ it.effect(
     const recorded: MarimoApiCall[] = [];
 
     const live = yield* Effect.gen(function* () {
-      const sessions = yield* SessionsService;
+      const sessions = yield* LiveSessions;
       return yield* sessions.get;
     }).pipe(Effect.provide(makeLayer(recorded)));
 
@@ -70,7 +70,7 @@ it.effect(
     };
 
     yield* Effect.gen(function* () {
-      const sessions = yield* SessionsService;
+      const sessions = yield* LiveSessions;
       yield* sessions.shutdownAll();
     }).pipe(Effect.provide(makeLayer(recorded, snapshot)));
 
@@ -87,7 +87,7 @@ it.effect(
   Effect.fn(function* () {
     const recorded: MarimoApiCall[] = [];
     const result = yield* Effect.gen(function* () {
-      const sessions = yield* SessionsService;
+      const sessions = yield* LiveSessions;
       return yield* Effect.result(sessions.restart(NOTEBOOK_URI));
     }).pipe(Effect.provide(makeLayer(recorded, { sessions: [] })));
 
@@ -107,7 +107,7 @@ it.effect(
     const recorded: MarimoApiCall[] = [];
 
     yield* Effect.gen(function* () {
-      const sessions = yield* SessionsService;
+      const sessions = yield* LiveSessions;
       yield* sessions.restart(NOTEBOOK_URI);
     }).pipe(Effect.provide(makeLayer(recorded)));
 

--- a/extension/src/panel/variables/NotebookVariables.ts
+++ b/extension/src/panel/variables/NotebookVariables.ts
@@ -43,8 +43,8 @@ const keyFor = (session: NotebookDocumentSession): VariableStateKey => [
  *
  * Uses SubscriptionRef for reactive state management.
  */
-export class VariablesService extends Context.Service<VariablesService>()(
-  "VariablesService",
+export class NotebookVariables extends Context.Service<NotebookVariables>()(
+  "NotebookVariables",
   {
     make: Effect.gen(function* () {
       const documentSessions = yield* NotebookDocumentSessions;
@@ -61,7 +61,7 @@ export class VariablesService extends Context.Service<VariablesService>()(
 
       const registeredSessionCleanups = new WeakSet<NotebookDocumentSession>();
 
-      const releaseSession = Effect.fn("VariablesService.releaseSession")(
+      const releaseSession = Effect.fn("NotebookVariables.releaseSession")(
         function* (session: NotebookDocumentSession) {
           const notebookUri = session.notebookId;
           registeredSessionCleanups.delete(session);
@@ -81,7 +81,7 @@ export class VariablesService extends Context.Service<VariablesService>()(
       );
 
       const registerSessionCleanup = Effect.fn(
-        "VariablesService.registerSessionCleanup",
+        "NotebookVariables.registerSessionCleanup",
       )((session: NotebookDocumentSession) =>
         Effect.suspend(() => {
           if (registeredSessionCleanups.has(session)) return Effect.void;

--- a/extension/src/panel/variables/VariablesView.ts
+++ b/extension/src/panel/variables/VariablesView.ts
@@ -3,7 +3,7 @@ import { Effect, HashMap, Layer, Option, Ref, Stream } from "effect";
 import { NotebookEditorRegistry } from "../../notebook/NotebookEditorRegistry.ts";
 import type { NotebookId } from "../../schemas/MarimoNotebookDocument.ts";
 import { TreeView } from "../TreeView.ts";
-import { VariablesService } from "./VariablesService.ts";
+import { NotebookVariables } from "./NotebookVariables.ts";
 
 interface VariableTreeItem {
   type: "variable";
@@ -23,7 +23,7 @@ interface VariableTreeItem {
 export const VariablesViewLive = Layer.effectDiscard(
   Effect.gen(function* () {
     const treeView = yield* TreeView;
-    const variablesService = yield* VariablesService;
+    const variables = yield* NotebookVariables;
     const editorRegistry = yield* NotebookEditorRegistry;
 
     // Track the current variable items for the active notebook
@@ -67,8 +67,7 @@ export const VariablesViewLive = Layer.effectDiscard(
       }
 
       const notebookUri = activeNotebookUri.value;
-      const variablesData =
-        yield* variablesService.getAllVariableData(notebookUri);
+      const variablesData = yield* variables.getAllVariableData(notebookUri);
 
       // Create a map of variable values for quick lookup
       const valueMap = new Map<string, { value?: string; datatype?: string }>();
@@ -114,14 +113,14 @@ export const VariablesViewLive = Layer.effectDiscard(
 
     // Subscribe to variable declarations changes
     yield* Effect.forkScoped(
-      variablesService.streamVariablesChanges.pipe(
+      variables.streamVariablesChanges.pipe(
         Stream.runForEach(() => refreshVariables()),
       ),
     );
 
     // Subscribe to variable values changes
     yield* Effect.forkScoped(
-      variablesService.streamVariableValuesChanges.pipe(
+      variables.streamVariableValuesChanges.pipe(
         Stream.runForEach(
           Effect.fn(function* (valuesMap) {
             const activeNotebookUri =

--- a/extension/src/panel/variables/__tests__/NotebookVariables.test.ts
+++ b/extension/src/panel/variables/__tests__/NotebookVariables.test.ts
@@ -16,7 +16,7 @@ import type {
   VariablesNotification,
   VariableValuesNotification,
 } from "../../../types.ts";
-import { VariablesService } from "../VariablesService.ts";
+import { NotebookVariables } from "../NotebookVariables.ts";
 
 const withTestCtx = () =>
   Effect.sync(() => {
@@ -31,7 +31,7 @@ const withTestCtx = () =>
         ),
       active: Stream.empty,
     });
-    const layer = Layer.effect(VariablesService, VariablesService.make).pipe(
+    const layer = Layer.effect(NotebookVariables, NotebookVariables.make).pipe(
       Layer.provide(documentSessions),
     );
     return { layer };
@@ -95,7 +95,7 @@ it.effect(
     const { layer } = yield* withTestCtx();
 
     const result = yield* Effect.gen(function* () {
-      const service = yield* VariablesService;
+      const service = yield* NotebookVariables;
       const notebookUri = NOTEBOOK_URI;
 
       return {
@@ -115,7 +115,7 @@ it.effect(
     const { layer } = yield* withTestCtx();
 
     const variables = yield* Effect.gen(function* () {
-      const service = yield* VariablesService;
+      const service = yield* NotebookVariables;
       const notebookUri = NOTEBOOK_URI;
 
       const mockOp = createMockVariablesOp([
@@ -143,7 +143,7 @@ it.effect(
     const { layer } = yield* withTestCtx();
 
     const values = yield* Effect.gen(function* () {
-      const service = yield* VariablesService;
+      const service = yield* NotebookVariables;
       const notebookUri = NOTEBOOK_URI;
 
       const mockOp = createMockVariableValuesOp([
@@ -171,7 +171,7 @@ it.effect(
     const { layer } = yield* withTestCtx();
 
     const allData = yield* Effect.gen(function* () {
-      const service = yield* VariablesService;
+      const service = yield* NotebookVariables;
       const notebookUri = NOTEBOOK_URI;
 
       const mockVariables = createMockVariablesOp([
@@ -202,7 +202,7 @@ it.effect(
     const { layer } = yield* withTestCtx();
 
     const result = yield* Effect.gen(function* () {
-      const service = yield* VariablesService;
+      const service = yield* NotebookVariables;
       const notebook1 = notebookId("file:///test/notebook1.py");
       const notebook2 = notebookId("file:///test/notebook2.py");
 
@@ -237,7 +237,7 @@ it.effect(
     const { layer } = yield* withTestCtx();
 
     const result = yield* Effect.gen(function* () {
-      const service = yield* VariablesService;
+      const service = yield* NotebookVariables;
       const notebookUri = NOTEBOOK_URI;
 
       const mockVariables = createMockVariablesOp([
@@ -289,7 +289,7 @@ it.effect(
     const { layer } = yield* withTestCtx();
 
     const result = yield* Effect.gen(function* () {
-      const service = yield* VariablesService;
+      const service = yield* NotebookVariables;
       const notebookUri = NOTEBOOK_URI;
       const displaced = sessionFor(notebookUri);
 
@@ -331,7 +331,7 @@ it.effect(
     const { layer } = yield* withTestCtx();
 
     const count = yield* Effect.gen(function* () {
-      const service = yield* VariablesService;
+      const service = yield* NotebookVariables;
       const notebookUri = NOTEBOOK_URI;
 
       const collected = yield* Ref.make(0);
@@ -388,7 +388,7 @@ it.effect(
     const { layer } = yield* withTestCtx();
 
     const count = yield* Effect.gen(function* () {
-      const service = yield* VariablesService;
+      const service = yield* NotebookVariables;
       const notebookUri = NOTEBOOK_URI;
 
       const collected = yield* Ref.make(0);
@@ -432,7 +432,7 @@ it.effect(
     const { layer } = yield* withTestCtx();
 
     const values = yield* Effect.gen(function* () {
-      const service = yield* VariablesService;
+      const service = yield* NotebookVariables;
       const notebookUri = NOTEBOOK_URI;
 
       // Set initial variable values


### PR DESCRIPTION
`Context.Service` already describes how these modules enter Effect. The `Service` suffix left notebook-owned state and live server sessions looking equivalent.

```ts
DatasourcesService -> NotebookDatasources
VariablesService   -> NotebookVariables
SessionsService    -> LiveSessions
```

`NotebookDatasources` and `NotebookVariables` are keyed by document session. `LiveSessions` owns the server's current kernel-session snapshot and controls. This is a naming-only change.
