### PR TITLE
Carry marimo version with kernel environments

### DIFF
--- a/extension/resources/wasm/kernel.py
+++ b/extension/resources/wasm/kernel.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import atexit
 import collections
 import contextlib
+import json
 import os
 import queue
 import signal
@@ -55,6 +56,11 @@ if TYPE_CHECKING:
 _write_lock = threading.Lock()
 _decoder = msgspec.json.Decoder(ToBridge)
 KERNEL_READY_TIMEOUT = 10.0
+_KERNEL_LAUNCH_CODE = """\
+import json, runpy, marimo
+print(json.dumps({"marimo_version": marimo.__version__}), flush=True)
+runpy.run_module("marimo._ipc.launch_kernel", run_name="__main__")
+"""
 
 
 def _read_frame() -> ToBridge | None:
@@ -111,8 +117,8 @@ class _Bridge:
 
         # Piped standard streams make CreateProcess hand the kernel real
         # handles, so its fds 0-2 are valid from birth.
-        process = subprocess.Popen(
-            [sys.executable, "-m", "marimo._ipc.launch_kernel"],
+        process = subprocess.Popen(  # noqa: S603 -- selected Python launches marimo
+            [sys.executable, "-c", _KERNEL_LAUNCH_CODE],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
@@ -127,6 +133,21 @@ class _Bridge:
         # Drain stderr before waiting for readiness so a noisy child cannot
         # fill its pipe and deadlock startup.
         threading.Thread(target=self._forward_stderr, daemon=True).start()
+        version_line = self._wait_for_kernel_ready()
+        try:
+            version_payload = json.loads(version_line)
+        except json.JSONDecodeError as error:
+            msg = f"Invalid kernel version response: {version_line!r}"
+            raise RuntimeError(self._with_stderr_tail(msg)) from error
+        marimo_version = (
+            version_payload.get("marimo_version")
+            if isinstance(version_payload, dict)
+            else None
+        )
+        if not isinstance(marimo_version, str):
+            msg = f"Invalid kernel version response: {version_line!r}"
+            raise TypeError(self._with_stderr_tail(msg))
+
         ready = self._wait_for_kernel_ready()
         if ready != "KERNEL_READY":
             msg = f"Expected KERNEL_READY, received {ready!r}"
@@ -138,7 +159,7 @@ class _Bridge:
         # during startup.
         threading.Thread(target=self._watch_kernel_exit, daemon=True).start()
         threading.Thread(target=self._forward_operations, daemon=True).start()
-        _write_frame(Ready())
+        _write_frame(Ready(marimo_version=marimo_version))
 
     def _with_stderr_tail(self, message: str) -> str:
         with self._stderr_lock:

--- a/extension/resources/wasm/protocol.py
+++ b/extension/resources/wasm/protocol.py
@@ -28,6 +28,7 @@ MAX_FRAME_SIZE = 64 * 1024 * 1024
 class Ready(msgspec.Struct, tag="ready", tag_field="type", rename="camel"):
     """The kernel bridge is ready."""
 
+    marimo_version: str | None = None
     version: Literal[1] = VERSION
 
 

--- a/extension/src/__tests__/__utils__/TestMarimoClient.ts
+++ b/extension/src/__tests__/__utils__/TestMarimoClient.ts
@@ -112,7 +112,10 @@ export function makeTestNotebookRuntime(options: Options = {}) {
               restart: client
                 .restartSession({
                   notebookUri: notebookId,
-                  inner: { executable: "", workingDirectory: "" },
+                  inner: {
+                    executable: "",
+                    workingDirectory: "",
+                  },
                 })
                 .pipe(Effect.as(undefined)),
               close: client
@@ -128,10 +131,11 @@ export function makeTestNotebookRuntime(options: Options = {}) {
         ): Effect.Effect<NotebookDocumentHandle> => {
           const notebookId = MarimoNotebookDocument.from(document).id;
           return Effect.succeed({
-            executeCells: (inner, executable) =>
+            executeCells: (inner, environment) =>
               client.executeCells({
                 notebookUri: notebookId,
-                executable,
+                executable: environment.executable,
+                marimoVersion: Option.getOrNull(environment.marimoVersion),
                 workingDirectory:
                   options.runtimeSession?.workingDirectory ?? process.cwd(),
                 inner,

--- a/extension/src/commands/__tests__/refreshPackages.test.ts
+++ b/extension/src/commands/__tests__/refreshPackages.test.ts
@@ -20,7 +20,11 @@ const NOTEBOOK_URI = notebookId("file:///test/notebook.py");
 const controller: NotebookController = {
   id: "script",
   drive: () => () => Effect.void,
-  resolveExecutable: () => Effect.succeed("/unused/python"),
+  resolveEnvironment: () =>
+    Effect.succeed({
+      executable: "/unused/python",
+      marimoVersion: Option.none(),
+    }),
 };
 
 it.effect("refreshes dependencies for the active document session", () =>

--- a/extension/src/features/__tests__/AutoExport.test.ts
+++ b/extension/src/features/__tests__/AutoExport.test.ts
@@ -30,7 +30,11 @@ import {
 const controller: NotebookController = {
   id: "test-controller",
   drive: () => () => Effect.void,
-  resolveExecutable: () => Effect.succeed("/usr/bin/python"),
+  resolveEnvironment: () =>
+    Effect.succeed({
+      executable: "/usr/bin/python",
+      marimoVersion: Option.none(),
+    }),
 };
 const SESSION_ID = kernelSessionId("00000000-0000-4000-8000-000000000001");
 
@@ -105,7 +109,11 @@ const withTestCtx = Effect.fn(function* (
     runtimeSession:
       options.hasRuntimeSession === false
         ? undefined
-        : { executable: "/usr/bin/python", workingDirectory: "/test" },
+        : {
+            executable: "/usr/bin/python",
+            workingDirectory: "/test",
+            marimoVersion: null,
+          },
     kernelNotifications: Stream.fromPubSub(operations),
     execute: (request) =>
       Ref.update(calls, (current) => [...current, request]).pipe(

--- a/extension/src/features/__tests__/ReloadOnConfigChange.test.ts
+++ b/extension/src/features/__tests__/ReloadOnConfigChange.test.ts
@@ -202,6 +202,7 @@ it.effect(
     const session = {
       executable: "/python",
       workingDirectory: "/project",
+      marimoVersion: null,
     };
     const services = Layer.merge(
       vscode.layer,

--- a/extension/src/kernel/KernelEnvironment.ts
+++ b/extension/src/kernel/KernelEnvironment.ts
@@ -1,0 +1,7 @@
+import type { Option } from "effect";
+
+/** The interpreter and exact marimo version observed before kernel launch. */
+export interface KernelEnvironment {
+  readonly executable: string;
+  readonly marimoVersion: Option.Option<string>;
+}

--- a/extension/src/kernel/NotebookRuntime.ts
+++ b/extension/src/kernel/NotebookRuntime.ts
@@ -57,6 +57,7 @@ import type {
 } from "../types.ts";
 import { CellExecutions, type Drive } from "./CellExecutions.ts";
 import { resolveImageDataUri, saveImageToDisk } from "./imageResolver.ts";
+import type { KernelEnvironment } from "./KernelEnvironment.ts";
 import { makeNotebookExecutor } from "./NotebookExecutor.ts";
 import {
   NotebookFileRootError,
@@ -95,9 +96,12 @@ export interface NotebookController {
   readonly id: string;
   readonly executable?: string;
   readonly drive: (notebook: MarimoNotebookDocument) => Drive;
-  readonly resolveExecutable: (
+  readonly resolveEnvironment: (
     notebook: MarimoNotebookDocument,
-  ) => Effect.Effect<string, ExecutableResolutionError | UnsavedNotebookError>;
+  ) => Effect.Effect<
+    KernelEnvironment,
+    KernelEnvironmentResolutionError | UnsavedNotebookError
+  >;
 }
 
 export interface NotebookControllerSelection {
@@ -110,9 +114,9 @@ export class NoActiveKernelError extends Data.TaggedError(
   "NoActiveKernelError",
 )<{ readonly notebookUri: NotebookId }> {}
 
-/** A controller could not resolve a Python executable for the notebook. */
-export class ExecutableResolutionError extends Data.TaggedError(
-  "ExecutableResolutionError",
+/** A controller could not resolve the kernel environment for the notebook. */
+export class KernelEnvironmentResolutionError extends Data.TaggedError(
+  "KernelEnvironmentResolutionError",
 )<{ readonly notebookUri: NotebookId; readonly cause: unknown }> {}
 
 /** A sandbox controller needs a saved notebook to resolve its environment. */
@@ -133,7 +137,7 @@ export interface NotebookHandle {
     code: string,
   ) => Stream.Stream<
     CellOperationNotification,
-    | ExecutableResolutionError
+    | KernelEnvironmentResolutionError
     | MarimoClientStartError
     | MarimoCommandError
     | NoActiveKernelError
@@ -164,7 +168,7 @@ export interface NotebookHandle {
 export interface NotebookDocumentHandle {
   readonly executeCells: (
     request: InnerRequest<"executeCells">,
-    executable: string,
+    environment: KernelEnvironment,
   ) => Effect.Effect<
     null,
     | MarimoClientStartError
@@ -187,6 +191,7 @@ type SessionNotification = KernelNotification & {
 export interface RuntimeSession {
   readonly executable: string;
   readonly workingDirectory: string;
+  readonly marimoVersion: string | null;
 }
 
 export interface RuntimeSessionEntry {
@@ -240,7 +245,7 @@ function isScratchpadOutput(
  * const documentHandle = yield* runtime.forDocument(rawNotebook);
  * const notebook = yield* runtime.forNotebook(notebookId);
  *
- * yield* documentHandle.executeCells(request, executable);
+ * yield* documentHandle.executeCells(request, environment);
  * yield* notebook.updateUIElements(update);
  * yield* notebook.interrupt;
  * ```
@@ -373,7 +378,7 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
         session: NotebookDocumentSession,
         controller: Ref.Ref<Option.Option<NotebookController>>,
       ): NotebookDocumentHandle => ({
-        executeCells: (request, executable) =>
+        executeCells: (request, environment) =>
           stateForDocumentSession(session).pipe(
             Effect.andThen(
               executor
@@ -386,12 +391,15 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
                     );
                     const workingDirectory = yield* resolveWorkingDirectory(
                       notebookId,
-                      executable,
+                      environment.executable,
                       notebook,
                     );
                     const send = marimo.executeCells({
                       notebookUri: notebookId,
-                      executable,
+                      executable: environment.executable,
+                      marimoVersion: Option.getOrNull(
+                        environment.marimoVersion,
+                      ),
                       workingDirectory,
                       inner: request,
                     });
@@ -503,18 +511,21 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
                       });
                     }
                     const notebook = yield* findOpenNotebook(notebookId);
-                    const executable =
-                      yield* selectedController.value.resolveExecutable(
+                    const environment =
+                      yield* selectedController.value.resolveEnvironment(
                         notebook,
                       );
                     const workingDirectory = yield* resolveWorkingDirectory(
                       notebookId,
-                      executable,
+                      environment.executable,
                       notebook,
                     );
                     yield* marimo.executeScratchpad({
                       notebookUri: notebookId,
-                      executable,
+                      executable: environment.executable,
+                      marimoVersion: Option.getOrNull(
+                        environment.marimoVersion,
+                      ),
                       workingDirectory,
                       inner: { code: sourceCode, runId },
                     });
@@ -934,19 +945,27 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
         getRuntimeSession(notebookId: NotebookId) {
           return liveSessions.find(notebookId).pipe(
             Effect.map(
-              Option.map(({ executable, workingDirectory }) => ({
+              Option.map(({ executable, workingDirectory, marimoVersion }) => ({
                 executable,
                 workingDirectory,
+                marimoVersion,
               })),
             ),
           );
         },
         getRuntimeSessions: liveSessions.get.pipe(
           Effect.map((sessions) =>
-            sessions.map(({ notebookUri, executable, workingDirectory }) => ({
-              notebookId: notebookUri,
-              session: { executable, workingDirectory },
-            })),
+            sessions.map(
+              ({
+                notebookUri,
+                executable,
+                workingDirectory,
+                marimoVersion,
+              }) => ({
+                notebookId: notebookUri,
+                session: { executable, workingDirectory, marimoVersion },
+              }),
+            ),
           ),
         ),
         activeRuntimeSession: Effect.gen(function* () {
@@ -959,9 +978,10 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
           }
           return Option.map(
             yield* liveSessions.find(activeNotebook.value.id),
-            ({ executable, workingDirectory }) => ({
+            ({ executable, workingDirectory, marimoVersion }) => ({
               executable,
               workingDirectory,
+              marimoVersion,
             }),
           );
         }),

--- a/extension/src/kernel/PythonController.ts
+++ b/extension/src/kernel/PythonController.ts
@@ -19,7 +19,11 @@ import { Uv } from "../python/Uv.ts";
 import { MarimoNotebookDocument } from "../schemas/MarimoNotebookDocument.ts";
 import type { Drive } from "./CellExecutions.ts";
 import { makeControllerSelectionChanges } from "./ControllerSelectionChanges.ts";
-import { NotebookRuntime } from "./NotebookRuntime.ts";
+import type { KernelEnvironment } from "./KernelEnvironment.ts";
+import {
+  KernelEnvironmentResolutionError,
+  NotebookRuntime,
+} from "./NotebookRuntime.ts";
 import { VsCodeCellDrive } from "./VsCodeCellDrive.ts";
 
 const NotebookControllerId = Brand.nominal<NotebookControllerId>();
@@ -70,13 +74,13 @@ export const createPythonController = Effect.fn("createPythonController")(
             return;
           }
 
+          // Cell execution is the hot path. Package/environment mutations
+          // invalidate this cache explicitly; lifecycle resolution below uses
+          // a fresh inspection when it needs to reconcile a restored session.
           const validEnv = yield* validator.validate(options.env);
 
           const documentHandle = yield* notebooks.forDocument(rawNotebook);
-          yield* documentHandle.executeCells(
-            request.value,
-            validEnv.executable,
-          );
+          yield* documentHandle.executeCells(request.value, validEnv);
         }).pipe(
           Effect.withSpan("PythonController.execute", {
             attributes: {
@@ -246,6 +250,16 @@ export const createPythonController = Effect.fn("createPythonController")(
     return new PythonController(
       controller,
       options.env.path,
+      (notebook) =>
+        validator.validateFresh(options.env).pipe(
+          Effect.mapError(
+            (cause) =>
+              new KernelEnvironmentResolutionError({
+                notebookUri: notebook.id,
+                cause,
+              }),
+          ),
+        ),
       selectedNotebookChanges,
       (notebook) =>
         cellDrive.bind({
@@ -265,6 +279,9 @@ export class PythonController {
   readonly drive: (notebook: MarimoNotebookDocument) => Drive;
   /** The python interpreter this controller's environment runs on. */
   executable: string;
+  readonly resolveEnvironment: (
+    notebook: MarimoNotebookDocument,
+  ) => Effect.Effect<KernelEnvironment, KernelEnvironmentResolutionError>;
   /**
    * Selection events buffered from the moment the controller was created
    * (see createPythonController). Backed by a queue, so a single consumer
@@ -277,6 +294,9 @@ export class PythonController {
   constructor(
     inner: Omit<vscode.NotebookController, "dispose">,
     executable: string,
+    resolveEnvironment: (
+      notebook: MarimoNotebookDocument,
+    ) => Effect.Effect<KernelEnvironment, KernelEnvironmentResolutionError>,
     selectedNotebookChanges: Stream.Stream<{
       notebook: vscode.NotebookDocument;
       selected: boolean;
@@ -285,6 +305,7 @@ export class PythonController {
   ) {
     this.#inner = inner;
     this.executable = executable;
+    this.resolveEnvironment = resolveEnvironment;
     this.selectedNotebookChanges = selectedNotebookChanges;
     this.drive = drive;
   }
@@ -303,9 +324,6 @@ export class PythonController {
       this.#inner.description = description;
       return this;
     });
-  }
-  resolveExecutable(_notebook: MarimoNotebookDocument) {
-    return Effect.succeed(this.executable);
   }
   updateNotebookAffinity(
     notebook: vscode.NotebookDocument,

--- a/extension/src/kernel/SandboxController.ts
+++ b/extension/src/kernel/SandboxController.ts
@@ -13,6 +13,7 @@ import { MarimoClient } from "../lsp/MarimoClient.ts";
 import { Constants } from "../platform/Constants.ts";
 import { OutputChannel } from "../platform/OutputChannel.ts";
 import { VsCode } from "../platform/VsCode.ts";
+import { EnvironmentValidator } from "../python/EnvironmentValidator.ts";
 import { getVenvPythonPath } from "../python/getVenvPythonPath.ts";
 import { PythonExtension } from "../python/PythonExtension.ts";
 import { Uv } from "../python/Uv.ts";
@@ -20,7 +21,7 @@ import { MarimoNotebookDocument } from "../schemas/MarimoNotebookDocument.ts";
 import { SemVerFromString } from "../schemas/SemVerFromString.ts";
 import { makeControllerSelectionChanges } from "./ControllerSelectionChanges.ts";
 import {
-  ExecutableResolutionError,
+  KernelEnvironmentResolutionError,
   NotebookRuntime,
   UnsavedNotebookError,
 } from "./NotebookRuntime.ts";
@@ -34,6 +35,7 @@ export const createSandboxController = Effect.fn("createSandboxController")(
     const marimo = yield* MarimoClient;
     const notebooks = yield* NotebookRuntime;
     const python = yield* PythonExtension;
+    const validator = yield* EnvironmentValidator;
     const { LanguageId } = yield* Constants;
 
     const runPromise = Effect.runPromiseWith(
@@ -51,37 +53,37 @@ export const createSandboxController = Effect.fn("createSandboxController")(
     controller.description = "marimo sandbox controller";
 
     // Sync the script's PEP 723 env and return the venv interpreter.
-    const resolveExecutable = Effect.fn("SandboxController.resolveExecutable")(
-      function* (notebook: MarimoNotebookDocument) {
-        // The sandbox venv is derived from the script file on disk; an unsaved
-        // notebook has no path to sync. The run handler guards this earlier
-        // (prompts to save); the scratchpad path reaches here directly.
-        if (notebook.isUntitled) {
-          return yield* new UnsavedNotebookError({ notebookUri: notebook.id });
-        }
+    const resolveEnvironment = Effect.fn(
+      "SandboxController.resolveEnvironment",
+    )(function* (notebook: MarimoNotebookDocument) {
+      // The sandbox venv is derived from the script file on disk; an unsaved
+      // notebook has no path to sync. The run handler guards this earlier
+      // (prompts to save); the scratchpad path reaches here directly.
+      if (notebook.isUntitled) {
+        return yield* new UnsavedNotebookError({ notebookUri: notebook.id });
+      }
 
-        const requirements = yield* findRequirements(notebook);
+      const requirements = yield* findRequirements(notebook);
 
-        if (requirements.length > 0) {
-          yield* uvAddScriptSafe(requirements, notebook).pipe(
-            Effect.provideService(VsCode, code),
-            Effect.provideService(Uv, uv),
-          );
-        }
-
-        // always ensure the env is up to date
-        const venv = yield* uv.syncScript({ script: notebook.uri.fsPath }).pipe(
-          // Should be added by findRequirements or uvAddScriptSafe
-          Effect.catchTag("UvMissingPep723MetadataError", () =>
-            Effect.die("Expected PEP 723 metadata to be present"),
-          ),
+      if (requirements.length > 0) {
+        yield* uvAddScriptSafe(requirements, notebook).pipe(
+          Effect.provideService(VsCode, code),
+          Effect.provideService(Uv, uv),
         );
+      }
 
-        const executable = getVenvPythonPath(venv);
-        yield* python.updateActiveEnvironmentPath(executable);
-        return executable;
-      },
-    );
+      // always ensure the env is up to date
+      const venv = yield* uv.syncScript({ script: notebook.uri.fsPath }).pipe(
+        // Should be added by findRequirements or uvAddScriptSafe
+        Effect.catchTag("UvMissingPep723MetadataError", () =>
+          Effect.die("Expected PEP 723 metadata to be present"),
+        ),
+      );
+
+      const executable = getVenvPythonPath(venv);
+      yield* python.updateActiveEnvironmentPath(executable);
+      return yield* validator.validateFresh({ path: executable });
+    });
 
     // Set up execution handler
     controller.executeHandler = (rawCells, rawNotebook) =>
@@ -106,14 +108,14 @@ export const createSandboxController = Effect.fn("createSandboxController")(
             return;
           }
 
-          // resolveExecutable rejects unsaved notebooks (UnsavedNotebookError),
+          // resolveEnvironment rejects unsaved notebooks (UnsavedNotebookError),
           // handled below with an interactive save prompt.
-          const executable = yield* resolveExecutable(notebook).pipe(
+          const environment = yield* resolveEnvironment(notebook).pipe(
             Effect.provideService(Uv, uv),
           );
 
           const documentHandle = yield* notebooks.forDocument(rawNotebook);
-          yield* documentHandle.executeCells(request.value, executable);
+          yield* documentHandle.executeCells(request.value, environment);
         }).pipe(
           // Handle the expected "unsaved notebook" path before logging, so a
           // normal save prompt isn't recorded as an error. (sandboxing only
@@ -158,6 +160,16 @@ export const createSandboxController = Effect.fn("createSandboxController")(
               { channel: uv.channel },
             ),
           ),
+          Effect.catchTags({
+            EnvironmentInspectionError: () =>
+              showErrorAndPromptLogs(
+                "Failed to inspect the marimo sandbox environment.",
+              ),
+            EnvironmentRequirementError: () =>
+              showErrorAndPromptLogs(
+                "The marimo sandbox environment does not meet the kernel requirements.",
+              ),
+          }),
           Effect.catchTag("MarimoCommandError", (error) => {
             const detail = extractPythonError(error.cause);
             return showErrorAndPromptLogs(
@@ -215,13 +227,13 @@ export const createSandboxController = Effect.fn("createSandboxController")(
 
     return {
       id: controller.id,
-      resolveExecutable: (notebook: MarimoNotebookDocument) =>
-        resolveExecutable(notebook).pipe(
+      resolveEnvironment: (notebook: MarimoNotebookDocument) =>
+        resolveEnvironment(notebook).pipe(
           Effect.provideService(Uv, uv),
           Effect.mapError((error) =>
             error._tag === "UnsavedNotebookError"
               ? error
-              : new ExecutableResolutionError({
+              : new KernelEnvironmentResolutionError({
                   notebookUri: notebook.id,
                   cause: error,
                 }),

--- a/extension/src/kernel/__tests__/NotebookRuntime.test.ts
+++ b/extension/src/kernel/__tests__/NotebookRuntime.test.ts
@@ -29,6 +29,11 @@ import {
 
 const notebook = notebookId("notebook-a");
 
+const kernelEnvironment = (executable: string) => ({
+  executable,
+  marimoVersion: Option.none(),
+});
+
 const makeTestLayer = Effect.fn(function* (
   options: Parameters<typeof makeTestMarimoClient>[0] = {},
   vscodeOptions: Parameters<typeof TestVsCode.make>[0] = {},
@@ -45,6 +50,7 @@ const makeTestLayer = Effect.fn(function* (
       startedAt: number;
       status: "idle";
       attached: boolean;
+      marimoVersion: string | null;
     }
   >();
   const execute = options.execute ?? (() => Effect.succeed(null));
@@ -69,6 +75,7 @@ const makeTestLayer = Effect.fn(function* (
               startedAt: 1,
               status: "idle",
               attached: true,
+              marimoVersion: request.params.marimoVersion ?? null,
             });
             break;
           }
@@ -122,7 +129,10 @@ it.effect(
       expect(first).toBe(second);
 
       yield* document
-        .executeCells({ cellIds: [], codes: [] }, "/usr/bin/python")
+        .executeCells(
+          { cellIds: [], codes: [] },
+          kernelEnvironment("/usr/bin/python"),
+        )
         .pipe(Effect.orDie);
       yield* first.interrupt.pipe(Effect.orDie);
 
@@ -136,6 +146,7 @@ it.effect(
           params: {
             notebookUri: id,
             executable: "/usr/bin/python",
+            marimoVersion: null,
             workingDirectory: process.cwd(),
             inner: { cellIds: [], codes: [] },
           },
@@ -156,6 +167,55 @@ it.effect(
           },
         },
       ]);
+    }).pipe(Effect.provide(layer));
+  }),
+);
+
+it.effect(
+  "sends the inspected marimo version with cell execution",
+  Effect.fn(function* () {
+    const requests = yield* Ref.make<ReadonlyArray<MarimoApiCall>>([]);
+    const editor = TestVsCode.makeNotebookEditor(
+      NodePath.join(process.cwd(), "notebook.py"),
+    );
+    const { layer } = yield* makeTestLayer(
+      {
+        execute: (request) =>
+          Ref.update(requests, (current) => [...current, request]).pipe(
+            Effect.as(
+              request.method === "list-sessions" ? { sessions: [] } : null,
+            ),
+          ),
+      },
+      { initialDocuments: [editor.notebook] },
+    );
+
+    yield* Effect.gen(function* () {
+      const runtime = yield* NotebookRuntime;
+      const document = yield* runtime.forDocument(editor.notebook);
+      yield* document.executeCells(
+        { cellIds: [], codes: [] },
+        {
+          executable: "/usr/bin/python",
+          marimoVersion: Option.some("1.2.3-rc1+build.7"),
+        },
+      );
+
+      const execute = (yield* Ref.get(requests)).find(
+        (request) => request.method === "execute-cells",
+      );
+      expect(execute?.params.marimoVersion).toBe("1.2.3-rc1+build.7");
+      expect(
+        yield* runtime.getRuntimeSession(
+          notebookId(editor.notebook.uri.toString()),
+        ),
+      ).toEqual(
+        Option.some({
+          executable: "/usr/bin/python",
+          workingDirectory: process.cwd(),
+          marimoVersion: "1.2.3-rc1+build.7",
+        }),
+      );
     }).pipe(Effect.provide(layer));
   }),
 );
@@ -194,11 +254,14 @@ it.effect(
       const document = yield* runtime.forDocument(editor.notebook);
       yield* document.executeCells(
         { cellIds: [], codes: [] },
-        "/usr/bin/python",
+        kernelEnvironment("/usr/bin/python"),
       );
 
       const execution = yield* document
-        .executeCells({ cellIds: [], codes: [] }, "/usr/bin/python")
+        .executeCells(
+          { cellIds: [], codes: [] },
+          kernelEnvironment("/usr/bin/python"),
+        )
         .pipe(Effect.forkChild);
       yield* Deferred.await(secondExecutionStarted);
 
@@ -267,7 +330,10 @@ it.effect(
       const runtime = yield* NotebookRuntime;
       const firstDocument = yield* runtime.forDocument(first.notebook);
       const pending = yield* firstDocument
-        .executeCells({ cellIds: [], codes: [] }, "/old-python")
+        .executeCells(
+          { cellIds: [], codes: [] },
+          kernelEnvironment("/old-python"),
+        )
         .pipe(Effect.exit, Effect.forkChild);
       yield* Deferred.await(requestStarted);
 
@@ -278,7 +344,7 @@ it.effect(
         .pipe(Effect.retry(Schedule.recurs(100)), Effect.orDie);
       yield* replacementDocument.executeCells(
         { cellIds: [], codes: [] },
-        "/new-python",
+        kernelEnvironment("/new-python"),
       );
 
       yield* Deferred.succeed(releaseRequest, undefined);
@@ -287,11 +353,15 @@ it.effect(
         Option.some({
           executable: "/new-python",
           workingDirectory: process.cwd(),
+          marimoVersion: null,
         }),
       );
 
       const ended = yield* firstDocument
-        .executeCells({ cellIds: [], codes: [] }, "/old-python")
+        .executeCells(
+          { cellIds: [], codes: [] },
+          kernelEnvironment("/old-python"),
+        )
         .pipe(Effect.flip);
       expect(ended._tag).toBe("NoActiveKernelError");
     }).pipe(Effect.provide(layer));
@@ -355,18 +425,19 @@ it.effect("tracks RuntimeSession until a successful kernel close", () =>
           const firstDocument = yield* runtime.forDocument(editor.notebook);
           yield* firstDocument.executeCells(
             { cellIds: [], codes: [] },
-            "/python-one",
+            kernelEnvironment("/python-one"),
           );
 
           configuredRoot = secondRoot;
           yield* firstDocument.executeCells(
             { cellIds: [], codes: [] },
-            "/python-one",
+            kernelEnvironment("/python-one"),
           );
           expect(yield* runtime.getRuntimeSession(id)).toEqual(
             Option.some({
               executable: "/python-one",
               workingDirectory: firstRoot,
+              marimoVersion: null,
             }),
           );
 
@@ -376,6 +447,7 @@ it.effect("tracks RuntimeSession until a successful kernel close", () =>
             Option.some({
               executable: "/python-one",
               workingDirectory: firstRoot,
+              marimoVersion: null,
             }),
           );
 
@@ -389,7 +461,7 @@ it.effect("tracks RuntimeSession until a successful kernel close", () =>
           const secondDocument = yield* runtime.forDocument(reopened.notebook);
           yield* secondDocument.executeCells(
             { cellIds: [], codes: [] },
-            "/python-two",
+            kernelEnvironment("/python-two"),
           );
           const notebook = yield* runtime.forNotebook(id);
           yield* notebook.close;
@@ -400,7 +472,7 @@ it.effect("tracks RuntimeSession until a successful kernel close", () =>
           configuredRoot = firstRoot;
           yield* secondDocument.executeCells(
             { cellIds: [], codes: [] },
-            "/python-two",
+            kernelEnvironment("/python-two"),
           );
 
           const launches = (yield* Ref.get(requests)).filter(
@@ -449,7 +521,8 @@ it.effect(
     const controller: NotebookController = {
       id: "marimo-/usr/bin/python",
       drive: () => () => Effect.void,
-      resolveExecutable: () => Effect.succeed("/usr/bin/python"),
+      resolveEnvironment: () =>
+        Effect.succeed(kernelEnvironment("/usr/bin/python")),
     };
 
     yield* Effect.gen(function* () {
@@ -472,7 +545,8 @@ it.effect(
     const controller: NotebookController = {
       id: "marimo-/usr/bin/python",
       drive: () => () => Effect.void,
-      resolveExecutable: () => Effect.succeed("/usr/bin/python"),
+      resolveEnvironment: () =>
+        Effect.succeed(kernelEnvironment("/usr/bin/python")),
     };
 
     yield* Effect.gen(function* () {
@@ -550,6 +624,7 @@ it.effect(
         startedAt: number;
         status: "idle";
         attached: boolean;
+        marimoVersion: string | null;
       }>;
     }>();
     const editor = TestVsCode.makeNotebookEditor("/test/notebook_mo.py");
@@ -573,6 +648,7 @@ it.effect(
             startedAt: 1,
             status: "idle",
             attached: true,
+            marimoVersion: null,
           },
         ],
       });
@@ -595,7 +671,8 @@ it.effect(
     const controller: NotebookController = {
       id: "marimo-/usr/bin/python",
       drive: () => () => Effect.void,
-      resolveExecutable: () => Effect.succeed("/usr/bin/python"),
+      resolveEnvironment: () =>
+        Effect.succeed(kernelEnvironment("/usr/bin/python")),
     };
 
     yield* Effect.gen(function* () {

--- a/extension/src/kernel/__tests__/NotebookRuntimeOperations.test.ts
+++ b/extension/src/kernel/__tests__/NotebookRuntimeOperations.test.ts
@@ -116,6 +116,7 @@ const withTestCtx = Effect.fn(function* (
         startedAt: 1,
         status: "idle",
         attached: true,
+        marimoVersion: null,
       },
     ],
   ]);
@@ -146,6 +147,11 @@ const withTestCtx = Effect.fn(function* (
     return new PythonController(
       controller,
       "/usr/bin/python3",
+      () =>
+        Effect.succeed({
+          executable: "/usr/bin/python3",
+          marimoVersion: Option.some("1.2.3"),
+        }),
       Stream.never,
       (document) =>
         cellDrive.bind({
@@ -186,6 +192,7 @@ const withTestCtx = Effect.fn(function* (
                 startedAt: 1,
                 status: "idle",
                 attached: true,
+                marimoVersion: request.params.marimoVersion ?? null,
               });
             }
             if (request.method === "restart-session") {
@@ -739,6 +746,7 @@ describe("NotebookRuntime scratch stream", () => {
           firstCommand !== undefined &&
             typeof firstCommand.inner.runId === "string",
         );
+        expect(firstCommand.marimoVersion).toBe("1.2.3");
 
         yield* PubSub.publish(ctx.operationsPubSub, {
           notebookUri: ctx.notebookUri,

--- a/extension/src/kernel/__tests__/operations.test.ts
+++ b/extension/src/kernel/__tests__/operations.test.ts
@@ -25,7 +25,7 @@ const alert: NotificationOf<"missing-package-alert"> = {
 const controller: NotebookController = {
   id: "test-controller",
   drive: () => () => Effect.void,
-  resolveExecutable: () => Effect.die("not implemented"),
+  resolveEnvironment: () => Effect.die("not implemented"),
 };
 
 const withTestCtx = Effect.fn(function* (options: {

--- a/extension/src/lsp/__tests__/MarimoClient.test.ts
+++ b/extension/src/lsp/__tests__/MarimoClient.test.ts
@@ -158,6 +158,7 @@ it.effect(
     yield* marimo.executeCells({
       notebookUri: notebook,
       executable: "/python",
+      marimoVersion: "1.2.3",
       workingDirectory: "/workspace",
       inner: { cellIds: [], codes: [] },
     });
@@ -169,6 +170,7 @@ it.effect(
         params: {
           notebookUri: notebook,
           executable: "/python",
+          marimoVersion: "1.2.3",
           workingDirectory: "/workspace",
           inner: { cellIds: [], codes: [] },
         },

--- a/extension/src/notebook/__tests__/NotebookDependencies.test.ts
+++ b/extension/src/notebook/__tests__/NotebookDependencies.test.ts
@@ -48,8 +48,11 @@ function makeController(options: {
   return {
     ...options,
     drive: () => () => Effect.void,
-    resolveExecutable: () =>
-      Effect.succeed(options.executable ?? "/unused/python"),
+    resolveEnvironment: () =>
+      Effect.succeed({
+        executable: options.executable ?? "/unused/python",
+        marimoVersion: Option.none(),
+      }),
   };
 }
 

--- a/extension/src/panel/sessions/__tests__/LiveSessions.test.ts
+++ b/extension/src/panel/sessions/__tests__/LiveSessions.test.ts
@@ -19,6 +19,7 @@ const SNAPSHOT = {
       startedAt: 42,
       status: "idle",
       attached: false,
+      marimoVersion: "1.2.3",
     },
   ],
 } as const;
@@ -49,6 +50,25 @@ it.effect(
 
     expect(live).toEqual(SNAPSHOT.sessions);
     expect(recorded).toEqual([{ method: "list-sessions", params: {} }]);
+  }),
+);
+
+it.effect(
+  "decodes an older session snapshot with an unknown marimo version",
+  Effect.fn(function* () {
+    const recorded: MarimoApiCall[] = [];
+    const legacy = {
+      sessions: SNAPSHOT.sessions.map(
+        ({ marimoVersion: _, ...session }) => session,
+      ),
+    };
+
+    const live = yield* Effect.gen(function* () {
+      const sessions = yield* LiveSessions;
+      return yield* sessions.get;
+    }).pipe(Effect.provide(makeLayer(recorded, legacy)));
+
+    expect(live[0]?.marimoVersion).toBeNull();
   }),
 );
 

--- a/extension/src/python/EnvironmentValidator.ts
+++ b/extension/src/python/EnvironmentValidator.ts
@@ -1,6 +1,5 @@
 import { NodeServices } from "@effect/platform-node";
 import * as semver from "@std/semver";
-import type * as py from "@vscode/python-extension";
 import {
   Cache,
   Context,
@@ -24,16 +23,20 @@ import { VsCode } from "../platform/VsCode.ts";
 import { SemVerFromString } from "../schemas/SemVerFromString.ts";
 import { PythonEnvInvalidation } from "./PythonEnvInvalidation.ts";
 
+interface PythonEnvironment {
+  readonly path: string;
+}
+
 class InvalidExecutableError extends Data.TaggedError(
   "InvalidExecutableError",
 )<{
-  readonly env: py.Environment;
+  readonly env: PythonEnvironment;
 }> {}
 
 class EnvironmentInspectionError extends Data.TaggedError(
   "EnvironmentInspectionError",
 )<{
-  readonly env: py.Environment;
+  readonly env: PythonEnvironment;
   readonly cause?: PlatformError | Schema.SchemaError | InvalidExecutableError;
   readonly stdout?: string;
   readonly stderr?: string;
@@ -54,11 +57,11 @@ const INSPECTION_TIMEOUT = Duration.seconds(10);
 
 /**
  * Cache key comparing environments by interpreter path while carrying the
- * full `py.Environment` for the cache's lookup function.
+ * environment for the cache's lookup function.
  */
 class EnvironmentKey implements Equal.Equal {
-  readonly env: py.Environment;
-  constructor(env: py.Environment) {
+  readonly env: PythonEnvironment;
+  constructor(env: PythonEnvironment) {
     this.env = env;
   }
   [Equal.symbol](that: unknown): boolean {
@@ -72,7 +75,7 @@ class EnvironmentKey implements Equal.Equal {
 class EnvironmentRequirementError extends Data.TaggedError(
   "EnvironmentRequirementError",
 )<{
-  readonly env: py.Environment;
+  readonly env: PythonEnvironment;
   readonly diagnostics: ReadonlyArray<RequirementDiagnostic>;
 }> {}
 
@@ -106,11 +109,11 @@ export class EnvironmentValidator extends Context.Service<EnvironmentValidator>(
       const EnvCheck = Schema.Array(
         Schema.Struct({
           name: Schema.String,
-          version: Schema.NullOr(SemVerFromString),
+          version: Schema.NullOr(Schema.String),
         }),
       );
 
-      const inspect = Effect.fnUntraced(function* (env: py.Environment) {
+      const inspect = Effect.fnUntraced(function* (env: PythonEnvironment) {
         const packages = yield* ChildProcess.make(env.path, [
           "-c",
           `\
@@ -196,24 +199,39 @@ print(json.dumps(packages), flush=True)`,
                 `This can happen when the environment lives on a slow filesystem (e.g. a Windows drive mounted in WSL2).`,
             ),
           );
-          return new ValidPythonEnvironment({ inner: env });
+          return new ValidPythonEnvironment({
+            executable: env.path,
+            marimoVersion: Option.none(),
+          });
         }
 
         const diagnostics: Array<RequirementDiagnostic> = [];
+        let marimoVersion = Option.none<string>();
 
         for (const pkg of packages.value) {
           if (pkg.version == null) {
             diagnostics.push({ kind: "missing", package: pkg.name });
-          } else if (
-            pkg.name === "marimo" &&
-            !semver.greaterOrEqual(pkg.version, MINIMUM_MARIMO_KERNEL_VERSION)
-          ) {
-            diagnostics.push({
-              kind: "outdated",
-              package: "marimo",
-              currentVersion: pkg.version,
-              requiredVersion: MINIMUM_MARIMO_KERNEL_VERSION,
-            });
+          } else if (pkg.name === "marimo") {
+            const parsed = Schema.decodeOption(SemVerFromString)(pkg.version);
+            if (Option.isNone(parsed)) {
+              diagnostics.push({ kind: "unknown", package: pkg.name });
+              continue;
+            }
+            if (
+              !semver.greaterOrEqual(
+                parsed.value,
+                MINIMUM_MARIMO_KERNEL_VERSION,
+              )
+            ) {
+              diagnostics.push({
+                kind: "outdated",
+                package: "marimo",
+                currentVersion: parsed.value,
+                requiredVersion: MINIMUM_MARIMO_KERNEL_VERSION,
+              });
+              continue;
+            }
+            marimoVersion = Option.some(pkg.version);
           }
         }
 
@@ -224,7 +242,10 @@ print(json.dumps(packages), flush=True)`,
           });
         }
 
-        return new ValidPythonEnvironment({ inner: env });
+        return new ValidPythonEnvironment({
+          executable: env.path,
+          marimoVersion,
+        });
       });
 
       const cache = yield* Cache.make({
@@ -245,8 +266,9 @@ print(json.dumps(packages), flush=True)`,
       );
 
       return {
+        validateFresh: inspect,
         validate: Effect.fn("EnvironmentValidator.validate")(function* (
-          env: py.Environment,
+          env: PythonEnvironment,
         ) {
           const key = new EnvironmentKey(env);
           // Only reuse successes: drop failed entries so a just-fixed
@@ -267,19 +289,15 @@ print(json.dumps(packages), flush=True)`,
 }
 
 /**
- * A validated `py.Environment`. Cached by interpreter path, so only expose
- * path-derived data — anything else (version, sysPrefix, …) can be stale on a
- * cache hit.
+ * A validated Python environment and the exact marimo version string observed
+ * by its inspection. `validate` caches this value; `validateFresh` does not.
  */
 export class ValidPythonEnvironment extends Data.TaggedClass(
   "ValidPythonEnvironment",
 )<{
-  inner: py.Environment;
-}> {
-  get executable(): string {
-    return this.inner.path;
-  }
-}
+  readonly executable: string;
+  readonly marimoVersion: Option.Option<string>;
+}> {}
 
 type RequirementDiagnostic =
   | { kind: "unknown"; package: string }

--- a/extension/src/python/__tests__/EnvironmentValidator.test.ts
+++ b/extension/src/python/__tests__/EnvironmentValidator.test.ts
@@ -4,7 +4,7 @@ import * as NodePath from "node:path";
 import * as NodeProcess from "node:process";
 
 import { assert, describe, expect, it } from "@effect/vitest";
-import { Context, Effect, Exit, Layer, Result, Schema } from "effect";
+import { Context, Effect, Exit, Layer, Option, Result, Schema } from "effect";
 
 import { TestPythonExtension } from "../../__mocks__/TestPythonExtension.ts";
 import { TestTelemetryLive } from "../../__mocks__/TestTelemetry.ts";
@@ -156,6 +156,10 @@ it.layer(EnvironmentValidatorLive)("EnvironmentValidator", (it) => {
 
       assert(Result.isSuccess(result), "Expected validation to succeed");
       assert.strictEqual(result.success._tag, "ValidPythonEnvironment");
+      assert(
+        Option.isSome(result.success.marimoVersion),
+        "Expected the installed marimo version",
+      );
     }),
     { timeout: 60_000 },
   );
@@ -293,7 +297,9 @@ it.layer(EnvironmentValidatorLive)("EnvironmentValidator", (it) => {
       Effect.fn(function* () {
         const validator = yield* EnvironmentValidator;
         const tmpdir = yield* TempDir;
-        const json = JSON.stringify([{ name: "marimo", version: "1.0.0" }]);
+        const json = JSON.stringify([
+          { name: "marimo", version: "1.0.0-rc1+build.7" },
+        ]);
         const script = makeFakeExecutable(tmpdir.path, "extra-whitespace", {
           stdout: `\n  ${json}  \n`,
           exitCode: 0,
@@ -305,6 +311,9 @@ it.layer(EnvironmentValidatorLive)("EnvironmentValidator", (it) => {
 
         assert(Result.isSuccess(result), "Expected validation to succeed");
         assert.strictEqual(result.success._tag, "ValidPythonEnvironment");
+        expect(result.success.marimoVersion).toEqual(
+          Option.some("1.0.0-rc1+build.7"),
+        );
       }),
     );
 
@@ -354,6 +363,35 @@ it.layer(EnvironmentValidatorLive)("EnvironmentValidator", (it) => {
         assert.strictEqual(first._tag, "ValidPythonEnvironment");
         assert.strictEqual(second._tag, "ValidPythonEnvironment");
         expect(runCount(countFile)).toBe(1);
+      }),
+    );
+
+    it.effect(
+      "should inspect a changed executable without using its cached version",
+      Effect.fn(function* () {
+        const validator = yield* EnvironmentValidator;
+        const tmpdir = yield* TempDir;
+        const countFile = NodePath.join(tmpdir.path, "fresh-version-count");
+        const script = makeFakeExecutable(tmpdir.path, "fresh-version", {
+          stdout: JSON.stringify([{ name: "marimo", version: "1.0.0" }]),
+          exitCode: 0,
+          countFile,
+        });
+        const env = TestPythonExtension.makeGlobalEnv(script);
+
+        const first = yield* validator.validate(env);
+        makeFakeExecutable(tmpdir.path, "fresh-version", {
+          stdout: JSON.stringify([{ name: "marimo", version: "1.1.0" }]),
+          exitCode: 0,
+          countFile,
+        });
+        const cached = yield* validator.validate(env);
+        const fresh = yield* validator.validateFresh(env);
+
+        expect(first.marimoVersion).toEqual(Option.some("1.0.0"));
+        expect(cached.marimoVersion).toEqual(Option.some("1.0.0"));
+        expect(fresh.marimoVersion).toEqual(Option.some("1.1.0"));
+        expect(runCount(countFile)).toBe(2);
       }),
     );
 

--- a/extension/src/schemas/Models.gen.ts
+++ b/extension/src/schemas/Models.gen.ts
@@ -463,6 +463,9 @@ export const ExecuteCellsPayload = Schema.Struct({
   inner: ExecuteCellsRequest,
   executable: Schema.String,
   workingDirectory: Schema.String,
+  marimoVersion: Schema.NullOr(Schema.String).pipe(
+    Schema.withDecodingDefault(Effect.sync(() => null)),
+  ),
 });
 
 export const UpdateUIElementRequest = Schema.Struct({
@@ -666,6 +669,9 @@ export const SessionInfo = Schema.Struct({
   startedAt: Schema.Number,
   status: Schema.Literals(["idle", "running"]),
   attached: Schema.Boolean,
+  marimoVersion: Schema.NullOr(Schema.String).pipe(
+    Schema.withDecodingDefault(Effect.sync(() => null)),
+  ),
 }).annotate({ identifier: "SessionInfo" });
 export type SessionInfo = typeof SessionInfo.Type;
 
@@ -686,6 +692,9 @@ export const ExecuteScratchpadPayload = Schema.Struct({
   inner: ExecuteScratchRequest,
   executable: Schema.String,
   workingDirectory: Schema.String,
+  marimoVersion: Schema.NullOr(Schema.String).pipe(
+    Schema.withDecodingDefault(Effect.sync(() => null)),
+  ),
 });
 
 export const PackageDescription = Schema.Struct({

--- a/extension/src/schemas/__tests__/Models.gen.test.ts
+++ b/extension/src/schemas/__tests__/Models.gen.test.ts
@@ -106,6 +106,17 @@ describe("Models.gen (msgspec → Effect Schema codegen)", () => {
     ).toThrow();
   });
 
+  it("decodes older session commands with an unknown marimo version", () => {
+    const decoded = Schema.decodeUnknownSync(ExecuteCellsPayload)({
+      notebookUri: "file:///nb.py",
+      executable: "/usr/bin/python",
+      workingDirectory: "/workspace",
+      inner: { cellIds: ["cell-1"], codes: ["print(1)"] },
+    });
+
+    expect(decoded.marimoVersion).toBeNull();
+  });
+
   it("names structs in parse errors via identifier annotations", () => {
     // The default formatter uses `identifier` as the expected label for a
     // type failure such as "Expected VenvSource". It does not use it for a

--- a/src/marimo_lsp/api.py
+++ b/src/marimo_lsp/api.py
@@ -270,7 +270,10 @@ async def run(
 ) -> None:
     logger.info(f"run for {args.notebook_uri}")
     session = await ctx.sessions.start(
-        args.notebook_uri, args.executable, args.working_directory
+        args.notebook_uri,
+        args.executable,
+        args.working_directory,
+        args.marimo_version,
     )
     # Reconcile document metadata before enqueueing execution. LSP change
     # notifications normally keep the session synchronized, but doing it here
@@ -464,7 +467,10 @@ async def execute_scratch(
         return
 
     session = await ctx.sessions.start(
-        args.notebook_uri, args.executable, args.working_directory
+        args.notebook_uri,
+        args.executable,
+        args.working_directory,
+        args.marimo_version,
     )
     while True:
         if not await session.wait_until_idle():

--- a/src/marimo_lsp/kernels/__init__.py
+++ b/src/marimo_lsp/kernels/__init__.py
@@ -21,6 +21,7 @@ class Kernel(typing.Protocol):
 
     executable: str
     working_directory: str
+    marimo_version: str | None
 
     def send(self, request: CommandMessage) -> None:
         """Send a command to the kernel."""

--- a/src/marimo_lsp/kernels/manager.py
+++ b/src/marimo_lsp/kernels/manager.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import json
 import subprocess
 import typing
 from pathlib import Path
@@ -27,6 +28,13 @@ if typing.TYPE_CHECKING:
 
 logger = get_logger()
 
+_KERNEL_LAUNCH_CODE = """\
+import json, runpy, marimo
+print(json.dumps({"marimo_version": marimo.__version__}), flush=True)
+runpy.run_module("marimo._ipc.launch_kernel", run_name="__main__")
+"""
+_MAX_STARTUP_STDERR_CHARS = 16_000
+
 
 class InvalidWorkingDirectoryError(ValueError):
     """The requested kernel working directory is unsafe or unavailable."""
@@ -45,14 +53,61 @@ def _validate_working_directory(path: Path) -> None:
         raise InvalidWorkingDirectoryError(path, "is not a directory")
 
 
+def _with_stderr_tail(
+    process: subprocess.Popen[bytes],
+    message: str,
+) -> str:
+    """Include stderr from a kernel process that has stopped."""
+    if process.poll() is None or process.stderr is None:
+        return message
+    stderr = process.stderr.read().decode("utf-8", errors="replace").strip()
+    if not stderr:
+        return message
+    return f"{message} Stderr: {stderr[-_MAX_STARTUP_STDERR_CHARS:]}"
+
+
+def _parse_kernel_version(version_line: str) -> str:
+    try:
+        version_payload = json.loads(version_line)
+    except json.JSONDecodeError as error:
+        msg = f"Invalid kernel version response: {version_line!r}"
+        raise RuntimeError(msg) from error
+    marimo_version = (
+        version_payload.get("marimo_version")
+        if isinstance(version_payload, dict)
+        else None
+    )
+    if not isinstance(marimo_version, str):
+        msg = f"Invalid kernel version response: {version_line!r}"
+        raise TypeError(msg)
+    return marimo_version
+
+
+def _require_kernel_ready(
+    process: subprocess.Popen[bytes],
+    ready_line: str,
+) -> None:
+    if ready_line == "KERNEL_READY":
+        return
+    exit_code = process.poll()
+    if exit_code is not None and exit_code != 0:
+        msg = f"Kernel failed to start (exit code {exit_code})"
+        logger.error(msg)
+        raise RuntimeError(msg)
+
+    msg = f"Invalid kernel response. Expected 'KERNEL_READY', got: {ready_line!r}."
+    logger.error(msg)
+    raise RuntimeError(msg)
+
+
 def launch_kernel(
     executable: str,
     args: ipc.KernelArgs,
     cwd: str | None = None,
 ) -> Process:
     """Launch kernel as a subprocess."""
-    cmd = [executable, "-m", "marimo._ipc.launch_kernel"]
-    logger.info(f"Launching kernel subprocess: {' '.join(cmd)}")
+    cmd = [executable, "-c", _KERNEL_LAUNCH_CODE]
+    logger.info(f"Launching kernel subprocess: {executable} -c <kernel bootstrap>")
     logger.debug(f"Connection info: {args.connection_info}")
     if cwd:
         logger.debug(f"Setting kernel working directory to: {cwd}")
@@ -64,39 +119,36 @@ def launch_kernel(
         stderr=subprocess.PIPE,
         cwd=cwd,
     )
+    owner = Process(inner=process)
+    try:
+        assert process.stdin, "Expect subprocess stdin pipe"
+        assert process.stdout, "Expect subprocess stdout pipe"
+        assert process.stderr, "Expect subprocess stderr pipe"
 
-    assert process.stdin, "Expect subprocess stdin pipe"
-    assert process.stdout, "Expect subprocess stdout pipe"
-    assert process.stderr, "Expect subprocess stderr pipe"
+        # Send over stdin
+        process.stdin.write(args.encode_json())
+        process.stdin.flush()
+        process.stdin.close()
 
-    # Send over stdin
-    process.stdin.write(args.encode_json())
-    process.stdin.flush()
-    process.stdin.close()
+        logger.debug("Waiting for marimo version from kernel subprocess")
 
-    logger.debug("Waiting for KERNEL_READY signal from kernel subprocess")
+        version_line = process.stdout.readline().decode("utf-8").strip()
+        marimo_version = _parse_kernel_version(version_line)
 
-    # Wait for "KERNEL_READY" message
-    ready_line = process.stdout.readline().decode("utf-8").strip()
-    if ready_line != "KERNEL_READY":
-        exit_code = process.poll()
-        stderr = process.stderr.read().decode("utf-8", errors="replace")
+        # Wait for "KERNEL_READY" message
+        ready_line = process.stdout.readline().decode("utf-8").strip()
+        _require_kernel_ready(process, ready_line)
+    except BaseException as error:
+        owner.terminate()
+        if isinstance(error, (RuntimeError, TypeError)):
+            message = _with_stderr_tail(process, str(error))
+            if message != str(error):
+                raise type(error)(message) from error
+        raise
 
-        if exit_code is not None and exit_code != 0:
-            msg = f"Kernel failed to start (exit code {exit_code}): {stderr}"
-            logger.error(msg)
-            raise RuntimeError(msg)
-
-        msg = (
-            f"Invalid kernel response. Expected 'KERNEL_READY', got: '{ready_line}'. "
-            f"Stderr: {stderr}"
-        )
-        logger.error(msg)
-        process.terminate()
-        raise RuntimeError(msg)
-
+    owner.marimo_version = marimo_version
     logger.info(f"Kernel subprocess started successfully with PID: {process.pid}")
-    return Process(inner=process)
+    return owner
 
 
 class Manager(KernelManagerImpl):
@@ -139,6 +191,7 @@ class Manager(KernelManagerImpl):
         self.executable = executable
         self.connection_info = connection_info
         self.working_directory = working_directory
+        self.marimo_version: str | None = None
 
     def start_kernel(self) -> None:
         """Start an instance of the marimo kernel using ZeroMQ IPC."""
@@ -157,6 +210,7 @@ class Manager(KernelManagerImpl):
             ),
             cwd=str(working_directory),
         )
+        self.marimo_version = self.kernel_task.marimo_version
 
 
 class Process(ProcessLike):
@@ -168,9 +222,14 @@ class Process(ProcessLike):
     # Timeout in seconds to wait for graceful termination before force killing
     TERMINATE_TIMEOUT = 2.0
 
-    def __init__(self, inner: subprocess.Popen[bytes]) -> None:
+    def __init__(
+        self,
+        inner: subprocess.Popen[bytes],
+        marimo_version: str | None = None,
+    ) -> None:
         """Initialize with a subprocess.Popen instance."""
         self.inner = inner
+        self.marimo_version = marimo_version
 
     @property
     def pid(self) -> int | None:

--- a/src/marimo_lsp/kernels/native.py
+++ b/src/marimo_lsp/kernels/native.py
@@ -43,10 +43,12 @@ class NativeKernel:
         self._listener_thread: threading.Thread | None = None
         self.executable = manager.executable
         self.working_directory = manager.working_directory
+        self.marimo_version: str | None = None
 
     def start(self, receive: Callable[[KernelMessage], None]) -> None:
         """Start the kernel process and operation listener."""
         self._manager.start_kernel()
+        self.marimo_version = self._manager.marimo_version
 
         def listen() -> None:
             stream_queue = self._queue_manager.stream_queue

--- a/src/marimo_lsp/models.py
+++ b/src/marimo_lsp/models.py
@@ -104,6 +104,9 @@ class SessionCommand(NotebookCommand[T]):
     working_directory: str
     """Absolute working directory for the launched kernel."""
 
+    marimo_version: str | None = None
+    """Inspected marimo version for the target environment, when known."""
+
 
 class VenvSource(msgspec.Struct, tag="venv", tag_field="kind", rename="camel"):
     """The notebook's environment is a concrete venv with a known python executable."""
@@ -371,6 +374,8 @@ class SessionInfo(msgspec.Struct, rename="camel", frozen=True):
     started_at: float
     status: typing.Literal["idle", "running"]
     attached: bool
+    marimo_version: str | None = None
+    """Exact version reported by the live kernel process, when known."""
 
 
 class ListSessionsResponse(msgspec.Struct, rename="camel"):

--- a/src/marimo_lsp/sessions.py
+++ b/src/marimo_lsp/sessions.py
@@ -178,6 +178,7 @@ class Session:
         on_change: typing.Callable[[], None] | None = None,
         session_view: SessionView | None = None,
         started_at: float | None = None,
+        environment_version: str | None = None,
     ) -> None:
         self.session_id = session_id
         self._notebook_uri = notebook_uri
@@ -195,6 +196,8 @@ class Session:
         self._closed = False
         self._runtime_config = config_manager.get_config(hide_secrets=False)
         self.started_at = started_at if started_at is not None else time.time()
+        self._marimo_version = kernel.marimo_version
+        self._environment_version = environment_version
         self._status: typing.Literal["idle", "running"] = "idle"
         self._idle = asyncio.Event()
         self._idle.set()
@@ -218,6 +221,20 @@ class Session:
     def working_directory(self) -> str:
         """Return the configured kernel working directory."""
         return self._kernel.working_directory
+
+    @property
+    def marimo_version(self) -> str | None:
+        """Return the exact version reported by the launched kernel."""
+        return self._marimo_version
+
+    @property
+    def environment_version(self) -> str | None:
+        """Return the version observed when this environment was selected."""
+        return self._environment_version
+
+    def adopt_environment_version(self, marimo_version: str) -> None:
+        """Record an inspection already confirmed by this live kernel."""
+        self._environment_version = marimo_version
 
     @property
     def attached(self) -> bool:
@@ -377,6 +394,7 @@ class Session:
                 started_at=self.started_at,
                 status=self._status,
                 attached=self.attached,
+                marimo_version=self.marimo_version,
             )
 
     def set_on_change(self, on_change: typing.Callable[[], None]) -> None:
@@ -588,21 +606,34 @@ class Sessions:
         notebook_uri: str,
         executable: str,
         working_directory: str,
+        marimo_version: str | None = None,
     ) -> Session:
         """Start or reuse the notebook's session.
 
-        A different executable replaces the existing session only after the
-        replacement has started successfully.
+        A different executable or environment inspection replaces the existing
+        session only after the replacement has started successfully. Kernel
+        provenance is kept separate because its import context may report a
+        different version from the client's environment inspection.
         """
         async with self._lifecycle_lock(notebook_uri):
             current = self.get(notebook_uri)
             if current is not None and current.executable == executable:
-                current.attach()
-                return current
+                if marimo_version is None or (
+                    current.environment_version == marimo_version
+                ):
+                    current.attach()
+                    return current
+                if current.marimo_version == marimo_version:
+                    current.adopt_environment_version(marimo_version)
+                    current.attach()
+                    return current
 
             version = self._lifecycle_version(notebook_uri)
             replacement = await self._create(
-                notebook_uri, executable, working_directory
+                notebook_uri,
+                executable,
+                working_directory,
+                environment_version=marimo_version,
             )
             with self._lock:
                 if version != self._lifecycle_version(notebook_uri):
@@ -630,6 +661,7 @@ class Sessions:
         executable: str,
         working_directory: str,
         *,
+        environment_version: str | None = None,
         previous: Session | None = None,
     ) -> Session:
         app_file_manager = previous.app_file_manager if previous else None
@@ -668,6 +700,12 @@ class Sessions:
             receive=receive,
         )
         try:
+            keep_previous_view = (
+                previous is not None
+                and previous.marimo_version is not None
+                and kernel.marimo_version is not None
+                and previous.marimo_version == kernel.marimo_version
+            )
             session = Session(
                 session_id=session_id,
                 notebook_uri=notebook_uri,
@@ -675,8 +713,9 @@ class Sessions:
                 kernel=kernel,
                 app_file_manager=app_file_manager,
                 config_manager=config_manager,
-                session_view=previous.session_view if previous else None,
+                session_view=previous.session_view if keep_previous_view else None,
                 started_at=previous.started_at if previous else None,
+                environment_version=environment_version,
             )
             session.set_on_kernel_failure(_raise_kernel_failure)
             for message in pending_messages:
@@ -710,13 +749,16 @@ class Sessions:
             version = self._lifecycle_version(notebook_uri)
             if current is None:
                 replacement = await self._create(
-                    notebook_uri, executable, working_directory
+                    notebook_uri,
+                    executable,
+                    working_directory,
                 )
             else:
                 replacement = await self._create(
                     notebook_uri,
                     current.executable,
                     current.working_directory,
+                    environment_version=current.environment_version,
                     previous=current,
                 )
                 if not current.attached:

--- a/src/marimo_lsp/wasm/kernels.py
+++ b/src/marimo_lsp/wasm/kernels.py
@@ -88,6 +88,7 @@ class WasmKernel:
         self._closed = False
         self.executable = executable
         self.working_directory = working_directory
+        self.marimo_version: str | None = None
 
     def accept(self, chunk: bytes) -> None:
         """Decode operations received from the kernel bridge."""
@@ -95,6 +96,7 @@ class WasmKernel:
             return
         for message in self._decoder.feed(chunk):
             if isinstance(message, Ready):
+                self.marimo_version = message.marimo_version
                 if not self._ready.done():
                     self._ready.set_result(None)
             elif isinstance(message, Operation):

--- a/src/marimo_lsp/wasm/protocol.py
+++ b/src/marimo_lsp/wasm/protocol.py
@@ -26,6 +26,7 @@ MAX_FRAME_SIZE = 64 * 1024 * 1024
 class Ready(msgspec.Struct, tag="ready", tag_field="type", rename="camel"):
     """The kernel bridge is ready."""
 
+    marimo_version: str | None = None
     version: Literal[1] = VERSION
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -29,6 +29,8 @@ from marimo_lsp.api import (
     interrupt,
     list_sql_schemas,
     list_sql_tables,
+    restart_session,
+    run,
     send_stdin,
     set_model_value,
     set_ui_element_value,
@@ -40,6 +42,7 @@ from marimo_lsp.models import (
     DeserializeInvalidSyntax,
     DeserializeRequest,
     DeserializeSuccess,
+    ExecuteCellsRequest,
     ExecuteScratchRequest,
     ExportAsMarkdownRequest,
     GetConfigurationRequest,
@@ -49,6 +52,7 @@ from marimo_lsp.models import (
     ListSQLTablesRequest,
     ModelRequest,
     NotebookCommand,
+    RestartSessionRequest,
     SessionCommand,
     SetDisplayThemeRequest,
     StdinRequest,
@@ -60,6 +64,65 @@ if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
 NOTEBOOK_URI = "file:///notebook.py"
+
+
+def test_old_session_command_decodes_with_unknown_marimo_version() -> None:
+    command = msgspec.json.decode(
+        b'{"notebookUri":"file:///notebook.py",'
+        b'"executable":"/usr/bin/python",'
+        b'"workingDirectory":"/workspace",'
+        b'"inner":{"cellIds":[],"codes":[]}}',
+        type=SessionCommand[ExecuteCellsRequest],
+    )
+
+    assert command.marimo_version is None
+
+
+@pytest.mark.asyncio
+async def test_run_starts_session_with_inspected_marimo_version() -> None:
+    sessions = MagicMock()
+    session = MagicMock()
+    sessions.start = AsyncMock(return_value=session)
+
+    await run(
+        _context(sessions),
+        SessionCommand(
+            notebook_uri=NOTEBOOK_URI,
+            executable="/usr/bin/python",
+            working_directory="/workspace",
+            marimo_version="1.2.3",
+            inner=ExecuteCellsRequest(cell_ids=[], codes=[]),
+        ),
+    )
+
+    sessions.start.assert_awaited_once_with(
+        NOTEBOOK_URI, "/usr/bin/python", "/workspace", "1.2.3"
+    )
+
+
+@pytest.mark.asyncio
+async def test_restart_forwards_restore_environment() -> None:
+    sessions = MagicMock()
+    sessions.restart = AsyncMock(return_value=MagicMock())
+
+    await restart_session(
+        _context(sessions),
+        NotebookCommand(
+            notebook_uri=NOTEBOOK_URI,
+            inner=RestartSessionRequest(
+                executable="/usr/bin/python",
+                working_directory="/workspace",
+                create_if_missing=True,
+            ),
+        ),
+    )
+
+    sessions.restart.assert_awaited_once_with(
+        NOTEBOOK_URI,
+        executable="/usr/bin/python",
+        working_directory="/workspace",
+        create_if_missing=True,
+    )
 
 
 @pytest.mark.asyncio
@@ -124,12 +187,19 @@ async def test_execute_scratch_claims_idle_session_before_dispatch() -> None:
                 notebook_uri=NOTEBOOK_URI,
                 executable="/usr/bin/python",
                 working_directory="/workspace",
+                marimo_version="1.2.3-rc1+build.7",
                 inner=ExecuteScratchRequest(code="print('later')", run_id="run-1"),
             ),
         )
 
     assert session.wait_until_idle.await_count == 2
     assert session.try_start_scratchpad.call_count == 2
+    sessions.start.assert_awaited_once_with(
+        NOTEBOOK_URI,
+        "/usr/bin/python",
+        "/workspace",
+        "1.2.3-rc1+build.7",
+    )
     session.put_control_request.assert_called_once()
 
 

--- a/tests/test_native_kernel.py
+++ b/tests/test_native_kernel.py
@@ -10,7 +10,7 @@ from unittest.mock import Mock
 
 import pytest
 
-from marimo_lsp.kernels.manager import Manager
+from marimo_lsp.kernels.manager import Manager, launch_kernel
 from marimo_lsp.kernels.native import NativeKernels
 
 if TYPE_CHECKING:
@@ -32,7 +32,8 @@ def _manager(notebook: Path, working_directory: str) -> Manager:
 def test_supplied_working_directory_reaches_launch_kernel(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    launch = Mock(return_value=Mock())
+    launched = Mock(marimo_version="1.2.3-rc1+build.7")
+    launch = Mock(return_value=launched)
     monkeypatch.setattr("marimo_lsp.kernels.manager.launch_kernel", launch)
     selected = tmp_path / "selected"
     selected.mkdir()
@@ -41,6 +42,111 @@ def test_supplied_working_directory_reaches_launch_kernel(
     manager.start_kernel()
 
     assert launch.call_args.kwargs["cwd"] == str(selected)
+    assert manager.marimo_version == "1.2.3-rc1+build.7"
+
+
+def test_kernel_reports_exact_marimo_version_from_launched_process(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    process = Mock()
+    process.stdout.readline.side_effect = [
+        b'{"marimo_version":"1.2.3-rc1+build.7"}\n',
+        b"KERNEL_READY\n",
+    ]
+    popen = Mock(return_value=process)
+    monkeypatch.setattr("marimo_lsp.kernels.manager.subprocess.Popen", popen)
+    args = Mock()
+    args.encode_json.return_value = b"{}"
+
+    kernel_process = launch_kernel("/python", args, cwd="/workspace")
+
+    assert kernel_process.marimo_version == "1.2.3-rc1+build.7"
+    command = popen.call_args.args[0]
+    assert command[:2] == ["/python", "-c"]
+    assert "runpy.run_module" in command[2]
+    assert popen.call_args.kwargs["cwd"] == "/workspace"
+
+
+@pytest.mark.parametrize(
+    ("version_line", "error_type"),
+    [
+        (b"", RuntimeError),
+        (b"not-json\n", RuntimeError),
+        (b'{"marimo_version": 123}\n', TypeError),
+    ],
+)
+def test_invalid_kernel_version_response_cleans_up_process(
+    version_line: bytes,
+    error_type: type[Exception],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    process = Mock()
+    process.stdout.readline.return_value = version_line
+    process.stderr.read.return_value = b"bootstrap failed"
+    process.poll.side_effect = [None, 1]
+    monkeypatch.setattr(
+        "marimo_lsp.kernels.manager.subprocess.Popen",
+        Mock(return_value=process),
+    )
+    args = Mock()
+    args.encode_json.return_value = b"{}"
+
+    with pytest.raises(error_type, match="bootstrap failed"):
+        launch_kernel("/python", args)
+
+    process.terminate.assert_called_once_with()
+    process.wait.assert_called_once()
+
+
+def test_invalid_ready_response_cleans_up_process(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    process = Mock()
+    process.stdout.readline.side_effect = [
+        b'{"marimo_version":"1.2.3"}\n',
+        b"NOT_READY\n",
+    ]
+    process.stderr.read.return_value = b"kernel failed"
+    process.poll.side_effect = [None, None, 1]
+    monkeypatch.setattr(
+        "marimo_lsp.kernels.manager.subprocess.Popen",
+        Mock(return_value=process),
+    )
+    args = Mock()
+    args.encode_json.return_value = b"{}"
+
+    with pytest.raises(RuntimeError, match="kernel failed"):
+        launch_kernel("/python", args)
+
+    process.terminate.assert_called_once_with()
+    process.wait.assert_called_once()
+
+
+@pytest.mark.parametrize("failure", ["write", "decode"])
+def test_unexpected_bootstrap_failure_cleans_up_process(
+    failure: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    process = Mock()
+    process.poll.return_value = None
+    if failure == "write":
+        process.stdin.write.side_effect = BrokenPipeError("closed pipe")
+        error_type = BrokenPipeError
+    else:
+        process.stdout.readline.return_value = b"\xff\n"
+        error_type = UnicodeDecodeError
+    monkeypatch.setattr(
+        "marimo_lsp.kernels.manager.subprocess.Popen",
+        Mock(return_value=process),
+    )
+    args = Mock()
+    args.encode_json.return_value = b"{}"
+
+    with pytest.raises(error_type):
+        launch_kernel("/python", args)
+
+    process.terminate.assert_called_once_with()
+    process.wait.assert_called_once()
 
 
 @pytest.mark.parametrize("kind", ["relative", "missing", "file"])

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -380,6 +380,7 @@ def test_sessions_changed_notification_contains_public_snapshot() -> None:
         started_at=42,
         status="idle",
         attached=False,
+        marimo_version="1.2.3",
     )
     sessions._sessions["file:///test.py"] = session
 
@@ -398,6 +399,7 @@ def test_sessions_changed_notification_contains_public_snapshot() -> None:
                     "startedAt": 42,
                     "status": "idle",
                     "attached": False,
+                    "marimoVersion": "1.2.3",
                 }
             ]
         },
@@ -409,10 +411,14 @@ async def test_start_reuses_session_with_same_executable() -> None:
     sessions = Sessions(Mock(), kernels=Mock())
     current = Mock(spec=Session)
     current.executable = "/usr/bin/python"
+    current.marimo_version = "1.2.3"
+    current.environment_version = "1.2.3"
     sessions._sessions["file:///test.py"] = current
     sessions._create = AsyncMock()
 
-    result = await sessions.start("file:///test.py", "/usr/bin/python", "/workspace")
+    result = await sessions.start(
+        "file:///test.py", "/usr/bin/python", "/workspace", "1.2.3"
+    )
 
     assert result is current
     current.attach.assert_called_once_with()
@@ -424,6 +430,8 @@ async def test_start_reuses_same_executable_despite_new_working_directory() -> N
     sessions = Sessions(Mock(), kernels=Mock())
     current = Mock(spec=Session)
     current.executable = "/usr/bin/python"
+    current.marimo_version = "1.2.3"
+    current.environment_version = "1.2.3"
     sessions._sessions["file:///test.py"] = current
     sessions._create = AsyncMock()
 
@@ -437,6 +445,107 @@ async def test_start_reuses_same_executable_despite_new_working_directory() -> N
 
 
 @pytest.mark.asyncio
+async def test_start_reuses_known_version_when_request_is_unknown() -> None:
+    sessions = Sessions(Mock(), kernels=Mock())
+    current = Mock(spec=Session)
+    current.executable = "/usr/bin/python"
+    current.marimo_version = "1.2.3"
+    current.environment_version = "1.2.3"
+    sessions._sessions["file:///test.py"] = current
+    sessions._create = AsyncMock()
+
+    result = await sessions.start(
+        "file:///test.py", "/usr/bin/python", "/workspace", None
+    )
+
+    assert result is current
+    assert result.marimo_version == "1.2.3"
+    sessions._create.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_start_compares_environment_hint_instead_of_kernel_version() -> None:
+    sessions = Sessions(Mock(), kernels=Mock())
+    current = Mock(spec=Session)
+    current.executable = "/usr/bin/python"
+    current.environment_version = "1.2.3"
+    current.marimo_version = "1.2.4"
+    sessions._sessions["file:///test.py"] = current
+    sessions._create = AsyncMock()
+
+    result = await sessions.start(
+        "file:///test.py", "/usr/bin/python", "/workspace", "1.2.3"
+    )
+
+    assert result is current
+    assert result.marimo_version == "1.2.4"
+    current.attach.assert_called_once_with()
+    sessions._create.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("environment_version", [None, "1.2.3"])
+async def test_start_adopts_version_confirmed_by_live_kernel(
+    environment_version: str | None,
+) -> None:
+    sessions = Sessions(Mock(), kernels=Mock())
+    current = Mock(spec=Session)
+    current.executable = "/usr/bin/python"
+    current.environment_version = environment_version
+    current.marimo_version = "1.2.4"
+    current.adopt_environment_version.side_effect = lambda value: setattr(
+        current, "environment_version", value
+    )
+    sessions._sessions["file:///test.py"] = current
+    sessions._create = AsyncMock()
+
+    result = await sessions.start(
+        "file:///test.py", "/usr/bin/python", "/workspace", "1.2.4"
+    )
+
+    assert result is current
+    assert result.environment_version == "1.2.4"
+    current.adopt_environment_version.assert_called_once_with("1.2.4")
+    current.attach.assert_called_once_with()
+    sessions._create.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("current_version", "requested_version"),
+    [("1.2.3", "1.2.4"), (None, "1.2.3")],
+)
+async def test_start_replaces_session_when_known_version_changes(
+    current_version: str | None,
+    requested_version: str,
+) -> None:
+    sessions = Sessions(Mock(), kernels=Mock())
+    current = Mock(spec=Session)
+    current.executable = "/usr/bin/python"
+    current.environment_version = current_version
+    current.marimo_version = "kernel-version"
+    replacement = Mock(spec=Session)
+    replacement.marimo_version = requested_version
+    sessions._sessions["file:///test.py"] = current
+    sessions._create = AsyncMock(return_value=replacement)
+    sessions._notify_changed = Mock()
+
+    result = await sessions.start(
+        "file:///test.py", "/usr/bin/python", "/workspace", requested_version
+    )
+
+    assert result is replacement
+    sessions._create.assert_awaited_once_with(
+        "file:///test.py",
+        "/usr/bin/python",
+        "/workspace",
+        environment_version=requested_version,
+    )
+    assert result.marimo_version == requested_version
+    current.close.assert_called_once_with()
+
+
+@pytest.mark.asyncio
 async def test_start_replaces_session_after_replacement_starts() -> None:
     events: list[str] = []
     sessions = Sessions(Mock(), kernels=Mock())
@@ -444,6 +553,7 @@ async def test_start_replaces_session_after_replacement_starts() -> None:
     current.executable = "/old/python"
     current.close.side_effect = lambda: events.append("old closed")
     replacement = Mock(spec=Session)
+    replacement.marimo_version = "1.2.4"
     replacement.describe.return_value = Mock()
     replacement.activate.side_effect = lambda: events.append("new activated")
     sessions._sessions["file:///test.py"] = current
@@ -570,6 +680,7 @@ async def test_startup_message_handoff_preserves_order(
     second = KernelMessage(b'{"op": "second"}')
     third = KernelMessage(b'{"op": "third"}')
     kernel = Mock()
+    kernel.marimo_version = "1.2.3-rc1+build.7"
     receive_callback: list[Callable[[KernelMessage], None]] = []
 
     async def launch(**kwargs: object) -> object:
@@ -595,6 +706,7 @@ async def test_startup_message_handoff_preserves_order(
     previous.config_manager.get_config.return_value = DEFAULT_CONFIG
     previous.session_view = Mock()
     previous.started_at = 42
+    previous.marimo_version = "1.2.3-rc1+build.7"
     loop_thread = threading.get_ident()
     observed: list[tuple[KernelMessage, int]] = []
     third_delivered = asyncio.Event()
@@ -606,12 +718,15 @@ async def test_startup_message_handoff_preserves_order(
 
     monkeypatch.setattr(Session, "accept_kernel_message", accept)
 
-    await sessions._create(
+    created = await sessions._create(
         "file:///test.py",
         "/usr/bin/python",
         "/workspace",
         previous=previous,
     )
+    assert created.marimo_version == "1.2.3-rc1+build.7"
+    assert created.environment_version is None
+    assert created.session_view is previous.session_view
     threading.Thread(target=receive_callback[0], args=(third,), daemon=True).start()
     await asyncio.wait_for(third_delivered.wait(), timeout=1)
 
@@ -620,6 +735,46 @@ async def test_startup_message_handoff_preserves_order(
         (second, loop_thread),
         (third, loop_thread),
     ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("previous_version", "kernel_version"),
+    [
+        ("1.2.3", "1.2.4"),
+        (None, None),
+        (None, "1.2.4"),
+        ("1.2.3", None),
+    ],
+)
+async def test_session_creation_drops_view_without_known_matching_versions(
+    previous_version: str | None,
+    kernel_version: str | None,
+) -> None:
+    kernel = Mock()
+    kernel.marimo_version = kernel_version
+    kernels = Mock()
+    kernels.launch = AsyncMock(return_value=kernel)
+    sessions = Sessions(Mock(), kernels=kernels)
+    previous = Mock(spec=Session)
+    previous.app_file_manager = Mock()
+    previous.config_manager = Mock()
+    previous.config_manager.get_config.return_value = DEFAULT_CONFIG
+    previous.session_view = SessionView()
+    previous.started_at = 42
+    previous.marimo_version = previous_version
+
+    created = await sessions._create(
+        "file:///test.py",
+        "/usr/bin/python",
+        "/workspace",
+        environment_version="1.2.3",
+        previous=previous,
+    )
+
+    assert created.marimo_version == kernel_version
+    assert created.environment_version == "1.2.3"
+    assert created.session_view is not previous.session_view
 
 
 @pytest.mark.asyncio
@@ -661,11 +816,14 @@ async def test_restart_replaces_kernel_without_reloading_closed_notebook() -> No
     current = Mock(spec=Session)
     current.executable = "/usr/bin/python"
     current.working_directory = "/workspace"
+    current.marimo_version = "1.2.3"
+    current.environment_version = "1.2.3"
     current.attached = False
     current.session_view = Mock()
     current.started_at = 42
     current.close.side_effect = lambda: events.append("old closed")
     replacement = Mock(spec=Session)
+    replacement.marimo_version = "1.2.4"
     replacement.activate.side_effect = lambda: events.append("new activated")
     sessions._sessions["file:///test.py"] = current
     sessions._create = AsyncMock(return_value=replacement)
@@ -684,8 +842,10 @@ async def test_restart_replaces_kernel_without_reloading_closed_notebook() -> No
         "file:///test.py",
         "/usr/bin/python",
         "/workspace",
+        environment_version="1.2.3",
         previous=current,
     )
+    assert result.marimo_version == "1.2.4"
     replacement.detach.assert_called_once_with(notify=False)
     current.close.assert_called_once_with()
     sessions._notify_changed.assert_called_once_with()
@@ -697,6 +857,7 @@ async def test_restart_replaces_kernel_without_reloading_closed_notebook() -> No
 async def test_restore_uses_requested_working_directory() -> None:
     sessions = Sessions(Mock(), kernels=Mock())
     replacement = Mock(spec=Session)
+    replacement.marimo_version = "1.2.4"
     sessions._create = AsyncMock(return_value=replacement)
     sessions._notify_changed = Mock()
 
@@ -709,8 +870,11 @@ async def test_restore_uses_requested_working_directory() -> None:
 
     assert result is replacement
     sessions._create.assert_called_once_with(
-        "file:///test.py", "/usr/bin/python", "/workspace"
+        "file:///test.py",
+        "/usr/bin/python",
+        "/workspace",
     )
+    assert result.marimo_version == "1.2.4"
 
 
 @pytest.mark.asyncio

--- a/tests/test_wasm_bridge.py
+++ b/tests/test_wasm_bridge.py
@@ -174,7 +174,10 @@ def test_bridge_launches_kernel_subprocess_over_marimo_ipc(
     """
     bridge_module = _load_bridge_module(monkeypatch)
     process = Mock()
-    process.stdout.readline.return_value = b"KERNEL_READY\n"
+    process.stdout.readline.side_effect = [
+        b'{"marimo_version":"1.2.3-rc1+build.7"}\n',
+        b"KERNEL_READY\n",
+    ]
     process.stderr = None
     popen = Mock(return_value=process)
     write_frame = Mock()
@@ -187,7 +190,8 @@ def test_bridge_launches_kernel_subprocess_over_marimo_ipc(
 
         popen.assert_called_once()
         command = popen.call_args.args[0]
-        assert command == [sys.executable, "-m", "marimo._ipc.launch_kernel"]
+        assert command[:2] == [sys.executable, "-c"]
+        assert "runpy.run_module" in command[2]
         assert popen.call_args.kwargs["cwd"] == str(tmp_path)
         assert popen.call_args.kwargs["stdin"] is bridge_module.subprocess.PIPE
         assert popen.call_args.kwargs["stdout"] is bridge_module.subprocess.PIPE
@@ -195,7 +199,9 @@ def test_bridge_launches_kernel_subprocess_over_marimo_ipc(
         sent = KernelLaunchArgs.decode_json(process.stdin.write.call_args.args[0])
         assert sent.connection_info is not None
         assert sent.parent_pid == os.getpid()
-        write_frame.assert_any_call(bridge_module.Ready())
+        write_frame.assert_any_call(
+            bridge_module.Ready(marimo_version="1.2.3-rc1+build.7")
+        )
     finally:
         bridge.close()
 

--- a/tests/test_wasm_kernel.py
+++ b/tests/test_wasm_kernel.py
@@ -83,8 +83,12 @@ async def _begin_launch():
 async def _launch_kernel():
     callbacks, kernels, launch, messages = await _begin_launch()
     process_id = callbacks.spawns[0][0]
-    kernels.accept(process_id, encode(Ready()))
+    kernels.accept(
+        process_id,
+        encode(Ready(marimo_version="1.2.3-rc1+build.7")),
+    )
     kernel = await launch
+    assert kernel.marimo_version == "1.2.3-rc1+build.7"
     return callbacks, kernels, kernel, messages
 
 
@@ -98,6 +102,21 @@ async def test_wasm_launch_fails_before_publishing_unready_kernel() -> None:
     with pytest.raises(KernelOpenError, match="failed to start"):
         await launch
     assert callbacks.closes == snapshot([process_id])
+
+
+@pytest.mark.asyncio
+async def test_wasm_launch_accepts_legacy_ready_without_version() -> None:
+    callbacks, kernels, launch, _messages = await _begin_launch()
+    process_id = callbacks.spawns[0][0]
+    payload = b'{"type":"ready","version":1}'
+
+    kernels.accept(
+        process_id,
+        len(payload).to_bytes(4, byteorder="big") + payload,
+    )
+
+    kernel = await launch
+    assert kernel.marimo_version is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Saved session outputs are compatible only with the exact marimo version that produced them. An executable path is not enough since its environment can change in place, and client inspection can differ from the process that launches.

Kernel environment resolution carries the inspected version as a reuse hint, while native and WASM kernels report their own exact version as session provenance. Keeping those identities separate lets restore and restart reuse a confirmed live kernel without treating inspection as proof of output compatibility. Session views survive only known, exact producer matches; unknown and mismatched versions fail closed.
