### PR TITLE
Preserve Lazy downstream staleness

### DIFF
--- a/extension/src/kernel/CellExecutions.ts
+++ b/extension/src/kernel/CellExecutions.ts
@@ -32,8 +32,10 @@ import {
   type NotebookCellId,
   type NotebookId,
 } from "../schemas/MarimoNotebookDocument.ts";
-import type { CellOperationNotification, CellRuntimeState } from "../types.ts";
+import type { CellOperationNotification } from "../types.ts";
 import {
+  acceptKernelState,
+  activeRunId,
   AcceptedSource,
   CellCommand,
   type CellRunState,
@@ -95,8 +97,8 @@ export interface NotebookExecutionBinding {
 
 export interface NotebookExecutions {
   /**
-   * Correlates and folds one Wire Cell Operation, then admits its presentation
-   * commands. Completion does not wait for the presentation adapter.
+   * Folds one Wire Cell Operation, then admits its presentation commands when
+   * its run correlates. Completion does not wait for the presentation adapter.
    */
   readonly apply: (
     operation: CellOperationNotification,
@@ -370,17 +372,12 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
             ),
           );
 
-        const correlate = Effect.fn("NotebookExecutions.correlate")(function* (
+        const correlationError = (
           record: CellRecord,
-          next: CellRuntimeState,
           wire: CellOperationNotification,
-        ) {
+        ): RunCorrelationError | undefined => {
           const cellId = extractCellIdFromCellMessage(wire);
-          const activeRunId =
-            record.run.phase._tag === "Queued" ||
-            record.run.phase._tag === "Running"
-              ? record.run.phase.runId
-              : undefined;
+          const expectedRunId = activeRunId(record.run.phase);
           const receivedRunId =
             typeof wire.run_id === "string" && wire.run_id.length > 0
               ? wire.run_id
@@ -389,29 +386,18 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
           if (
             wire.status !== "queued" &&
             receivedRunId !== undefined &&
-            receivedRunId !== activeRunId
+            receivedRunId !== expectedRunId
           ) {
-            return yield* new RunCorrelationError({
+            return new RunCorrelationError({
               cellId,
-              expectedRunId: activeRunId,
+              expectedRunId,
               receivedRunId,
               status: wire.status,
               reason: "superseded-run",
             });
           }
-
-          const op = parseOp(next, wire, RunId(crypto.randomUUID()));
-          if (Option.isNone(op)) {
-            return yield* new RunCorrelationError({
-              cellId,
-              expectedRunId: activeRunId,
-              receivedRunId,
-              status: wire.status,
-              reason: "untracked-queue",
-            });
-          }
-          return op.value;
-        });
+          return undefined;
+        };
 
         const takeSubmittedSource = (cellId: NotebookCellId) => {
           const pending = submittedSources.get(cellId);
@@ -431,34 +417,53 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
                 drive: Option.none<DriveBinding>(),
               };
               const next = transitionCell(record.run.state, wire);
-              const retainUncorrelatedState = Effect.sync(() => {
+              const retainKernelState = Effect.gen(function* () {
                 if (wire.status === "queued") takeSubmittedSource(cellId);
-                // Keep the kernel's state fold even for an op we cannot
-                // correlate to a run — only presentation is withheld.
-                // Late console appends from threads of a finished run
-                // land here, and the kernel remains the source of truth
-                // for cell state.
+                // Keep kernel-owned state even when this operation cannot
+                // drive a host run. Lazy execution tags descendant staleness
+                // with the ancestor's run ID; late console appends likewise
+                // arrive after their presentation run has closed.
                 records.set(cellId, {
                   ...record,
-                  run: { ...record.run, state: next },
+                  run: acceptKernelState(record.run, next),
                 });
+                yield* refreshStale([cellId]);
               });
-              const op = yield* correlate(record, next, wire).pipe(
-                Effect.tapError(() => retainUncorrelatedState),
+              const op = yield* Option.match(
+                parseOp(next, wire, RunId(crypto.randomUUID())),
+                {
+                  onNone: () =>
+                    retainKernelState.pipe(
+                      Effect.andThen(
+                        Effect.fail(
+                          new RunCorrelationError({
+                            cellId,
+                            expectedRunId: activeRunId(record.run.phase),
+                            receivedRunId: undefined,
+                            status: wire.status,
+                            reason: "untracked-queue",
+                          }),
+                        ),
+                      ),
+                    ),
+                  onSome: Effect.succeed,
+                },
               );
+              const source = Op.$is("Queue")(op)
+                ? (takeSubmittedSource(cellId) ?? currentSources.get(cellId))
+                : undefined;
+              const result = step(record.run, op, source);
+              const mismatch = correlationError(record, wire);
+              yield* mismatch !== undefined && result.commands.length > 0
+                ? retainKernelState.pipe(Effect.andThen(Effect.fail(mismatch)))
+                : Effect.void;
               if (
                 wire.status === "idle" &&
-                record.run.phase._tag !== "Queued" &&
-                record.run.phase._tag !== "Running"
+                activeRunId(record.run.phase) === undefined
               ) {
                 takeSubmittedSource(cellId);
               }
               const currentDrive = yield* binding.getDrive;
-              const source =
-                op._tag === "Queue"
-                  ? (takeSubmittedSource(cellId) ?? currentSources.get(cellId))
-                  : undefined;
-              const result = step(record.run, op, source);
               // A run's presentation stays on the drive that opened it:
               // OpenRun binds the drive current at open time, and later
               // commands for that run reuse the binding even after the
@@ -474,12 +479,13 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
                   ),
                 );
               const phase = result.entry.phase;
+              const runId = activeRunId(phase);
               records.set(cellId, {
                 run: result.entry,
                 drive:
-                  phase._tag === "Queued" || phase._tag === "Running"
-                    ? Option.map(driveForRun(phase.runId), (value) => ({
-                        runId: phase.runId,
+                  runId !== undefined
+                    ? Option.map(driveForRun(runId), (value) => ({
+                        runId,
                         value,
                       }))
                     : Option.none(),

--- a/extension/src/kernel/CellRunReducer.ts
+++ b/extension/src/kernel/CellRunReducer.ts
@@ -100,6 +100,26 @@ export function transitionCell(
 }
 
 /**
+ * Accept kernel-owned cell state without changing the host run lifecycle.
+ *
+ * Some state-only notifications are tagged with the run that caused them,
+ * rather than a run of the target cell. Their presentation may not correlate,
+ * but their state remains authoritative.
+ */
+export function acceptKernelState(
+  entry: CellRunState,
+  state: CellRuntimeState,
+): CellRunState {
+  return {
+    ...entry,
+    state,
+    acceptedSource: state.staleInputs
+      ? AcceptedSource.Invalidated()
+      : entry.acceptedSource,
+  };
+}
+
+/**
  * Categorize a `cell-op` into an {@link Op}.
  *
  * `next` is the folded state (`transitionCell(prev, msg)`); the caller folds it
@@ -140,8 +160,13 @@ export function parseOp(
   }
 }
 
-const activeRunId = (phase: RunPhase): RunId | undefined =>
-  phase._tag === "Queued" || phase._tag === "Running" ? phase.runId : undefined;
+export const activeRunId: (phase: RunPhase) => RunId | undefined =
+  RunPhase.$match({
+    Idle: () => undefined,
+    Queued: ({ runId }) => runId,
+    Running: ({ runId }) => runId,
+    Completed: () => undefined,
+  });
 
 const isError = (state: CellRuntimeState): boolean =>
   state.output?.channel === "marimo-error";
@@ -232,7 +257,7 @@ export function step(
     Start: ({ startTime, next, ephemeralRunId }) => {
       const commands: CellCommand[] = [];
       let phase = entry.phase;
-      if (entry.phase._tag === "Queued") {
+      if (RunPhase.$is("Queued")(entry.phase)) {
         commands.push(
           CellCommand.StartRun({
             runId: entry.phase.runId,
@@ -255,12 +280,8 @@ export function step(
       }
       return {
         entry: {
-          ...entry,
-          state: next,
+          ...acceptKernelState(entry, next),
           phase,
-          acceptedSource: next.staleInputs
-            ? AcceptedSource.Invalidated()
-            : entry.acceptedSource,
         },
         commands,
       };
@@ -281,22 +302,14 @@ export function step(
         );
       }
       return {
-        entry: {
-          ...entry,
-          state: next,
-          acceptedSource: next.staleInputs
-            ? AcceptedSource.Invalidated()
-            : entry.acceptedSource,
-        },
+        entry: acceptKernelState(entry, next),
         commands,
       };
     },
 
     Settle: ({ success, endTime, next, ephemeralRunId }) => {
       const commands: CellCommand[] = [];
-      const acceptedSource = next.staleInputs
-        ? AcceptedSource.Invalidated()
-        : entry.acceptedSource;
+      const accepted = acceptKernelState(entry, next);
       const runId = activeRunId(entry.phase);
       if (runId !== undefined) {
         commands.push(
@@ -306,10 +319,8 @@ export function step(
         );
         return {
           entry: {
-            ...entry,
-            state: next,
+            ...accepted,
             phase: RunPhase.Completed(),
-            acceptedSource,
           },
           commands,
         };
@@ -326,7 +337,7 @@ export function step(
         commands.push(CellCommand.SetDiagnostic({ state: Option.some(next) }));
       }
       return {
-        entry: { ...entry, state: next, acceptedSource },
+        entry: accepted,
         commands,
       };
     },

--- a/extension/src/kernel/NotebookRuntime.ts
+++ b/extension/src/kernel/NotebookRuntime.ts
@@ -1251,7 +1251,9 @@ function processNotebookOperation(
       if (extractCellIdFromCellMessage(operation) === SCRATCH_CELL_ID) return;
       yield* notebookExecutions.apply(operation).pipe(
         Effect.catchTag("RunCorrelationError", (error) =>
-          Effect.logWarning("Ignoring uncorrelated cell operation").pipe(
+          Effect.logWarning(
+            "Withheld presentation for uncorrelated cell operation",
+          ).pipe(
             Effect.annotateLogs({
               cellId: error.cellId,
               expectedRunId: error.expectedRunId,

--- a/extension/src/kernel/__tests__/CellExecutions.test.ts
+++ b/extension/src/kernel/__tests__/CellExecutions.test.ts
@@ -2231,6 +2231,76 @@ describe("NotebookExecutions", () => {
   );
 
   it.effect(
+    "retains downstream staleness tagged with an ancestor run",
+    Effect.fn(function* () {
+      const editor = TestVsCode.makeNotebookEditor("/test/notebook.py", {
+        data: {
+          cells: [
+            {
+              kind: 1,
+              value: "x = 1",
+              languageId: "python",
+              metadata: MarimoNotebookCell.createMetadata({
+                marimoRuntime: { stableId: "ancestor" },
+              }),
+            },
+            {
+              kind: 1,
+              value: "y = x + 1",
+              languageId: "python",
+              metadata: MarimoNotebookCell.createMetadata({
+                marimoRuntime: { stableId: "descendant" },
+              }),
+            },
+          ],
+        },
+      });
+      const ctx = yield* withTestCtx({ initialDocuments: [editor.notebook] });
+
+      yield* Effect.gen(function* () {
+        const executions = yield* CellExecutions;
+        const { notebook } = yield* openNotebook(executions, editor.notebook);
+        const document = MarimoNotebookDocument.from(editor.notebook);
+        const ancestorId = Option.getOrThrow(document.cellAt(0).id);
+        const descendantId = Option.getOrThrow(document.cellAt(1).id);
+
+        yield* acknowledgeSubmission(
+          notebook,
+          descendantId,
+          "y = x + 1",
+          "initial-run",
+        );
+        yield* notebook.apply({
+          op: "cell-op",
+          cell_id: descendantId,
+          status: "idle",
+          run_id: "initial-run",
+        });
+        yield* notebook.apply({
+          op: "cell-op",
+          cell_id: ancestorId,
+          status: "queued",
+          run_id: "ancestor-run",
+        });
+
+        // Lazy execution tags every notification in the cascade with the
+        // ancestor's run ID, including stale-only updates for idle descendants.
+        yield* notebook.apply({
+          op: "cell-op",
+          cell_id: descendantId,
+          status: null,
+          run_id: "ancestor-run",
+          stale_inputs: true,
+        });
+
+        expect(
+          HashSet.has(yield* notebook.staleCells.current, descendantId),
+        ).toBe(true);
+      }).pipe(Effect.provide(ctx.layer));
+    }),
+  );
+
+  it.effect(
     "rejects a tagged operation after its run completes",
     Effect.fn(function* () {
       const editor = TestVsCode.makeNotebookEditor("/test/notebook.py", {


### PR DESCRIPTION
Lazy execution tags state-only descendant invalidations with the ancestor run ID. Correlation therefore cannot decide whether kernel state is authoritative; it only decides whether a notification may drive an existing VS Code execution.

Fold all kernel state, but withhold presentation commands when the run ID does not correlate. This keeps downstream stale tracking accurate without attaching descendant updates to the ancestor host run.