### PR TITLE
Model document execution state

### DIFF
--- a/extension/src/kernel/CellExecutions.ts
+++ b/extension/src/kernel/CellExecutions.ts
@@ -65,9 +65,30 @@ interface DriveBinding {
   readonly value: Drive;
 }
 
-interface CellRecord {
+interface CellExecutionState {
   readonly run: CellRunState;
-  readonly drive: Option.Option<DriveBinding>;
+  readonly editorSource: Option.Option<string>;
+  readonly pendingSources: ReadonlyArray<SubmittedSource>;
+}
+
+type DocumentExecutionState = HashMap.HashMap<
+  NotebookCellId,
+  CellExecutionState
+>;
+
+interface CellTransition {
+  readonly cellId: NotebookCellId;
+  readonly current: CellRunState;
+  readonly commands: ReadonlyArray<CellCommand>;
+}
+
+interface DocumentTransition {
+  readonly state: DocumentExecutionState;
+  readonly cells: ReadonlyArray<CellTransition>;
+}
+
+interface OperationTransition extends DocumentTransition {
+  readonly error: Option.Option<RunCorrelationError>;
 }
 
 export class RunCorrelationError extends Data.TaggedError(
@@ -178,10 +199,252 @@ const cellRef = (notebookId: NotebookId, cellId: NotebookCellId): CellRef => ({
   cellId,
 });
 
-/** The drive bound when the given run opened, if the record still holds it. */
-const boundDrive = (record: CellRecord, runId: RunId): Option.Option<Drive> =>
-  Option.filter(record.drive, (binding) => binding.runId === runId).pipe(
+/** The drive bound when the given run opened, if the binding still holds it. */
+const boundDrive = (
+  binding: Option.Option<DriveBinding>,
+  runId: RunId,
+): Option.Option<Drive> =>
+  Option.filter(binding, (candidate) => candidate.runId === runId).pipe(
     Option.map((binding) => binding.value),
+  );
+
+const makeCellState = (
+  editorSource: Option.Option<string> = Option.none(),
+): CellExecutionState => ({
+  run: makeCellRunState(),
+  editorSource,
+  pendingSources: [],
+});
+
+const getCell = (
+  state: DocumentExecutionState,
+  cellId: NotebookCellId,
+): CellExecutionState =>
+  Option.getOrElse(HashMap.get(state, cellId), () => makeCellState());
+
+const setCell = (
+  state: DocumentExecutionState,
+  cellId: NotebookCellId,
+  cell: CellExecutionState,
+): DocumentExecutionState => HashMap.set(state, cellId, cell);
+
+const makeDocumentExecutionState = (
+  sources: ReadonlyArray<CellSource>,
+): DocumentExecutionState => updateExecutionSources(HashMap.empty(), sources);
+
+function updateExecutionSources(
+  state: DocumentExecutionState,
+  sources: ReadonlyArray<CellSource>,
+): DocumentExecutionState {
+  for (const { cellId, source } of sources) {
+    state = setCell(state, cellId, {
+      ...getCell(state, cellId),
+      editorSource: Option.some(source),
+    });
+  }
+  return state;
+}
+
+const registerSubmission = (
+  state: DocumentExecutionState,
+  token: symbol,
+  sources: ReadonlyArray<CellSource>,
+): DocumentExecutionState => {
+  for (const { cellId, source } of sources) {
+    const cell = getCell(state, cellId);
+    state = setCell(state, cellId, {
+      ...cell,
+      pendingSources: [...cell.pendingSources, { token, source }],
+    });
+  }
+  return state;
+};
+
+const rollbackSubmission = (
+  state: DocumentExecutionState,
+  token: symbol,
+  cellIds: ReadonlyArray<NotebookCellId>,
+): DocumentExecutionState => {
+  for (const cellId of cellIds) {
+    const cell = HashMap.get(state, cellId);
+    if (Option.isNone(cell)) continue;
+    state = setCell(state, cellId, {
+      ...cell.value,
+      pendingSources: cell.value.pendingSources.filter(
+        (submitted) => submitted.token !== token,
+      ),
+    });
+  }
+  return state;
+};
+
+const clearPendingSources = (
+  state: DocumentExecutionState,
+): DocumentExecutionState => {
+  for (const [cellId, cell] of state) {
+    if (cell.pendingSources.length === 0) continue;
+    state = setCell(state, cellId, { ...cell, pendingSources: [] });
+  }
+  return state;
+};
+
+const dequeueSubmittedSource = (
+  cell: CellExecutionState,
+): readonly [Option.Option<string>, CellExecutionState] => {
+  const [submitted, ...pendingSources] = cell.pendingSources;
+  return [
+    Option.fromNullishOr(submitted).pipe(Option.map(({ source }) => source)),
+    { ...cell, pendingSources },
+  ];
+};
+
+const correlationError = (
+  run: CellRunState,
+  wire: CellOperationNotification,
+): Option.Option<RunCorrelationError> => {
+  const cellId = extractCellIdFromCellMessage(wire);
+  const expectedRunId = activeRunId(run.phase);
+  const receivedRunId = runIdFromWire(wire.run_id);
+  if (
+    wire.status !== "queued" &&
+    Option.isSome(receivedRunId) &&
+    !Equal.equals(expectedRunId, receivedRunId)
+  ) {
+    return Option.some(
+      new RunCorrelationError({
+        cellId,
+        expectedRunId,
+        receivedRunId,
+        status: wire.status,
+        reason: "superseded-run",
+      }),
+    );
+  }
+  return Option.none();
+};
+
+const transitionFor = (
+  cellId: NotebookCellId,
+  current: CellRunState,
+  commands: ReadonlyArray<CellCommand>,
+): CellTransition => ({ cellId, current, commands });
+
+const applyKernelOperation = (
+  state: DocumentExecutionState,
+  wire: CellOperationNotification,
+): OperationTransition => {
+  const cellId = extractCellIdFromCellMessage(wire);
+  const previousCell = getCell(state, cellId);
+  const nextRuntime = transitionCell(previousCell.run.state, wire);
+  const parsed = parseOp(nextRuntime, wire);
+
+  if (Option.isNone(parsed)) {
+    const [, dequeued] =
+      wire.status === "queued"
+        ? dequeueSubmittedSource(previousCell)
+        : [Option.none<string>(), previousCell];
+    const current = acceptKernelState(dequeued.run, nextRuntime);
+    return {
+      state: setCell(state, cellId, { ...dequeued, run: current }),
+      cells: [transitionFor(cellId, current, [])],
+      error: Option.some(
+        new RunCorrelationError({
+          cellId,
+          expectedRunId: activeRunId(previousCell.run.phase),
+          receivedRunId: Option.none(),
+          status: wire.status,
+          reason: "untracked-queue",
+        }),
+      ),
+    };
+  }
+
+  const op = parsed.value;
+  let nextCell = previousCell;
+  let source = Option.none<string>();
+  if (Op.$is("Queue")(op)) {
+    const [submittedSource, dequeued] = dequeueSubmittedSource(previousCell);
+    nextCell = dequeued;
+    source = submittedSource.pipe(
+      Option.orElse(() => previousCell.editorSource),
+    );
+  }
+
+  const result = step(previousCell.run, op, source);
+  const mismatch = correlationError(previousCell.run, wire);
+  if (Option.isSome(mismatch) && result.commands.length > 0) {
+    const current = acceptKernelState(previousCell.run, nextRuntime);
+    return {
+      state: setCell(state, cellId, { ...previousCell, run: current }),
+      cells: [transitionFor(cellId, current, [])],
+      error: mismatch,
+    };
+  }
+
+  if (
+    wire.status === "idle" &&
+    Option.isNone(activeRunId(previousCell.run.phase))
+  ) {
+    [, nextCell] = dequeueSubmittedSource(nextCell);
+  }
+  nextCell = { ...nextCell, run: result.entry };
+  return {
+    state: setCell(state, cellId, nextCell),
+    cells: [transitionFor(cellId, result.entry, result.commands)],
+    error: Option.none(),
+  };
+};
+
+const releaseAll = (
+  state: DocumentExecutionState,
+  operation: Op,
+  remove: boolean,
+): DocumentTransition => {
+  const cells: CellTransition[] = [];
+  state = clearPendingSources(state);
+  for (const [cellId, cell] of state) {
+    const result = step(cell.run, operation);
+    cells.push(transitionFor(cellId, result.entry, result.commands));
+    state = remove
+      ? HashMap.remove(state, cellId)
+      : setCell(state, cellId, { ...cell, run: result.entry });
+  }
+  return { state, cells };
+};
+
+const interruptAll = (state: DocumentExecutionState): DocumentTransition =>
+  releaseAll(state, Op.Interrupt(), false);
+
+const invalidateAll = (state: DocumentExecutionState): DocumentTransition =>
+  releaseAll(state, Op.Invalidate(), false);
+
+const closeExecution = (state: DocumentExecutionState): DocumentTransition =>
+  releaseAll(state, Op.Interrupt(), true);
+
+const removeExecutionCell = (
+  state: DocumentExecutionState,
+  cellId: NotebookCellId,
+): DocumentTransition => {
+  const cell = HashMap.get(state, cellId);
+  if (Option.isNone(cell)) return { state, cells: [] };
+  const result = step(cell.value.run, Op.Interrupt());
+  return {
+    state: HashMap.remove(state, cellId),
+    cells: [transitionFor(cellId, result.entry, result.commands)],
+  };
+};
+
+const isCellStale = (
+  state: DocumentExecutionState,
+  cellId: NotebookCellId,
+): boolean =>
+  Option.exists(HashMap.get(state, cellId), (cell) =>
+    AcceptedSource.$match(cell.run.acceptedSource, {
+      Unknown: () => false,
+      Invalidated: () => true,
+      Accepted: ({ source }) =>
+        Option.exists(cell.editorSource, (current) => current !== source),
+    }),
   );
 
 /** Owns one ordered collection of cell runs per exact notebook session. */
@@ -275,17 +538,14 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
         binding: NotebookExecutionBinding,
       ) {
         const notebookId = notebook.id;
-        const records = new Map<NotebookCellId, CellRecord>();
-        const submittedSources = new Map<
-          NotebookCellId,
-          Array<SubmittedSource>
-        >();
-        const currentSources = new Map<NotebookCellId, string>();
-        for (const cell of notebook.getCells()) {
-          if (Option.isSome(cell.id)) {
-            currentSources.set(cell.id.value, cell.document.getText());
-          }
-        }
+        const initialSources = notebook.getCells().flatMap((cell) =>
+          Option.match(cell.id, {
+            onNone: () => [],
+            onSome: (cellId) => [{ cellId, source: cell.document.getText() }],
+          }),
+        );
+        let state = makeDocumentExecutionState(initialSources);
+        const driveBindings = new Map<NotebookCellId, DriveBinding>();
         const staleRef = yield* SubscriptionRef.make(
           HashSet.empty<NotebookCellId>(),
         );
@@ -307,18 +567,8 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
           });
 
         /** Returns whether a cell is invalidated or differs from its accepted source. */
-        const isStale = (cellId: NotebookCellId): boolean => {
-          const record = records.get(cellId);
-          if (record === undefined) return false;
-          return AcceptedSource.$match(record.run.acceptedSource, {
-            Unknown: () => false,
-            Invalidated: () => true,
-            Accepted: ({ source }) => {
-              const currentSource = currentSources.get(cellId);
-              return currentSource !== undefined && source !== currentSource;
-            },
-          });
-        };
+        const isStale = (cellId: NotebookCellId): boolean =>
+          isCellStale(state, cellId);
 
         /** Recomputes staleness for the given cells. */
         const refreshStale = (cellIds: Iterable<NotebookCellId>) =>
@@ -337,9 +587,7 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
           ordering.withPermit(
             Effect.gen(function* () {
               if (closed) return;
-              for (const { cellId, source } of sources) {
-                currentSources.set(cellId, source);
-              }
+              state = updateExecutionSources(state, sources);
               yield* refreshStale(sources.map(({ cellId }) => cellId));
             }),
           );
@@ -411,160 +659,70 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
             ),
           );
 
-        /** Returns an error when an operation names a different run. */
-        const correlationError = (
-          record: CellRecord,
-          wire: CellOperationNotification,
-        ): Option.Option<RunCorrelationError> => {
-          const cellId = extractCellIdFromCellMessage(wire);
-          const expectedRunId = activeRunId(record.run.phase);
-          const receivedRunId = runIdFromWire(wire.run_id);
-          if (
-            wire.status !== "queued" &&
-            Option.isSome(receivedRunId) &&
-            !Equal.equals(expectedRunId, receivedRunId)
-          ) {
-            return Option.some(
-              new RunCorrelationError({
-                cellId,
-                expectedRunId,
-                receivedRunId,
-                status: wire.status,
-                reason: "superseded-run",
-              }),
-            );
-          }
-          return Option.none();
-        };
-
-        /** Removes and returns the oldest submitted source for a cell. */
-        const dequeueSubmittedSource = Effect.fn(
-          "CellExecutions.dequeueSubmittedSource",
-        )((cellId: NotebookCellId) =>
-          Effect.sync(() => {
-            const pending = submittedSources.get(cellId);
-            if (pending === undefined || pending.length === 0) {
-              return Option.none<string>();
-            }
-            const submitted = pending.shift();
-            if (pending.length === 0) {
-              submittedSources.delete(cellId);
-            }
-            return Option.fromNullishOr(submitted).pipe(
-              Option.map(({ source }) => source),
-            );
-          }),
-        );
-
-        const apply: NotebookExecutions["apply"] = (wire) =>
-          ordering.withPermit(
-            Effect.gen(function* () {
-              if (closed) return;
-              const cellId = extractCellIdFromCellMessage(wire);
-              const record = records.get(cellId) ?? {
-                run: makeCellRunState(cellId),
-                drive: Option.none<DriveBinding>(),
-              };
-              const next = transitionCell(record.run.state, wire);
-              const retainKernelState = Effect.gen(function* () {
-                if (wire.status === "queued") {
-                  yield* dequeueSubmittedSource(cellId);
-                }
-                // Keep kernel-owned state even when this operation cannot
-                // drive a host run. Lazy execution tags descendant staleness
-                // with the ancestor's run ID; late console appends likewise
-                // arrive after their presentation run has closed.
-                records.set(cellId, {
-                  ...record,
-                  run: acceptKernelState(record.run, next),
-                });
-                yield* refreshStale([cellId]);
-              });
-              const op = yield* Option.match(parseOp(next, wire), {
-                onNone: () =>
-                  retainKernelState.pipe(
-                    Effect.andThen(
-                      Effect.fail(
-                        new RunCorrelationError({
-                          cellId,
-                          expectedRunId: activeRunId(record.run.phase),
-                          receivedRunId: Option.none(),
-                          status: wire.status,
-                          reason: "untracked-queue",
-                        }),
-                      ),
-                    ),
-                  ),
-                onSome: Effect.succeed,
-              });
-              let source = Option.none<string>();
-              if (Op.$is("Queue")(op)) {
-                const submittedSource = yield* dequeueSubmittedSource(cellId);
-                source = submittedSource.pipe(
-                  Option.orElse(() =>
-                    Option.fromNullishOr(currentSources.get(cellId)),
-                  ),
-                );
-              }
-
-              const result = step(record.run, op, source);
-              const mismatch = correlationError(record, wire);
-              const enforceCorrelation =
-                Option.isSome(mismatch) && result.commands.length > 0
-                  ? retainKernelState.pipe(
-                      Effect.andThen(Effect.fail(mismatch.value)),
-                    )
-                  : Effect.void;
-              yield* enforceCorrelation;
-              if (
-                wire.status === "idle" &&
-                Option.isNone(activeRunId(record.run.phase))
-              ) {
-                yield* dequeueSubmittedSource(cellId);
-              }
-              const currentDrive = yield* binding.getDrive;
+        /** Binds commands to the drive that owns each transitioned run. */
+        const admitTransition = (
+          transition: DocumentTransition,
+          currentDrive: Option.Option<Drive>,
+        ) =>
+          Effect.gen(function* () {
+            for (const result of transition.cells) {
+              const previousBinding = Option.fromNullishOr(
+                driveBindings.get(result.cellId),
+              );
               const opened = new Set<RunId>();
               for (const command of result.commands) {
                 if (CellCommand.$is("OpenRun")(command)) {
                   opened.add(command.runId);
                 }
               }
-              /** Returns the drive captured when this run opened. */
               const driveForRun = (runId: RunId): Option.Option<Drive> =>
-                boundDrive(record, runId).pipe(
+                boundDrive(previousBinding, runId).pipe(
                   Option.orElse(() =>
                     opened.has(runId) ? currentDrive : Option.none(),
                   ),
                 );
-              const phase = result.entry.phase;
-              const runId = activeRunId(phase);
-              records.set(cellId, {
-                run: result.entry,
-                drive: runId.pipe(
-                  Option.flatMap((runId) =>
-                    driveForRun(runId).pipe(
-                      Option.map((value) => ({
-                        runId,
-                        value,
-                      })),
-                    ),
+              const nextBinding = activeRunId(result.current.phase).pipe(
+                Option.flatMap((runId) =>
+                  driveForRun(runId).pipe(
+                    Option.map((value) => ({ runId, value })),
                   ),
                 ),
-              });
-              yield* refreshStale([cellId]);
+              );
+              if (Option.isSome(nextBinding)) {
+                driveBindings.set(result.cellId, nextBinding.value);
+              } else {
+                driveBindings.delete(result.cellId);
+              }
 
-              const cell = cellRef(notebookId, cellId);
               const driveForCommand = selectCommandDrive(
                 currentDrive,
                 driveForRun,
               );
               for (const command of result.commands) {
                 yield* present({
-                  cell,
+                  cell: cellRef(notebookId, result.cellId),
                   command,
                   drive: driveForCommand(command),
                 });
               }
+            }
+          });
+
+        const apply: NotebookExecutions["apply"] = (wire) =>
+          ordering.withPermit(
+            Effect.gen(function* () {
+              if (closed) return;
+              const cellId = extractCellIdFromCellMessage(wire);
+              const result = applyKernelOperation(state, wire);
+              state = result.state;
+              yield* refreshStale([cellId]);
+              yield* Option.match(result.error, {
+                onNone: () =>
+                  binding.getDrive.pipe(
+                    Effect.flatMap((drive) => admitTransition(result, drive)),
+                  ),
+                onSome: Effect.fail,
+              });
             }).pipe(
               Effect.annotateLogs({
                 notebookId,
@@ -573,55 +731,25 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
             ),
           );
 
-        /** Applies an operation and releases matching presentation state. */
-        const release = (
-          target: (cellId: NotebookCellId) => boolean,
-          remove: boolean,
-          operation: Op = Op.Interrupt(),
-        ) =>
+        /** Applies a bulk transition and releases matching presentation state. */
+        const release = (result: DocumentTransition) =>
           Effect.gen(function* () {
-            const released: NotebookCellId[] = [];
-            for (const [cellId, record] of records) {
-              if (!target(cellId)) continue;
-              released.push(cellId);
-              const result = step(record.run, operation);
-              const cell = cellRef(notebookId, cellId);
-              const driveForCommand = selectCommandDrive(
-                Option.none(),
-                (runId) => boundDrive(record, runId),
-              );
-              for (const command of result.commands) {
-                yield* present({
-                  cell,
-                  command,
-                  drive: driveForCommand(command),
-                });
-              }
-              if (remove) {
-                records.delete(cellId);
-              } else {
-                records.set(cellId, {
-                  run: result.entry,
-                  drive: Option.none(),
-                });
-              }
-            }
-            yield* refreshStale(released);
+            state = result.state;
+            yield* admitTransition(result, Option.none());
+            yield* refreshStale(result.cells.map(({ cellId }) => cellId));
           });
 
         const interrupt = ordering.withPermit(
           Effect.gen(function* () {
             if (closed) return;
-            submittedSources.clear();
-            yield* release(() => true, false);
+            yield* release(interruptAll(state));
           }),
         );
 
         const invalidate = ordering.withPermit(
           Effect.gen(function* () {
             if (closed) return;
-            submittedSources.clear();
-            yield* release(() => true, false, Op.Invalidate());
+            yield* release(invalidateAll(state));
           }),
         );
 
@@ -629,10 +757,7 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
           ordering.withPermit(
             Effect.gen(function* () {
               if (closed) return;
-              yield* release((candidate) => candidate === cellId, true);
-              currentSources.delete(cellId);
-              submittedSources.delete(cellId);
-              yield* refreshStale([cellId]);
+              yield* release(removeExecutionCell(state, cellId));
             }),
           );
 
@@ -640,24 +765,16 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
           const token = Symbol("cell submission");
           const register = ordering.withPermit(
             Effect.sync(() => {
-              for (const { cellId, source } of cells) {
-                const pending = submittedSources.get(cellId) ?? [];
-                pending.push({ token, source });
-                submittedSources.set(cellId, pending);
-              }
+              state = registerSubmission(state, token, cells);
             }),
           );
           const rollback = ordering.withPermit(
             Effect.sync(() => {
-              for (const { cellId } of cells) {
-                const pending = submittedSources.get(cellId);
-                if (pending === undefined) continue;
-                const remaining = pending.filter(
-                  (submitted) => submitted.token !== token,
-                );
-                if (remaining.length === 0) submittedSources.delete(cellId);
-                else submittedSources.set(cellId, remaining);
-              }
+              state = rollbackSubmission(
+                state,
+                token,
+                cells.map(({ cellId }) => cellId),
+              );
             }),
           );
           return register.pipe(
@@ -673,11 +790,10 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
             Effect.gen(function* () {
               if (closed) return;
               closed = true;
-              yield* release(() => true, true);
+              yield* release(closeExecution(state));
               yield* Queue.end(presentation);
               yield* Fiber.join(presentationWorker);
-              submittedSources.clear();
-              currentSources.clear();
+              driveBindings.clear();
               yield* SubscriptionRef.set(staleRef, HashSet.empty());
               yield* SubscriptionRef.update(allStaleCells, (all) =>
                 HashMap.remove(all, notebookId),

--- a/extension/src/kernel/CellExecutions.ts
+++ b/extension/src/kernel/CellExecutions.ts
@@ -1,16 +1,11 @@
 import {
-  Cause,
   Context,
-  Data,
   Effect,
   Equal,
-  Exit,
-  Fiber,
   HashMap,
   HashSet,
   Layer,
   Option,
-  Queue,
   Scope,
   Semaphore,
   Stream,
@@ -26,7 +21,6 @@ import {
 import { NotebookEditorRegistry } from "../notebook/NotebookEditorRegistry.ts";
 import { VsCode } from "../platform/VsCode.ts";
 import {
-  extractCellIdFromCellMessage,
   MarimoNotebookCell,
   MarimoNotebookDocument,
   type NotebookCellId,
@@ -34,77 +28,15 @@ import {
 } from "../schemas/MarimoNotebookDocument.ts";
 import type { CellOperationNotification } from "../types.ts";
 import {
-  acceptKernelState,
-  activeRunId,
-  AcceptedSource,
-  CellCommand,
-  type CellRunState,
-  makeCellRunState,
-  Op,
-  parseOp,
-  type RunId,
-  runIdFromWire,
-  step,
-  transitionCell,
-} from "./CellRunReducer.ts";
+  type CellSource,
+  type CellStalenessChange,
+  DocumentExecutionSession,
+  type Drive,
+  RunCorrelationError,
+} from "./DocumentExecutionSession.ts";
 
-/** Stable identity of one cell whose commands can be presented. */
-export interface CellRef {
-  readonly notebookId: NotebookId;
-  readonly cellId: NotebookCellId;
-}
-
-/** Effectful capability supplied by a host presentation adapter. */
-export type Drive = (
-  cell: CellRef,
-  command: CellCommand,
-) => Effect.Effect<void>;
-
-interface DriveBinding {
-  readonly runId: RunId;
-  readonly value: Drive;
-}
-
-interface CellExecutionState {
-  readonly run: CellRunState;
-  readonly editorSource: Option.Option<string>;
-  readonly pendingSources: ReadonlyArray<SubmittedSource>;
-}
-
-type DocumentExecutionState = HashMap.HashMap<
-  NotebookCellId,
-  CellExecutionState
->;
-
-interface CellTransition {
-  readonly cellId: NotebookCellId;
-  readonly current: CellRunState;
-  readonly commands: ReadonlyArray<CellCommand>;
-}
-
-interface DocumentTransition {
-  readonly state: DocumentExecutionState;
-  readonly cells: ReadonlyArray<CellTransition>;
-}
-
-interface OperationTransition extends DocumentTransition {
-  readonly error: Option.Option<RunCorrelationError>;
-}
-
-export class RunCorrelationError extends Data.TaggedError(
-  "RunCorrelationError",
-)<{
-  readonly cellId: NotebookCellId;
-  readonly expectedRunId: Option.Option<RunId>;
-  readonly receivedRunId: Option.Option<RunId>;
-  readonly status: CellOperationNotification["status"];
-  /**
-   * `superseded-run`: a tagged operation named a run other than the active
-   * one. `untracked-queue`: a queued operation carried no run id at all, so
-   * no run can be opened for it.
-   */
-  readonly reason: "superseded-run" | "untracked-queue";
-}> {}
+export { RunCorrelationError } from "./DocumentExecutionSession.ts";
+export type { CellRef, Drive } from "./DocumentExecutionSession.ts";
 
 export interface CellStaleness {
   /** Returns the cells currently considered stale. */
@@ -120,34 +52,17 @@ export interface NotebookExecutionBinding {
 
 /** Controls execution state for one exact notebook session. */
 export interface NotebookExecutions {
-  /**
-   * Folds one Wire Cell Operation, then admits its presentation commands when
-   * its run correlates. Completion does not wait for the presentation adapter.
-   */
   readonly apply: (
     operation: CellOperationNotification,
   ) => Effect.Effect<void, RunCorrelationError>;
-  /** Interrupts every active run and clears pending submissions. */
   readonly interrupt: Effect.Effect<void>;
-  /** Invalidates every cell and ends its active run. */
   readonly invalidate: Effect.Effect<void>;
-  /** Removes a cell and its execution state. */
   readonly remove: (cellId: NotebookCellId) => Effect.Effect<void>;
-  /** Tracks submitted sources while sending them to the kernel. */
   readonly submit: <A, E, R>(
-    cells: ReadonlyArray<{
-      readonly cellId: NotebookCellId;
-      readonly source: string;
-    }>,
+    cells: ReadonlyArray<CellSource>,
     send: Effect.Effect<A, E, R>,
   ) => Effect.Effect<A, E, R>;
-  /** Exposes current and changing stale-cell state. */
   readonly staleCells: CellStaleness;
-}
-
-interface CellSource {
-  readonly cellId: NotebookCellId;
-  readonly source: string;
 }
 
 interface NotebookEntry {
@@ -157,295 +72,6 @@ interface NotebookEntry {
     sources: ReadonlyArray<CellSource>,
   ) => Effect.Effect<void>;
 }
-
-interface SubmittedSource {
-  readonly token: symbol;
-  readonly source: string;
-}
-
-interface Work {
-  readonly cell: CellRef;
-  readonly command: CellCommand;
-  readonly drive: Option.Option<Drive>;
-}
-
-/** Returns true when a command supersedes older pending output. */
-const isConflatableOutput: (command: CellCommand) => boolean =
-  CellCommand.$match({
-    OpenRun: () => false,
-    StartRun: () => false,
-    RenderOutputs: () => true,
-    CloseRun: () => false,
-    PresentUntrackedError: () => true,
-    SetDiagnostic: () => false,
-  });
-
-/** Selects the current or run-bound drive that owns a command. */
-const selectCommandDrive = (
-  current: Option.Option<Drive>,
-  forRun: (runId: RunId) => Option.Option<Drive>,
-): ((command: CellCommand) => Option.Option<Drive>) =>
-  CellCommand.$match({
-    OpenRun: () => current,
-    StartRun: ({ runId }) => forRun(runId),
-    RenderOutputs: ({ runId }) => forRun(runId),
-    CloseRun: ({ runId }) => forRun(runId),
-    PresentUntrackedError: () => current,
-    SetDiagnostic: () => current,
-  });
-
-const cellRef = (notebookId: NotebookId, cellId: NotebookCellId): CellRef => ({
-  notebookId,
-  cellId,
-});
-
-/** The drive bound when the given run opened, if the binding still holds it. */
-const boundDrive = (
-  binding: Option.Option<DriveBinding>,
-  runId: RunId,
-): Option.Option<Drive> =>
-  Option.filter(binding, (candidate) => candidate.runId === runId).pipe(
-    Option.map((binding) => binding.value),
-  );
-
-const makeCellState = (
-  editorSource: Option.Option<string> = Option.none(),
-): CellExecutionState => ({
-  run: makeCellRunState(),
-  editorSource,
-  pendingSources: [],
-});
-
-const getCell = (
-  state: DocumentExecutionState,
-  cellId: NotebookCellId,
-): CellExecutionState =>
-  Option.getOrElse(HashMap.get(state, cellId), () => makeCellState());
-
-const setCell = (
-  state: DocumentExecutionState,
-  cellId: NotebookCellId,
-  cell: CellExecutionState,
-): DocumentExecutionState => HashMap.set(state, cellId, cell);
-
-const makeDocumentExecutionState = (
-  sources: ReadonlyArray<CellSource>,
-): DocumentExecutionState => updateExecutionSources(HashMap.empty(), sources);
-
-function updateExecutionSources(
-  state: DocumentExecutionState,
-  sources: ReadonlyArray<CellSource>,
-): DocumentExecutionState {
-  for (const { cellId, source } of sources) {
-    state = setCell(state, cellId, {
-      ...getCell(state, cellId),
-      editorSource: Option.some(source),
-    });
-  }
-  return state;
-}
-
-const registerSubmission = (
-  state: DocumentExecutionState,
-  token: symbol,
-  sources: ReadonlyArray<CellSource>,
-): DocumentExecutionState => {
-  for (const { cellId, source } of sources) {
-    const cell = getCell(state, cellId);
-    state = setCell(state, cellId, {
-      ...cell,
-      pendingSources: [...cell.pendingSources, { token, source }],
-    });
-  }
-  return state;
-};
-
-const rollbackSubmission = (
-  state: DocumentExecutionState,
-  token: symbol,
-  cellIds: ReadonlyArray<NotebookCellId>,
-): DocumentExecutionState => {
-  for (const cellId of cellIds) {
-    const cell = HashMap.get(state, cellId);
-    if (Option.isNone(cell)) continue;
-    state = setCell(state, cellId, {
-      ...cell.value,
-      pendingSources: cell.value.pendingSources.filter(
-        (submitted) => submitted.token !== token,
-      ),
-    });
-  }
-  return state;
-};
-
-const clearPendingSources = (
-  state: DocumentExecutionState,
-): DocumentExecutionState => {
-  for (const [cellId, cell] of state) {
-    if (cell.pendingSources.length === 0) continue;
-    state = setCell(state, cellId, { ...cell, pendingSources: [] });
-  }
-  return state;
-};
-
-const dequeueSubmittedSource = (
-  cell: CellExecutionState,
-): readonly [Option.Option<string>, CellExecutionState] => {
-  const [submitted, ...pendingSources] = cell.pendingSources;
-  return [
-    Option.fromNullishOr(submitted).pipe(Option.map(({ source }) => source)),
-    { ...cell, pendingSources },
-  ];
-};
-
-const correlationError = (
-  run: CellRunState,
-  wire: CellOperationNotification,
-): Option.Option<RunCorrelationError> => {
-  const cellId = extractCellIdFromCellMessage(wire);
-  const expectedRunId = activeRunId(run.phase);
-  const receivedRunId = runIdFromWire(wire.run_id);
-  if (
-    wire.status !== "queued" &&
-    Option.isSome(receivedRunId) &&
-    !Equal.equals(expectedRunId, receivedRunId)
-  ) {
-    return Option.some(
-      new RunCorrelationError({
-        cellId,
-        expectedRunId,
-        receivedRunId,
-        status: wire.status,
-        reason: "superseded-run",
-      }),
-    );
-  }
-  return Option.none();
-};
-
-const transitionFor = (
-  cellId: NotebookCellId,
-  current: CellRunState,
-  commands: ReadonlyArray<CellCommand>,
-): CellTransition => ({ cellId, current, commands });
-
-const applyKernelOperation = (
-  state: DocumentExecutionState,
-  wire: CellOperationNotification,
-): OperationTransition => {
-  const cellId = extractCellIdFromCellMessage(wire);
-  const previousCell = getCell(state, cellId);
-  const nextRuntime = transitionCell(previousCell.run.state, wire);
-  const parsed = parseOp(nextRuntime, wire);
-
-  if (Option.isNone(parsed)) {
-    const [, dequeued] =
-      wire.status === "queued"
-        ? dequeueSubmittedSource(previousCell)
-        : [Option.none<string>(), previousCell];
-    const current = acceptKernelState(dequeued.run, nextRuntime);
-    return {
-      state: setCell(state, cellId, { ...dequeued, run: current }),
-      cells: [transitionFor(cellId, current, [])],
-      error: Option.some(
-        new RunCorrelationError({
-          cellId,
-          expectedRunId: activeRunId(previousCell.run.phase),
-          receivedRunId: Option.none(),
-          status: wire.status,
-          reason: "untracked-queue",
-        }),
-      ),
-    };
-  }
-
-  const op = parsed.value;
-  let nextCell = previousCell;
-  let source = Option.none<string>();
-  if (Op.$is("Queue")(op)) {
-    const [submittedSource, dequeued] = dequeueSubmittedSource(previousCell);
-    nextCell = dequeued;
-    source = submittedSource.pipe(
-      Option.orElse(() => previousCell.editorSource),
-    );
-  }
-
-  const result = step(previousCell.run, op, source);
-  const mismatch = correlationError(previousCell.run, wire);
-  if (Option.isSome(mismatch) && result.commands.length > 0) {
-    const current = acceptKernelState(previousCell.run, nextRuntime);
-    return {
-      state: setCell(state, cellId, { ...previousCell, run: current }),
-      cells: [transitionFor(cellId, current, [])],
-      error: mismatch,
-    };
-  }
-
-  if (
-    wire.status === "idle" &&
-    Option.isNone(activeRunId(previousCell.run.phase))
-  ) {
-    [, nextCell] = dequeueSubmittedSource(nextCell);
-  }
-  nextCell = { ...nextCell, run: result.entry };
-  return {
-    state: setCell(state, cellId, nextCell),
-    cells: [transitionFor(cellId, result.entry, result.commands)],
-    error: Option.none(),
-  };
-};
-
-const releaseAll = (
-  state: DocumentExecutionState,
-  operation: Op,
-  remove: boolean,
-): DocumentTransition => {
-  const cells: CellTransition[] = [];
-  state = clearPendingSources(state);
-  for (const [cellId, cell] of state) {
-    const result = step(cell.run, operation);
-    cells.push(transitionFor(cellId, result.entry, result.commands));
-    state = remove
-      ? HashMap.remove(state, cellId)
-      : setCell(state, cellId, { ...cell, run: result.entry });
-  }
-  return { state, cells };
-};
-
-const interruptAll = (state: DocumentExecutionState): DocumentTransition =>
-  releaseAll(state, Op.Interrupt(), false);
-
-const invalidateAll = (state: DocumentExecutionState): DocumentTransition =>
-  releaseAll(state, Op.Invalidate(), false);
-
-const closeExecution = (state: DocumentExecutionState): DocumentTransition =>
-  releaseAll(state, Op.Interrupt(), true);
-
-const removeExecutionCell = (
-  state: DocumentExecutionState,
-  cellId: NotebookCellId,
-): DocumentTransition => {
-  const cell = HashMap.get(state, cellId);
-  if (Option.isNone(cell)) return { state, cells: [] };
-  const result = step(cell.value.run, Op.Interrupt());
-  return {
-    state: HashMap.remove(state, cellId),
-    cells: [transitionFor(cellId, result.entry, result.commands)],
-  };
-};
-
-const isCellStale = (
-  state: DocumentExecutionState,
-  cellId: NotebookCellId,
-): boolean =>
-  Option.exists(HashMap.get(state, cellId), (cell) =>
-    AcceptedSource.$match(cell.run.acceptedSource, {
-      Unknown: () => false,
-      Invalidated: () => true,
-      Accepted: ({ source }) =>
-        Option.exists(cell.editorSource, (current) => current !== source),
-    }),
-  );
 
 /** Owns one ordered collection of cell runs per exact notebook session. */
 export class CellExecutions extends Context.Service<CellExecutions>()(
@@ -538,27 +164,19 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
         binding: NotebookExecutionBinding,
       ) {
         const notebookId = notebook.id;
-        const initialSources = notebook.getCells().flatMap((cell) =>
-          Option.match(cell.id, {
-            onNone: () => [],
-            onSome: (cellId) => [{ cellId, source: cell.document.getText() }],
-          }),
-        );
-        let state = makeDocumentExecutionState(initialSources);
-        const driveBindings = new Map<NotebookCellId, DriveBinding>();
         const staleRef = yield* SubscriptionRef.make(
           HashSet.empty<NotebookCellId>(),
         );
-        const ordering = Semaphore.makeUnsafe(1);
-        const scope = yield* Effect.scope;
-        const presentationScope = yield* Scope.fork(scope);
-        const presentation = yield* Queue.unbounded<Work, Cause.Done>();
-        let closed = false;
 
-        /** Publishes a changed stale-cell set locally and globally. */
-        const publishStale = (next: HashSet.HashSet<NotebookCellId>) =>
+        const publishStale = (changes: ReadonlyArray<CellStalenessChange>) =>
           Effect.gen(function* () {
             const current = yield* SubscriptionRef.get(staleRef);
+            let next = current;
+            for (const { cellId, stale } of changes) {
+              next = stale
+                ? HashSet.add(next, cellId)
+                : HashSet.remove(next, cellId);
+            }
             if (Equal.equals(current, next)) return;
             yield* SubscriptionRef.set(staleRef, next);
             yield* SubscriptionRef.update(allStaleCells, (all) =>
@@ -566,255 +184,42 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
             );
           });
 
-        /** Returns whether a cell is invalidated or differs from its accepted source. */
-        const isStale = (cellId: NotebookCellId): boolean =>
-          isCellStale(state, cellId);
+        const session = yield* DocumentExecutionSession.make({
+          notebook,
+          getDrive: binding.getDrive,
+          onStaleChange: publishStale,
+        });
 
-        /** Recomputes staleness for the given cells. */
-        const refreshStale = (cellIds: Iterable<NotebookCellId>) =>
-          Effect.gen(function* () {
-            let next = yield* SubscriptionRef.get(staleRef);
-            for (const cellId of cellIds) {
-              next = isStale(cellId)
-                ? HashSet.add(next, cellId)
-                : HashSet.remove(next, cellId);
-            }
-            yield* publishStale(next);
-          });
-
-        /** Records current sources and refreshes their staleness. */
-        const updateSources = (sources: ReadonlyArray<CellSource>) =>
-          ordering.withPermit(
-            Effect.gen(function* () {
-              if (closed) return;
-              state = updateExecutionSources(state, sources);
-              yield* refreshStale(sources.map(({ cellId }) => cellId));
-            }),
-          );
-
-        /** Runs one presentation command and logs non-interruption failures. */
-        const drive = ({ cell, command, drive: target }: Work) =>
-          Option.match(target, {
-            onNone: () =>
-              Effect.logDebug(
-                "Cell run has no presentation; skipping command",
+        yield* Effect.addFinalizer(() =>
+          session.close.pipe(
+            Effect.andThen(session.drained),
+            Effect.ensuring(
+              SubscriptionRef.set(
+                staleRef,
+                HashSet.empty<NotebookCellId>(),
               ).pipe(
-                Effect.annotateLogs({
-                  ...cell,
-                  command: command._tag,
-                  ...("runId" in command ? { runId: command.runId } : {}),
-                }),
-              ),
-            onSome: (apply) =>
-              apply(cell, command).pipe(
-                Effect.catchCause((cause) =>
-                  Cause.hasInterrupts(cause)
-                    ? Effect.failCause(cause)
-                    : Effect.logWarning("Failed to drive cell command").pipe(
-                        Effect.annotateLogs({
-                          cause,
-                          ...cell,
-                          command: command._tag,
-                          ...("runId" in command
-                            ? { runId: command.runId }
-                            : {}),
-                        }),
-                      ),
-                ),
-              ),
-          });
-
-        /** Runs a batch while conflating pending output for each cell. */
-        const driveBatch = (batch: ReadonlyArray<Work>) => {
-          const newestOutput = new Map<NotebookCellId, number>();
-          for (const [index, work] of batch.entries()) {
-            if (isConflatableOutput(work.command)) {
-              newestOutput.set(work.cell.cellId, index);
-            }
-          }
-
-          return Effect.forEach(
-            batch,
-            (work, index) =>
-              isConflatableOutput(work.command) &&
-              newestOutput.get(work.cell.cellId) !== index
-                ? Effect.void
-                : drive(work),
-            { discard: true },
-          );
-        };
-
-        const presentationWorker = yield* Stream.fromQueue(presentation).pipe(
-          Stream.runForEachArray(driveBatch),
-          Effect.forkIn(presentationScope),
-        );
-
-        /** Enqueues one command for ordered presentation. */
-        const present = (work: Work) =>
-          Queue.offer(presentation, work).pipe(
-            Effect.flatMap((admitted) =>
-              admitted
-                ? Effect.void
-                : Effect.die("Cell presentation is closed"),
-            ),
-          );
-
-        /** Binds commands to the drive that owns each transitioned run. */
-        const admitTransition = (
-          transition: DocumentTransition,
-          currentDrive: Option.Option<Drive>,
-        ) =>
-          Effect.gen(function* () {
-            for (const result of transition.cells) {
-              const previousBinding = Option.fromNullishOr(
-                driveBindings.get(result.cellId),
-              );
-              const opened = new Set<RunId>();
-              for (const command of result.commands) {
-                if (CellCommand.$is("OpenRun")(command)) {
-                  opened.add(command.runId);
-                }
-              }
-              const driveForRun = (runId: RunId): Option.Option<Drive> =>
-                boundDrive(previousBinding, runId).pipe(
-                  Option.orElse(() =>
-                    opened.has(runId) ? currentDrive : Option.none(),
-                  ),
-                );
-              const nextBinding = activeRunId(result.current.phase).pipe(
-                Option.flatMap((runId) =>
-                  driveForRun(runId).pipe(
-                    Option.map((value) => ({ runId, value })),
+                Effect.andThen(
+                  SubscriptionRef.update(allStaleCells, (all) =>
+                    HashMap.remove(all, notebookId),
                   ),
                 ),
-              );
-              if (Option.isSome(nextBinding)) {
-                driveBindings.set(result.cellId, nextBinding.value);
-              } else {
-                driveBindings.delete(result.cellId);
-              }
-
-              const driveForCommand = selectCommandDrive(
-                currentDrive,
-                driveForRun,
-              );
-              for (const command of result.commands) {
-                yield* present({
-                  cell: cellRef(notebookId, result.cellId),
-                  command,
-                  drive: driveForCommand(command),
-                });
-              }
-            }
-          });
-
-        const apply: NotebookExecutions["apply"] = (wire) =>
-          ordering.withPermit(
-            Effect.gen(function* () {
-              if (closed) return;
-              const cellId = extractCellIdFromCellMessage(wire);
-              const result = applyKernelOperation(state, wire);
-              state = result.state;
-              yield* refreshStale([cellId]);
-              yield* Option.match(result.error, {
-                onNone: () =>
-                  binding.getDrive.pipe(
-                    Effect.flatMap((drive) => admitTransition(result, drive)),
-                  ),
-                onSome: Effect.fail,
-              });
-            }).pipe(
-              Effect.annotateLogs({
-                notebookId,
-                cellId: extractCellIdFromCellMessage(wire),
-              }),
+              ),
             ),
-          );
-
-        /** Applies a bulk transition and releases matching presentation state. */
-        const release = (result: DocumentTransition) =>
-          Effect.gen(function* () {
-            state = result.state;
-            yield* admitTransition(result, Option.none());
-            yield* refreshStale(result.cells.map(({ cellId }) => cellId));
-          });
-
-        const interrupt = ordering.withPermit(
-          Effect.gen(function* () {
-            if (closed) return;
-            yield* release(interruptAll(state));
-          }),
-        );
-
-        const invalidate = ordering.withPermit(
-          Effect.gen(function* () {
-            if (closed) return;
-            yield* release(invalidateAll(state));
-          }),
-        );
-
-        const remove = (cellId: NotebookCellId) =>
-          ordering.withPermit(
-            Effect.gen(function* () {
-              if (closed) return;
-              yield* release(removeExecutionCell(state, cellId));
-            }),
-          );
-
-        const submit: NotebookExecutions["submit"] = (cells, send) => {
-          const token = Symbol("cell submission");
-          const register = ordering.withPermit(
-            Effect.sync(() => {
-              state = registerSubmission(state, token, cells);
-            }),
-          );
-          const rollback = ordering.withPermit(
-            Effect.sync(() => {
-              state = rollbackSubmission(
-                state,
-                token,
-                cells.map(({ cellId }) => cellId),
-              );
-            }),
-          );
-          return register.pipe(
-            Effect.andThen(send),
-            Effect.onExit((exit) =>
-              Exit.isSuccess(exit) ? Effect.void : rollback,
-            ),
-          );
-        };
-
-        const cleanup = Effect.uninterruptible(
-          ordering.withPermit(
-            Effect.gen(function* () {
-              if (closed) return;
-              closed = true;
-              yield* release(closeExecution(state));
-              yield* Queue.end(presentation);
-              yield* Fiber.join(presentationWorker);
-              driveBindings.clear();
-              yield* SubscriptionRef.set(staleRef, HashSet.empty());
-              yield* SubscriptionRef.update(allStaleCells, (all) =>
-                HashMap.remove(all, notebookId),
-              );
-            }),
           ),
         );
-        yield* Scope.addFinalizer(presentationScope, cleanup);
 
         const executions: NotebookExecutions = {
-          apply,
-          interrupt,
-          invalidate,
-          remove,
-          submit,
+          apply: session.apply,
+          interrupt: session.interrupt,
+          invalidate: session.invalidate,
+          remove: session.remove,
+          submit: session.submit,
           staleCells: {
             current: SubscriptionRef.get(staleRef),
             changes: SubscriptionRef.changes(staleRef),
           },
         };
-        return { executions, updateSources } as const;
+        return { executions, updateSources: session.updateSources } as const;
       });
 
       const open = Effect.fn("CellExecutions.open")(function (

--- a/extension/src/kernel/CellRunReducer.ts
+++ b/extension/src/kernel/CellRunReducer.ts
@@ -3,7 +3,6 @@ import { transitionCell as untypedTransitionCell } from "@marimo-team/frontend/u
 import { createCellRuntimeState } from "@marimo-team/frontend/unstable_internal/core/cells/types.ts";
 import { Brand, Data, Option } from "effect";
 
-import type { NotebookCellId } from "../schemas/MarimoNotebookDocument.ts";
 import type { CellOperationNotification, CellRuntimeState } from "../types.ts";
 
 export type RunId = Brand.Branded<string, "RunId">;
@@ -82,15 +81,13 @@ export const CellCommand = Data.taggedEnum<CellCommand>();
 
 /** Pure, vscode-free per-cell reducer state. */
 export interface CellRunState {
-  readonly id: NotebookCellId;
   readonly state: CellRuntimeState;
   readonly phase: RunPhase;
   readonly acceptedSource: AcceptedSource;
 }
 
-export function makeCellRunState(id: NotebookCellId): CellRunState {
+export function makeCellRunState(): CellRunState {
   return {
-    id,
     state: createCellRuntimeState(),
     phase: RunPhase.Idle(),
     acceptedSource: AcceptedSource.Unknown(),

--- a/extension/src/kernel/DocumentExecutionSession.ts
+++ b/extension/src/kernel/DocumentExecutionSession.ts
@@ -1,0 +1,664 @@
+import {
+  Cause,
+  Data,
+  Effect,
+  Equal,
+  Exit,
+  Fiber,
+  HashMap,
+  Option,
+  Queue,
+  Scope,
+  Semaphore,
+  Stream,
+} from "effect";
+
+import {
+  extractCellIdFromCellMessage,
+  type MarimoNotebookDocument,
+  type NotebookCellId,
+  type NotebookId,
+} from "../schemas/MarimoNotebookDocument.ts";
+import type { CellOperationNotification } from "../types.ts";
+import {
+  acceptKernelState,
+  activeRunId,
+  AcceptedSource,
+  CellCommand,
+  type CellRunState,
+  makeCellRunState,
+  Op,
+  parseOp,
+  type RunId,
+  runIdFromWire,
+  step,
+  transitionCell,
+} from "./CellRunReducer.ts";
+
+/** Stable identity of one cell whose commands can be presented. */
+export interface CellRef {
+  readonly notebookId: NotebookId;
+  readonly cellId: NotebookCellId;
+}
+
+/** Effectful capability supplied by a host presentation adapter. */
+export type Drive = (
+  cell: CellRef,
+  command: CellCommand,
+) => Effect.Effect<void>;
+
+export interface CellSource {
+  readonly cellId: NotebookCellId;
+  readonly source: string;
+}
+
+export interface CellStalenessChange {
+  readonly cellId: NotebookCellId;
+  readonly stale: boolean;
+}
+
+export class RunCorrelationError extends Data.TaggedError(
+  "RunCorrelationError",
+)<{
+  readonly cellId: NotebookCellId;
+  readonly expectedRunId: Option.Option<RunId>;
+  readonly receivedRunId: Option.Option<RunId>;
+  readonly status: CellOperationNotification["status"];
+  /**
+   * `superseded-run`: a tagged operation named a run other than the active
+   * one. `untracked-queue`: a queued operation carried no run id at all, so
+   * no run can be opened for it.
+   */
+  readonly reason: "superseded-run" | "untracked-queue";
+}> {}
+
+interface DocumentExecutionSessionOptions {
+  readonly notebook: MarimoNotebookDocument;
+  readonly getDrive: Effect.Effect<Option.Option<Drive>>;
+  readonly onStaleChange: (
+    changes: ReadonlyArray<CellStalenessChange>,
+  ) => Effect.Effect<void>;
+}
+
+interface DriveBinding {
+  readonly runId: RunId;
+  readonly value: Drive;
+}
+
+interface SubmittedSource {
+  readonly token: symbol;
+  readonly source: string;
+}
+
+interface CellExecutionState {
+  readonly run: CellRunState;
+  readonly editorSource: Option.Option<string>;
+  readonly pendingSources: ReadonlyArray<SubmittedSource>;
+}
+
+type DocumentExecutionState = HashMap.HashMap<
+  NotebookCellId,
+  CellExecutionState
+>;
+
+interface CellTransition {
+  readonly cellId: NotebookCellId;
+  readonly current: CellRunState;
+  readonly commands: ReadonlyArray<CellCommand>;
+}
+
+interface DocumentTransition {
+  readonly state: DocumentExecutionState;
+  readonly cells: ReadonlyArray<CellTransition>;
+}
+
+interface OperationTransition extends DocumentTransition {
+  readonly error: Option.Option<RunCorrelationError>;
+}
+
+interface Work {
+  readonly cell: CellRef;
+  readonly command: CellCommand;
+  readonly drive: Option.Option<Drive>;
+}
+
+/** Returns true when a command supersedes older pending output. */
+const isConflatableOutput: (command: CellCommand) => boolean =
+  CellCommand.$match({
+    OpenRun: () => false,
+    StartRun: () => false,
+    RenderOutputs: () => true,
+    CloseRun: () => false,
+    PresentUntrackedError: () => true,
+    SetDiagnostic: () => false,
+  });
+
+/** Selects the current or run-bound drive that owns a command. */
+const selectCommandDrive = (
+  current: Option.Option<Drive>,
+  forRun: (runId: RunId) => Option.Option<Drive>,
+): ((command: CellCommand) => Option.Option<Drive>) =>
+  CellCommand.$match({
+    OpenRun: () => current,
+    StartRun: ({ runId }) => forRun(runId),
+    RenderOutputs: ({ runId }) => forRun(runId),
+    CloseRun: ({ runId }) => forRun(runId),
+    PresentUntrackedError: () => current,
+    SetDiagnostic: () => current,
+  });
+
+const cellRef = (notebookId: NotebookId, cellId: NotebookCellId): CellRef => ({
+  notebookId,
+  cellId,
+});
+
+const boundDrive = (
+  binding: Option.Option<DriveBinding>,
+  runId: RunId,
+): Option.Option<Drive> =>
+  Option.filter(binding, (candidate) => candidate.runId === runId).pipe(
+    Option.map((binding) => binding.value),
+  );
+
+const makeCellState = (
+  editorSource: Option.Option<string> = Option.none(),
+): CellExecutionState => ({
+  run: makeCellRunState(),
+  editorSource,
+  pendingSources: [],
+});
+
+const getCell = (
+  state: DocumentExecutionState,
+  cellId: NotebookCellId,
+): CellExecutionState =>
+  Option.getOrElse(HashMap.get(state, cellId), () => makeCellState());
+
+const setCell = (
+  state: DocumentExecutionState,
+  cellId: NotebookCellId,
+  cell: CellExecutionState,
+): DocumentExecutionState => HashMap.set(state, cellId, cell);
+
+const makeDocumentExecutionState = (
+  sources: ReadonlyArray<CellSource>,
+): DocumentExecutionState => updateExecutionSources(HashMap.empty(), sources);
+
+function updateExecutionSources(
+  state: DocumentExecutionState,
+  sources: ReadonlyArray<CellSource>,
+): DocumentExecutionState {
+  for (const { cellId, source } of sources) {
+    state = setCell(state, cellId, {
+      ...getCell(state, cellId),
+      editorSource: Option.some(source),
+    });
+  }
+  return state;
+}
+
+const registerSubmission = (
+  state: DocumentExecutionState,
+  token: symbol,
+  sources: ReadonlyArray<CellSource>,
+): DocumentExecutionState => {
+  for (const { cellId, source } of sources) {
+    const cell = getCell(state, cellId);
+    state = setCell(state, cellId, {
+      ...cell,
+      pendingSources: [...cell.pendingSources, { token, source }],
+    });
+  }
+  return state;
+};
+
+const rollbackSubmission = (
+  state: DocumentExecutionState,
+  token: symbol,
+  cellIds: ReadonlyArray<NotebookCellId>,
+): DocumentExecutionState => {
+  for (const cellId of cellIds) {
+    const cell = HashMap.get(state, cellId);
+    if (Option.isNone(cell)) continue;
+    state = setCell(state, cellId, {
+      ...cell.value,
+      pendingSources: cell.value.pendingSources.filter(
+        (submitted) => submitted.token !== token,
+      ),
+    });
+  }
+  return state;
+};
+
+const clearPendingSources = (
+  state: DocumentExecutionState,
+): DocumentExecutionState => {
+  for (const [cellId, cell] of state) {
+    if (cell.pendingSources.length === 0) continue;
+    state = setCell(state, cellId, { ...cell, pendingSources: [] });
+  }
+  return state;
+};
+
+const dequeueSubmittedSource = (
+  cell: CellExecutionState,
+): readonly [Option.Option<string>, CellExecutionState] => {
+  const [submitted, ...pendingSources] = cell.pendingSources;
+  return [
+    Option.fromNullishOr(submitted).pipe(Option.map(({ source }) => source)),
+    { ...cell, pendingSources },
+  ];
+};
+
+const correlationError = (
+  run: CellRunState,
+  wire: CellOperationNotification,
+): Option.Option<RunCorrelationError> => {
+  const cellId = extractCellIdFromCellMessage(wire);
+  const expectedRunId = activeRunId(run.phase);
+  const receivedRunId = runIdFromWire(wire.run_id);
+  if (
+    wire.status !== "queued" &&
+    Option.isSome(receivedRunId) &&
+    !Equal.equals(expectedRunId, receivedRunId)
+  ) {
+    return Option.some(
+      new RunCorrelationError({
+        cellId,
+        expectedRunId,
+        receivedRunId,
+        status: wire.status,
+        reason: "superseded-run",
+      }),
+    );
+  }
+  return Option.none();
+};
+
+const transitionFor = (
+  cellId: NotebookCellId,
+  current: CellRunState,
+  commands: ReadonlyArray<CellCommand>,
+): CellTransition => ({ cellId, current, commands });
+
+const applyKernelOperation = (
+  state: DocumentExecutionState,
+  wire: CellOperationNotification,
+): OperationTransition => {
+  const cellId = extractCellIdFromCellMessage(wire);
+  const previousCell = getCell(state, cellId);
+  const nextRuntime = transitionCell(previousCell.run.state, wire);
+  const parsed = parseOp(nextRuntime, wire);
+
+  if (Option.isNone(parsed)) {
+    const [, dequeued] =
+      wire.status === "queued"
+        ? dequeueSubmittedSource(previousCell)
+        : [Option.none<string>(), previousCell];
+    const current = acceptKernelState(dequeued.run, nextRuntime);
+    return {
+      state: setCell(state, cellId, { ...dequeued, run: current }),
+      cells: [transitionFor(cellId, current, [])],
+      error: Option.some(
+        new RunCorrelationError({
+          cellId,
+          expectedRunId: activeRunId(previousCell.run.phase),
+          receivedRunId: Option.none(),
+          status: wire.status,
+          reason: "untracked-queue",
+        }),
+      ),
+    };
+  }
+
+  const op = parsed.value;
+  let nextCell = previousCell;
+  let source = Option.none<string>();
+  if (Op.$is("Queue")(op)) {
+    const [submittedSource, dequeued] = dequeueSubmittedSource(previousCell);
+    nextCell = dequeued;
+    source = submittedSource.pipe(
+      Option.orElse(() => previousCell.editorSource),
+    );
+  }
+
+  const result = step(previousCell.run, op, source);
+  const mismatch = correlationError(previousCell.run, wire);
+  if (Option.isSome(mismatch) && result.commands.length > 0) {
+    const current = acceptKernelState(previousCell.run, nextRuntime);
+    return {
+      state: setCell(state, cellId, { ...previousCell, run: current }),
+      cells: [transitionFor(cellId, current, [])],
+      error: mismatch,
+    };
+  }
+
+  if (
+    wire.status === "idle" &&
+    Option.isNone(activeRunId(previousCell.run.phase))
+  ) {
+    [, nextCell] = dequeueSubmittedSource(nextCell);
+  }
+  nextCell = { ...nextCell, run: result.entry };
+  return {
+    state: setCell(state, cellId, nextCell),
+    cells: [transitionFor(cellId, result.entry, result.commands)],
+    error: Option.none(),
+  };
+};
+
+const releaseAll = (
+  state: DocumentExecutionState,
+  operation: Op,
+  remove: boolean,
+): DocumentTransition => {
+  const cells: CellTransition[] = [];
+  state = clearPendingSources(state);
+  for (const [cellId, cell] of state) {
+    const result = step(cell.run, operation);
+    cells.push(transitionFor(cellId, result.entry, result.commands));
+    state = remove
+      ? HashMap.remove(state, cellId)
+      : setCell(state, cellId, { ...cell, run: result.entry });
+  }
+  return { state, cells };
+};
+
+const interruptAll = (state: DocumentExecutionState): DocumentTransition =>
+  releaseAll(state, Op.Interrupt(), false);
+
+const invalidateAll = (state: DocumentExecutionState): DocumentTransition =>
+  releaseAll(state, Op.Invalidate(), false);
+
+const closeExecution = (state: DocumentExecutionState): DocumentTransition =>
+  releaseAll(state, Op.Interrupt(), true);
+
+const removeExecutionCell = (
+  state: DocumentExecutionState,
+  cellId: NotebookCellId,
+): DocumentTransition => {
+  const cell = HashMap.get(state, cellId);
+  if (Option.isNone(cell)) return { state, cells: [] };
+  const result = step(cell.value.run, Op.Interrupt());
+  return {
+    state: HashMap.remove(state, cellId),
+    cells: [transitionFor(cellId, result.entry, result.commands)],
+  };
+};
+
+const isCellStale = (
+  state: DocumentExecutionState,
+  cellId: NotebookCellId,
+): boolean =>
+  Option.exists(HashMap.get(state, cellId), (cell) =>
+    AcceptedSource.$match(cell.run.acceptedSource, {
+      Unknown: () => false,
+      Invalidated: () => true,
+      Accepted: ({ source }) =>
+        Option.exists(cell.editorSource, (current) => current !== source),
+    }),
+  );
+
+/** Execution state and presentation for one exact notebook document session. */
+export class DocumentExecutionSession {
+  private state: DocumentExecutionState;
+  private readonly driveBindings = new Map<NotebookCellId, DriveBinding>();
+  private readonly ordering = Semaphore.makeUnsafe(1);
+  private readonly options: DocumentExecutionSessionOptions;
+  private readonly presentationScope: Scope.Closeable;
+  private readonly presentation: Queue.Queue<Work, Cause.Done>;
+  private presentationWorker!: Fiber.Fiber<void>;
+  private closed = false;
+
+  private constructor(
+    options: DocumentExecutionSessionOptions,
+    presentationScope: Scope.Closeable,
+    presentation: Queue.Queue<Work, Cause.Done>,
+  ) {
+    this.options = options;
+    this.presentationScope = presentationScope;
+    this.presentation = presentation;
+    const initialSources = options.notebook.getCells().flatMap((cell) =>
+      Option.match(cell.id, {
+        onNone: () => [],
+        onSome: (cellId) => [{ cellId, source: cell.document.getText() }],
+      }),
+    );
+    this.state = makeDocumentExecutionState(initialSources);
+  }
+
+  static readonly make = Effect.fn("DocumentExecutionSession.make")(function* (
+    options: DocumentExecutionSessionOptions,
+  ) {
+    const presentationScope = yield* Scope.make();
+    const presentation = yield* Queue.unbounded<Work, Cause.Done>();
+    const session = new DocumentExecutionSession(
+      options,
+      presentationScope,
+      presentation,
+    );
+    session.presentationWorker = yield* Stream.fromQueue(presentation).pipe(
+      Stream.runForEachArray((batch) => session.driveBatch(batch)),
+      Effect.forkIn(presentationScope),
+    );
+    return session;
+  });
+
+  /** Publishes changed staleness for only the affected cells. */
+  private publishStale(cellIds: Iterable<NotebookCellId>) {
+    const changes = [...new Set(cellIds)].map((cellId) => ({
+      cellId,
+      stale: isCellStale(this.state, cellId),
+    }));
+    return changes.length === 0
+      ? Effect.void
+      : this.options.onStaleChange(changes);
+  }
+
+  readonly updateSources = (sources: ReadonlyArray<CellSource>) =>
+    this.ordering.withPermit(
+      Effect.gen({ self: this }, function* () {
+        if (this.closed) return;
+        this.state = updateExecutionSources(this.state, sources);
+        yield* this.publishStale(sources.map(({ cellId }) => cellId));
+      }),
+    );
+
+  /** Runs one presentation command and logs non-interruption failures. */
+  private drive({ cell, command, drive: target }: Work) {
+    return Option.match(target, {
+      onNone: () =>
+        Effect.logDebug("Cell run has no presentation; skipping command").pipe(
+          Effect.annotateLogs({
+            ...cell,
+            command: command._tag,
+            ...("runId" in command ? { runId: command.runId } : {}),
+          }),
+        ),
+      onSome: (apply) =>
+        apply(cell, command).pipe(
+          Effect.catchCause((cause) =>
+            Cause.hasInterrupts(cause)
+              ? Effect.failCause(cause)
+              : Effect.logWarning("Failed to drive cell command").pipe(
+                  Effect.annotateLogs({
+                    cause,
+                    ...cell,
+                    command: command._tag,
+                    ...("runId" in command ? { runId: command.runId } : {}),
+                  }),
+                ),
+          ),
+        ),
+    });
+  }
+
+  /** Runs a batch while conflating pending output for each cell. */
+  private driveBatch(batch: ReadonlyArray<Work>) {
+    const newestOutput = new Map<NotebookCellId, number>();
+    for (const [index, work] of batch.entries()) {
+      if (isConflatableOutput(work.command)) {
+        newestOutput.set(work.cell.cellId, index);
+      }
+    }
+
+    return Effect.forEach(
+      batch,
+      (work, index) =>
+        isConflatableOutput(work.command) &&
+        newestOutput.get(work.cell.cellId) !== index
+          ? Effect.void
+          : this.drive(work),
+      { discard: true },
+    );
+  }
+
+  /** Enqueues one command for ordered presentation. */
+  private present(work: Work) {
+    return Queue.offer(this.presentation, work).pipe(
+      Effect.flatMap((admitted) =>
+        admitted ? Effect.void : Effect.die("Cell presentation is closed"),
+      ),
+    );
+  }
+
+  /** Binds commands to the drive that owns each transitioned run. */
+  private admitTransition(
+    transition: DocumentTransition,
+    currentDrive: Option.Option<Drive>,
+  ) {
+    return Effect.gen({ self: this }, function* () {
+      for (const result of transition.cells) {
+        const previousBinding = Option.fromNullishOr(
+          this.driveBindings.get(result.cellId),
+        );
+        const opened = new Set<RunId>();
+        for (const command of result.commands) {
+          if (CellCommand.$is("OpenRun")(command)) opened.add(command.runId);
+        }
+        const driveForRun = (runId: RunId): Option.Option<Drive> =>
+          boundDrive(previousBinding, runId).pipe(
+            Option.orElse(() =>
+              opened.has(runId) ? currentDrive : Option.none(),
+            ),
+          );
+        const nextBinding = activeRunId(result.current.phase).pipe(
+          Option.flatMap((runId) =>
+            driveForRun(runId).pipe(Option.map((value) => ({ runId, value }))),
+          ),
+        );
+        if (Option.isSome(nextBinding)) {
+          this.driveBindings.set(result.cellId, nextBinding.value);
+        } else {
+          this.driveBindings.delete(result.cellId);
+        }
+
+        const driveForCommand = selectCommandDrive(currentDrive, driveForRun);
+        for (const command of result.commands) {
+          yield* this.present({
+            cell: cellRef(this.options.notebook.id, result.cellId),
+            command,
+            drive: driveForCommand(command),
+          });
+        }
+      }
+    });
+  }
+
+  readonly apply = (wire: CellOperationNotification) =>
+    this.ordering.withPermit(
+      Effect.gen({ self: this }, function* () {
+        if (this.closed) return;
+        const cellId = extractCellIdFromCellMessage(wire);
+        const result = applyKernelOperation(this.state, wire);
+        this.state = result.state;
+        yield* this.publishStale([cellId]);
+        yield* Option.match(result.error, {
+          onNone: () =>
+            this.options.getDrive.pipe(
+              Effect.flatMap((drive) => this.admitTransition(result, drive)),
+            ),
+          onSome: Effect.fail,
+        });
+      }).pipe(Effect.annotateLogs({ notebookId: this.options.notebook.id })),
+    );
+
+  private release(result: DocumentTransition) {
+    return Effect.gen({ self: this }, function* () {
+      this.state = result.state;
+      yield* this.admitTransition(result, Option.none());
+      yield* this.publishStale(result.cells.map(({ cellId }) => cellId));
+    });
+  }
+
+  get interrupt() {
+    return this.ordering.withPermit(
+      Effect.gen({ self: this }, function* () {
+        if (this.closed) return;
+        yield* this.release(interruptAll(this.state));
+      }),
+    );
+  }
+
+  get invalidate() {
+    return this.ordering.withPermit(
+      Effect.gen({ self: this }, function* () {
+        if (this.closed) return;
+        yield* this.release(invalidateAll(this.state));
+      }),
+    );
+  }
+
+  readonly remove = (cellId: NotebookCellId) =>
+    this.ordering.withPermit(
+      Effect.gen({ self: this }, function* () {
+        if (this.closed) return;
+        yield* this.release(removeExecutionCell(this.state, cellId));
+      }),
+    );
+
+  readonly submit = <A, E, R>(
+    cells: ReadonlyArray<CellSource>,
+    send: Effect.Effect<A, E, R>,
+  ): Effect.Effect<A, E, R> => {
+    const token = Symbol("cell submission");
+    const register = this.ordering.withPermit(
+      Effect.sync(() => {
+        this.state = registerSubmission(this.state, token, cells);
+      }),
+    );
+    const rollback = this.ordering.withPermit(
+      Effect.sync(() => {
+        this.state = rollbackSubmission(
+          this.state,
+          token,
+          cells.map(({ cellId }) => cellId),
+        );
+      }),
+    );
+    return register.pipe(
+      Effect.andThen(send),
+      Effect.onExit((exit) => (Exit.isSuccess(exit) ? Effect.void : rollback)),
+    );
+  };
+
+  get close() {
+    return Effect.uninterruptible(
+      this.ordering.withPermit(
+        Effect.gen({ self: this }, function* () {
+          if (this.closed) return;
+          this.closed = true;
+          yield* this.release(closeExecution(this.state));
+          yield* Queue.end(this.presentation);
+          this.driveBindings.clear();
+        }),
+      ),
+    );
+  }
+
+  get drained() {
+    return Fiber.join(this.presentationWorker).pipe(
+      Effect.ensuring(Scope.close(this.presentationScope, Exit.void)),
+    );
+  }
+}

--- a/extension/src/kernel/DocumentExecutionSession.ts
+++ b/extension/src/kernel/DocumentExecutionSession.ts
@@ -6,6 +6,7 @@ import {
   Exit,
   Fiber,
   HashMap,
+  HashSet,
   Option,
   Queue,
   Scope,
@@ -96,10 +97,10 @@ interface CellExecutionState {
   readonly pendingSources: ReadonlyArray<SubmittedSource>;
 }
 
-type DocumentExecutionState = HashMap.HashMap<
-  NotebookCellId,
-  CellExecutionState
->;
+interface DocumentExecutionState {
+  readonly cells: HashMap.HashMap<NotebookCellId, CellExecutionState>;
+  readonly removedCells: HashSet.HashSet<NotebookCellId>;
+}
 
 interface CellTransition {
   readonly cellId: NotebookCellId;
@@ -172,24 +173,40 @@ const getCell = (
   state: DocumentExecutionState,
   cellId: NotebookCellId,
 ): CellExecutionState =>
-  Option.getOrElse(HashMap.get(state, cellId), () => makeCellState());
+  Option.getOrElse(HashMap.get(state.cells, cellId), () => makeCellState());
 
 const setCell = (
   state: DocumentExecutionState,
   cellId: NotebookCellId,
   cell: CellExecutionState,
-): DocumentExecutionState => HashMap.set(state, cellId, cell);
+): DocumentExecutionState => ({
+  cells: HashMap.set(state.cells, cellId, cell),
+  removedCells: state.removedCells,
+});
+
+const restoreCell = (
+  state: DocumentExecutionState,
+  cellId: NotebookCellId,
+  cell: CellExecutionState,
+): DocumentExecutionState => ({
+  cells: HashMap.set(state.cells, cellId, cell),
+  removedCells: HashSet.remove(state.removedCells, cellId),
+});
 
 const makeDocumentExecutionState = (
   sources: ReadonlyArray<CellSource>,
-): DocumentExecutionState => updateExecutionSources(HashMap.empty(), sources);
+): DocumentExecutionState =>
+  updateExecutionSources(
+    { cells: HashMap.empty(), removedCells: HashSet.empty() },
+    sources,
+  );
 
 function updateExecutionSources(
   state: DocumentExecutionState,
   sources: ReadonlyArray<CellSource>,
 ): DocumentExecutionState {
   for (const { cellId, source } of sources) {
-    state = setCell(state, cellId, {
+    state = restoreCell(state, cellId, {
       ...getCell(state, cellId),
       editorSource: Option.some(source),
     });
@@ -212,19 +229,44 @@ const registerSubmission = (
   return state;
 };
 
+const confirmSubmission = (
+  state: DocumentExecutionState,
+  token: symbol,
+  cellIds: ReadonlyArray<NotebookCellId>,
+): DocumentExecutionState => {
+  for (const cellId of cellIds) {
+    const cell = HashMap.get(state.cells, cellId);
+    if (
+      Option.isSome(cell) &&
+      cell.value.pendingSources.some((submitted) => submitted.token === token)
+    ) {
+      state = restoreCell(state, cellId, cell.value);
+    }
+  }
+  return state;
+};
+
 const rollbackSubmission = (
   state: DocumentExecutionState,
   token: symbol,
   cellIds: ReadonlyArray<NotebookCellId>,
 ): DocumentExecutionState => {
   for (const cellId of cellIds) {
-    const cell = HashMap.get(state, cellId);
+    const cell = HashMap.get(state.cells, cellId);
     if (Option.isNone(cell)) continue;
+    const pendingSources = cell.value.pendingSources.filter(
+      (submitted) => submitted.token !== token,
+    );
+    if (
+      pendingSources.length === 0 &&
+      HashSet.has(state.removedCells, cellId)
+    ) {
+      state = { ...state, cells: HashMap.remove(state.cells, cellId) };
+      continue;
+    }
     state = setCell(state, cellId, {
       ...cell.value,
-      pendingSources: cell.value.pendingSources.filter(
-        (submitted) => submitted.token !== token,
-      ),
+      pendingSources,
     });
   }
   return state;
@@ -233,7 +275,7 @@ const rollbackSubmission = (
 const clearPendingSources = (
   state: DocumentExecutionState,
 ): DocumentExecutionState => {
-  for (const [cellId, cell] of state) {
+  for (const [cellId, cell] of state.cells) {
     if (cell.pendingSources.length === 0) continue;
     state = setCell(state, cellId, { ...cell, pendingSources: [] });
   }
@@ -354,11 +396,11 @@ const releaseAll = (
 ): DocumentTransition => {
   const cells: CellTransition[] = [];
   state = clearPendingSources(state);
-  for (const [cellId, cell] of state) {
+  for (const [cellId, cell] of state.cells) {
     const result = step(cell.run, operation);
     cells.push(transitionFor(cellId, result.entry, result.commands));
     state = remove
-      ? HashMap.remove(state, cellId)
+      ? { ...state, cells: HashMap.remove(state.cells, cellId) }
       : setCell(state, cellId, { ...cell, run: result.entry });
   }
   return { state, cells };
@@ -377,11 +419,15 @@ const removeExecutionCell = (
   state: DocumentExecutionState,
   cellId: NotebookCellId,
 ): DocumentTransition => {
-  const cell = HashMap.get(state, cellId);
-  if (Option.isNone(cell)) return { state, cells: [] };
+  const cell = HashMap.get(state.cells, cellId);
+  const removed = {
+    cells: HashMap.remove(state.cells, cellId),
+    removedCells: HashSet.add(state.removedCells, cellId),
+  };
+  if (Option.isNone(cell)) return { state: removed, cells: [] };
   const result = step(cell.value.run, Op.Interrupt());
   return {
-    state: HashMap.remove(state, cellId),
+    state: removed,
     cells: [transitionFor(cellId, result.entry, result.commands)],
   };
 };
@@ -390,7 +436,7 @@ const isCellStale = (
   state: DocumentExecutionState,
   cellId: NotebookCellId,
 ): boolean =>
-  Option.exists(HashMap.get(state, cellId), (cell) =>
+  Option.exists(HashMap.get(state.cells, cellId), (cell) =>
     AcceptedSource.$match(cell.run.acceptedSource, {
       Unknown: () => false,
       Invalidated: () => true,
@@ -570,6 +616,7 @@ export class DocumentExecutionSession {
       Effect.gen({ self: this }, function* () {
         if (this.closed) return;
         const cellId = extractCellIdFromCellMessage(wire);
+        if (HashSet.has(this.state.removedCells, cellId)) return;
         const result = applyKernelOperation(this.state, wire);
         this.state = result.state;
         yield* this.publishStale([cellId]);
@@ -636,9 +683,18 @@ export class DocumentExecutionSession {
         );
       }),
     );
+    const confirm = this.ordering.withPermit(
+      Effect.sync(() => {
+        this.state = confirmSubmission(
+          this.state,
+          token,
+          cells.map(({ cellId }) => cellId),
+        );
+      }),
+    );
     return register.pipe(
       Effect.andThen(send),
-      Effect.onExit((exit) => (Exit.isSuccess(exit) ? Effect.void : rollback)),
+      Effect.onExit((exit) => (Exit.isSuccess(exit) ? confirm : rollback)),
     );
   };
 

--- a/extension/src/kernel/__tests__/CellExecutions.test.ts
+++ b/extension/src/kernel/__tests__/CellExecutions.test.ts
@@ -1965,6 +1965,140 @@ describe("NotebookExecutions", () => {
   );
 
   it.effect(
+    "acknowledges multiple submissions for one cell in order",
+    Effect.fn(function* () {
+      const editor = TestVsCode.makeNotebookEditor("/test/notebook.py", {
+        data: {
+          cells: [
+            {
+              kind: 1,
+              value: "x = 2",
+              languageId: "python",
+              metadata: MarimoNotebookCell.createMetadata({
+                marimoRuntime: { stableId: "cell-1" },
+              }),
+            },
+          ],
+        },
+      });
+      const ctx = yield* withTestCtx({ initialDocuments: [editor.notebook] });
+
+      yield* Effect.gen(function* () {
+        const executions = yield* CellExecutions;
+        const { notebook } = yield* openNotebook(executions, editor.notebook);
+        const id = Option.getOrThrow(
+          MarimoNotebookDocument.from(editor.notebook).cellAt(0).id,
+        );
+        const firstStarted = yield* Latch.make();
+        const secondStarted = yield* Latch.make();
+        const release = yield* Latch.make();
+
+        const first = yield* notebook
+          .submit(
+            [{ cellId: id, source: "x = 1" }],
+            firstStarted.open.pipe(Effect.andThen(release.await)),
+          )
+          .pipe(Effect.forkChild);
+        yield* firstStarted.await;
+        const second = yield* notebook
+          .submit(
+            [{ cellId: id, source: "x = 2" }],
+            secondStarted.open.pipe(Effect.andThen(release.await)),
+          )
+          .pipe(Effect.forkChild);
+        yield* secondStarted.await;
+
+        yield* notebook.apply({
+          op: "cell-op",
+          cell_id: id,
+          status: "queued",
+          run_id: "run-1",
+        });
+        expect(HashSet.has(yield* notebook.staleCells.current, id)).toBe(true);
+
+        yield* notebook.apply({
+          op: "cell-op",
+          cell_id: id,
+          status: "queued",
+          run_id: "run-2",
+        });
+        expect(HashSet.has(yield* notebook.staleCells.current, id)).toBe(false);
+
+        yield* release.open;
+        yield* Fiber.join(first);
+        yield* Fiber.join(second);
+      }).pipe(Effect.provide(ctx.layer));
+    }),
+  );
+
+  it.effect(
+    "rolls back one submission without disturbing a later submission",
+    Effect.fn(function* () {
+      const cellData = {
+        kind: 1,
+        value: "x = 3",
+        languageId: "python",
+        metadata: MarimoNotebookCell.createMetadata({
+          marimoRuntime: { stableId: "cell-1" },
+        }),
+      };
+      const editor = TestVsCode.makeNotebookEditor("/test/notebook.py", {
+        data: { cells: [cellData] },
+      });
+      const ctx = yield* withTestCtx({ initialDocuments: [editor.notebook] });
+
+      yield* Effect.gen(function* () {
+        const executions = yield* CellExecutions;
+        const { notebook } = yield* openNotebook(executions, editor.notebook);
+        const id = Option.getOrThrow(
+          MarimoNotebookDocument.from(editor.notebook).cellAt(0).id,
+        );
+        const firstStarted = yield* Latch.make();
+        const failFirst = yield* Latch.make();
+
+        const first = yield* notebook
+          .submit(
+            [{ cellId: id, source: "x = 1" }],
+            firstStarted.open.pipe(
+              Effect.andThen(failFirst.await),
+              Effect.andThen(Effect.fail("no")),
+            ),
+          )
+          .pipe(Effect.ignore, Effect.forkChild);
+        yield* firstStarted.await;
+        yield* notebook.submit([{ cellId: id, source: "x = 2" }], Effect.void);
+        yield* failFirst.open;
+        yield* Fiber.join(first);
+
+        yield* notebook.apply({
+          op: "cell-op",
+          cell_id: id,
+          status: "queued",
+          run_id: "run-1",
+        });
+        expect(HashSet.has(yield* notebook.staleCells.current, id)).toBe(true);
+
+        cellData.value = "x = 2";
+        yield* ctx.vscode.notebookChange({
+          notebook: editor.notebook,
+          metadata: undefined,
+          cellChanges: [
+            {
+              cell: editor.notebook.cellAt(0),
+              document: editor.notebook.cellAt(0).document,
+              metadata: undefined,
+              outputs: [],
+              executionSummary: undefined,
+            },
+          ],
+          contentChanges: [],
+        });
+        expect(HashSet.has(yield* notebook.staleCells.current, id)).toBe(false);
+      }).pipe(Effect.provide(ctx.layer));
+    }),
+  );
+
+  it.effect(
     "drops source provenance when interrupted before queued",
     Effect.fn(function* () {
       const editor = TestVsCode.makeNotebookEditor("/test/notebook.py", {

--- a/extension/src/kernel/__tests__/CellExecutions.test.ts
+++ b/extension/src/kernel/__tests__/CellExecutions.test.ts
@@ -1466,7 +1466,7 @@ describe("NotebookExecutions", () => {
   );
 
   it.effect(
-    "removing a cell closes its active presented run",
+    "removing a cell closes its run and ignores late operations",
     Effect.fn(function* () {
       const editor = TestVsCode.makeNotebookEditor("/test/notebook.py", {
         data: {
@@ -1488,12 +1488,19 @@ describe("NotebookExecutions", () => {
         const executions = yield* CellExecutions;
         const events: string[] = [];
         const removed = yield* Latch.make();
+        const restored = yield* Latch.make();
         const drive: Drive = (_cell, command) =>
           Effect.gen(function* () {
             if ("runId" in command) {
               events.push(`${command._tag}:${command.runId}`);
             }
             if (command._tag === "CloseRun") yield* removed.open;
+            if (
+              command._tag === "OpenRun" &&
+              command.runId === runId("restored-run")
+            ) {
+              yield* restored.open;
+            }
           });
         const { notebook } = yield* openNotebook(
           executions,
@@ -1514,6 +1521,38 @@ describe("NotebookExecutions", () => {
         yield* removed.await;
 
         expect(events).toEqual(["OpenRun:run-1", "CloseRun:run-1"]);
+        yield* notebook.apply({
+          op: "cell-op",
+          cell_id: id,
+          status: "queued",
+          run_id: "late-run",
+        });
+        yield* notebook
+          .submit(
+            [{ cellId: id, source: "never sent" }],
+            Effect.fail("send failed"),
+          )
+          .pipe(Effect.ignore);
+        yield* notebook.apply({
+          op: "cell-op",
+          cell_id: id,
+          status: "queued",
+          run_id: "failed-run",
+        });
+        yield* notebook.submit([{ cellId: id, source: "x = 2" }], Effect.void);
+        yield* notebook.apply({
+          op: "cell-op",
+          cell_id: id,
+          status: "queued",
+          run_id: "restored-run",
+        });
+        yield* restored.await;
+
+        expect(events).toEqual([
+          "OpenRun:run-1",
+          "CloseRun:run-1",
+          "OpenRun:restored-run",
+        ]);
       }).pipe(Effect.provide(ctx.layer));
     }),
   );

--- a/extension/src/kernel/__tests__/CellRunReducer.test.ts
+++ b/extension/src/kernel/__tests__/CellRunReducer.test.ts
@@ -2,7 +2,7 @@ import { createCellRuntimeState } from "@marimo-team/frontend/unstable_internal/
 import { Option } from "effect";
 import { describe, expect, it } from "vite-plus/test";
 
-import { cellId, runId } from "../../lib/__tests__/branded.ts";
+import { runId } from "../../lib/__tests__/branded.ts";
 import type { CellRuntimeState } from "../../types.ts";
 import {
   AcceptedSource,
@@ -13,11 +13,9 @@ import {
   step,
 } from "../CellRunReducer.ts";
 
-const ID = cellId("cell-1");
 const RUN = runId("run-1");
 
 const entry = (phase: RunPhase): CellRunState => ({
-  id: ID,
   state: createCellRuntimeState(),
   phase,
   acceptedSource: AcceptedSource.Unknown(),


### PR DESCRIPTION
`CellExecutions` stores each cell's run state, editor source, and pending submitted sources in separate collections. Acknowledging a submission dequeues one collection, then falls back to the source in another.

```ts
const submittedSource = yield* dequeueSubmittedSource(cellId);
source = submittedSource.pipe(
  Option.orElse(() => Option.fromNullishOr(currentSources.get(cellId))),
);
```

This PR stores those values together and updates them with pure functions.

```ts
interface CellExecutionState {
  readonly run: CellRunState;
  readonly editorSource: Option.Option<string>;
  readonly pendingSources: ReadonlyArray<SubmittedSource>;
}

const [submittedSource, dequeued] = dequeueSubmittedSource(previousCell);
nextCell = dequeued;
```

`DocumentExecutionSession` stores this state for one document and sends the resulting commands to the existing presentation queue. `CellExecutions` still creates a session for each open document. `DocumentExecutionSession` serializes state changes within that session. Notebook runtime lifecycle is unchanged.

Removed cell IDs are kept in a set. Later kernel operations for those IDs are ignored. Setting an editor source or successfully submitting the cell removes the ID from the set.

The tests cover FIFO source acknowledgement, token-specific rollback, and late operations after removal.
