### PR TITLE
Reserve `RunId` for kernel-tracked runs

### DIFF
--- a/extension/src/kernel/CellExecutions.ts
+++ b/extension/src/kernel/CellExecutions.ts
@@ -42,7 +42,7 @@ import {
   makeCellRunState,
   Op,
   parseOp,
-  RunId,
+  type RunId,
   runIdFromWire,
   step,
   transitionCell,
@@ -86,6 +86,7 @@ export class RunCorrelationError extends Data.TaggedError(
 }> {}
 
 export interface CellStaleness {
+  /** Returns the cells currently considered stale. */
   readonly current: Effect.Effect<HashSet.HashSet<NotebookCellId>>;
   /** Emits the current set immediately, followed by changed sets. */
   readonly changes: Stream.Stream<HashSet.HashSet<NotebookCellId>>;
@@ -96,6 +97,7 @@ export interface NotebookExecutionBinding {
   readonly getDrive: Effect.Effect<Option.Option<Drive>>;
 }
 
+/** Controls execution state for one exact notebook session. */
 export interface NotebookExecutions {
   /**
    * Folds one Wire Cell Operation, then admits its presentation commands when
@@ -104,9 +106,13 @@ export interface NotebookExecutions {
   readonly apply: (
     operation: CellOperationNotification,
   ) => Effect.Effect<void, RunCorrelationError>;
+  /** Interrupts every active run and clears pending submissions. */
   readonly interrupt: Effect.Effect<void>;
+  /** Invalidates every cell and ends its active run. */
   readonly invalidate: Effect.Effect<void>;
+  /** Removes a cell and its execution state. */
   readonly remove: (cellId: NotebookCellId) => Effect.Effect<void>;
+  /** Tracks submitted sources while sending them to the kernel. */
   readonly submit: <A, E, R>(
     cells: ReadonlyArray<{
       readonly cellId: NotebookCellId;
@@ -114,6 +120,7 @@ export interface NotebookExecutions {
     }>,
     send: Effect.Effect<A, E, R>,
   ) => Effect.Effect<A, E, R>;
+  /** Exposes current and changing stale-cell state. */
   readonly staleCells: CellStaleness;
 }
 
@@ -141,6 +148,31 @@ interface Work {
   readonly drive: Option.Option<Drive>;
 }
 
+/** Returns true when a command supersedes older pending output. */
+const isConflatableOutput: (command: CellCommand) => boolean =
+  CellCommand.$match({
+    OpenRun: () => false,
+    StartRun: () => false,
+    RenderOutputs: () => true,
+    CloseRun: () => false,
+    PresentUntrackedError: () => true,
+    SetDiagnostic: () => false,
+  });
+
+/** Selects the current or run-bound drive that owns a command. */
+const selectCommandDrive = (
+  current: Option.Option<Drive>,
+  forRun: (runId: RunId) => Option.Option<Drive>,
+): ((command: CellCommand) => Option.Option<Drive>) =>
+  CellCommand.$match({
+    OpenRun: () => current,
+    StartRun: ({ runId }) => forRun(runId),
+    RenderOutputs: ({ runId }) => forRun(runId),
+    CloseRun: ({ runId }) => forRun(runId),
+    PresentUntrackedError: () => current,
+    SetDiagnostic: () => current,
+  });
+
 const cellRef = (notebookId: NotebookId, cellId: NotebookCellId): CellRef => ({
   notebookId,
   cellId,
@@ -167,6 +199,7 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
       );
       let staleContextValue: boolean | undefined;
 
+      /** Updates VS Code's stale-cell context for the active notebook. */
       const updateStaleContext = Effect.fn("CellExecutions.updateStaleContext")(
         function* () {
           const activeNotebook = yield* editorRegistry.getActiveNotebookUri;
@@ -262,6 +295,7 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
         const presentation = yield* Queue.unbounded<Work, Cause.Done>();
         let closed = false;
 
+        /** Publishes a changed stale-cell set locally and globally. */
         const publishStale = (next: HashSet.HashSet<NotebookCellId>) =>
           Effect.gen(function* () {
             const current = yield* SubscriptionRef.get(staleRef);
@@ -272,6 +306,7 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
             );
           });
 
+        /** Returns whether a cell is invalidated or differs from its accepted source. */
         const isStale = (cellId: NotebookCellId): boolean => {
           const record = records.get(cellId);
           if (record === undefined) return false;
@@ -285,6 +320,7 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
           });
         };
 
+        /** Recomputes staleness for the given cells. */
         const refreshStale = (cellIds: Iterable<NotebookCellId>) =>
           Effect.gen(function* () {
             let next = yield* SubscriptionRef.get(staleRef);
@@ -296,6 +332,7 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
             yield* publishStale(next);
           });
 
+        /** Records current sources and refreshes their staleness. */
         const updateSources = (sources: ReadonlyArray<CellSource>) =>
           ordering.withPermit(
             Effect.gen(function* () {
@@ -307,6 +344,7 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
             }),
           );
 
+        /** Runs one presentation command and logs non-interruption failures. */
         const drive = ({ cell, command, drive: target }: Work) =>
           Option.match(target, {
             onNone: () =>
@@ -338,12 +376,11 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
               ),
           });
 
+        /** Runs a batch while conflating pending output for each cell. */
         const driveBatch = (batch: ReadonlyArray<Work>) => {
-          // Preserve every lifecycle command, but project only the newest
-          // output pending for each cell while the previous batch was driven.
           const newestOutput = new Map<NotebookCellId, number>();
           for (const [index, work] of batch.entries()) {
-            if (work.command._tag === "RenderOutputs") {
+            if (isConflatableOutput(work.command)) {
               newestOutput.set(work.cell.cellId, index);
             }
           }
@@ -351,7 +388,7 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
           return Effect.forEach(
             batch,
             (work, index) =>
-              work.command._tag === "RenderOutputs" &&
+              isConflatableOutput(work.command) &&
               newestOutput.get(work.cell.cellId) !== index
                 ? Effect.void
                 : drive(work),
@@ -364,6 +401,7 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
           Effect.forkIn(presentationScope),
         );
 
+        /** Enqueues one command for ordered presentation. */
         const present = (work: Work) =>
           Queue.offer(presentation, work).pipe(
             Effect.flatMap((admitted) =>
@@ -373,6 +411,7 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
             ),
           );
 
+        /** Returns an error when an operation names a different run. */
         const correlationError = (
           record: CellRecord,
           wire: CellOperationNotification,
@@ -398,6 +437,7 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
           return Option.none();
         };
 
+        /** Removes and returns the oldest submitted source for a cell. */
         const dequeueSubmittedSource = Effect.fn(
           "CellExecutions.dequeueSubmittedSource",
         )((cellId: NotebookCellId) =>
@@ -440,26 +480,23 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
                 });
                 yield* refreshStale([cellId]);
               });
-              const op = yield* Option.match(
-                parseOp(next, wire, RunId(crypto.randomUUID())),
-                {
-                  onNone: () =>
-                    retainKernelState.pipe(
-                      Effect.andThen(
-                        Effect.fail(
-                          new RunCorrelationError({
-                            cellId,
-                            expectedRunId: activeRunId(record.run.phase),
-                            receivedRunId: Option.none(),
-                            status: wire.status,
-                            reason: "untracked-queue",
-                          }),
-                        ),
+              const op = yield* Option.match(parseOp(next, wire), {
+                onNone: () =>
+                  retainKernelState.pipe(
+                    Effect.andThen(
+                      Effect.fail(
+                        new RunCorrelationError({
+                          cellId,
+                          expectedRunId: activeRunId(record.run.phase),
+                          receivedRunId: Option.none(),
+                          status: wire.status,
+                          reason: "untracked-queue",
+                        }),
                       ),
                     ),
-                  onSome: Effect.succeed,
-                },
-              );
+                  ),
+                onSome: Effect.succeed,
+              });
               let source = Option.none<string>();
               if (Op.$is("Queue")(op)) {
                 const submittedSource = yield* dequeueSubmittedSource(cellId);
@@ -486,14 +523,13 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
                 yield* dequeueSubmittedSource(cellId);
               }
               const currentDrive = yield* binding.getDrive;
-              // A run's presentation stays on the drive that opened it:
-              // OpenRun binds the drive current at open time, and later
-              // commands for that run reuse the binding even after the
-              // controller changes or detaches.
               const opened = new Set<RunId>();
               for (const command of result.commands) {
-                if (command._tag === "OpenRun") opened.add(command.runId);
+                if (CellCommand.$is("OpenRun")(command)) {
+                  opened.add(command.runId);
+                }
               }
+              /** Returns the drive captured when this run opened. */
               const driveForRun = (runId: RunId): Option.Option<Drive> =>
                 boundDrive(record, runId).pipe(
                   Option.orElse(() =>
@@ -518,15 +554,15 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
               yield* refreshStale([cellId]);
 
               const cell = cellRef(notebookId, cellId);
+              const driveForCommand = selectCommandDrive(
+                currentDrive,
+                driveForRun,
+              );
               for (const command of result.commands) {
                 yield* present({
                   cell,
                   command,
-                  drive:
-                    command._tag === "OpenRun" ||
-                    command._tag === "SetDiagnostic"
-                      ? currentDrive
-                      : driveForRun(command.runId),
+                  drive: driveForCommand(command),
                 });
               }
             }).pipe(
@@ -537,6 +573,7 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
             ),
           );
 
+        /** Applies an operation and releases matching presentation state. */
         const release = (
           target: (cellId: NotebookCellId) => boolean,
           remove: boolean,
@@ -549,15 +586,15 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
               released.push(cellId);
               const result = step(record.run, operation);
               const cell = cellRef(notebookId, cellId);
+              const driveForCommand = selectCommandDrive(
+                Option.none(),
+                (runId) => boundDrive(record, runId),
+              );
               for (const command of result.commands) {
                 yield* present({
                   cell,
                   command,
-                  drive:
-                    command._tag === "OpenRun" ||
-                    command._tag === "SetDiagnostic"
-                      ? Option.none()
-                      : boundDrive(record, command.runId),
+                  drive: driveForCommand(command),
                 });
               }
               if (remove) {

--- a/extension/src/kernel/CellRunReducer.ts
+++ b/extension/src/kernel/CellRunReducer.ts
@@ -7,7 +7,7 @@ import type { NotebookCellId } from "../schemas/MarimoNotebookDocument.ts";
 import type { CellOperationNotification, CellRuntimeState } from "../types.ts";
 
 export type RunId = Brand.Branded<string, "RunId">;
-export const RunId = Brand.nominal<RunId>();
+const brandRunId = Brand.nominal<RunId>();
 
 /**
  * Where a cell is in its current run.
@@ -42,18 +42,13 @@ export type Op = Data.TaggedEnum<{
   Start: {
     readonly startTime: number;
     readonly next: CellRuntimeState;
-    readonly ephemeralRunId: RunId;
   };
   Settle: {
     readonly success: boolean;
     readonly endTime: Option.Option<number>;
     readonly next: CellRuntimeState;
-    readonly ephemeralRunId: RunId;
   };
-  Update: {
-    readonly next: CellRuntimeState;
-    readonly ephemeralRunId: RunId;
-  };
+  Update: { readonly next: CellRuntimeState };
   Interrupt: {};
   Invalidate: {};
 }>;
@@ -75,6 +70,11 @@ export type CellCommand = Data.TaggedEnum<{
     readonly runId: RunId;
     readonly success: boolean;
     readonly at: Option.Option<number>;
+  };
+  /** Present an error that arrived without a kernel-tracked run. */
+  PresentUntrackedError: {
+    readonly state: CellRuntimeState;
+    readonly applyDiagnostic: boolean;
   };
   SetDiagnostic: { readonly state: Option.Option<CellRuntimeState> };
 }>;
@@ -125,13 +125,13 @@ export function acceptKernelState(
   };
 }
 
-/** Normalize the nullable wire representation of a run ID. */
+/** The sole production boundary from a nullable wire string to a RunId. */
 export const runIdFromWire = (
   runId: CellOperationNotification["run_id"],
 ): Option.Option<RunId> =>
   Option.fromNullishOr(runId).pipe(
     Option.filter((value) => value.length > 0),
-    Option.map(RunId),
+    Option.map(brandRunId),
   );
 
 /**
@@ -144,7 +144,6 @@ export const runIdFromWire = (
 export function parseOp(
   next: CellRuntimeState,
   msg: CellOperationNotification,
-  ephemeralRunId: RunId,
 ): Option.Option<Op> {
   switch (msg.status) {
     case "queued": {
@@ -157,7 +156,6 @@ export function parseOp(
         Op.Start({
           startTime: (msg.timestamp ?? 0) * 1000,
           next,
-          ephemeralRunId,
         }),
       );
     case "idle":
@@ -170,14 +168,14 @@ export function parseOp(
             Option.map((timestamp) => timestamp * 1000),
           ),
           next,
-          ephemeralRunId,
         }),
       );
     default:
-      return Option.some(Op.Update({ next, ephemeralRunId }));
+      return Option.some(Op.Update({ next }));
   }
 }
 
+/** Returns the active RunId, if this phase owns one. */
 export const activeRunId: (phase: RunPhase) => Option.Option<RunId> =
   RunPhase.$match({
     Idle: () => Option.none(),
@@ -186,7 +184,7 @@ export const activeRunId: (phase: RunPhase) => Option.Option<RunId> =
     Completed: () => Option.none(),
   });
 
-const isError = (state: CellRuntimeState): boolean =>
+const hasMarimoErrorOutput = (state: CellRuntimeState): boolean =>
   state.output?.channel === "marimo-error";
 
 /**
@@ -282,7 +280,7 @@ export function step(
       };
     },
 
-    Start: ({ startTime, next, ephemeralRunId }) => {
+    Start: ({ startTime, next }) => {
       const commands: CellCommand[] = [];
       let phase = entry.phase;
       if (RunPhase.$is("Queued")(entry.phase)) {
@@ -303,9 +301,10 @@ export function step(
             final: false,
           }),
         );
-      } else if (isError(next)) {
+      } else if (hasMarimoErrorOutput(next)) {
         commands.push(
-          ...ephemeralError(ephemeralRunId, next, {
+          CellCommand.PresentUntrackedError({
+            state: next,
             applyDiagnostic: false,
           }),
         );
@@ -319,7 +318,7 @@ export function step(
       };
     },
 
-    Update: ({ next, ephemeralRunId }) => {
+    Update: ({ next }) => {
       const commands: CellCommand[] = [];
       const runId = activeRunId(entry.phase);
       if (Option.isSome(runId)) {
@@ -330,9 +329,10 @@ export function step(
             final: false,
           }),
         );
-      } else if (isError(next)) {
+      } else if (hasMarimoErrorOutput(next)) {
         commands.push(
-          ...ephemeralError(ephemeralRunId, next, {
+          CellCommand.PresentUntrackedError({
+            state: next,
             applyDiagnostic: false,
           }),
         );
@@ -343,7 +343,7 @@ export function step(
       };
     },
 
-    Settle: ({ success, endTime, next, ephemeralRunId }) => {
+    Settle: ({ success, endTime, next }) => {
       const commands: CellCommand[] = [];
       const accepted = acceptKernelState(entry, next);
       const runId = activeRunId(entry.phase);
@@ -367,9 +367,10 @@ export function step(
       }
       // No live execution: show a one-off execution for an error, and always
       // reconcile the squiggle (clears it when there's no in-cell frame).
-      if (isError(next)) {
+      if (hasMarimoErrorOutput(next)) {
         commands.push(
-          ...ephemeralError(ephemeralRunId, next, {
+          CellCommand.PresentUntrackedError({
+            state: next,
             applyDiagnostic: true,
           }),
         );
@@ -382,26 +383,4 @@ export function step(
       };
     },
   });
-}
-
-/**
- * Commands to render an error from a cell that never queued (e.g. a compile
- * error), which has no live execution: spin up a one-off execution, emit the
- * error, end it. `applyDiagnostic` also reconciles the squiggle, which only the
- * terminal `idle` op does.
- */
-function ephemeralError(
-  runId: RunId,
-  next: CellRuntimeState,
-  opts: { readonly applyDiagnostic: boolean },
-): CellCommand[] {
-  return [
-    CellCommand.OpenRun({ runId }),
-    CellCommand.StartRun({ runId, at: Option.none() }),
-    CellCommand.RenderOutputs({ runId, state: next, final: true }),
-    ...(opts.applyDiagnostic
-      ? [CellCommand.SetDiagnostic({ state: Option.some(next) })]
-      : []),
-    CellCommand.CloseRun({ runId, success: false, at: Option.none() }),
-  ];
 }

--- a/extension/src/kernel/VsCodeCellDrive.ts
+++ b/extension/src/kernel/VsCodeCellDrive.ts
@@ -68,6 +68,7 @@ export class VsCodeCellDrive extends Context.Service<VsCodeCellDrive>()(
         }),
       );
 
+      /** Applies a function while a cell run still has live resources. */
       const withResource = (
         cell: CellRef,
         runId: RunId,
@@ -81,6 +82,7 @@ export class VsCodeCellDrive extends Context.Service<VsCodeCellDrive>()(
           : apply(resource);
       };
 
+      /** Resolves a cell within the notebook bound to this drive. */
       const resolveCell = (cell: CellRef, binding: VsCodeDriveBinding) =>
         Effect.gen(function* () {
           if (binding.notebook.id !== cell.notebookId) {
@@ -92,6 +94,19 @@ export class VsCodeCellDrive extends Context.Service<VsCodeCellDrive>()(
           return yield* findNotebookCell(binding.notebook, cell.cellId);
         });
 
+      /** Creates a VS Code execution for a resolved cell. */
+      const createExecution = (cell: CellRef, binding: VsCodeDriveBinding) =>
+        Effect.gen(function* () {
+          const notebookCell = yield* resolveCell(cell, binding);
+          return yield* Effect.try({
+            try: () =>
+              binding.controller.createNotebookCellExecution(notebookCell),
+            catch: (cause) =>
+              new InvalidCellError({ cellId: cell.cellId, cause }),
+          });
+        });
+
+      /** Projects state onto a tracked run's live execution. */
       const renderOutputs = (
         cell: CellRef,
         runId: RunId,
@@ -116,6 +131,7 @@ export class VsCodeCellDrive extends Context.Service<VsCodeCellDrive>()(
           );
         });
 
+      /** Reconciles the runtime diagnostic for a cell. */
       const setDiagnostic = (
         cell: CellRef,
         binding: VsCodeDriveBinding,
@@ -152,6 +168,43 @@ export class VsCodeCellDrive extends Context.Service<VsCodeCellDrive>()(
           ),
         );
 
+      /** Presents an untracked error in one self-contained execution. */
+      const presentUntrackedError = (
+        cell: CellRef,
+        binding: VsCodeDriveBinding,
+        state: CellRuntimeState,
+        applyDiagnostic: boolean,
+      ) =>
+        Effect.gen(function* () {
+          const execution = yield* createExecution(cell, binding);
+          return yield* Effect.gen(function* () {
+            yield* Effect.sync(() => execution.start());
+            const outputs = buildKeyedCellOutputs(
+              cell.cellId,
+              state,
+              code,
+              binding.notebook.rawNotebookDocument,
+            );
+            yield* Effect.tryPromise(() =>
+              new CellOutputProjection(execution).commit(outputs),
+            ).pipe(
+              Effect.catchCause((cause) =>
+                Effect.logWarning("Failed to update cell output").pipe(
+                  Effect.annotateLogs({ cause, ...cell }),
+                ),
+              ),
+            );
+            if (applyDiagnostic) {
+              yield* setDiagnostic(cell, binding, Option.some(state));
+            }
+          }).pipe(
+            Effect.ensuring(
+              Effect.try(() => execution.end(false)).pipe(Effect.ignore),
+            ),
+          );
+        });
+
+      /** Interprets one reducer command against a VS Code binding. */
       const apply = (
         cell: CellRef,
         binding: VsCodeDriveBinding,
@@ -160,13 +213,7 @@ export class VsCodeCellDrive extends Context.Service<VsCodeCellDrive>()(
         CellCommand.$match(command, {
           OpenRun: ({ runId }) =>
             Effect.gen(function* () {
-              const notebookCell = yield* resolveCell(cell, binding);
-              const execution = yield* Effect.try({
-                try: () =>
-                  binding.controller.createNotebookCellExecution(notebookCell),
-                catch: (cause) =>
-                  new InvalidCellError({ cellId: cell.cellId, cause }),
-              });
+              const execution = yield* createExecution(cell, binding);
               resources.set(resourceKey(cell, runId), {
                 execution,
                 projection: new CellOutputProjection(execution),
@@ -188,6 +235,8 @@ export class VsCodeCellDrive extends Context.Service<VsCodeCellDrive>()(
                 resources.delete(resourceKey(cell, runId));
               }),
             ),
+          PresentUntrackedError: ({ state, applyDiagnostic }) =>
+            presentUntrackedError(cell, binding, state, applyDiagnostic),
           SetDiagnostic: ({ state }) => setDiagnostic(cell, binding, state),
         }).pipe(
           Effect.catchTag("NotebookCellNotFoundError", () =>

--- a/extension/src/kernel/__tests__/CellExecutions.test.ts
+++ b/extension/src/kernel/__tests__/CellExecutions.test.ts
@@ -25,10 +25,11 @@ import {
   type Drive,
   type NotebookExecutions,
 } from "../../kernel/CellExecutions.ts";
-import { CellCommand, RunId } from "../../kernel/CellRunReducer.ts";
+import { CellCommand } from "../../kernel/CellRunReducer.ts";
 import { buildCellOutputs } from "../../kernel/VsCodeCellOutputs.ts";
 import {
   cellId,
+  runId,
   UNSAFE_castForNegativeTest,
 } from "../../lib/__tests__/branded.ts";
 import { NotebookDocumentSessions } from "../../notebook/NotebookDocumentSessions.ts";
@@ -1170,7 +1171,7 @@ describe("NotebookExecutions", () => {
               if (
                 name === "second" &&
                 command._tag === "RenderOutputs" &&
-                command.runId === RunId("run-2")
+                command.runId === runId("run-2")
               ) {
                 yield* presented.open;
               }
@@ -1249,9 +1250,9 @@ describe("NotebookExecutions", () => {
         }> = [];
         const drive: Drive = (_cell, command) =>
           Effect.gen(function* () {
-            const runId = "runId" in command ? `:${command.runId}` : "";
+            const runIdSuffix = "runId" in command ? `:${command.runId}` : "";
             events.push({
-              label: `${command._tag}${runId}`,
+              label: `${command._tag}${runIdSuffix}`,
               console:
                 command._tag === "RenderOutputs"
                   ? command.state.consoleOutputs.map((output) => output.data)
@@ -1259,7 +1260,7 @@ describe("NotebookExecutions", () => {
             });
             if (
               command._tag === "RenderOutputs" &&
-              command.runId === RunId("run-1") &&
+              command.runId === runId("run-1") &&
               !command.final
             ) {
               yield* projectionStarted.open;
@@ -1267,7 +1268,7 @@ describe("NotebookExecutions", () => {
             }
             if (
               command._tag === "CloseRun" &&
-              command.runId === RunId("run-2")
+              command.runId === runId("run-2")
             ) {
               yield* latestClosed.open;
             }
@@ -1885,7 +1886,7 @@ describe("NotebookExecutions", () => {
         expect(HashSet.has(yield* notebook.staleCells.current, id)).toBe(true);
         expect(commands.at(-1)).toEqual(
           CellCommand.CloseRun({
-            runId: RunId("run-1"),
+            runId: runId("run-1"),
             success: false,
             at: Option.none(),
           }),
@@ -2141,8 +2142,8 @@ describe("NotebookExecutions", () => {
           .pipe(Effect.flip);
 
         expect(error._tag).toBe("RunCorrelationError");
-        expect(error.expectedRunId).toEqual(Option.some(RunId("run-2")));
-        expect(error.receivedRunId).toEqual(Option.some(RunId("run-1")));
+        expect(error.expectedRunId).toEqual(Option.some(runId("run-2")));
+        expect(error.receivedRunId).toEqual(Option.some(runId("run-1")));
         expect(error.reason).toBe("superseded-run");
       }).pipe(Effect.provide(ctx.layer));
     }),
@@ -2370,7 +2371,7 @@ describe("NotebookExecutions", () => {
 
         expect(error._tag).toBe("RunCorrelationError");
         expect(error.expectedRunId).toEqual(Option.none());
-        expect(error.receivedRunId).toEqual(Option.some(RunId("run-1")));
+        expect(error.receivedRunId).toEqual(Option.some(runId("run-1")));
         expect(opened).toBe(1);
       }).pipe(Effect.provide(ctx.layer));
     }),

--- a/extension/src/kernel/__tests__/CellRunReducer.test.ts
+++ b/extension/src/kernel/__tests__/CellRunReducer.test.ts
@@ -2,21 +2,19 @@ import { createCellRuntimeState } from "@marimo-team/frontend/unstable_internal/
 import { Option } from "effect";
 import { describe, expect, it } from "vite-plus/test";
 
-import { cellId } from "../../lib/__tests__/branded.ts";
+import { cellId, runId } from "../../lib/__tests__/branded.ts";
 import type { CellRuntimeState } from "../../types.ts";
 import {
   AcceptedSource,
   CellCommand,
   type CellRunState,
   Op,
-  RunId,
   RunPhase,
   step,
 } from "../CellRunReducer.ts";
 
 const ID = cellId("cell-1");
-const RUN = RunId("run-1");
-const EPHEMERAL_RUN = RunId("ephemeral-run");
+const RUN = runId("run-1");
 
 const entry = (phase: RunPhase): CellRunState => ({
   id: ID,
@@ -65,17 +63,13 @@ describe("cell run reducer", () => {
       Op.Start({
         startTime: 5,
         next: okState(),
-        ephemeralRunId: EPHEMERAL_RUN,
       }),
     );
     expect(tags(started.commands)).toEqual(["StartRun", "RenderOutputs"]);
     expect(started.entry.phase).toEqual(RunPhase.Running({ runId: RUN }));
     e = started.entry;
 
-    const updated = step(
-      e,
-      Op.Update({ next: okState(), ephemeralRunId: EPHEMERAL_RUN }),
-    );
+    const updated = step(e, Op.Update({ next: okState() }));
     expect(tags(updated.commands)).toEqual(["RenderOutputs"]);
     e = updated.entry;
 
@@ -85,7 +79,6 @@ describe("cell run reducer", () => {
         success: true,
         endTime: Option.some(9),
         next: okState(),
-        ephemeralRunId: EPHEMERAL_RUN,
       }),
     );
     expect(tags(settled.commands)).toEqual([
@@ -104,7 +97,6 @@ describe("cell run reducer", () => {
         success: false,
         endTime: Option.none(),
         next: errorState(),
-        ephemeralRunId: EPHEMERAL_RUN,
       }),
     );
     const end = commands.find((command) => command._tag === "CloseRun");
@@ -121,7 +113,7 @@ describe("cell run reducer", () => {
     const running = entry(RunPhase.Running({ runId: RUN }));
     const { commands } = step(
       running,
-      Op.Queue({ runId: RunId("run-2"), next: okState() }),
+      Op.Queue({ runId: runId("run-2"), next: okState() }),
     );
     expect(tags(commands)).toEqual(["SetDiagnostic", "CloseRun", "OpenRun"]);
     // The prior run is ended as a success — it's superseded, not failed.
@@ -168,29 +160,22 @@ describe("cell run reducer", () => {
     ]);
   });
 
-  it("renders a compile error with no prior run via an ephemeral execution", () => {
+  it("renders a compile error with no prior run as one untracked execution", () => {
+    const error = errorState();
     const { commands, entry: next } = step(
       entry(RunPhase.Idle()),
       Op.Settle({
         success: false,
         endTime: Option.none(),
-        next: errorState(),
-        ephemeralRunId: EPHEMERAL_RUN,
+        next: error,
       }),
     );
-    expect(tags(commands)).toEqual([
-      "OpenRun",
-      "StartRun",
-      "RenderOutputs",
-      "SetDiagnostic",
-      "CloseRun",
+    expect(commands).toEqual([
+      CellCommand.PresentUntrackedError({
+        state: error,
+        applyDiagnostic: true,
+      }),
     ]);
-    expect(
-      commands.every(
-        (command) =>
-          command._tag === "SetDiagnostic" || command.runId === EPHEMERAL_RUN,
-      ),
-    ).toBe(true);
     // The cell never entered a tracked run, so it stays Idle.
     expect(next.phase).toEqual(RunPhase.Idle());
   });
@@ -202,7 +187,6 @@ describe("cell run reducer", () => {
         success: true,
         endTime: Option.none(),
         next: okState(),
-        ephemeralRunId: EPHEMERAL_RUN,
       }),
     );
     expect(tags(commands)).toEqual(["SetDiagnostic"]);
@@ -211,7 +195,7 @@ describe("cell run reducer", () => {
   it("invalidates the accepted source when an op carries stale inputs", () => {
     const { entry: next } = step(
       entry(RunPhase.Running({ runId: RUN })),
-      Op.Update({ next: staleState(), ephemeralRunId: EPHEMERAL_RUN }),
+      Op.Update({ next: staleState() }),
     );
     expect(next.acceptedSource).toEqual(AcceptedSource.Invalidated());
   });

--- a/extension/src/kernel/__tests__/VsCodeCellDrive.test.ts
+++ b/extension/src/kernel/__tests__/VsCodeCellDrive.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "@effect/vitest";
+import { createCellRuntimeState } from "@marimo-team/frontend/unstable_internal/core/cells/types.ts";
+import { Effect, Option } from "effect";
+import type * as vscode from "vscode";
+
+import { TestVsCode } from "../../__mocks__/TestVsCode.ts";
+import {
+  MarimoNotebookCell,
+  MarimoNotebookDocument,
+} from "../../schemas/MarimoNotebookDocument.ts";
+import type { CellRuntimeState } from "../../types.ts";
+import { CellCommand } from "../CellRunReducer.ts";
+import { VsCodeCellDrive } from "../VsCodeCellDrive.ts";
+
+const errorState = (): CellRuntimeState => ({
+  ...createCellRuntimeState(),
+  output: {
+    channel: "marimo-error",
+    mimetype: "application/vnd.marimo+error",
+    data: [{ type: "syntax", msg: "invalid syntax" }],
+    timestamp: 0,
+  },
+});
+
+describe("VsCodeCellDrive", () => {
+  it.effect(
+    "presents an untracked error in one execution lifecycle",
+    Effect.fn(function* () {
+      const editor = TestVsCode.makeNotebookEditor("/test/notebook.py", {
+        data: {
+          cells: [
+            {
+              kind: 1,
+              value: "x =",
+              languageId: "python",
+              metadata: MarimoNotebookCell.createMetadata({
+                marimoRuntime: { stableId: "cell-1" },
+              }),
+            },
+          ],
+        },
+      });
+      const code = yield* TestVsCode.make({
+        initialDocuments: [editor.notebook],
+      });
+      const notebook = MarimoNotebookDocument.from(editor.notebook);
+      const cellId = Option.getOrThrow(notebook.cellAt(0).id);
+      const events: string[] = [];
+      const execution: vscode.NotebookCellExecution = {
+        cell: editor.notebook.cellAt(0),
+        executionOrder: undefined,
+        token: {
+          isCancellationRequested: false,
+          onCancellationRequested: () => ({ dispose() {} }),
+        },
+        start: () => events.push("start"),
+        end: (success) => events.push(`end:${success}`),
+        clearOutput: async () => {
+          events.push("clear");
+        },
+        appendOutput: async () => {
+          events.push("append");
+        },
+        replaceOutput: async () => {},
+        appendOutputItems: async () => {},
+        replaceOutputItems: async () => {
+          events.push("finalize");
+        },
+      };
+      const cellDrive = yield* VsCodeCellDrive.make.pipe(
+        Effect.provide(code.layer),
+      );
+
+      yield* cellDrive.bind({
+        notebook,
+        controller: { createNotebookCellExecution: () => execution },
+      })(
+        { notebookId: notebook.id, cellId },
+        CellCommand.PresentUntrackedError({
+          state: errorState(),
+          applyDiagnostic: true,
+        }),
+      );
+
+      expect(events).toEqual([
+        "start",
+        "clear",
+        "append",
+        "finalize",
+        "end:false",
+      ]);
+    }),
+  );
+});

--- a/extension/src/lib/__tests__/branded.ts
+++ b/extension/src/lib/__tests__/branded.ts
@@ -16,6 +16,7 @@
 import type { components as Api } from "@marimo-team/openapi/src/api";
 import { Schema } from "effect";
 
+import type { RunId } from "../../kernel/CellRunReducer.ts";
 import type { NotebookId } from "../../schemas/MarimoNotebookDocument.ts";
 import {
   KernelSessionIdFromString,
@@ -39,6 +40,7 @@ export const uiElementId = (s: string) => s as UIElementId;
 export const widgetModelId = (s: string) => s as WidgetModelId;
 export const base64String = (s: string) => s as Base64String;
 export const notebookId = (s: string) => s as NotebookId;
+export const runId = (s: string) => s as RunId;
 export const kernelSessionId = Schema.decodeUnknownSync(
   KernelSessionIdFromString,
 );


### PR DESCRIPTION
Unqueued errors previously received a synthetic UUID so a sequence of VS Code lifecycle commands could share a resource. That made `parseOp` responsible for host-only identity and exposed arbitrary `RunId` construction.

These changes present an untracked error as a drive command instead. `RunId` now enters only at the kernel notification boundary, while the drive opens, renders, diagnoses, and closes the one-off execution without registering it as a run.