### PR TITLE
Represent cell execution absence with Option

### DIFF
--- a/extension/src/kernel/CellExecutions.ts
+++ b/extension/src/kernel/CellExecutions.ts
@@ -43,6 +43,7 @@ import {
   Op,
   parseOp,
   RunId,
+  runIdFromWire,
   step,
   transitionCell,
 } from "./CellRunReducer.ts";
@@ -73,8 +74,8 @@ export class RunCorrelationError extends Data.TaggedError(
   "RunCorrelationError",
 )<{
   readonly cellId: NotebookCellId;
-  readonly expectedRunId: string | undefined;
-  readonly receivedRunId: string | undefined;
+  readonly expectedRunId: Option.Option<RunId>;
+  readonly receivedRunId: Option.Option<RunId>;
   readonly status: CellOperationNotification["status"];
   /**
    * `superseded-run`: a tagged operation named a run other than the active
@@ -375,37 +376,45 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
         const correlationError = (
           record: CellRecord,
           wire: CellOperationNotification,
-        ): RunCorrelationError | undefined => {
+        ): Option.Option<RunCorrelationError> => {
           const cellId = extractCellIdFromCellMessage(wire);
           const expectedRunId = activeRunId(record.run.phase);
-          const receivedRunId =
-            typeof wire.run_id === "string" && wire.run_id.length > 0
-              ? wire.run_id
-              : undefined;
-
+          const receivedRunId = runIdFromWire(wire.run_id);
           if (
             wire.status !== "queued" &&
-            receivedRunId !== undefined &&
-            receivedRunId !== expectedRunId
+            Option.isSome(receivedRunId) &&
+            !Equal.equals(expectedRunId, receivedRunId)
           ) {
-            return new RunCorrelationError({
-              cellId,
-              expectedRunId,
-              receivedRunId,
-              status: wire.status,
-              reason: "superseded-run",
-            });
+            return Option.some(
+              new RunCorrelationError({
+                cellId,
+                expectedRunId,
+                receivedRunId,
+                status: wire.status,
+                reason: "superseded-run",
+              }),
+            );
           }
-          return undefined;
+          return Option.none();
         };
 
-        const takeSubmittedSource = (cellId: NotebookCellId) => {
-          const pending = submittedSources.get(cellId);
-          if (pending === undefined || pending.length === 0) return undefined;
-          const submitted = pending.shift();
-          if (pending.length === 0) submittedSources.delete(cellId);
-          return submitted?.source;
-        };
+        const dequeueSubmittedSource = Effect.fn(
+          "CellExecutions.dequeueSubmittedSource",
+        )((cellId: NotebookCellId) =>
+          Effect.sync(() => {
+            const pending = submittedSources.get(cellId);
+            if (pending === undefined || pending.length === 0) {
+              return Option.none<string>();
+            }
+            const submitted = pending.shift();
+            if (pending.length === 0) {
+              submittedSources.delete(cellId);
+            }
+            return Option.fromNullishOr(submitted).pipe(
+              Option.map(({ source }) => source),
+            );
+          }),
+        );
 
         const apply: NotebookExecutions["apply"] = (wire) =>
           ordering.withPermit(
@@ -418,7 +427,9 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
               };
               const next = transitionCell(record.run.state, wire);
               const retainKernelState = Effect.gen(function* () {
-                if (wire.status === "queued") takeSubmittedSource(cellId);
+                if (wire.status === "queued") {
+                  yield* dequeueSubmittedSource(cellId);
+                }
                 // Keep kernel-owned state even when this operation cannot
                 // drive a host run. Lazy execution tags descendant staleness
                 // with the ancestor's run ID; late console appends likewise
@@ -439,7 +450,7 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
                           new RunCorrelationError({
                             cellId,
                             expectedRunId: activeRunId(record.run.phase),
-                            receivedRunId: undefined,
+                            receivedRunId: Option.none(),
                             status: wire.status,
                             reason: "untracked-queue",
                           }),
@@ -449,19 +460,30 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
                   onSome: Effect.succeed,
                 },
               );
-              const source = Op.$is("Queue")(op)
-                ? (takeSubmittedSource(cellId) ?? currentSources.get(cellId))
-                : undefined;
+              let source = Option.none<string>();
+              if (Op.$is("Queue")(op)) {
+                const submittedSource = yield* dequeueSubmittedSource(cellId);
+                source = submittedSource.pipe(
+                  Option.orElse(() =>
+                    Option.fromNullishOr(currentSources.get(cellId)),
+                  ),
+                );
+              }
+
               const result = step(record.run, op, source);
               const mismatch = correlationError(record, wire);
-              yield* mismatch !== undefined && result.commands.length > 0
-                ? retainKernelState.pipe(Effect.andThen(Effect.fail(mismatch)))
-                : Effect.void;
+              const enforceCorrelation =
+                Option.isSome(mismatch) && result.commands.length > 0
+                  ? retainKernelState.pipe(
+                      Effect.andThen(Effect.fail(mismatch.value)),
+                    )
+                  : Effect.void;
+              yield* enforceCorrelation;
               if (
                 wire.status === "idle" &&
-                activeRunId(record.run.phase) === undefined
+                Option.isNone(activeRunId(record.run.phase))
               ) {
-                takeSubmittedSource(cellId);
+                yield* dequeueSubmittedSource(cellId);
               }
               const currentDrive = yield* binding.getDrive;
               // A run's presentation stays on the drive that opened it:
@@ -482,13 +504,16 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
               const runId = activeRunId(phase);
               records.set(cellId, {
                 run: result.entry,
-                drive:
-                  runId !== undefined
-                    ? Option.map(driveForRun(runId), (value) => ({
+                drive: runId.pipe(
+                  Option.flatMap((runId) =>
+                    driveForRun(runId).pipe(
+                      Option.map((value) => ({
                         runId,
                         value,
-                      }))
-                    : Option.none(),
+                      })),
+                    ),
+                  ),
+                ),
               });
               yield* refreshStale([cellId]);
 

--- a/extension/src/kernel/CellRunReducer.ts
+++ b/extension/src/kernel/CellRunReducer.ts
@@ -46,11 +46,14 @@ export type Op = Data.TaggedEnum<{
   };
   Settle: {
     readonly success: boolean;
-    readonly endTime: number | undefined;
+    readonly endTime: Option.Option<number>;
     readonly next: CellRuntimeState;
     readonly ephemeralRunId: RunId;
   };
-  Update: { readonly next: CellRuntimeState; readonly ephemeralRunId: RunId };
+  Update: {
+    readonly next: CellRuntimeState;
+    readonly ephemeralRunId: RunId;
+  };
   Interrupt: {};
   Invalidate: {};
 }>;
@@ -59,7 +62,10 @@ export const Op = Data.taggedEnum<Op>();
 /** One host effect requested by the reducer. */
 export type CellCommand = Data.TaggedEnum<{
   OpenRun: { readonly runId: RunId };
-  StartRun: { readonly runId: RunId; readonly at: number | undefined };
+  StartRun: {
+    readonly runId: RunId;
+    readonly at: Option.Option<number>;
+  };
   RenderOutputs: {
     readonly runId: RunId;
     readonly state: CellRuntimeState;
@@ -68,7 +74,7 @@ export type CellCommand = Data.TaggedEnum<{
   CloseRun: {
     readonly runId: RunId;
     readonly success: boolean;
-    readonly at: number | undefined;
+    readonly at: Option.Option<number>;
   };
   SetDiagnostic: { readonly state: Option.Option<CellRuntimeState> };
 }>;
@@ -119,6 +125,15 @@ export function acceptKernelState(
   };
 }
 
+/** Normalize the nullable wire representation of a run ID. */
+export const runIdFromWire = (
+  runId: CellOperationNotification["run_id"],
+): Option.Option<RunId> =>
+  Option.fromNullishOr(runId).pipe(
+    Option.filter((value) => value.length > 0),
+    Option.map(RunId),
+  );
+
 /**
  * Categorize a `cell-op` into an {@link Op}.
  *
@@ -133,8 +148,9 @@ export function parseOp(
 ): Option.Option<Op> {
   switch (msg.status) {
     case "queued": {
-      const runId = Option.fromNullishOr(msg.run_id).pipe(Option.map(RunId));
-      return Option.map(runId, (id) => Op.Queue({ runId: id, next }));
+      return runIdFromWire(msg.run_id).pipe(
+        Option.map((runId) => Op.Queue({ runId, next })),
+      );
     }
     case "running":
       return Option.some(
@@ -150,7 +166,9 @@ export function parseOp(
           // A marimo-error output channel is the kernel's signal that the run
           // raised — report failure so VS Code shows the red error icon.
           success: next.output?.channel !== "marimo-error",
-          endTime: msg.timestamp == null ? undefined : msg.timestamp * 1000,
+          endTime: Option.fromNullishOr(msg.timestamp).pipe(
+            Option.map((timestamp) => timestamp * 1000),
+          ),
           next,
           ephemeralRunId,
         }),
@@ -160,12 +178,12 @@ export function parseOp(
   }
 }
 
-export const activeRunId: (phase: RunPhase) => RunId | undefined =
+export const activeRunId: (phase: RunPhase) => Option.Option<RunId> =
   RunPhase.$match({
-    Idle: () => undefined,
-    Queued: ({ runId }) => runId,
-    Running: ({ runId }) => runId,
-    Completed: () => undefined,
+    Idle: () => Option.none(),
+    Queued: ({ runId }) => Option.some(runId),
+    Running: ({ runId }) => Option.some(runId),
+    Completed: () => Option.none(),
   });
 
 const isError = (state: CellRuntimeState): boolean =>
@@ -180,7 +198,7 @@ const isError = (state: CellRuntimeState): boolean =>
 export function step(
   entry: CellRunState,
   op: Op,
-  source?: string,
+  source: Option.Option<string> = Option.none(),
 ): {
   readonly entry: CellRunState;
   readonly commands: ReadonlyArray<CellCommand>;
@@ -193,7 +211,7 @@ export function step(
         Invalidated: () => entry.acceptedSource,
         Accepted: () => AcceptedSource.Invalidated(),
       });
-      if (runId === undefined) {
+      if (Option.isNone(runId)) {
         return {
           entry: { ...entry, acceptedSource },
           commands: [],
@@ -206,18 +224,28 @@ export function step(
           acceptedSource,
         },
         commands: [
-          CellCommand.CloseRun({ runId, success: false, at: undefined }),
+          CellCommand.CloseRun({
+            runId: runId.value,
+            success: false,
+            at: Option.none(),
+          }),
         ],
       };
     },
 
     Interrupt: () => {
       const runId = activeRunId(entry.phase);
-      if (runId === undefined) return { entry, commands: [] };
+      if (Option.isNone(runId)) {
+        return { entry, commands: [] };
+      }
       return {
         entry: { ...entry, phase: RunPhase.Completed() },
         commands: [
-          CellCommand.CloseRun({ runId, success: false, at: undefined }),
+          CellCommand.CloseRun({
+            runId: runId.value,
+            success: false,
+            at: Option.none(),
+          }),
         ],
       };
     },
@@ -226,19 +254,19 @@ export function step(
       const commands: CellCommand[] = [];
       // Queue is the kernel's acknowledgement that it accepted this source.
       // It wins over `staleInputs` when both arrive on the same operation.
-      const acceptedSource =
-        source === undefined
-          ? entry.acceptedSource
-          : AcceptedSource.Accepted({ source });
+      const acceptedSource = Option.match(source, {
+        onNone: () => entry.acceptedSource,
+        onSome: (source) => AcceptedSource.Accepted({ source }),
+      });
       commands.push(CellCommand.SetDiagnostic({ state: Option.none() }));
       // End any still-running prior execution before creating the new one.
       const previousRunId = activeRunId(entry.phase);
-      if (previousRunId !== undefined) {
+      if (Option.isSome(previousRunId)) {
         commands.push(
           CellCommand.CloseRun({
-            runId: previousRunId,
+            runId: previousRunId.value,
             success: true,
-            at: undefined,
+            at: Option.none(),
           }),
         );
       }
@@ -261,15 +289,19 @@ export function step(
         commands.push(
           CellCommand.StartRun({
             runId: entry.phase.runId,
-            at: startTime,
+            at: Option.some(startTime),
           }),
         );
         phase = RunPhase.Running({ runId: entry.phase.runId });
       }
       const runId = activeRunId(phase);
-      if (runId !== undefined) {
+      if (Option.isSome(runId)) {
         commands.push(
-          CellCommand.RenderOutputs({ runId, state: next, final: false }),
+          CellCommand.RenderOutputs({
+            runId: runId.value,
+            state: next,
+            final: false,
+          }),
         );
       } else if (isError(next)) {
         commands.push(
@@ -290,9 +322,13 @@ export function step(
     Update: ({ next, ephemeralRunId }) => {
       const commands: CellCommand[] = [];
       const runId = activeRunId(entry.phase);
-      if (runId !== undefined) {
+      if (Option.isSome(runId)) {
         commands.push(
-          CellCommand.RenderOutputs({ runId, state: next, final: false }),
+          CellCommand.RenderOutputs({
+            runId: runId.value,
+            state: next,
+            final: false,
+          }),
         );
       } else if (isError(next)) {
         commands.push(
@@ -311,11 +347,15 @@ export function step(
       const commands: CellCommand[] = [];
       const accepted = acceptKernelState(entry, next);
       const runId = activeRunId(entry.phase);
-      if (runId !== undefined) {
+      if (Option.isSome(runId)) {
         commands.push(
-          CellCommand.RenderOutputs({ runId, state: next, final: true }),
+          CellCommand.RenderOutputs({
+            runId: runId.value,
+            state: next,
+            final: true,
+          }),
           CellCommand.SetDiagnostic({ state: Option.some(next) }),
-          CellCommand.CloseRun({ runId, success, at: endTime }),
+          CellCommand.CloseRun({ runId: runId.value, success, at: endTime }),
         );
         return {
           entry: {
@@ -357,11 +397,11 @@ function ephemeralError(
 ): CellCommand[] {
   return [
     CellCommand.OpenRun({ runId }),
-    CellCommand.StartRun({ runId, at: undefined }),
+    CellCommand.StartRun({ runId, at: Option.none() }),
     CellCommand.RenderOutputs({ runId, state: next, final: true }),
     ...(opts.applyDiagnostic
       ? [CellCommand.SetDiagnostic({ state: Option.some(next) })]
       : []),
-    CellCommand.CloseRun({ runId, success: false, at: undefined }),
+    CellCommand.CloseRun({ runId, success: false, at: Option.none() }),
   ];
 }

--- a/extension/src/kernel/VsCodeCellDrive.ts
+++ b/extension/src/kernel/VsCodeCellDrive.ts
@@ -175,16 +175,16 @@ export class VsCodeCellDrive extends Context.Service<VsCodeCellDrive>()(
             }),
           StartRun: ({ runId, at }) =>
             withResource(cell, runId, ({ execution }) =>
-              Effect.sync(() => execution.start(at)),
+              Effect.sync(() => execution.start(Option.getOrUndefined(at))),
             ),
           RenderOutputs: ({ runId, state, final }) =>
             renderOutputs(cell, runId, state, final),
           CloseRun: ({ runId, success, at }) =>
             withResource(cell, runId, ({ execution }) =>
               Effect.gen(function* () {
-                yield* Effect.try(() => execution.end(success, at)).pipe(
-                  Effect.ignore,
-                );
+                yield* Effect.try(() =>
+                  execution.end(success, Option.getOrUndefined(at)),
+                ).pipe(Effect.ignore);
                 resources.delete(resourceKey(cell, runId));
               }),
             ),

--- a/extension/src/kernel/__tests__/CellExecutions.test.ts
+++ b/extension/src/kernel/__tests__/CellExecutions.test.ts
@@ -1887,7 +1887,7 @@ describe("NotebookExecutions", () => {
           CellCommand.CloseRun({
             runId: RunId("run-1"),
             success: false,
-            at: undefined,
+            at: Option.none(),
           }),
         );
       }).pipe(Effect.provide(ctx.layer));
@@ -2141,8 +2141,8 @@ describe("NotebookExecutions", () => {
           .pipe(Effect.flip);
 
         expect(error._tag).toBe("RunCorrelationError");
-        expect(error.expectedRunId).toBe("run-2");
-        expect(error.receivedRunId).toBe("run-1");
+        expect(error.expectedRunId).toEqual(Option.some(RunId("run-2")));
+        expect(error.receivedRunId).toEqual(Option.some(RunId("run-1")));
         expect(error.reason).toBe("superseded-run");
       }).pipe(Effect.provide(ctx.layer));
     }),
@@ -2369,8 +2369,8 @@ describe("NotebookExecutions", () => {
           .pipe(Effect.flip);
 
         expect(error._tag).toBe("RunCorrelationError");
-        expect(error.expectedRunId).toBeUndefined();
-        expect(error.receivedRunId).toBe("run-1");
+        expect(error.expectedRunId).toEqual(Option.none());
+        expect(error.receivedRunId).toEqual(Option.some(RunId("run-1")));
         expect(opened).toBe(1);
       }).pipe(Effect.provide(ctx.layer));
     }),

--- a/extension/src/kernel/__tests__/CellRunReducer.test.ts
+++ b/extension/src/kernel/__tests__/CellRunReducer.test.ts
@@ -1,4 +1,5 @@
 import { createCellRuntimeState } from "@marimo-team/frontend/unstable_internal/core/cells/types.ts";
+import { Option } from "effect";
 import { describe, expect, it } from "vite-plus/test";
 
 import { cellId } from "../../lib/__tests__/branded.ts";
@@ -47,7 +48,11 @@ describe("cell run reducer", () => {
   it("drives a normal run: queue → start → update → settle", () => {
     let e = entry(RunPhase.Idle());
 
-    const queued = step(e, Op.Queue({ runId: RUN, next: okState() }), "x = 1");
+    const queued = step(
+      e,
+      Op.Queue({ runId: RUN, next: okState() }),
+      Option.some("x = 1"),
+    );
     expect(tags(queued.commands)).toEqual(["SetDiagnostic", "OpenRun"]);
     expect(queued.entry.phase).toEqual(RunPhase.Queued({ runId: RUN }));
     expect(queued.entry.acceptedSource).toEqual(
@@ -78,7 +83,7 @@ describe("cell run reducer", () => {
       e,
       Op.Settle({
         success: true,
-        endTime: 9,
+        endTime: Option.some(9),
         next: okState(),
         ephemeralRunId: EPHEMERAL_RUN,
       }),
@@ -97,14 +102,18 @@ describe("cell run reducer", () => {
       running,
       Op.Settle({
         success: false,
-        endTime: undefined,
+        endTime: Option.none(),
         next: errorState(),
         ephemeralRunId: EPHEMERAL_RUN,
       }),
     );
     const end = commands.find((command) => command._tag === "CloseRun");
     expect(end).toEqual(
-      CellCommand.CloseRun({ runId: RUN, success: false, at: undefined }),
+      CellCommand.CloseRun({
+        runId: RUN,
+        success: false,
+        at: Option.none(),
+      }),
     );
   });
 
@@ -118,7 +127,11 @@ describe("cell run reducer", () => {
     // The prior run is ended as a success — it's superseded, not failed.
     const end = commands.find((command) => command._tag === "CloseRun");
     expect(end).toEqual(
-      CellCommand.CloseRun({ runId: RUN, success: true, at: undefined }),
+      CellCommand.CloseRun({
+        runId: RUN,
+        success: true,
+        at: Option.none(),
+      }),
     );
   });
 
@@ -147,7 +160,11 @@ describe("cell run reducer", () => {
       AcceptedSource.Invalidated(),
     );
     expect(invalidated.commands).toEqual([
-      CellCommand.CloseRun({ runId: RUN, success: false, at: undefined }),
+      CellCommand.CloseRun({
+        runId: RUN,
+        success: false,
+        at: Option.none(),
+      }),
     ]);
   });
 
@@ -156,7 +173,7 @@ describe("cell run reducer", () => {
       entry(RunPhase.Idle()),
       Op.Settle({
         success: false,
-        endTime: undefined,
+        endTime: Option.none(),
         next: errorState(),
         ephemeralRunId: EPHEMERAL_RUN,
       }),
@@ -183,7 +200,7 @@ describe("cell run reducer", () => {
       entry(RunPhase.Idle()),
       Op.Settle({
         success: true,
-        endTime: undefined,
+        endTime: Option.none(),
         next: okState(),
         ephemeralRunId: EPHEMERAL_RUN,
       }),
@@ -203,7 +220,7 @@ describe("cell run reducer", () => {
     const { entry: next } = step(
       entry(RunPhase.Idle()),
       Op.Queue({ runId: RUN, next: staleState() }),
-      "x = 1",
+      Option.some("x = 1"),
     );
     expect(next.acceptedSource).toEqual(
       AcceptedSource.Accepted({ source: "x = 1" }),


### PR DESCRIPTION
Cell execution state mixed `Option` and undefined, so `Option.none()` bypassed the current-source fallback because it is not nullish.