### PR TITLE
Treat LSP teardown cancellation as expected

### DIFF
--- a/extension/src/lib/__tests__/isExpectedCancellation.test.ts
+++ b/extension/src/lib/__tests__/isExpectedCancellation.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Cause } from "effect";
+
+import { isExpectedCancellation } from "../isExpectedCancellation.ts";
+
+const canceled = () => {
+  const error = new Error("Canceled");
+  error.name = "Canceled";
+  return error;
+};
+
+describe("isExpectedCancellation", () => {
+  it("accepts interruptions and canceled failures or defects", () => {
+    expect(isExpectedCancellation(Cause.interrupt())).toBe(true);
+    expect(isExpectedCancellation(Cause.fail(canceled()))).toBe(true);
+    expect(isExpectedCancellation(Cause.die(canceled()))).toBe(true);
+  });
+
+  it("rejects empty causes and ordinary failures", () => {
+    expect(isExpectedCancellation(Cause.empty)).toBe(false);
+    expect(isExpectedCancellation(Cause.fail(new Error("boom")))).toBe(false);
+    expect(isExpectedCancellation(Cause.die(new Error("boom")))).toBe(false);
+  });
+
+  it("does not suppress a real failure mixed with cancellation", () => {
+    const cause = Cause.fromReasons([
+      Cause.makeInterruptReason(),
+      Cause.makeDieReason(canceled()),
+      Cause.makeFailReason(new Error("boom")),
+    ]);
+
+    expect(isExpectedCancellation(cause)).toBe(false);
+  });
+});

--- a/extension/src/lib/isExpectedCancellation.ts
+++ b/extension/src/lib/isExpectedCancellation.ts
@@ -1,0 +1,20 @@
+import { Cause } from "effect";
+
+const isCanceledError = (value: unknown): boolean =>
+  value instanceof Error && value.name === "Canceled";
+
+/**
+ * Returns whether every reason in a non-empty cause is expected cancellation
+ * control flow. A cause that also contains a real failure is never suppressed.
+ */
+export function isExpectedCancellation(cause: Cause.Cause<unknown>): boolean {
+  return (
+    cause.reasons.length > 0 &&
+    cause.reasons.every((reason) => {
+      if (Cause.isInterruptReason(reason)) return true;
+      if (Cause.isFailReason(reason)) return isCanceledError(reason.error);
+      if (Cause.isDieReason(reason)) return isCanceledError(reason.defect);
+      return false;
+    })
+  );
+}

--- a/extension/src/lsp/TyLanguageServer.ts
+++ b/extension/src/lsp/TyLanguageServer.ts
@@ -22,6 +22,7 @@ import {
   validateBinary,
 } from "../lib/binaryResolution.ts";
 import { getExtensionVersion } from "../lib/getExtensionVersion.ts";
+import { isExpectedCancellation } from "../lib/isExpectedCancellation.ts";
 import { showErrorAndPromptLogs } from "../lib/showErrorAndPromptLogs.ts";
 import { NotebookVariables } from "../panel/variables/NotebookVariables.ts";
 import { OutputChannel } from "../platform/OutputChannel.ts";
@@ -280,7 +281,7 @@ export class TyLanguageServer extends Context.Service<TyLanguageServer>()(
             ),
             Effect.catchCause((cause) =>
               Effect.gen(function* () {
-                if (Cause.hasInterruptsOnly(cause)) return;
+                if (isExpectedCancellation(cause)) return;
                 const message = "Failed to start ty language server";
                 yield* Ref.set(
                   statusRef,

--- a/extension/src/lsp/__tests__/clientCleanup.test.ts
+++ b/extension/src/lsp/__tests__/clientCleanup.test.ts
@@ -1,0 +1,43 @@
+import { expect, it } from "@effect/vitest";
+import { Effect, Logger } from "effect";
+
+import { runLspCleanup } from "../client.ts";
+
+it.effect(
+  "suppresses canceled LSP cleanup",
+  Effect.fn(function* () {
+    const logs: Array<{ level: string; message: unknown }> = [];
+    const logger = Logger.make<unknown, void>(({ logLevel, message }) => {
+      logs.push({ level: logLevel, message });
+    });
+    const canceled = new Error("Canceled");
+    canceled.name = "Canceled";
+
+    yield* runLspCleanup("connection.dispose", () => {
+      throw canceled;
+    }).pipe(Effect.provide(Logger.layer([logger])));
+
+    expect(logs).toEqual([]);
+  }),
+);
+
+it.effect(
+  "downgrades other LSP cleanup failures to warnings",
+  Effect.fn(function* () {
+    const logs: Array<{ level: string; message: unknown }> = [];
+    const logger = Logger.make<unknown, void>(({ logLevel, message }) => {
+      logs.push({ level: logLevel, message });
+    });
+
+    yield* runLspCleanup("connection.dispose", () => {
+      throw new Error("boom");
+    }).pipe(Effect.provide(Logger.layer([logger])));
+
+    expect(logs).toEqual([
+      {
+        level: "Warn",
+        message: ["LSP cleanup failed during connection.dispose"],
+      },
+    ]);
+  }),
+);

--- a/extension/src/lsp/client.ts
+++ b/extension/src/lsp/client.ts
@@ -23,6 +23,7 @@ import * as NodeProcess from "node:process";
 import * as NodeReadline from "node:readline";
 
 import {
+  Cause,
   Data,
   Effect,
   HashMap,
@@ -38,6 +39,7 @@ import * as lsp from "vscode-languageserver-protocol";
 
 import { NOTEBOOK_TYPE } from "../constants.ts";
 import { getTopologicalCells } from "../lib/getTopologicalCells.ts";
+import { isExpectedCancellation } from "../lib/isExpectedCancellation.ts";
 import { NotebookVariables } from "../panel/variables/NotebookVariables.ts";
 import { MarimoNotebookDocument } from "../schemas/MarimoNotebookDocument.ts";
 import type { NotebookId } from "../schemas/MarimoNotebookDocument.ts";
@@ -61,6 +63,30 @@ export class LspRequestError extends Data.TaggedError("LspRequestError")<{
   readonly code: number;
   readonly message: string;
 }> {}
+
+class LspCleanupError extends Data.TaggedError("LspCleanupError")<{
+  readonly cause: unknown;
+}> {}
+
+/** Run dependency cleanup without allowing it to fail the owning LSP scope. */
+export function runLspCleanup(
+  stage: string,
+  cleanup: () => unknown,
+): Effect.Effect<void> {
+  return Effect.try({
+    try: cleanup,
+    catch: (cause) => new LspCleanupError({ cause }),
+  }).pipe(
+    Effect.asVoid,
+    Effect.catchTag("LspCleanupError", (error) => {
+      const cause = Cause.die(error.cause);
+      if (isExpectedCancellation(cause)) return Effect.void;
+      return Effect.logWarning(`LSP cleanup failed during ${stage}`).pipe(
+        Effect.annotateLogs({ cause, "lsp.cleanup.stage": stage }),
+      );
+    }),
+  );
+}
 
 function hasCode(value: unknown): value is { code: number } {
   return (
@@ -621,7 +647,9 @@ export const makeNotebookLspClient = Effect.fn("makeNotebookLspClient")(
       env: { ...NodeProcess.env, ...config.env },
     });
 
-    yield* Effect.addFinalizer(() => Effect.sync(() => proc.kill()));
+    yield* Effect.addFinalizer(() =>
+      runLspCleanup("process.kill", () => proc.kill()),
+    );
 
     // Pipe stderr to output channel, line by line
     if (proc.stderr) {
@@ -649,7 +677,9 @@ export const makeNotebookLspClient = Effect.fn("makeNotebookLspClient")(
     );
     conn.listen();
 
-    yield* Effect.addFinalizer(() => Effect.sync(() => conn.dispose()));
+    yield* Effect.addFinalizer(() =>
+      runLspCleanup("connection.dispose", () => conn.dispose()),
+    );
 
     // -- 3. Initialize handshake --------------------------------------------
 

--- a/extension/src/platform/VsCode.ts
+++ b/extension/src/platform/VsCode.ts
@@ -1,5 +1,4 @@
 import {
-  Cause,
   Context,
   Data,
   Effect,
@@ -44,6 +43,7 @@ import {
 } from "../commands.ts";
 import type { MarimoContextKey } from "../constants.ts";
 import { acquireDisposable } from "../lib/acquireDisposable.ts";
+import { isExpectedCancellation } from "../lib/isExpectedCancellation.ts";
 import { signalFromToken } from "../lib/signalFromToken.ts";
 import { tokenFromSignal } from "../lib/tokenFromSignal.ts";
 
@@ -324,16 +324,6 @@ type ContextMap = {
   "marimo.notebook.hasStaleCells": boolean;
   "marimo.notebook.hasKernel": boolean;
 };
-
-const isExpectedCancellation = (cause: Cause.Cause<unknown>) =>
-  Cause.hasInterruptsOnly(cause) ||
-  cause.reasons
-    .filter(Cause.isDieReason)
-    .map((reason) => reason.defect)
-    .some(
-      (defect: unknown) =>
-        defect instanceof Error && defect.name === "Canceled",
-    );
 
 export const withCommandContext = (command: MarimoCommand) => {
   const wireId = commandId(command);


### PR DESCRIPTION
VS Code reports some connection disposal as `Canceled` defects rather than Effect interruptions. The ty supervisor therefore marked normal scope cleanup as a startup failure and sent it to Sentry.

Classify a cause as expected only when every reason is an interruption or `Canceled`; mixed causes remain reportable. Managed LSP finalizers suppress those cancellations and downgrade other cleanup failures to warning breadcrumbs, while active server failures keep the existing error path.