### PR TITLE
Decode marimo saved session outputs

### DIFF
--- a/extension/src/notebook/__tests__/loadSavedSessionOutputs.test.ts
+++ b/extension/src/notebook/__tests__/loadSavedSessionOutputs.test.ts
@@ -1,0 +1,527 @@
+import * as NodeFs from "node:fs";
+import * as NodeOs from "node:os";
+import * as NodePath from "node:path";
+import * as NodeProcess from "node:process";
+
+import { NodeServices } from "@effect/platform-node";
+import { assert, describe, expect, it } from "@effect/vitest";
+import { Deferred, Effect, Fiber, Layer, Option, Ref } from "effect";
+import { TestClock } from "effect/testing";
+
+import { Uri } from "../../__mocks__/TestVsCode.ts";
+import { makeTestMarimoClient } from "../../__tests__/__utils__/TestMarimoClient.ts";
+import type { MarimoApiCall } from "../../types.ts";
+import { loadSavedSessionOutputs } from "../loadSavedSessionOutputs.ts";
+
+const isWindows = NodeProcess.platform === "win32";
+
+it.effect(
+  "does not probe non-file notebooks",
+  Effect.fn(function* () {
+    const calls = yield* Ref.make<ReadonlyArray<MarimoApiCall>>([]);
+    const layer = Layer.merge(
+      NodeServices.layer,
+      makeTestMarimoClient({
+        execute: (request) =>
+          Ref.update(calls, (current) => [...current, request]),
+      }),
+    );
+    const uri = Uri.parse("untitled:Untitled-1");
+
+    const result = yield* loadSavedSessionOutputs({
+      notebook: { isClosed: false, uri, version: 1 },
+      executable: "/does/not/exist",
+      workingDirectory: "/does/not/exist",
+    }).pipe(Effect.provide(layer));
+
+    assert(Option.isNone(result));
+    expect(yield* Ref.get(calls)).toEqual([]);
+  }),
+);
+
+it.effect(
+  "does not probe a missing or non-file notebook path",
+  Effect.fn(function* () {
+    const directory = yield* tempDirectory;
+    const missing = Uri.file(NodePath.join(directory, "missing.py"));
+    const directoryPath = NodePath.join(directory, "directory.py");
+    NodeFs.mkdirSync(directoryPath);
+    const layer = Layer.merge(
+      NodeServices.layer,
+      makeTestMarimoClient({ execute: () => Effect.die("unexpected call") }),
+    );
+
+    for (const notebookUri of [missing, Uri.file(directoryPath)]) {
+      const result = yield* loadSavedSessionOutputs({
+        notebook: { isClosed: false, uri: notebookUri, version: 1 },
+        executable: "/does/not/exist",
+        workingDirectory: directory,
+      }).pipe(Effect.provide(layer));
+      assert(Option.isNone(result));
+    }
+  }),
+);
+
+describe.skipIf(isWindows)("loadSavedSessionOutputs", () => {
+  it.effect(
+    "reads the located sidecar and sends its contents with exact provenance",
+    Effect.fn(function* () {
+      const directory = yield* tempDirectory;
+      const workingDirectory = NodePath.join(directory, "working directory");
+      NodeFs.mkdirSync(workingDirectory);
+      const notebookPath = NodePath.join(
+        directory,
+        "notebook 'Δ' with spaces\nand newline.py",
+      );
+      NodeFs.writeFileSync(notebookPath, "# notebook");
+      const cachePath = NodePath.join(directory, "saved session.json");
+      const invocationPath = NodePath.join(directory, "invocation.txt");
+      const executable = makeProbeExecutable(directory, {
+        name: "python",
+        result: JSON.stringify({
+          marimoVersion: "0.24.0.dev1+local",
+          cachePath,
+        }),
+        stdout: "sitecustomize noise",
+        invocationPath,
+      });
+      NodeFs.writeFileSync(cachePath, "saved contents");
+
+      const calls = yield* Ref.make<ReadonlyArray<MarimoApiCall>>([]);
+      const layer = Layer.merge(
+        NodeServices.layer,
+        makeTestMarimoClient({
+          execute: (request) =>
+            Ref.update(calls, (current) => [...current, request]).pipe(
+              Effect.as({
+                outputs: [
+                  {
+                    cellId: "cell-1",
+                    output: {
+                      channel: "output",
+                      mimetype: "text/plain",
+                      data: "42",
+                    },
+                    console: [],
+                  },
+                ],
+                marimoVersion: "0.24.0.dev1+local",
+                notebookVersion: 7,
+              }),
+            ),
+        }),
+      );
+      const uri = Uri.file(notebookPath);
+
+      const result = yield* loadSavedSessionOutputs({
+        notebook: { isClosed: false, uri, version: 7 },
+        executable,
+        workingDirectory,
+      }).pipe(Effect.provide(layer));
+
+      assert(Option.isSome(result));
+      expect(result.value).toEqual({
+        outputs: [
+          {
+            cellId: "cell-1",
+            output: {
+              channel: "output",
+              mimetype: "text/plain",
+              data: "42",
+            },
+            console: [],
+          },
+        ],
+        marimoVersion: "0.24.0.dev1+local",
+        notebookVersion: 7,
+      });
+      expect(yield* Ref.get(calls)).toEqual([
+        {
+          method: "decode-saved-session",
+          params: {
+            notebookUri: uri.toString(),
+            inner: {
+              contents: "saved contents",
+              marimoVersion: "0.24.0.dev1+local",
+              notebookVersion: 7,
+            },
+          },
+        },
+      ]);
+      expect(NodeFs.readFileSync(invocationPath, "utf8")).toBe(
+        `${NodeFs.realpathSync(workingDirectory)}\n${notebookPath}`,
+      );
+    }),
+  );
+
+  it.effect(
+    "treats an oversized sidecar as a cache miss before decoding",
+    Effect.fn(function* () {
+      const directory = yield* tempDirectory;
+      const notebookPath = NodePath.join(directory, "notebook.py");
+      const cachePath = NodePath.join(directory, "large.json");
+      NodeFs.writeFileSync(cachePath, "");
+      NodeFs.writeFileSync(notebookPath, "# notebook");
+      NodeFs.truncateSync(cachePath, 64 * 1024 * 1024 + 1);
+      const executable = makeProbeExecutable(directory, {
+        name: "python-large",
+        result: JSON.stringify({ marimoVersion: "0.24.0", cachePath }),
+      });
+      const calls = yield* Ref.make<ReadonlyArray<MarimoApiCall>>([]);
+      const uri = Uri.file(notebookPath);
+
+      const result = yield* loadSavedSessionOutputs({
+        notebook: { isClosed: false, uri, version: 1 },
+        executable,
+        workingDirectory: directory,
+      }).pipe(
+        Effect.provide(
+          Layer.merge(
+            NodeServices.layer,
+            makeTestMarimoClient({
+              execute: (request) =>
+                Ref.update(calls, (current) => [...current, request]),
+            }),
+          ),
+        ),
+      );
+
+      assert(Option.isNone(result));
+      expect(yield* Ref.get(calls)).toEqual([]);
+    }),
+  );
+
+  it.effect(
+    "treats malformed probe output and invalid UTF-8 as cache misses",
+    Effect.fn(function* () {
+      const directory = yield* tempDirectory;
+      const notebookPath = NodePath.join(directory, "notebook.py");
+      const invalidCachePath = NodePath.join(directory, "invalid.json");
+      NodeFs.writeFileSync(invalidCachePath, Uint8Array.of(0xff));
+      NodeFs.writeFileSync(notebookPath, "# notebook");
+      const malformed = makeProbeExecutable(directory, {
+        name: "python-malformed",
+        result: "not a probe result",
+      });
+      const relativePath = makeProbeExecutable(directory, {
+        name: "python-relative-path",
+        result: JSON.stringify({
+          marimoVersion: "0.24.0",
+          cachePath: "relative/session.json",
+        }),
+      });
+      const invalidUtf8 = makeProbeExecutable(directory, {
+        name: "python-invalid-utf8",
+        result: JSON.stringify({
+          marimoVersion: "0.24.0",
+          cachePath: invalidCachePath,
+        }),
+      });
+      const uri = Uri.file(notebookPath);
+      const layer = Layer.merge(
+        NodeServices.layer,
+        makeTestMarimoClient({ execute: () => Effect.die("unexpected call") }),
+      );
+
+      for (const executable of [malformed, relativePath, invalidUtf8]) {
+        const result = yield* loadSavedSessionOutputs({
+          notebook: { isClosed: false, uri, version: 1 },
+          executable,
+          workingDirectory: directory,
+        }).pipe(Effect.provide(layer));
+        assert(Option.isNone(result));
+      }
+    }),
+  );
+
+  it.effect(
+    "bounds a stalled language-server decode request",
+    Effect.fn(function* () {
+      const directory = yield* tempDirectory;
+      const notebookPath = NodePath.join(directory, "notebook.py");
+      const cachePath = NodePath.join(directory, "saved.json");
+      NodeFs.writeFileSync(notebookPath, "# notebook");
+      NodeFs.writeFileSync(cachePath, "saved contents");
+      const executable = makeProbeExecutable(directory, {
+        name: "python-stalled-api",
+        result: JSON.stringify({ marimoVersion: "0.24.0", cachePath }),
+      });
+      const started = yield* Deferred.make<void>();
+      const layer = Layer.merge(
+        NodeServices.layer,
+        makeTestMarimoClient({
+          execute: () =>
+            Deferred.succeed(started, undefined).pipe(
+              Effect.andThen(Effect.never),
+            ),
+        }),
+      );
+      const uri = Uri.file(notebookPath);
+      const fiber = yield* loadSavedSessionOutputs({
+        notebook: { isClosed: false, uri, version: 1 },
+        executable,
+        workingDirectory: directory,
+      }).pipe(Effect.provide(layer), Effect.forkChild);
+
+      yield* Deferred.await(started);
+      yield* TestClock.adjust("10 seconds");
+
+      assert(Option.isNone(yield* Fiber.join(fiber)));
+    }),
+  );
+
+  it.effect(
+    "drops a result when the notebook changes during decoding",
+    Effect.fn(function* () {
+      const directory = yield* tempDirectory;
+      const notebookPath = NodePath.join(directory, "notebook.py");
+      const cachePath = NodePath.join(directory, "saved.json");
+      NodeFs.writeFileSync(notebookPath, "# notebook");
+      NodeFs.writeFileSync(cachePath, "saved contents");
+      const executable = makeProbeExecutable(directory, {
+        name: "python-edited-notebook",
+        result: JSON.stringify({ marimoVersion: "0.24.0", cachePath }),
+      });
+      const notebook = {
+        isClosed: false,
+        uri: Uri.file(notebookPath),
+        version: 1,
+      };
+      const layer = Layer.merge(
+        NodeServices.layer,
+        makeTestMarimoClient({
+          execute: () =>
+            Effect.sync(() => {
+              notebook.version = 2;
+              return {
+                outputs: [],
+                marimoVersion: "0.24.0",
+                notebookVersion: 1,
+              };
+            }),
+        }),
+      );
+
+      const result = yield* loadSavedSessionOutputs({
+        notebook,
+        executable,
+        workingDirectory: directory,
+      }).pipe(Effect.provide(layer));
+
+      assert(Option.isNone(result));
+    }),
+  );
+
+  it.effect(
+    "drops a result when the notebook closes during decoding",
+    Effect.fn(function* () {
+      const directory = yield* tempDirectory;
+      const notebookPath = NodePath.join(directory, "notebook.py");
+      const cachePath = NodePath.join(directory, "saved.json");
+      NodeFs.writeFileSync(notebookPath, "# notebook");
+      NodeFs.writeFileSync(cachePath, "saved contents");
+      const executable = makeProbeExecutable(directory, {
+        name: "python-closed-notebook",
+        result: JSON.stringify({ marimoVersion: "0.24.0", cachePath }),
+      });
+      const notebook = {
+        isClosed: false,
+        uri: Uri.file(notebookPath),
+        version: 1,
+      };
+      const layer = Layer.merge(
+        NodeServices.layer,
+        makeTestMarimoClient({
+          execute: () =>
+            Effect.sync(() => {
+              notebook.isClosed = true;
+              return {
+                outputs: [],
+                marimoVersion: "0.24.0",
+                notebookVersion: 1,
+              };
+            }),
+        }),
+      );
+
+      const result = yield* loadSavedSessionOutputs({
+        notebook,
+        executable,
+        workingDirectory: directory,
+      }).pipe(Effect.provide(layer));
+
+      assert(Option.isNone(result));
+    }),
+  );
+
+  it.effect(
+    "force-kills a probe that ignores graceful termination",
+    Effect.fn(function* () {
+      const directory = yield* tempDirectory;
+      const notebookPath = NodePath.join(directory, "notebook.py");
+      const pidPath = NodePath.join(directory, "probe.pid");
+      NodeFs.writeFileSync(notebookPath, "# notebook");
+      const executable = makeStalledExecutable(directory, pidPath);
+      const uri = Uri.file(notebookPath);
+      const layer = Layer.merge(
+        NodeServices.layer,
+        makeTestMarimoClient({ execute: () => Effect.die("unexpected call") }),
+      );
+      const fiber = yield* loadSavedSessionOutputs({
+        notebook: { isClosed: false, uri, version: 1 },
+        executable,
+        workingDirectory: directory,
+      }).pipe(Effect.provide(layer), Effect.forkChild);
+      const pid = yield* Effect.promise(() => waitForPid(pidPath, 100));
+
+      yield* TestClock.adjust("10 seconds");
+      yield* Effect.yieldNow;
+      yield* TestClock.adjust("1 second");
+
+      assert(Option.isNone(yield* Fiber.join(fiber)));
+      expect(() => NodeProcess.kill(pid, 0)).toThrow();
+    }),
+  );
+
+  it.effect(
+    "kills descendants left by a successful probe",
+    Effect.fn(function* () {
+      const directory = yield* tempDirectory;
+      const notebookPath = NodePath.join(directory, "notebook.py");
+      const cachePath = NodePath.join(directory, "saved.json");
+      const pidPath = NodePath.join(directory, "descendant.pid");
+      NodeFs.writeFileSync(notebookPath, "# notebook");
+      NodeFs.writeFileSync(cachePath, "saved contents");
+      const executable = makeExitedLeaderExecutable(directory, {
+        cachePath,
+        pidPath,
+      });
+      const uri = Uri.file(notebookPath);
+      const layer = Layer.merge(
+        NodeServices.layer,
+        makeTestMarimoClient({
+          execute: () =>
+            Effect.succeed({
+              outputs: [],
+              marimoVersion: "0.24.0",
+              notebookVersion: 1,
+            }),
+        }),
+      );
+
+      const result = yield* loadSavedSessionOutputs({
+        notebook: { isClosed: false, uri, version: 1 },
+        executable,
+        workingDirectory: directory,
+      }).pipe(Effect.provide(layer));
+
+      assert(Option.isSome(result));
+      const pid = Number.parseInt(NodeFs.readFileSync(pidPath, "utf8"), 10);
+      yield* Effect.promise(() => waitForProcessExit(pid, 100));
+    }),
+  );
+});
+
+const tempDirectory = Effect.acquireRelease(
+  Effect.sync(
+    () =>
+      NodeFs.mkdtempDisposableSync(
+        NodePath.join(NodeOs.tmpdir(), "marimo-saved-session-"),
+      ).path,
+  ),
+  (path) => Effect.sync(() => NodeFs.rmSync(path, { recursive: true })),
+);
+
+function makeProbeExecutable(
+  directory: string,
+  options: {
+    readonly name: string;
+    readonly result: string;
+    readonly stdout?: string;
+    readonly invocationPath?: string;
+  },
+) {
+  const executable = NodePath.join(directory, options.name);
+  const lines = ["#!/bin/bash"];
+  if (options.invocationPath !== undefined) {
+    lines.push(
+      `printf '%s\\n%s' "$PWD" "$3" > ${shellEscape(options.invocationPath)}`,
+    );
+  }
+  if (options.stdout !== undefined) {
+    lines.push(`printf '%s' ${shellEscape(options.stdout)}`);
+  }
+  lines.push(`printf '%s' ${shellEscape(options.result)} > "$4"`);
+  NodeFs.writeFileSync(executable, lines.join("\n"), { mode: 0o755 });
+  return executable;
+}
+
+function makeExitedLeaderExecutable(
+  directory: string,
+  options: { readonly cachePath: string; readonly pidPath: string },
+) {
+  const executable = NodePath.join(directory, "python-exited-probe");
+  const descendant = [
+    'process.on("SIGTERM", () => {});',
+    "setInterval(() => {}, 1000);",
+  ].join("");
+  const result = JSON.stringify({
+    marimoVersion: "0.24.0",
+    cachePath: options.cachePath,
+  });
+  NodeFs.writeFileSync(
+    executable,
+    [
+      "#!/bin/bash",
+      `node -e ${shellEscape(descendant)} >/dev/null 2>&1 &`,
+      `printf '%s' "$!" > ${shellEscape(options.pidPath)}`,
+      `printf '%s' ${shellEscape(result)} > "$4"`,
+    ].join("\n"),
+    { mode: 0o755 },
+  );
+  return executable;
+}
+
+function makeStalledExecutable(directory: string, pidPath: string) {
+  const executable = NodePath.join(directory, "python-stalled-probe");
+  NodeFs.writeFileSync(
+    executable,
+    [
+      "#!/usr/bin/env node",
+      'const fs = require("node:fs");',
+      'process.on("SIGTERM", () => {});',
+      `fs.writeFileSync(${JSON.stringify(pidPath)}, String(process.pid));`,
+      "setInterval(() => {}, 1000);",
+    ].join("\n"),
+    { mode: 0o755 },
+  );
+  return executable;
+}
+
+async function waitForPid(pidPath: string, attempts: number): Promise<number> {
+  try {
+    return Number.parseInt(NodeFs.readFileSync(pidPath, "utf8"), 10);
+  } catch {
+    if (attempts === 0) throw new Error("probe did not start");
+    await new Promise<void>((resolve) => setTimeout(resolve, 10));
+    return waitForPid(pidPath, attempts - 1);
+  }
+}
+
+async function waitForProcessExit(
+  pid: number,
+  attempts: number,
+): Promise<void> {
+  try {
+    NodeProcess.kill(pid, 0);
+  } catch {
+    return;
+  }
+  if (attempts === 0) throw new Error(`process ${pid} is still running`);
+  await new Promise<void>((resolve) => setTimeout(resolve, 10));
+  return waitForProcessExit(pid, attempts - 1);
+}
+
+function shellEscape(value: string) {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}

--- a/extension/src/notebook/loadSavedSessionOutputs.ts
+++ b/extension/src/notebook/loadSavedSessionOutputs.ts
@@ -1,0 +1,242 @@
+import * as NodePath from "node:path";
+
+import {
+  Data,
+  Duration,
+  Effect,
+  FileSystem,
+  Option,
+  Schema,
+  Stream,
+} from "effect";
+import { ChildProcess } from "effect/unstable/process";
+import type * as vscode from "vscode";
+
+import { MarimoClient } from "../lsp/MarimoClient.ts";
+import { NotebookIdFromString } from "../schemas/Models.gen.ts";
+
+const MAX_SAVED_SESSION_BYTES = 64 * 1024 * 1024;
+const MAX_PROBE_OUTPUT_BYTES = 1024 * 1024;
+const LOAD_TIMEOUT = Duration.seconds(10);
+const FORCE_KILL_AFTER = Duration.seconds(1);
+
+const ProbeResult = Schema.Struct({
+  marimoVersion: Schema.String,
+  cachePath: Schema.String,
+});
+
+class SavedSessionProbeError extends Data.TaggedError(
+  "SavedSessionProbeError",
+)<{
+  readonly reason:
+    | "exit"
+    | "invalid-path"
+    | "invalid-utf8"
+    | "output-too-large"
+    | "not-a-file"
+    | "provenance";
+}> {}
+
+interface LoadSavedSessionOptions {
+  readonly notebook: Pick<
+    vscode.NotebookDocument,
+    "isClosed" | "uri" | "version"
+  >;
+  readonly executable: string;
+  readonly workingDirectory: string;
+}
+
+const PROBE = `\
+import io, json, os, pathlib, sys
+
+sys.stdout = io.StringIO()
+
+import marimo
+from marimo._session.state.serialize import get_session_cache_file
+
+_cache_path = get_session_cache_file(pathlib.Path(sys.argv[1]))
+_payload = {
+    "marimoVersion": marimo.__version__,
+    "cachePath": os.path.abspath(os.fspath(_cache_path)),
+}
+
+with open(sys.argv[2], "w", encoding="utf-8") as _result:
+    json.dump(_payload, _result)
+`;
+
+/**
+ * Load outputs saved by marimo CLI for one local, ordinary Python notebook.
+ *
+ * The selected interpreter owns cache-location and version semantics. The
+ * extension owns the bounded file read; the language server only receives
+ * contents and validates them against its synchronized notebook snapshot.
+ */
+export const loadSavedSessionOutputs = Effect.fn("loadSavedSessionOutputs")(
+  function* (options: LoadSavedSessionOptions) {
+    const notebookUri = options.notebook.uri;
+    const notebookVersion = options.notebook.version;
+    if (
+      options.notebook.isClosed ||
+      notebookUri.scheme !== "file" ||
+      !NodePath.isAbsolute(notebookUri.fsPath) ||
+      NodePath.extname(notebookUri.fsPath).toLowerCase() !== ".py"
+    ) {
+      return Option.none();
+    }
+
+    return yield* Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const marimo = yield* MarimoClient;
+      const notebookId = yield* Schema.decodeUnknownEffect(
+        NotebookIdFromString,
+      )(notebookUri.toString());
+      const notebookStat = yield* fs.stat(notebookUri.fsPath);
+      if (notebookStat.type !== "File") {
+        return yield* new SavedSessionProbeError({ reason: "not-a-file" });
+      }
+      yield* fs.access(notebookUri.fsPath, { readable: true });
+
+      const probe = yield* runProbe(options);
+      if (!NodePath.isAbsolute(probe.cachePath)) {
+        return yield* new SavedSessionProbeError({ reason: "invalid-path" });
+      }
+      const stat = yield* fs.stat(probe.cachePath);
+      if (stat.type !== "File" || stat.size > BigInt(MAX_SAVED_SESSION_BYTES)) {
+        return yield* new SavedSessionProbeError({ reason: "not-a-file" });
+      }
+
+      const contents = yield* collectUtf8(
+        fs.stream(probe.cachePath, {
+          bytesToRead: MAX_SAVED_SESSION_BYTES + 1,
+        }),
+        MAX_SAVED_SESSION_BYTES,
+      );
+      if (
+        options.notebook.isClosed ||
+        options.notebook.version !== notebookVersion
+      ) {
+        return yield* new SavedSessionProbeError({ reason: "provenance" });
+      }
+      const decoded = yield* marimo.decodeSavedSession({
+        notebookUri: notebookId,
+        inner: {
+          contents,
+          marimoVersion: probe.marimoVersion,
+          notebookVersion,
+        },
+      });
+      if (
+        decoded.marimoVersion !== probe.marimoVersion ||
+        decoded.notebookVersion !== notebookVersion ||
+        options.notebook.isClosed ||
+        options.notebook.version !== notebookVersion
+      ) {
+        return yield* new SavedSessionProbeError({ reason: "provenance" });
+      }
+      return decoded;
+    }).pipe(
+      Effect.timeout(LOAD_TIMEOUT),
+      Effect.tapCause((cause) =>
+        Effect.logDebug("Saved session unavailable").pipe(
+          Effect.annotateLogs({
+            cause,
+            notebookUri: notebookUri.toString(),
+          }),
+        ),
+      ),
+      Effect.option,
+    );
+  },
+);
+
+const runProbe = Effect.fnUntraced(function* (
+  options: LoadSavedSessionOptions,
+) {
+  const fs = yield* FileSystem.FileSystem;
+  return yield* Effect.gen(function* () {
+    const resultPath = yield* fs.makeTempFileScoped({
+      prefix: "marimo-saved-session-probe-",
+      suffix: ".json",
+    });
+    const command = ChildProcess.make(
+      options.executable,
+      ["-c", PROBE, options.notebook.uri.fsPath, resultPath],
+      {
+        cwd: options.workingDirectory,
+        extendEnv: true,
+        forceKillAfter: FORCE_KILL_AFTER,
+        stdout: "ignore",
+        stderr: "ignore",
+      },
+    );
+    const exitCode = yield* command.pipe(
+      Effect.flatMap((handle) =>
+        handle.exitCode.pipe(
+          Effect.ensuring(
+            handle
+              .kill({ forceKillAfter: FORCE_KILL_AFTER })
+              .pipe(
+                Effect.andThen(handle.kill({ killSignal: "SIGKILL" })),
+                Effect.ignore,
+              ),
+          ),
+        ),
+      ),
+    );
+    if (exitCode !== 0) {
+      return yield* new SavedSessionProbeError({ reason: "exit" });
+    }
+    const stat = yield* fs.stat(resultPath);
+    if (stat.type !== "File" || stat.size > BigInt(MAX_PROBE_OUTPUT_BYTES)) {
+      return yield* new SavedSessionProbeError({ reason: "output-too-large" });
+    }
+    const result = yield* collectUtf8(
+      fs.stream(resultPath, { bytesToRead: MAX_PROBE_OUTPUT_BYTES + 1 }),
+      MAX_PROBE_OUTPUT_BYTES,
+    );
+    return yield* Schema.decodeUnknownEffect(
+      Schema.fromJsonString(ProbeResult),
+    )(result);
+  }).pipe(Effect.scoped);
+});
+
+function collectUtf8<E, R>(
+  stream: Stream.Stream<Uint8Array, E, R>,
+  limit: number,
+) {
+  return stream.pipe(
+    Stream.runFoldEffect(
+      () => ({
+        decoder: new TextDecoder("utf-8", { fatal: true }),
+        parts: [] as Array<string>,
+        size: 0,
+      }),
+      (collected, chunk) => {
+        const size = collected.size + chunk.length;
+        if (size > limit) {
+          return Effect.fail(
+            new SavedSessionProbeError({ reason: "output-too-large" }),
+          );
+        }
+        return Effect.try({
+          try: () => {
+            collected.parts.push(
+              collected.decoder.decode(chunk, { stream: true }),
+            );
+            return { ...collected, size };
+          },
+          catch: () => new SavedSessionProbeError({ reason: "invalid-utf8" }),
+        });
+      },
+    ),
+    Effect.flatMap(({ decoder, parts }) => {
+      return Effect.try({
+        try: () => {
+          parts.push(decoder.decode());
+          return parts.join("");
+        },
+        catch: () => new SavedSessionProbeError({ reason: "invalid-utf8" }),
+      });
+    }),
+  );
+}

--- a/extension/src/schemas/Models.gen.ts
+++ b/extension/src/schemas/Models.gen.ts
@@ -21,6 +21,19 @@ const VariablesNotification = Schema.declare<VariablesNotification>(
     Schema.is(MarimoNotification)(value) && value.op === "variables",
 );
 
+type CellOperationNotification = Extract<MarimoNotification, { op: "cell-op" }>;
+type MarimoCellOutput = NonNullable<CellOperationNotification["output"]>;
+const MarimoCellOutput = Schema.declare<MarimoCellOutput>(
+  (value): value is MarimoCellOutput =>
+    typeof value === "object" &&
+    value !== null &&
+    "channel" in value &&
+    typeof value.channel === "string" &&
+    "mimetype" in value &&
+    typeof value.mimetype === "string" &&
+    "data" in value,
+);
+
 // The id is an opaque token minted by the server; only equality matters.
 // Validating its shape here would turn a harmless server-side format
 // change into silently dropped notifications.
@@ -420,6 +433,36 @@ export const SetDisplayThemeRequest = Schema.Struct({
   theme: Schema.Literals(["dark", "light"]),
 }).annotate({ identifier: "SetDisplayThemeRequest" });
 export type SetDisplayThemeRequest = typeof SetDisplayThemeRequest.Type;
+
+/**
+ * Saved-session contents read by the extension from the kernel environment.
+ */
+export const DecodeSavedSessionRequest = Schema.Struct({
+  contents: Schema.String,
+  marimoVersion: Schema.String,
+  notebookVersion: Schema.Int,
+}).annotate({ identifier: "DecodeSavedSessionRequest" });
+export type DecodeSavedSessionRequest = typeof DecodeSavedSessionRequest.Type;
+
+/**
+ * Archived display data for one current notebook cell.
+ */
+export const SavedCellOutput = Schema.Struct({
+  cellId: Schema.String,
+  output: Schema.NullOr(MarimoCellOutput),
+  console: Schema.Array(MarimoCellOutput),
+}).annotate({ identifier: "SavedCellOutput" });
+export type SavedCellOutput = typeof SavedCellOutput.Type;
+
+/**
+ * Compatible display outputs and the snapshot provenance they require.
+ */
+export const DecodeSavedSessionResponse = Schema.Struct({
+  outputs: Schema.Array(SavedCellOutput),
+  marimoVersion: Schema.String,
+  notebookVersion: Schema.Int,
+}).annotate({ identifier: "DecodeSavedSessionResponse" });
+export type DecodeSavedSessionResponse = typeof DecodeSavedSessionResponse.Type;
 
 /**
  * Serializable HTTP request representation.
@@ -1402,6 +1445,11 @@ export const SetDisplayThemePayload = Schema.Struct({
   theme: Schema.Literals(["dark", "light"]),
 });
 
+export const DecodeSavedSessionPayload = Schema.Struct({
+  notebookUri: NotebookIdFromString,
+  inner: DecodeSavedSessionRequest,
+});
+
 export const ExportAsHTMLRequest = Schema.Struct({
   download: Schema.Boolean,
   files: Schema.Array(Schema.String),
@@ -1529,6 +1577,10 @@ export type MarimoApiCall =
   | {
       readonly method: "set-display-theme";
       readonly params: typeof SetDisplayThemePayload.Encoded;
+    }
+  | {
+      readonly method: "decode-saved-session";
+      readonly params: typeof DecodeSavedSessionPayload.Encoded;
     }
   | {
       readonly method: "export-as-html";
@@ -1726,6 +1778,13 @@ export const makeApiClient = <E, R>(execute: Execute<E, R>) => ({
       { method: "set-display-theme", params },
       SetDisplayThemePayload,
       SetDisplayThemeResponse,
+    ),
+  decodeSavedSession: (params: typeof DecodeSavedSessionPayload.Encoded) =>
+    dispatch(
+      execute,
+      { method: "decode-saved-session", params },
+      DecodeSavedSessionPayload,
+      DecodeSavedSessionResponse,
     ),
   exportAsHtml: (params: typeof ExportAsHtmlPayload.Encoded) =>
     dispatch(

--- a/extension/src/schemas/__tests__/Models.gen.test.ts
+++ b/extension/src/schemas/__tests__/Models.gen.test.ts
@@ -3,6 +3,7 @@ import { Effect, Result, Schema } from "effect";
 
 import {
   CellMetadata,
+  DecodeSavedSessionResponse,
   ExecuteCellsPayload,
   ExecuteScratchRequest,
   GetPackageListPayload,
@@ -84,6 +85,34 @@ describe("Models.gen (msgspec → Effect Schema codegen)", () => {
       runId: "abc",
     });
     expect(Result.isFailure(missingCode)).toBe(true);
+  });
+
+  it("validates archived outputs independently from live cell operations", () => {
+    const valid = Schema.decodeUnknownResult(DecodeSavedSessionResponse)({
+      outputs: [
+        {
+          cellId: "cell-1",
+          output: {
+            channel: "output",
+            mimetype: "text/plain",
+            data: "42",
+          },
+          console: [],
+        },
+      ],
+      marimoVersion: "0.24.0",
+      notebookVersion: 3,
+    });
+    expect(Result.isSuccess(valid)).toBe(true);
+
+    const liveOperation = Schema.decodeUnknownResult(
+      DecodeSavedSessionResponse,
+    )({
+      outputs: [{ op: "cell-op", cell_id: "cell-1" }],
+      marimoVersion: "0.24.0",
+      notebookVersion: 3,
+    });
+    expect(Result.isFailure(liveOperation)).toBe(true);
   });
 
   it("decodes a generated package command payload", () => {

--- a/scripts/codegen/effect_schemas.py
+++ b/scripts/codegen/effect_schemas.py
@@ -51,6 +51,19 @@ const VariablesNotification = Schema.declare<VariablesNotification>(
     Schema.is(MarimoNotification)(value) && value.op === "variables",
 );
 
+type CellOperationNotification = Extract<MarimoNotification, { op: "cell-op" }>;
+type MarimoCellOutput = NonNullable<CellOperationNotification["output"]>;
+const MarimoCellOutput = Schema.declare<MarimoCellOutput>(
+  (value): value is MarimoCellOutput =>
+    typeof value === "object" &&
+    value !== null &&
+    "channel" in value &&
+    typeof value.channel === "string" &&
+    "mimetype" in value &&
+    typeof value.mimetype === "string" &&
+    "data" in value,
+);
+
 // The id is an opaque token minted by the server; only equality matters.
 // Validating its shape here would turn a harmless server-side format
 // change into silently dropped notifications.
@@ -90,6 +103,9 @@ CONCRETE: list[tuple[str, type | object]] = [
     ("ExecuteScratchRequest", models.ExecuteScratchRequest),
     ("UpdateConfigurationRequest", models.UpdateConfigurationRequest),
     ("SetDisplayThemeRequest", models.SetDisplayThemeRequest),
+    ("DecodeSavedSessionRequest", models.DecodeSavedSessionRequest),
+    ("SavedCellOutput", models.SavedCellOutput),
+    ("DecodeSavedSessionResponse", models.DecodeSavedSessionResponse),
 ]
 
 
@@ -361,7 +377,10 @@ class Emitter:
             tag = _ts_string(str(t.tag))
             lines.append(f"{indent}{_prop(t.tag_field)}: Schema.Literal({tag}),")
         for field in t.fields:
-            if t.cls is models.KernelNotification and field.name == "notification":
+            saved_output = self.saved_output_field_expr(t, field)
+            if saved_output is not None:
+                expr = saved_output
+            elif t.cls is models.KernelNotification and field.name == "notification":
                 expr = "MarimoNotification"
             elif t.cls is models.DocumentAnalysis and field.name == "analysis":
                 expr = "VariablesNotification"
@@ -398,6 +417,16 @@ class Emitter:
                     )
             lines.append(f"{indent}{rendered},")
         return "\n".join(lines) + "\n" if lines else ""
+
+    @staticmethod
+    def saved_output_field_expr(t: _StructLike, field: mi.Field) -> str | None:
+        if t.cls is not models.SavedCellOutput:
+            return None
+        if field.name == "output":
+            return "Schema.NullOr(MarimoCellOutput)"
+        if field.name == "console":
+            return "Schema.Array(MarimoCellOutput)"
+        return None
 
     def default_expr(self, field: mi.Field) -> str | None:
         """Render the field default so decode fills omitted fields, like msgspec."""

--- a/src/marimo_lsp/api.py
+++ b/src/marimo_lsp/api.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import ast
+import asyncio
 import dataclasses
 import inspect
 import json
@@ -26,6 +27,7 @@ from marimo._export.requests import (
     MarkdownExportRequest,
 )
 from marimo._export.serialization import serialize_notebook_snapshot
+from marimo._messaging.cell_output import CellOutput
 from marimo._runtime.commands import (
     ExecuteScratchpadCommand,
     InvokeFunctionCommand,
@@ -43,10 +45,16 @@ from marimo._session.state.serialize import serialize_session_view
 from pygls.uris import to_fs_path
 from typing_extensions import TypeForm
 
-from marimo_lsp.app_file_manager import find_notebook_document, snapshot_for_scratchpad
+from marimo_lsp.app_file_manager import (
+    LspAppFileManager,
+    find_notebook_document,
+    snapshot_for_scratchpad,
+)
 from marimo_lsp.loggers import get_logger
 from marimo_lsp.models import (
     CloseSessionRequest,
+    DecodeSavedSessionRequest,
+    DecodeSavedSessionResponse,
     DeleteCellRequest,
     DependencyTreeRequest,
     DependencyTreeResponse,
@@ -75,6 +83,7 @@ from marimo_lsp.models import (
     NotebookDocument,
     PackageCommand,
     RestartSessionRequest,
+    SavedCellOutput,
     ScriptSource,
     SerializeResponse,
     SessionCommand,
@@ -87,6 +96,8 @@ from marimo_lsp.models import (
     VenvSource,
 )
 from marimo_lsp.package_manager import LspPackageManager
+from marimo_lsp.saved_sessions import decode_saved_session_view
+from marimo_lsp.utils import decode_notebook_document_metadata
 
 if TYPE_CHECKING:
     from marimo._config.config import (
@@ -815,6 +826,79 @@ async def set_display_theme(
         )
         session.update_runtime_config(updated)
     return SetDisplayThemeResponse(success=True)
+
+
+@marimo_api("decode-saved-session")
+async def decode_saved_session(
+    ctx: ApiContext,
+    args: NotebookCommand[DecodeSavedSessionRequest],
+) -> DecodeSavedSessionResponse:
+    """Decode saved display outputs against the synchronized notebook."""
+    empty = DecodeSavedSessionResponse(
+        outputs=[],
+        marimo_version=args.inner.marimo_version,
+        notebook_version=args.inner.notebook_version,
+    )
+    if ctx.sessions.is_live_or_starting(args.notebook_uri):
+        return empty
+
+    notebook = find_notebook_document(ctx.ls.workspace, args.notebook_uri)
+    if notebook.version != args.inner.notebook_version:
+        return empty
+
+    file_manager = LspAppFileManager(
+        server=ctx.ls,
+        notebook_uri=args.notebook_uri,
+    )
+    metadata = decode_notebook_document_metadata(notebook)
+    cell_manager = file_manager.app.cell_manager
+    codes = tuple(cell_manager.codes())
+    cell_ids = tuple(cell_manager.cell_ids())
+    view = await asyncio.to_thread(
+        decode_saved_session_view,
+        args.inner.contents,
+        codes=codes,
+        cell_ids=cell_ids,
+        marimo_version=args.inner.marimo_version,
+        header=metadata.header,
+    )
+    if view is None:
+        return empty
+    current_notebook = find_notebook_document(ctx.ls.workspace, args.notebook_uri)
+    if (
+        current_notebook is not notebook
+        or current_notebook.version != args.inner.notebook_version
+        or ctx.sessions.is_live_or_starting(args.notebook_uri)
+    ):
+        return empty
+
+    outputs = [
+        SavedCellOutput(
+            cell_id=cell_id,
+            output=notification.output,
+            console=[
+                output
+                for output in (
+                    notification.console
+                    if isinstance(notification.console, list)
+                    else [notification.console]
+                )
+                if isinstance(output, CellOutput)
+            ],
+        )
+        for cell_id in cell_ids
+        if (notification := view.cell_notifications.get(cell_id)) is not None
+        and (notification.output is not None or bool(notification.console))
+    ]
+    try:
+        json.dumps(msgspec.to_builtins(outputs), allow_nan=False)
+    except (TypeError, ValueError):
+        return empty
+    return DecodeSavedSessionResponse(
+        outputs=outputs,
+        marimo_version=args.inner.marimo_version,
+        notebook_version=args.inner.notebook_version,
+    )
 
 
 @marimo_api("export-as-html")

--- a/src/marimo_lsp/models.py
+++ b/src/marimo_lsp/models.py
@@ -14,6 +14,7 @@ import msgspec
 # are first encoded/inspected, which fails under TYPE_CHECKING-only imports.
 from marimo._config.config import MarimoConfig  # noqa: TC002
 from marimo._convert.common.format import DEFAULT_MARKDOWN_PREFIX
+from marimo._messaging.cell_output import CellOutput  # noqa: TC002
 from marimo._messaging.notification import (  # noqa: TC002
     NotificationMessage,
     VariablesNotification,
@@ -25,7 +26,7 @@ from marimo._schemas.notebook import (
     NotebookV1,
 )
 from marimo._server.models.packages import DependencyTreeNode  # noqa: TC002
-from marimo._types.ids import SessionId  # noqa: TC002
+from marimo._types.ids import CellId_t, SessionId  # noqa: TC002
 
 # NOTE: the generic structs below use the legacy TypeVar spelling (noqa: UP046)
 # because msgspec's annotation resolver cannot see PEP 695 type parameters —
@@ -421,6 +422,19 @@ class SetDisplayThemeRequest(msgspec.Struct, rename="camel"):
     """The theme to set ('light' or 'dark')."""
 
 
+class DecodeSavedSessionRequest(msgspec.Struct, rename="camel"):
+    """Saved-session contents read by the extension from the kernel environment."""
+
+    contents: str
+    """The bounded UTF-8 contents of the marimo session sidecar."""
+
+    marimo_version: str
+    """Exact version reported by the environment that located the sidecar."""
+
+    notebook_version: int
+    """Client revision expected to be synchronized in the language server."""
+
+
 class ApiRequest(msgspec.Struct, rename="camel"):
     """A unified API request for all marimo internal methods."""
 
@@ -463,6 +477,22 @@ class SetDisplayThemeResponse(msgspec.Struct, rename="camel"):
     """Response for ``set-display-theme``."""
 
     success: bool
+
+
+class SavedCellOutput(msgspec.Struct, rename="camel"):
+    """Archived display data for one current notebook cell."""
+
+    cell_id: CellId_t
+    output: CellOutput | None
+    console: list[CellOutput]
+
+
+class DecodeSavedSessionResponse(msgspec.Struct, rename="camel"):
+    """Compatible display outputs and the snapshot provenance they require."""
+
+    outputs: list[SavedCellOutput]
+    marimo_version: str
+    notebook_version: int
 
 
 ExecuteCellsRequest = core.ExecuteCellsRequest

--- a/src/marimo_lsp/saved_sessions.py
+++ b/src/marimo_lsp/saved_sessions.py
@@ -1,0 +1,189 @@
+# Copyright 2026 Marimo. All rights reserved.
+
+"""Decode display outputs saved by marimo CLI sessions."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Literal, cast
+
+import msgspec
+from marimo._messaging.notebook.document import NotebookDocument
+from marimo._session.state.serialize import (
+    SessionCacheKey,
+    SessionCacheManager,
+    deserialize_session,
+)
+from marimo._session.state.session_view import SessionView
+from marimo._utils.code import hash_code
+from marimo._utils.inline_script_metadata import read_pyproject_from_script
+
+from marimo_lsp.loggers import get_logger
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from marimo._schemas.session import NotebookSessionV1
+    from marimo._types.ids import CellId_t
+
+
+logger = get_logger()
+_MAX_SAVED_SESSION_BYTES = 64 * 1024 * 1024
+_SIZE_CHUNK_CHARACTERS = 1024 * 1024
+
+# TODO: Replace this adapter when marimo exposes a content-based session
+# reader. SessionCacheManager currently couples decoding to local filesystem
+# access, which cannot represent every VS Code workspace.
+
+
+class _DataOutput(msgspec.Struct, tag="data", tag_field="type"):
+    data: dict[str, object]
+
+
+class _ErrorOutput(msgspec.Struct, tag="error", tag_field="type"):
+    ename: str
+    evalue: str
+    # marimo's declared V1 schema says list[str], while its serializer writes
+    # the exception model's formatted HTML string or None.
+    traceback: list[str] | str | None
+
+
+type _Output = _DataOutput | _ErrorOutput
+
+
+class _StreamOutput(msgspec.Struct, tag="stream", tag_field="type"):
+    name: Literal["stdout", "stderr"]
+    text: str
+    # Keep MIME types open to additions made by newer marimo versions that
+    # retain the backwards-compatible V1 wire format.
+    mimetype: str | None = None
+
+
+class _StreamMediaOutput(msgspec.Struct, tag="streamMedia", tag_field="type"):
+    name: Literal["media"]
+    data: str
+    mimetype: str
+
+
+type _Console = _StreamOutput | _StreamMediaOutput
+
+
+class _Cell(msgspec.Struct):
+    id: str
+    code_hash: str | None
+    outputs: list[_Output]
+    console: list[_Console]
+
+
+class _Metadata(msgspec.Struct):
+    marimo_version: str | None
+    script_metadata_hash: str | None
+
+
+class _SavedSessionV1(msgspec.Struct):
+    version: Literal["1"]
+    metadata: _Metadata
+    cells: list[_Cell]
+
+
+def _script_metadata_hash(header: str | None) -> str | None:
+    try:
+        project = read_pyproject_from_script(header or "")
+    except Exception:  # noqa: BLE001 - parity with marimo's filename helper
+        # Match marimo's filename-based helper: malformed PEP 723 metadata is
+        # treated as absent rather than making the session cache unreadable.
+        return None
+    if project is None:
+        return None
+    return hash_code(
+        json.dumps(
+            project,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        )
+    )
+
+
+def _within_size_limit(contents: str) -> bool:
+    if len(contents) > _MAX_SAVED_SESSION_BYTES:
+        return False
+
+    encoded_size = 0
+    try:
+        for start in range(0, len(contents), _SIZE_CHUNK_CHARACTERS):
+            encoded_size += len(
+                contents[start : start + _SIZE_CHUNK_CHARACTERS].encode("utf-8")
+            )
+            if encoded_size > _MAX_SAVED_SESSION_BYTES:
+                return False
+    except (MemoryError, UnicodeEncodeError):
+        return False
+    return True
+
+
+def decode_saved_session_view(
+    contents: str,
+    *,
+    codes: Iterable[str],
+    cell_ids: Iterable[CellId_t],
+    marimo_version: str | None,
+    header: str | None,
+) -> SessionView | None:
+    """Decode a compatible marimo session sidecar, if one can be proven.
+
+    ``codes``, ``cell_ids``, and ``header`` must come from the same synchronized
+    notebook snapshot. Deriving the PEP 723 hash here keeps every cache-key
+    component on the language-server side of that boundary.
+    """
+    if marimo_version is None or not _within_size_limit(contents):
+        return None
+
+    current_codes = tuple(codes)
+    current_cell_ids = tuple(cell_ids)
+    code_hashes = tuple(hash_code(code) for code in current_codes if code)
+    if (
+        len(current_codes) != len(current_cell_ids)
+        or len(current_cell_ids) != len(set(current_cell_ids))
+        or len(code_hashes) != len(set(code_hashes))
+    ):
+        return None
+
+    manager = SessionCacheManager(
+        session_view=SessionView(),
+        document=NotebookDocument([]),
+        path=None,
+        interval=1,
+    )
+    try:
+        script_metadata_hash = _script_metadata_hash(header)
+        decoded = msgspec.convert(
+            json.loads(contents),
+            type=_SavedSessionV1,
+        )
+        notebook_session = cast(
+            "NotebookSessionV1",
+            msgspec.to_builtins(decoded),
+        )
+        key = SessionCacheKey(
+            codes=current_codes,
+            marimo_version=marimo_version,
+            cell_ids=current_cell_ids,
+            script_metadata_hash=script_metadata_hash,
+        )
+        if not manager.is_cache_hit(notebook_session, key):
+            return None
+
+        code_hash_to_cell_id = {
+            hash_code(code): cell_id
+            for code, cell_id in zip(
+                current_codes,
+                current_cell_ids,
+                strict=True,
+            )
+            if code
+        }
+        return deserialize_session(notebook_session, code_hash_to_cell_id)
+    except Exception:
+        logger.exception("Ignored malformed saved session")
+        return None

--- a/src/marimo_lsp/sessions.py
+++ b/src/marimo_lsp/sessions.py
@@ -580,6 +580,14 @@ class Sessions:
         with self._lock:
             return self._sessions.get(notebook_uri)
 
+    def is_live_or_starting(self, notebook_uri: str) -> bool:
+        """Return whether live state owns this notebook URI."""
+        with self._lock:
+            lifecycle_lock = self._lifecycle_locks.get(notebook_uri)
+            return notebook_uri in self._sessions or (
+                lifecycle_lock is not None and lifecycle_lock.locked()
+            )
+
     def cancel_scratchpad(self, notebook_uri: str, run_id: str) -> None:
         """Remember a cancellation and interrupt only its active scratchpad."""
         key = (notebook_uri, run_id)

--- a/tests/test_saved_session_api.py
+++ b/tests/test_saved_session_api.py
@@ -1,0 +1,315 @@
+# Copyright 2026 Marimo. All rights reserved.
+
+"""Tests for decoding saved outputs against the synchronized LSP document."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, cast
+from unittest.mock import MagicMock, patch
+
+import lsprotocol.types as lsp
+import msgspec
+import pytest
+from marimo import __version__
+from marimo._messaging.cell_output import CellChannel, CellOutput
+from marimo._messaging.notification import CellNotification
+from marimo._session.state.serialize import serialize_session_view
+from marimo._session.state.session_view import SessionView
+from marimo._types.ids import CellId_t
+from marimo._utils.code import hash_code
+from marimo._utils.inline_script_metadata import read_pyproject_from_script
+
+from marimo_lsp.api import ApiContext, decode_saved_session, handle_api_command
+from marimo_lsp.models import DecodeSavedSessionRequest, NotebookCommand
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+NOTEBOOK_URI = "file:///workspace/notebook.py"
+CELL_URI = f"{NOTEBOOK_URI}#cell"
+SAVED_ID = CellId_t("saved")
+CURRENT_ID = CellId_t("current")
+CODE = "answer = 42\nanswer"
+HEADER = """# /// script
+# dependencies = ["polars"]
+# ///
+"""
+
+
+def _metadata(value: dict[str, object]) -> lsp.LSPObject:
+    return cast("lsp.LSPObject", value)
+
+
+def _saved_contents() -> str:
+    project = read_pyproject_from_script(HEADER)
+    assert project is not None
+    script_metadata_hash = hash_code(
+        json.dumps(
+            project,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        )
+    )
+    view = SessionView()
+    view.cell_notifications[SAVED_ID] = CellNotification(
+        cell_id=SAVED_ID,
+        status="idle",
+        output=CellOutput(
+            channel=CellChannel.OUTPUT,
+            mimetype="text/plain",
+            data="42",
+        ),
+    )
+    view.last_executed_code[SAVED_ID] = CODE
+    return json.dumps(
+        serialize_session_view(
+            view,
+            cell_ids=[SAVED_ID],
+            drop_virtual_file_outputs=True,
+            script_metadata_hash=script_metadata_hash,
+        )
+    )
+
+
+def _context(*, code: str = CODE, header: str = HEADER) -> ApiContext:
+    notebook = lsp.NotebookDocument(
+        uri=NOTEBOOK_URI,
+        notebook_type="marimo-notebook",
+        version=1,
+        cells=[
+            lsp.NotebookCell(
+                kind=lsp.NotebookCellKind.Code,
+                document=CELL_URI,
+                metadata=_metadata({"marimoRuntime": {"stableId": str(CURRENT_ID)}}),
+            )
+        ],
+        metadata=_metadata({"marimo": {"header": header}}),
+    )
+    workspace = MagicMock()
+    workspace.notebook_documents = {NOTEBOOK_URI: notebook}
+    workspace.text_documents = {CELL_URI: MagicMock(source=code, language_id="python")}
+    server = MagicMock(workspace=workspace)
+    sessions = MagicMock()
+    sessions.get.return_value = None
+    sessions.is_live_or_starting.return_value = False
+    return ApiContext(ls=server, sessions=sessions)
+
+
+@pytest.mark.asyncio
+async def test_decodes_output_without_restoring_runtime_state() -> None:
+    result = await decode_saved_session(
+        _context(),
+        NotebookCommand(
+            notebook_uri=NOTEBOOK_URI,
+            inner=DecodeSavedSessionRequest(
+                contents=_saved_contents(),
+                marimo_version=__version__,
+                notebook_version=1,
+            ),
+        ),
+    )
+
+    [output] = result.outputs
+    assert output.cell_id == CURRENT_ID
+    assert output.output is not None
+    assert output.output.data == "42"
+    assert output.console == []
+    assert result.marimo_version == __version__
+    assert result.notebook_version == 1
+
+
+@pytest.mark.asyncio
+async def test_omits_cells_without_saved_display_data() -> None:
+    payload = json.loads(_saved_contents())
+    payload["cells"][0]["outputs"] = []
+
+    result = await decode_saved_session(
+        _context(),
+        NotebookCommand(
+            notebook_uri=NOTEBOOK_URI,
+            inner=DecodeSavedSessionRequest(
+                contents=json.dumps(payload),
+                marimo_version=__version__,
+                notebook_version=1,
+            ),
+        ),
+    )
+
+    assert result.outputs == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "context",
+    [
+        pytest.param(_context(code="answer = 43"), id="edited-code"),
+        pytest.param(_context(header=HEADER.replace("polars", "pandas")), id="header"),
+    ],
+)
+async def test_incompatible_synchronized_snapshot_returns_no_outputs(
+    context: ApiContext,
+) -> None:
+    result = await decode_saved_session(
+        context,
+        NotebookCommand(
+            notebook_uri=NOTEBOOK_URI,
+            inner=DecodeSavedSessionRequest(
+                contents=_saved_contents(),
+                marimo_version=__version__,
+                notebook_version=1,
+            ),
+        ),
+    )
+
+    assert result.outputs == []
+
+
+@pytest.mark.asyncio
+async def test_rejects_unsynchronized_document_revision() -> None:
+    result = await decode_saved_session(
+        _context(),
+        NotebookCommand(
+            notebook_uri=NOTEBOOK_URI,
+            inner=DecodeSavedSessionRequest(
+                contents=_saved_contents(),
+                marimo_version=__version__,
+                notebook_version=2,
+            ),
+        ),
+    )
+
+    assert result.outputs == []
+    assert result.notebook_version == 2
+
+
+@pytest.mark.asyncio
+async def test_drops_output_when_document_changes_during_decode() -> None:
+    context = _context()
+
+    async def decode_then_edit(
+        decoder: Callable[..., object],
+        *args: object,
+        **kwargs: object,
+    ) -> object:
+        result = decoder(*args, **kwargs)
+        context.ls.workspace.notebook_documents[NOTEBOOK_URI].version = 2
+        return result
+
+    with patch("marimo_lsp.api.asyncio.to_thread", side_effect=decode_then_edit):
+        result = await decode_saved_session(
+            context,
+            NotebookCommand(
+                notebook_uri=NOTEBOOK_URI,
+                inner=DecodeSavedSessionRequest(
+                    contents=_saved_contents(),
+                    marimo_version=__version__,
+                    notebook_version=1,
+                ),
+            ),
+        )
+
+    assert result.outputs == []
+
+
+@pytest.mark.asyncio
+async def test_drops_output_when_document_is_reopened_during_decode() -> None:
+    context = _context()
+
+    async def decode_then_reopen(
+        decoder: Callable[..., object],
+        *args: object,
+        **kwargs: object,
+    ) -> object:
+        result = decoder(*args, **kwargs)
+        reopened = _context().ls.workspace.notebook_documents[NOTEBOOK_URI]
+        context.ls.workspace.notebook_documents[NOTEBOOK_URI] = reopened
+        return result
+
+    with patch("marimo_lsp.api.asyncio.to_thread", side_effect=decode_then_reopen):
+        result = await decode_saved_session(
+            context,
+            NotebookCommand(
+                notebook_uri=NOTEBOOK_URI,
+                inner=DecodeSavedSessionRequest(
+                    contents=_saved_contents(),
+                    marimo_version=__version__,
+                    notebook_version=1,
+                ),
+            ),
+        )
+
+    assert result.outputs == []
+
+
+@pytest.mark.asyncio
+async def test_rejects_any_live_kernel() -> None:
+    context = _context()
+    sessions = MagicMock()
+    sessions.is_live_or_starting.return_value = True
+    context = ApiContext(ls=context.ls, sessions=sessions)
+
+    result = await decode_saved_session(
+        context,
+        NotebookCommand(
+            notebook_uri=NOTEBOOK_URI,
+            inner=DecodeSavedSessionRequest(
+                contents=_saved_contents(),
+                marimo_version=__version__,
+                notebook_version=1,
+            ),
+        ),
+    )
+
+    assert result.outputs == []
+
+
+@pytest.mark.asyncio
+async def test_drops_output_when_kernel_starts_during_decode() -> None:
+    context = _context()
+    sessions = MagicMock()
+    sessions.is_live_or_starting.side_effect = [False, True]
+    context = ApiContext(ls=context.ls, sessions=sessions)
+
+    result = await decode_saved_session(
+        context,
+        NotebookCommand(
+            notebook_uri=NOTEBOOK_URI,
+            inner=DecodeSavedSessionRequest(
+                contents=_saved_contents(),
+                marimo_version=__version__,
+                notebook_version=1,
+            ),
+        ),
+    )
+
+    assert result.outputs == []
+
+
+@pytest.mark.asyncio
+async def test_non_finite_output_is_a_json_wire_safe_cache_miss() -> None:
+    payload = json.loads(_saved_contents())
+    payload["cells"][0]["outputs"][0]["data"]["text/plain"] = float("nan")
+    context = _context()
+    params = msgspec.to_builtins(
+        NotebookCommand(
+            notebook_uri=NOTEBOOK_URI,
+            inner=DecodeSavedSessionRequest(
+                contents=json.dumps(payload),
+                marimo_version=__version__,
+                notebook_version=1,
+            ),
+        )
+    )
+
+    result = await handle_api_command(
+        context.ls,
+        context.sessions,
+        "decode-saved-session",
+        params,
+    )
+
+    wire = cast("dict[str, object]", result)
+    assert wire["outputs"] == []
+    json.dumps(wire, allow_nan=False)

--- a/tests/test_saved_session_decoder.py
+++ b/tests/test_saved_session_decoder.py
@@ -1,0 +1,362 @@
+# Copyright 2026 Marimo. All rights reserved.
+
+"""Tests for the marimo-compatible saved-session decoder."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from marimo import __version__
+from marimo._messaging.cell_output import CellChannel, CellOutput
+from marimo._messaging.errors import MarimoExceptionRaisedError
+from marimo._messaging.notification import CellNotification
+from marimo._session.state.serialize import serialize_session_view
+from marimo._session.state.session_view import SessionView
+from marimo._types.ids import CellId_t
+from marimo._utils.code import hash_code
+from marimo._utils.inline_script_metadata import read_pyproject_from_script
+
+from marimo_lsp import saved_sessions
+from marimo_lsp.saved_sessions import decode_saved_session_view
+
+SAVED_ID = CellId_t("saved")
+CURRENT_ID = CellId_t("current")
+SECOND_CURRENT_ID = CellId_t("current-2")
+CODE = "answer = 42\nanswer"
+SECOND_CODE = "other = 7\nother"
+HEADER = """# /// script
+# dependencies = [\"polars\"]
+# ///
+"""
+
+
+def _script_metadata_hash(header: str) -> str:
+    project = read_pyproject_from_script(header)
+    assert project is not None
+    return hash_code(
+        json.dumps(
+            project,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        )
+    )
+
+
+SCRIPT_METADATA_HASH = _script_metadata_hash(HEADER)
+
+
+def _saved_session_contents() -> str:
+    view = SessionView()
+    view.cell_notifications[SAVED_ID] = CellNotification(
+        cell_id=SAVED_ID,
+        status="idle",
+        output=CellOutput(
+            channel=CellChannel.OUTPUT,
+            mimetype="text/html",
+            data="<strong>42</strong>",
+        ),
+        console=[
+            CellOutput(
+                channel=CellChannel.STDOUT,
+                mimetype="text/plain",
+                data="ready\n",
+            )
+        ],
+    )
+    view.last_executed_code[SAVED_ID] = CODE
+    saved = serialize_session_view(
+        view,
+        cell_ids=[SAVED_ID],
+        drop_virtual_file_outputs=True,
+        script_metadata_hash=SCRIPT_METADATA_HASH,
+    )
+    return json.dumps(saved)
+
+
+def _decode(
+    contents: str | None = None,
+    *,
+    version: str | None = __version__,
+):
+    return decode_saved_session_view(
+        contents if contents is not None else _saved_session_contents(),
+        codes=(CODE,),
+        cell_ids=(CURRENT_ID,),
+        marimo_version=version,
+        header=HEADER,
+    )
+
+
+def test_decodes_compatible_outputs_by_code_hash() -> None:
+    restored = _decode()
+
+    assert restored is not None
+    assert set(restored.cell_notifications) == {CURRENT_ID}
+    notification = restored.cell_notifications[CURRENT_ID]
+    assert notification.status == "idle"
+    assert notification.timestamp == 0
+    assert notification.output is not None
+    assert notification.output.channel == CellChannel.OUTPUT
+    assert notification.output.mimetype == "text/html"
+    assert notification.output.data == "<strong>42</strong>"
+    assert isinstance(notification.console, list)
+    [console] = notification.console
+    assert isinstance(console, CellOutput)
+    assert console.channel == CellChannel.STDOUT
+    assert console.data == "ready\n"
+    assert restored.last_executed_code == {}
+
+
+@pytest.mark.parametrize("traceback", [None, "<span>traceback</span>"])
+def test_decodes_exception_outputs_written_by_marimo(
+    traceback: str | None,
+) -> None:
+    view = SessionView()
+    view.cell_notifications[SAVED_ID] = CellNotification(
+        cell_id=SAVED_ID,
+        status="idle",
+        output=CellOutput.errors(
+            [
+                MarimoExceptionRaisedError(
+                    msg="bad value",
+                    exception_type="ValueError",
+                    raising_cell=None,
+                    traceback=traceback,
+                )
+            ]
+        ),
+    )
+    view.last_executed_code[SAVED_ID] = CODE
+    saved = serialize_session_view(
+        view,
+        cell_ids=[SAVED_ID],
+        drop_virtual_file_outputs=True,
+        script_metadata_hash=SCRIPT_METADATA_HASH,
+    )
+
+    restored = _decode(json.dumps(saved))
+
+    assert restored is not None
+    output = restored.cell_notifications[CURRENT_ID].output
+    assert output is not None
+    assert output.channel == CellChannel.MARIMO_ERROR
+
+
+@pytest.mark.parametrize(
+    "data",
+    [{"value": float("nan")}, "\ud800"],
+    ids=["non-finite-number", "escaped-lone-surrogate"],
+)
+def test_decodes_mime_data_written_by_marimo(
+    data: str | dict[str, float],
+) -> None:
+    view = SessionView()
+    view.cell_notifications[SAVED_ID] = CellNotification(
+        cell_id=SAVED_ID,
+        status="idle",
+        output=CellOutput(
+            channel=CellChannel.OUTPUT,
+            mimetype="application/json",
+            data=data,
+        ),
+    )
+    view.last_executed_code[SAVED_ID] = CODE
+    saved = serialize_session_view(
+        view,
+        cell_ids=[SAVED_ID],
+        drop_virtual_file_outputs=True,
+        script_metadata_hash=SCRIPT_METADATA_HASH,
+    )
+
+    restored = _decode(json.dumps(saved))
+
+    assert restored is not None
+    assert restored.cell_notifications[CURRENT_ID].output is not None
+
+
+@pytest.mark.parametrize(
+    ("codes", "cell_ids", "version"),
+    [
+        (("changed",), (CURRENT_ID,), __version__),
+        ((CODE,), (CURRENT_ID,), "0.0.0"),
+        ((CODE,), (), __version__),
+    ],
+    ids=["code", "version", "unaligned-key"],
+)
+def test_rejects_incompatible_cache_keys(
+    codes: tuple[str, ...],
+    cell_ids: tuple[CellId_t, ...],
+    version: str,
+) -> None:
+    assert (
+        decode_saved_session_view(
+            _saved_session_contents(),
+            codes=codes,
+            cell_ids=cell_ids,
+            marimo_version=version,
+            header=HEADER,
+        )
+        is None
+    )
+
+
+def test_rejects_changed_script_metadata() -> None:
+    assert (
+        decode_saved_session_view(
+            _saved_session_contents(),
+            codes=(CODE,),
+            cell_ids=(CURRENT_ID,),
+            marimo_version=__version__,
+            header=HEADER.replace("polars", "pandas"),
+        )
+        is None
+    )
+
+
+def test_accepts_notebook_without_script_metadata() -> None:
+    payload = json.loads(_saved_session_contents())
+    payload["metadata"]["script_metadata_hash"] = None
+
+    assert (
+        decode_saved_session_view(
+            json.dumps(payload),
+            codes=(CODE,),
+            cell_ids=(CURRENT_ID,),
+            marimo_version=__version__,
+            header=None,
+        )
+        is not None
+    )
+
+
+def test_malformed_script_metadata_matches_marimo_missing_hash_semantics() -> None:
+    payload = json.loads(_saved_session_contents())
+    payload["metadata"]["script_metadata_hash"] = None
+    malformed_header = HEADER + HEADER
+
+    assert (
+        decode_saved_session_view(
+            json.dumps(payload),
+            codes=(CODE,),
+            cell_ids=(CURRENT_ID,),
+            marimo_version=__version__,
+            header=malformed_header,
+        )
+        is not None
+    )
+
+
+def test_unknown_kernel_version_fails_closed() -> None:
+    assert _decode(version=None) is None
+
+
+def test_accepts_v1_cache_from_matching_foreign_kernel_version() -> None:
+    payload = json.loads(_saved_session_contents())
+    payload["metadata"]["marimo_version"] = "0.23.3"
+
+    assert _decode(json.dumps(payload), version="0.23.3") is not None
+
+
+@pytest.mark.parametrize("wire_version", [None, "999"])
+def test_rejects_missing_or_unsupported_wire_version(
+    wire_version: str | None,
+) -> None:
+    payload = json.loads(_saved_session_contents())
+    if wire_version is None:
+        del payload["version"]
+    else:
+        payload["version"] = wire_version
+
+    assert _decode(json.dumps(payload)) is None
+
+
+def test_duplicate_code_hashes_fail_closed() -> None:
+    payload = json.loads(_saved_session_contents())
+    duplicate = json.loads(json.dumps(payload["cells"][0]))
+    duplicate["id"] = "saved-2"
+    duplicate["outputs"][0]["data"]["text/html"] = "<strong>second</strong>"
+    payload["cells"].append(duplicate)
+
+    assert (
+        decode_saved_session_view(
+            json.dumps(payload),
+            codes=(CODE, CODE),
+            cell_ids=(CURRENT_ID, SECOND_CURRENT_ID),
+            marimo_version=__version__,
+            header=HEADER,
+        )
+        is None
+    )
+
+
+def test_duplicate_current_cell_ids_fail_closed() -> None:
+    payload = json.loads(_saved_session_contents())
+    second = json.loads(json.dumps(payload["cells"][0]))
+    second["id"] = "saved-2"
+    second["code_hash"] = hash_code(SECOND_CODE)
+    payload["cells"].append(second)
+
+    assert (
+        decode_saved_session_view(
+            json.dumps(payload),
+            codes=(CODE, SECOND_CODE),
+            cell_ids=(CURRENT_ID, CURRENT_ID),
+            marimo_version=__version__,
+            header=HEADER,
+        )
+        is None
+    )
+
+
+def test_invalid_json_fails_closed() -> None:
+    assert _decode("not json") is None
+
+
+def test_invalid_cell_shape_fails_closed() -> None:
+    payload = json.loads(_saved_session_contents())
+    payload["cells"][0] = None
+
+    assert _decode(json.dumps(payload)) is None
+
+
+def test_unknown_output_type_fails_closed() -> None:
+    payload = json.loads(_saved_session_contents())
+    payload["cells"][0]["outputs"][0]["type"] = "future"
+
+    assert _decode(json.dumps(payload)) is None
+
+
+def test_invalid_console_name_fails_closed() -> None:
+    payload = json.loads(_saved_session_contents())
+    payload["cells"][0]["console"][0]["name"] = "stdin"
+
+    assert _decode(json.dumps(payload)) is None
+
+
+def test_oversized_contents_fail_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(saved_sessions, "_MAX_SAVED_SESSION_BYTES", 8)
+
+    assert _decode(" " * 9) is None
+
+
+def test_oversized_character_count_returns_before_encoding(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class MustNotEncode(str):
+        __slots__ = ()
+
+        def encode(
+            self,
+            encoding: str = "utf-8",
+            errors: str = "strict",
+        ) -> bytes:
+            del encoding, errors
+            raise AssertionError
+
+    monkeypatch.setattr(saved_sessions, "_MAX_SAVED_SESSION_BYTES", 8)
+
+    assert _decode(MustNotEncode(" " * 9)) is None

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -426,6 +426,51 @@ async def test_start_reuses_session_with_same_executable() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ["start", "restore"])
+async def test_session_lifecycle_is_reserved_during_creation(
+    operation: str,
+) -> None:
+    notebook_uri = "file:///test.py"
+    started = asyncio.Event()
+    release = asyncio.Event()
+    sessions = Sessions(Mock(), kernels=Mock())
+    replacement = Mock(spec=Session)
+
+    async def create(*args: object, **kwargs: object) -> Session:
+        del args, kwargs
+        started.set()
+        await release.wait()
+        return replacement
+
+    sessions._create = AsyncMock(side_effect=create)
+    sessions._notify_changed = Mock()
+    if operation == "start":
+        task = asyncio.create_task(
+            sessions.start(notebook_uri, "/usr/bin/python", "/workspace")
+        )
+    else:
+        task = asyncio.create_task(
+            sessions.restart(
+                notebook_uri,
+                executable="/usr/bin/python",
+                working_directory="/workspace",
+                create_if_missing=True,
+            )
+        )
+
+    await started.wait()
+    assert sessions.get(notebook_uri) is None
+    assert sessions.is_live_or_starting(notebook_uri)
+
+    release.set()
+    assert await task is replacement
+    assert sessions.is_live_or_starting(notebook_uri)
+
+    sessions.close(notebook_uri)
+    assert not sessions.is_live_or_starting(notebook_uri)
+
+
+@pytest.mark.asyncio
 async def test_start_reuses_same_executable_despite_new_working_directory() -> None:
     sessions = Sessions(Mock(), kernels=Mock())
     current = Mock(spec=Session)


### PR DESCRIPTION
marimo sidecars cache stale display data, not kernel state. The selected interpreter locates the sidecar and reports its exact marimo version, the extension performs bounded local I/O, and the language server validates the contents against its synchronized notebook snapshot.

Disk output is available only before a session starts. Any live or starting session is authoritative, and document lifecycle changes turn the load into a cache miss.
