### PR TITLE
Read marimo saved session outputs

### DIFF
--- a/extension/src/notebook/__tests__/readSessionOutputs.test.ts
+++ b/extension/src/notebook/__tests__/readSessionOutputs.test.ts
@@ -1,0 +1,390 @@
+import * as NodeFs from "node:fs";
+import * as NodeOs from "node:os";
+import * as NodePath from "node:path";
+import * as NodeProcess from "node:process";
+
+import { NodeServices } from "@effect/platform-node";
+import { assert, describe, expect, it } from "@effect/vitest";
+import { Deferred, Effect, Fiber, Layer, Ref } from "effect";
+import { TestClock } from "effect/testing";
+
+import { Uri } from "../../__mocks__/TestVsCode.ts";
+import { makeTestMarimoClient } from "../../__tests__/__utils__/TestMarimoClient.ts";
+import type { MarimoApiCall } from "../../types.ts";
+import { readSessionOutputs } from "../readSessionOutputs.ts";
+
+const isWindows = NodeProcess.platform === "win32";
+const notification = {
+  op: "cell-op",
+  cell_id: "cell-1",
+  output: {
+    channel: "output",
+    mimetype: "text/plain",
+    data: "42",
+  },
+  console: [],
+} as const;
+
+it.effect(
+  "asks for a live replay without probing a non-file notebook",
+  Effect.fn(function* () {
+    const calls = yield* Ref.make<ReadonlyArray<MarimoApiCall>>([]);
+    const uri = Uri.parse("untitled:Untitled-1");
+    const result = yield* readSessionOutputs({
+      notebook: { isClosed: false, uri },
+      environment: {
+        executable: "/does/not/exist",
+        workingDirectory: "/does/not/exist",
+      },
+    }).pipe(
+      Effect.provide(
+        Layer.merge(
+          NodeServices.layer,
+          makeTestMarimoClient({
+            execute: (request) =>
+              Ref.update(calls, (current) => [...current, request]).pipe(
+                Effect.as({ notifications: [notification] }),
+              ),
+          }),
+        ),
+      ),
+    );
+
+    expect(result).toEqual([notification]);
+    expect(yield* Ref.get(calls)).toEqual([
+      {
+        method: "read-session-outputs",
+        params: { notebookUri: uri.toString(), inner: { location: null } },
+      },
+    ]);
+  }),
+);
+
+it.effect(
+  "discards a replay when the notebook closes during the request",
+  Effect.fn(function* () {
+    const requested = yield* Deferred.make<void>();
+    const response = yield* Deferred.make<{
+      notifications: ReadonlyArray<typeof notification>;
+    }>();
+    const notebook = {
+      isClosed: false,
+      uri: Uri.parse("untitled:Untitled-1"),
+    };
+    const fiber = yield* readSessionOutputs({ notebook }).pipe(
+      Effect.provide(
+        Layer.merge(
+          NodeServices.layer,
+          makeTestMarimoClient({
+            execute: () =>
+              Deferred.succeed(requested, undefined).pipe(
+                Effect.andThen(Deferred.await(response)),
+              ),
+          }),
+        ),
+      ),
+      Effect.forkChild,
+    );
+
+    yield* Deferred.await(requested);
+    notebook.isClosed = true;
+    yield* Deferred.succeed(response, { notifications: [notification] });
+
+    expect(yield* Fiber.join(fiber)).toEqual([]);
+  }),
+);
+
+it.effect(
+  "interrupts an in-flight language-server read",
+  Effect.fn(function* () {
+    const requested = yield* Deferred.make<void>();
+    const interrupted = yield* Deferred.make<void>();
+    const fiber = yield* readSessionOutputs({
+      notebook: {
+        isClosed: false,
+        uri: Uri.parse("untitled:Untitled-1"),
+      },
+    }).pipe(
+      Effect.provide(
+        Layer.merge(
+          NodeServices.layer,
+          makeTestMarimoClient({
+            execute: () =>
+              Deferred.succeed(requested, undefined).pipe(
+                Effect.andThen(Effect.never),
+                Effect.ensuring(Deferred.succeed(interrupted, undefined)),
+              ),
+          }),
+        ),
+      ),
+      Effect.forkChild,
+    );
+
+    yield* Deferred.await(requested);
+    yield* Fiber.interrupt(fiber);
+
+    expect(yield* Deferred.isDone(interrupted)).toBe(true);
+  }),
+);
+
+describe.skipIf(isWindows)("readSessionOutputs", () => {
+  it.effect(
+    "sends only the selected environment's location",
+    Effect.fn(function* () {
+      const directory = yield* tempDirectory;
+      const workingDirectory = NodePath.join(directory, "working directory");
+      NodeFs.mkdirSync(workingDirectory);
+      const notebookPath = NodePath.join(directory, "notebook with spaces.py");
+      const cachePath = NodePath.join(directory, "saved session.json");
+      const invocationPath = NodePath.join(directory, "invocation.txt");
+      NodeFs.writeFileSync(notebookPath, "# notebook");
+      const executable = makeProbeExecutable(directory, {
+        name: "python",
+        result: JSON.stringify({
+          marimoVersion: "0.24.0.dev1+local",
+          cachePath,
+        }),
+        stdout: "sitecustomize noise",
+        invocationPath,
+      });
+      const calls = yield* Ref.make<ReadonlyArray<MarimoApiCall>>([]);
+      const uri = Uri.file(notebookPath);
+
+      const result = yield* readSessionOutputs({
+        notebook: { isClosed: false, uri },
+        environment: { executable, workingDirectory },
+      }).pipe(
+        Effect.provide(
+          Layer.merge(
+            NodeServices.layer,
+            makeTestMarimoClient({
+              execute: (request) =>
+                Ref.update(calls, (current) => [...current, request]).pipe(
+                  Effect.as({ notifications: [notification] }),
+                ),
+            }),
+          ),
+        ),
+      );
+
+      expect(result).toEqual([notification]);
+      expect(yield* Ref.get(calls)).toEqual([
+        {
+          method: "read-session-outputs",
+          params: {
+            notebookUri: uri.toString(),
+            inner: {
+              location: {
+                cachePath,
+                marimoVersion: "0.24.0.dev1+local",
+              },
+            },
+          },
+        },
+      ]);
+      expect(NodeFs.readFileSync(invocationPath, "utf8")).toBe(
+        `${NodeFs.realpathSync(workingDirectory)}\n${notebookPath}`,
+      );
+    }),
+  );
+
+  it.effect(
+    "runs a probe through an existing sandbox environment",
+    Effect.fn(function* () {
+      const directory = yield* tempDirectory;
+      const notebookPath = NodePath.join(directory, "sandbox.py");
+      const cachePath = NodePath.join(directory, "saved session.json");
+      NodeFs.writeFileSync(notebookPath, "# /// script");
+      const executable = makeProbeExecutable(directory, {
+        name: "uv",
+        result: JSON.stringify({
+          marimoVersion: "0.24.0",
+          cachePath,
+        }),
+        expectedPrefix: "run --no-sync --script sandbox.py python",
+      });
+      const calls = yield* Ref.make<ReadonlyArray<MarimoApiCall>>([]);
+      const uri = Uri.file(notebookPath);
+
+      yield* readSessionOutputs({
+        notebook: { isClosed: false, uri },
+        environment: {
+          executable,
+          arguments: ["run", "--no-sync", "--script", "sandbox.py", "python"],
+          workingDirectory: directory,
+        },
+      }).pipe(
+        Effect.provide(
+          Layer.merge(
+            NodeServices.layer,
+            makeTestMarimoClient({
+              execute: (request) =>
+                Ref.update(calls, (current) => [...current, request]).pipe(
+                  Effect.as({ notifications: [] }),
+                ),
+            }),
+          ),
+        ),
+      );
+
+      expect(yield* Ref.get(calls)).toEqual([
+        {
+          method: "read-session-outputs",
+          params: {
+            notebookUri: uri.toString(),
+            inner: {
+              location: { cachePath, marimoVersion: "0.24.0" },
+            },
+          },
+        },
+      ]);
+    }),
+  );
+
+  it.effect(
+    "falls back to a live replay when the probe is invalid",
+    Effect.fn(function* () {
+      const directory = yield* tempDirectory;
+      const notebookPath = NodePath.join(directory, "notebook.py");
+      NodeFs.writeFileSync(notebookPath, "# notebook");
+      const executable = makeProbeExecutable(directory, {
+        name: "python-invalid",
+        result: JSON.stringify({
+          marimoVersion: "0.24.0",
+          cachePath: "relative/session.json",
+        }),
+      });
+      const calls = yield* Ref.make<ReadonlyArray<MarimoApiCall>>([]);
+      const uri = Uri.file(notebookPath);
+
+      const result = yield* readSessionOutputs({
+        notebook: { isClosed: false, uri },
+        environment: { executable, workingDirectory: directory },
+      }).pipe(
+        Effect.provide(
+          Layer.merge(
+            NodeServices.layer,
+            makeTestMarimoClient({
+              execute: (request) =>
+                Ref.update(calls, (current) => [...current, request]).pipe(
+                  Effect.as({ notifications: [] }),
+                ),
+            }),
+          ),
+        ),
+      );
+
+      expect(result).toEqual([]);
+      expect(yield* Ref.get(calls)).toEqual([
+        {
+          method: "read-session-outputs",
+          params: { notebookUri: uri.toString(), inner: { location: null } },
+        },
+      ]);
+    }),
+  );
+
+  it.effect(
+    "force-kills a probe that ignores cancellation",
+    Effect.fn(function* () {
+      const directory = yield* tempDirectory;
+      const notebookPath = NodePath.join(directory, "notebook.py");
+      const pidPath = NodePath.join(directory, "probe.pid");
+      NodeFs.writeFileSync(notebookPath, "# notebook");
+      const executable = makeStalledExecutable(directory, pidPath);
+      const uri = Uri.file(notebookPath);
+      const fiber = yield* readSessionOutputs({
+        notebook: { isClosed: false, uri },
+        environment: { executable, workingDirectory: directory },
+      }).pipe(
+        Effect.provide(
+          Layer.merge(
+            NodeServices.layer,
+            makeTestMarimoClient({
+              execute: () => Effect.succeed({ notifications: [] }),
+            }),
+          ),
+        ),
+        Effect.forkChild,
+      );
+      const pid = yield* Effect.promise(() => waitForPid(pidPath, 100));
+
+      yield* TestClock.adjust("10 seconds");
+      yield* Effect.yieldNow;
+      yield* TestClock.adjust("1 second");
+
+      assert.deepStrictEqual(yield* Fiber.join(fiber), []);
+      expect(() => NodeProcess.kill(pid, 0)).toThrow();
+    }),
+  );
+});
+
+const tempDirectory = Effect.acquireRelease(
+  Effect.sync(
+    () =>
+      NodeFs.mkdtempDisposableSync(
+        NodePath.join(NodeOs.tmpdir(), "marimo-saved-session-"),
+      ).path,
+  ),
+  (path) => Effect.sync(() => NodeFs.rmSync(path, { recursive: true })),
+);
+
+function makeProbeExecutable(
+  directory: string,
+  options: {
+    readonly name: string;
+    readonly result: string;
+    readonly stdout?: string;
+    readonly invocationPath?: string;
+    readonly expectedPrefix?: string;
+  },
+) {
+  const executable = NodePath.join(directory, options.name);
+  const lines = ["#!/bin/bash"];
+  if (options.expectedPrefix !== undefined) {
+    lines.push(
+      `[ "$1 $2 $3 $4 $5" = ${shellEscape(options.expectedPrefix)} ] || exit 1`,
+    );
+  }
+  if (options.invocationPath !== undefined) {
+    lines.push(
+      `printf '%s\\n%s' "$PWD" "\${@: -2:1}" > ${shellEscape(options.invocationPath)}`,
+    );
+  }
+  if (options.stdout !== undefined) {
+    lines.push(`printf '%s' ${shellEscape(options.stdout)}`);
+  }
+  lines.push(`printf '%s' ${shellEscape(options.result)} > "\${@: -1}"`);
+  NodeFs.writeFileSync(executable, lines.join("\n"), { mode: 0o755 });
+  return executable;
+}
+
+function makeStalledExecutable(directory: string, pidPath: string) {
+  const executable = NodePath.join(directory, "python-stalled-probe");
+  NodeFs.writeFileSync(
+    executable,
+    [
+      "#!/usr/bin/env node",
+      'const fs = require("node:fs");',
+      'process.on("SIGTERM", () => {});',
+      `fs.writeFileSync(${JSON.stringify(pidPath)}, String(process.pid));`,
+      "setInterval(() => {}, 1000);",
+    ].join("\n"),
+    { mode: 0o755 },
+  );
+  return executable;
+}
+
+async function waitForPid(pidPath: string, attempts: number): Promise<number> {
+  try {
+    return Number.parseInt(NodeFs.readFileSync(pidPath, "utf8"), 10);
+  } catch {
+    if (attempts === 0) throw new Error("probe did not start");
+    await new Promise<void>((resolve) => setTimeout(resolve, 10));
+    return waitForPid(pidPath, attempts - 1);
+  }
+}
+
+function shellEscape(value: string) {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}

--- a/extension/src/notebook/readSessionOutputs.ts
+++ b/extension/src/notebook/readSessionOutputs.ts
@@ -1,0 +1,153 @@
+import * as NodePath from "node:path";
+
+import { Data, Duration, Effect, FileSystem, Option, Schema } from "effect";
+import { ChildProcess } from "effect/unstable/process";
+import type * as vscode from "vscode";
+
+import { MarimoClient } from "../lsp/MarimoClient.ts";
+import { NotebookIdFromString } from "../schemas/Models.gen.ts";
+
+const PROBE_TIMEOUT = Duration.seconds(10);
+const FORCE_KILL_AFTER = Duration.seconds(1);
+
+const ProbeResult = Schema.Struct({
+  marimoVersion: Schema.String,
+  cachePath: Schema.String,
+});
+
+class SavedSessionProbeError extends Data.TaggedError(
+  "SavedSessionProbeError",
+)<{
+  readonly reason: "exit" | "invalid-path" | "not-a-file";
+}> {}
+
+export interface SelectedEnvironment {
+  readonly executable: string;
+  readonly arguments?: ReadonlyArray<string>;
+  readonly workingDirectory: string;
+}
+
+interface ReadSessionOutputsOptions {
+  readonly notebook: Pick<vscode.NotebookDocument, "isClosed" | "uri">;
+  readonly environment?: SelectedEnvironment;
+}
+
+const PROBE = `\
+import io, json, os, pathlib, sys
+
+sys.stdout = io.StringIO()
+
+import marimo
+from marimo._session.state.serialize import get_session_cache_file
+
+_cache_path = get_session_cache_file(pathlib.Path(sys.argv[1]))
+_payload = {
+    "marimoVersion": marimo.__version__,
+    "cachePath": os.path.abspath(os.fspath(_cache_path)),
+}
+
+with open(sys.argv[2], "w", encoding="utf-8") as _result:
+    json.dump(_payload, _result)
+`;
+
+/** Read marimo's replay notifications for an open notebook. */
+export const readSessionOutputs = Effect.fn("readSessionOutputs")(function* (
+  options: ReadSessionOutputsOptions,
+) {
+  if (options.notebook.isClosed) {
+    return [];
+  }
+
+  const marimo = yield* MarimoClient;
+  const notebookId = yield* Schema.decodeUnknownEffect(NotebookIdFromString)(
+    options.notebook.uri.toString(),
+  );
+  const location = yield* locateSavedSession(options).pipe(
+    Effect.tapCause((cause) =>
+      Effect.logDebug("Saved session location unavailable").pipe(
+        Effect.annotateLogs({
+          cause,
+          notebookUri: options.notebook.uri.toString(),
+        }),
+      ),
+    ),
+    Effect.option,
+    Effect.map(Option.flatten),
+    Effect.map(Option.getOrNull),
+  );
+
+  if (options.notebook.isClosed) {
+    return [];
+  }
+  const response = yield* marimo.readSessionOutputs({
+    notebookUri: notebookId,
+    inner: { location },
+  });
+  if (options.notebook.isClosed) {
+    return [];
+  }
+
+  return response.notifications;
+});
+
+const locateSavedSession = Effect.fnUntraced(function* (
+  options: ReadSessionOutputsOptions,
+) {
+  const environment = options.environment;
+  const notebookUri = options.notebook.uri;
+  if (
+    environment === undefined ||
+    notebookUri.scheme !== "file" ||
+    !NodePath.isAbsolute(notebookUri.fsPath) ||
+    NodePath.extname(notebookUri.fsPath).toLowerCase() !== ".py"
+  ) {
+    return Option.none();
+  }
+
+  const fs = yield* FileSystem.FileSystem;
+  const result = yield* Effect.gen(function* () {
+    const notebookStat = yield* fs.stat(notebookUri.fsPath);
+    if (notebookStat.type !== "File") {
+      return yield* new SavedSessionProbeError({ reason: "not-a-file" });
+    }
+    yield* fs.access(notebookUri.fsPath, { readable: true });
+
+    const resultPath = yield* fs.makeTempFileScoped({
+      prefix: "marimo-saved-session-probe-",
+      suffix: ".json",
+    });
+    const command = ChildProcess.make(
+      environment.executable,
+      [
+        ...(environment.arguments ?? []),
+        "-c",
+        PROBE,
+        notebookUri.fsPath,
+        resultPath,
+      ],
+      {
+        cwd: environment.workingDirectory,
+        extendEnv: true,
+        forceKillAfter: FORCE_KILL_AFTER,
+        stdout: "ignore",
+        stderr: "ignore",
+      },
+    );
+    const exitCode = yield* command.pipe(
+      Effect.flatMap((handle) => handle.exitCode),
+    );
+    if (exitCode !== 0) {
+      return yield* new SavedSessionProbeError({ reason: "exit" });
+    }
+
+    const probe = yield* Schema.decodeUnknownEffect(
+      Schema.fromJsonString(ProbeResult),
+    )(yield* fs.readFileString(resultPath));
+    if (!NodePath.isAbsolute(probe.cachePath)) {
+      return yield* new SavedSessionProbeError({ reason: "invalid-path" });
+    }
+    return probe;
+  }).pipe(Effect.scoped, Effect.timeout(PROBE_TIMEOUT));
+
+  return Option.some(result);
+});

--- a/extension/src/schemas/Models.gen.ts
+++ b/extension/src/schemas/Models.gen.ts
@@ -15,6 +15,12 @@ const MarimoNotification = Schema.declare<MarimoNotification>(
     typeof value.op === "string",
 );
 
+type CellOperationNotification = Extract<MarimoNotification, { op: "cell-op" }>;
+const CellOperationNotification = Schema.declare<CellOperationNotification>(
+  (value): value is CellOperationNotification =>
+    Schema.is(MarimoNotification)(value) && value.op === "cell-op",
+);
+
 type VariablesNotification = Extract<MarimoNotification, { op: "variables" }>;
 const VariablesNotification = Schema.declare<VariablesNotification>(
   (value): value is VariablesNotification =>
@@ -420,6 +426,33 @@ export const SetDisplayThemeRequest = Schema.Struct({
   theme: Schema.Literals(["dark", "light"]),
 }).annotate({ identifier: "SetDisplayThemeRequest" });
 export type SetDisplayThemeRequest = typeof SetDisplayThemeRequest.Type;
+
+/**
+ * A sidecar located by the notebook's selected marimo environment.
+ */
+export const SavedSessionLocation = Schema.Struct({
+  cachePath: Schema.String,
+  marimoVersion: Schema.String,
+}).annotate({ identifier: "SavedSessionLocation" });
+export type SavedSessionLocation = typeof SavedSessionLocation.Type;
+
+/**
+ * Read display outputs from the live session or a compatible sidecar.
+ */
+export const ReadSessionOutputsRequest = Schema.Struct({
+  location: Schema.NullOr(SavedSessionLocation).pipe(
+    Schema.withDecodingDefault(Effect.sync(() => null)),
+  ),
+}).annotate({ identifier: "ReadSessionOutputsRequest" });
+export type ReadSessionOutputsRequest = typeof ReadSessionOutputsRequest.Type;
+
+/**
+ * Display outputs retained by the authoritative session snapshot.
+ */
+export const ReadSessionOutputsResponse = Schema.Struct({
+  notifications: Schema.Array(CellOperationNotification),
+}).annotate({ identifier: "ReadSessionOutputsResponse" });
+export type ReadSessionOutputsResponse = typeof ReadSessionOutputsResponse.Type;
 
 /**
  * Serializable HTTP request representation.
@@ -1393,6 +1426,11 @@ export const SetDisplayThemePayload = Schema.Struct({
   theme: Schema.Literals(["dark", "light"]),
 });
 
+export const ReadSessionOutputsPayload = Schema.Struct({
+  notebookUri: NotebookIdFromString,
+  inner: ReadSessionOutputsRequest,
+});
+
 export const ExportAsHTMLRequest = Schema.Struct({
   download: Schema.Boolean,
   files: Schema.Array(Schema.String),
@@ -1520,6 +1558,10 @@ export type MarimoApiCall =
   | {
       readonly method: "set-display-theme";
       readonly params: typeof SetDisplayThemePayload.Encoded;
+    }
+  | {
+      readonly method: "read-session-outputs";
+      readonly params: typeof ReadSessionOutputsPayload.Encoded;
     }
   | {
       readonly method: "export-as-html";
@@ -1717,6 +1759,13 @@ export const makeApiClient = <E, R>(execute: Execute<E, R>) => ({
       { method: "set-display-theme", params },
       SetDisplayThemePayload,
       SetDisplayThemeResponse,
+    ),
+  readSessionOutputs: (params: typeof ReadSessionOutputsPayload.Encoded) =>
+    dispatch(
+      execute,
+      { method: "read-session-outputs", params },
+      ReadSessionOutputsPayload,
+      ReadSessionOutputsResponse,
     ),
   exportAsHtml: (params: typeof ExportAsHtmlPayload.Encoded) =>
     dispatch(

--- a/scripts/codegen/effect_schemas.py
+++ b/scripts/codegen/effect_schemas.py
@@ -45,6 +45,15 @@ const MarimoNotification = Schema.declare<MarimoNotification>(
     typeof value.op === "string",
 );
 
+type CellOperationNotification = Extract<
+  MarimoNotification,
+  { op: "cell-op" }
+>;
+const CellOperationNotification = Schema.declare<CellOperationNotification>(
+  (value): value is CellOperationNotification =>
+    Schema.is(MarimoNotification)(value) && value.op === "cell-op",
+);
+
 type VariablesNotification = Extract<MarimoNotification, { op: "variables" }>;
 const VariablesNotification = Schema.declare<VariablesNotification>(
   (value): value is VariablesNotification =>
@@ -90,6 +99,9 @@ CONCRETE: list[tuple[str, type | object]] = [
     ("ExecuteScratchRequest", models.ExecuteScratchRequest),
     ("UpdateConfigurationRequest", models.UpdateConfigurationRequest),
     ("SetDisplayThemeRequest", models.SetDisplayThemeRequest),
+    ("SavedSessionLocation", models.SavedSessionLocation),
+    ("ReadSessionOutputsRequest", models.ReadSessionOutputsRequest),
+    ("ReadSessionOutputsResponse", models.ReadSessionOutputsResponse),
 ]
 
 
@@ -361,7 +373,10 @@ class Emitter:
             tag = _ts_string(str(t.tag))
             lines.append(f"{indent}{_prop(t.tag_field)}: Schema.Literal({tag}),")
         for field in t.fields:
-            if t.cls is models.KernelNotification and field.name == "notification":
+            notification_field = self.notification_field_expr(t, field)
+            if notification_field is not None:
+                expr = notification_field
+            elif t.cls is models.KernelNotification and field.name == "notification":
                 expr = "MarimoNotification"
             elif t.cls is models.DocumentAnalysis and field.name == "analysis":
                 expr = "VariablesNotification"
@@ -398,6 +413,12 @@ class Emitter:
                     )
             lines.append(f"{indent}{rendered},")
         return "\n".join(lines) + "\n" if lines else ""
+
+    @staticmethod
+    def notification_field_expr(t: _StructLike, field: mi.Field) -> str | None:
+        if t.cls is models.ReadSessionOutputsResponse and field.name == "notifications":
+            return "Schema.Array(CellOperationNotification)"
+        return None
 
     def default_expr(self, field: mi.Field) -> str | None:
         """Render the field default so decode fills omitted fields, like msgspec."""

--- a/src/marimo_lsp/api.py
+++ b/src/marimo_lsp/api.py
@@ -26,6 +26,8 @@ from marimo._export.requests import (
     MarkdownExportRequest,
 )
 from marimo._export.serialization import serialize_notebook_snapshot
+from marimo._messaging.msgspec_encoder import encode_json_bytes
+from marimo._messaging.notification import CellNotification
 from marimo._runtime.commands import (
     ExecuteScratchpadCommand,
     InvokeFunctionCommand,
@@ -74,6 +76,8 @@ from marimo_lsp.models import (
     NotebookCommand,
     NotebookDocument,
     PackageCommand,
+    ReadSessionOutputsRequest,
+    ReadSessionOutputsResponse,
     RestartSessionRequest,
     ScriptSource,
     SerializeResponse,
@@ -250,8 +254,15 @@ def _require_kernel_session(
     session = ctx.sessions.get(notebook_uri)
     if session is None:
         raise SessionNotFoundError(notebook_uri)
-    if session.session_id != session_id:
+    if session.session_id != session_id or session.requires_restart:
         raise KernelSessionMismatchError(notebook_uri)
+    return session
+
+
+def _require_current_session(ctx: ApiContext, notebook_uri: str) -> Session:
+    session = ctx.sessions.get(notebook_uri)
+    if session is None or session.requires_restart:
+        raise SessionNotFoundError(notebook_uri)
     return session
 
 
@@ -811,6 +822,30 @@ async def set_display_theme(
     return SetDisplayThemeResponse(success=True)
 
 
+@marimo_api("read-session-outputs")
+async def read_session_outputs(
+    ctx: ApiContext,
+    args: NotebookCommand[ReadSessionOutputsRequest],
+) -> ReadSessionOutputsResponse:
+    """Read display outputs without restoring kernel state."""
+    snapshot = await ctx.sessions.read_session_outputs(
+        args.notebook_uri,
+        args.inner.location,
+    )
+    normalized: list[CellNotification] = []
+    for notification in snapshot:
+        try:
+            normalized.append(
+                msgspec.json.decode(
+                    encode_json_bytes(notification),
+                    type=CellNotification,
+                )
+            )
+        except Exception:
+            logger.exception("Ignored unserializable saved output notification")
+    return ReadSessionOutputsResponse(notifications=normalized)
+
+
 @marimo_api("export-as-html")
 async def export_as_html(
     ctx: ApiContext,
@@ -818,8 +853,7 @@ async def export_as_html(
 ) -> str:
     """Export the notebook as HTML with current outputs."""
     logger.info(f"export_as_html for {args.notebook_uri}")
-    session = ctx.sessions.get(args.notebook_uri)
-    assert session, f"No session in workspace for {args.notebook_uri}"
+    session = _require_current_session(ctx, args.notebook_uri)
 
     # Export the notebook with current outputs using the Exporter
     app = session.app
@@ -851,8 +885,7 @@ async def export_as_ipynb(
 ) -> str:
     """Export the notebook as ipynb with current outputs."""
     logger.info(f"export_as_ipynb for {args.notebook_uri}")
-    session = ctx.sessions.get(args.notebook_uri)
-    assert session, f"No session in workspace for {args.notebook_uri}"
+    session = _require_current_session(ctx, args.notebook_uri)
 
     ipynb_str = Exporter().export_as_ipynb(
         IPYNBExportRequest(
@@ -881,8 +914,7 @@ async def export_as_markdown(
 ) -> str:
     """Export the notebook as Markdown."""
     logger.info(f"export_as_markdown for {args.notebook_uri}")
-    session = ctx.sessions.get(args.notebook_uri)
-    assert session, f"No session in workspace for {args.notebook_uri}"
+    session = _require_current_session(ctx, args.notebook_uri)
 
     result = export_markdown(
         MarkdownExportRequest(

--- a/src/marimo_lsp/app_file_manager.py
+++ b/src/marimo_lsp/app_file_manager.py
@@ -67,6 +67,36 @@ class LspAppFileManager:
             app=self.app,
         )
 
+    def workspace_code_lookup(self, workspace: Workspace) -> dict[CellId_t, str]:
+        """Read the notebook's current cell identity without changing the live app."""
+        return sync_app_with_workspace(
+            workspace,
+            self._notebook_uri,
+            None,
+        ).cell_manager.code_lookup()
+
+    def source_snapshot(self) -> tuple[object, ...]:
+        """Return the notebook state that determines a kernel graph."""
+        return _source_snapshot(self.app)
+
+    def workspace_source_snapshot(self, workspace: Workspace) -> tuple[object, ...]:
+        """Read the current kernel graph state without changing this manager."""
+        app = sync_app_with_workspace(workspace, self._notebook_uri, None)
+        return _source_snapshot(app)
+
+    def document_snapshot(self) -> tuple[object, ...]:
+        """Return source and metadata synchronized from the LSP document."""
+        return (self._header, self.source_snapshot())
+
+    def workspace_document_snapshot(
+        self,
+        workspace: Workspace,
+    ) -> tuple[object, ...]:
+        """Read current source and metadata without changing this manager."""
+        notebook = find_notebook_document(workspace, self._notebook_uri)
+        header = decode_notebook_document_metadata(notebook).header
+        return (header, self.workspace_source_snapshot(workspace))
+
     @property
     def filename(self) -> str | None:
         """The notebook file name."""
@@ -108,6 +138,17 @@ def find_notebook_document(
             return doc
 
     raise KeyError(notebook_uri)
+
+
+def _source_snapshot(app: InternalApp) -> tuple[object, ...]:
+    cells = app.cell_manager
+    return (
+        app.config.asdict(),
+        tuple(cells.cell_ids()),
+        tuple(cells.codes()),
+        tuple(cells.names()),
+        tuple(config.asdict() for config in cells.configs()),
+    )
 
 
 def _iter_notebook_cells(

--- a/src/marimo_lsp/models.py
+++ b/src/marimo_lsp/models.py
@@ -15,6 +15,7 @@ import msgspec
 from marimo._config.config import MarimoConfig  # noqa: TC002
 from marimo._convert.common.format import DEFAULT_MARKDOWN_PREFIX
 from marimo._messaging.notification import (  # noqa: TC002
+    CellNotification,
     NotificationMessage,
     VariablesNotification,
 )
@@ -416,6 +417,19 @@ class SetDisplayThemeRequest(msgspec.Struct, rename="camel"):
     """The theme to set ('light' or 'dark')."""
 
 
+class SavedSessionLocation(msgspec.Struct, rename="camel", frozen=True):
+    """A sidecar located by the notebook's selected marimo environment."""
+
+    cache_path: str
+    marimo_version: str
+
+
+class ReadSessionOutputsRequest(msgspec.Struct, rename="camel"):
+    """Read display outputs from the live session or a compatible sidecar."""
+
+    location: SavedSessionLocation | None = None
+
+
 class ApiRequest(msgspec.Struct, rename="camel"):
     """A unified API request for all marimo internal methods."""
 
@@ -458,6 +472,12 @@ class SetDisplayThemeResponse(msgspec.Struct, rename="camel"):
     """Response for ``set-display-theme``."""
 
     success: bool
+
+
+class ReadSessionOutputsResponse(msgspec.Struct, rename="camel"):
+    """Display outputs retained by the authoritative session snapshot."""
+
+    notifications: list[CellNotification]
 
 
 ExecuteCellsRequest = core.ExecuteCellsRequest

--- a/src/marimo_lsp/saved_sessions.py
+++ b/src/marimo_lsp/saved_sessions.py
@@ -87,6 +87,31 @@ def decode_saved_session_view(
     header: str | None,
 ) -> SessionView | None:
     """Decode a compatible marimo session sidecar, if one can be proven."""
+    try:
+        decoded = json.loads(contents)
+        if not isinstance(decoded, dict):
+            return None
+        return restore_saved_session_view(
+            cast("NotebookSessionV1", decoded),
+            codes=codes,
+            cell_ids=cell_ids,
+            marimo_version=marimo_version,
+            header=header,
+        )
+    except Exception:
+        logger.exception("Ignored malformed saved session")
+        return None
+
+
+def restore_saved_session_view(
+    notebook_session: NotebookSessionV1,
+    *,
+    codes: Iterable[str],
+    cell_ids: Iterable[CellId_t],
+    marimo_version: str | None,
+    header: str | None,
+) -> SessionView | None:
+    """Restore a compatible marimo session snapshot into current cell IDs."""
     marimo_version = normalize_marimo_version(marimo_version)
     if marimo_version is None:
         return None
@@ -108,13 +133,11 @@ def decode_saved_session_view(
         interval=1,
     )
     try:
-        decoded = json.loads(contents)
-        if not isinstance(decoded, dict) or decoded.get("version") != "1":
+        if notebook_session.get("version") != "1":
             return None
         # Delegate field and output compatibility to marimo. In particular,
         # its V1 reader skips future output tags instead of rejecting the
         # otherwise-compatible session.
-        notebook_session = cast("NotebookSessionV1", decoded)
         key = SessionCacheKey(
             codes=current_codes,
             marimo_version=marimo_version,

--- a/src/marimo_lsp/sessions.py
+++ b/src/marimo_lsp/sessions.py
@@ -9,12 +9,14 @@ import json
 import threading
 import time
 import typing
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, cast
 from uuid import uuid4
 
 import msgspec
 from marimo._config.manager import get_default_config_manager
 from marimo._messaging.msgspec_encoder import asdict
+from marimo._messaging.notification import CellNotification
 from marimo._messaging.serde import (
     deserialize_kernel_message,
     deserialize_kernel_notification_name,
@@ -30,15 +32,24 @@ from marimo._runtime.commands import (
     UpdateUserConfigCommand,
 )
 from marimo._session.state.session_view import SessionView
-from marimo._types.ids import SessionId
+from marimo._types.ids import CellId_t, SessionId
 
-from marimo_lsp.app_file_manager import LspAppFileManager
+from marimo_lsp.app_file_manager import LspAppFileManager, find_notebook_document
 from marimo_lsp.kernels import KernelOpenError, normalize_marimo_version
 from marimo_lsp.loggers import get_logger
-from marimo_lsp.models import KernelNotification, ListSessionsResponse, SessionInfo
+from marimo_lsp.models import (
+    KernelNotification,
+    ListSessionsResponse,
+    SavedSessionLocation,
+    SessionInfo,
+)
 from marimo_lsp.saved_session_store import LocalSavedSessionFiles
 from marimo_lsp.saved_session_writer import SavedSessionWriter
-from marimo_lsp.saved_sessions import decode_saved_session_view
+from marimo_lsp.saved_sessions import (
+    decode_saved_session_view,
+    restore_saved_session_view,
+    serialize_saved_session_view,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -52,6 +63,7 @@ if TYPE_CHECKING:
     from marimo._config.manager import MarimoConfigManager
     from marimo._messaging.notification import NotificationMessage
     from marimo._messaging.types import KernelMessage
+    from marimo._schemas.session import NotebookSessionV1
     from marimo._session.requests import InstantiateNotebookRequest
     from marimo._types.ids import ConsumerId
     from pygls.lsp.server import LanguageServer
@@ -64,6 +76,23 @@ if TYPE_CHECKING:
 logger = get_logger()
 
 _MAX_CANCELLED_SCRATCHPAD_RUNS = 1024
+
+
+@dataclass(frozen=True)
+class _SessionViewSource:
+    session: Session
+    reuse_live_view: bool
+
+
+def _session_view_source(
+    previous: Session | None,
+    saved_session_source: Session | None,
+) -> _SessionViewSource | None:
+    if previous is not None:
+        return _SessionViewSource(previous, reuse_live_view=True)
+    if saved_session_source is not None:
+        return _SessionViewSource(saved_session_source, reuse_live_view=False)
+    return None
 
 
 def _raise_kernel_failure(_session: Session, error: str) -> None:
@@ -121,25 +150,57 @@ async def _read_saved_session(
 
 
 async def _initial_session_view(
-    previous: Session | None,
+    source: _SessionViewSource | None,
     kernel: Kernel,
     files: SavedSessionFiles,
     target: str | None,
     app_file_manager: LspAppFileManager,
 ) -> tuple[SessionView | None, bool]:
     """Reuse a compatible live view, otherwise restore the selected cache."""
-    previous_version = normalize_marimo_version(
-        previous.marimo_version if previous is not None else None
+    source_session = source.session if source is not None else None
+    source_version = normalize_marimo_version(
+        source_session.marimo_version if source_session is not None else None
     )
     kernel_version = normalize_marimo_version(kernel.marimo_version)
     reuse_previous = (
-        previous is not None
-        and previous_version is not None
+        source is not None
+        and source.reuse_live_view
+        and not source.session.requires_restart
+        and source_version is not None
         and kernel_version is not None
-        and previous_version == kernel_version
+        and source_version == kernel_version
     )
     if reuse_previous:
-        return previous.session_view, True
+        return source.session.session_view, True
+
+    if (
+        source_session is not None
+        and source_version is not None
+        and source_version == kernel_version
+    ):
+        previous_snapshot = serialize_saved_session_view(
+            source_session.session_view,
+            cell_ids=source_session.app_file_manager.app.cell_manager.cell_ids(),
+            marimo_version=source_version,
+            header=source_session.app_file_manager.header,
+        )
+        if previous_snapshot is not None:
+            cell_manager = app_file_manager.app.cell_manager
+            current_codes = tuple(cell_manager.codes())
+            current_cell_ids = tuple(cell_manager.cell_ids())
+            restored = restore_saved_session_view(
+                previous_snapshot,
+                codes=current_codes,
+                cell_ids=current_cell_ids,
+                marimo_version=kernel_version,
+                header=app_file_manager.header,
+            )
+            if restored is not None:
+                restored.last_executed_code.update(
+                    zip(current_cell_ids, current_codes, strict=True)
+                )
+                return restored, True
+
     return (
         await _read_saved_session(
             files,
@@ -149,6 +210,31 @@ async def _initial_session_view(
         ),
         False,
     )
+
+
+def _session_output_notifications(
+    view: SessionView,
+    code_lookup: typing.Mapping[CellId_t, str],
+    *,
+    stale: bool = False,
+) -> list[CellNotification]:
+    notifications: list[CellNotification] = []
+    for notification in view.notifications:
+        if not isinstance(notification, CellNotification):
+            continue
+        code = code_lookup.get(notification.cell_id)
+        has_display = notification.output is not None or bool(notification.console)
+        is_in_flight = notification.status in ("queued", "running")
+        if code is None or (not has_display and not is_in_flight):
+            continue
+        current_notification = notification
+        if stale or view.last_executed_code.get(notification.cell_id) != code:
+            current_notification = msgspec.structs.replace(
+                notification,
+                stale_inputs=True,
+            )
+        notifications.append(current_notification)
+    return notifications
 
 
 class _OperationSink:
@@ -278,6 +364,7 @@ class Session:
         )
         self._activated = False
         self._closed = False
+        self._requires_restart = False
         self._runtime_config = config_manager.get_config(hide_secrets=False)
         self.started_at = started_at if started_at is not None else time.time()
         self._status: typing.Literal["idle", "running"] = "idle"
@@ -367,6 +454,11 @@ class Session:
         """Return the configuration used to build a replacement kernel."""
         return self._config_manager
 
+    @property
+    def requires_restart(self) -> bool:
+        """Return whether detached source changes invalidated the live graph."""
+        return self._requires_restart
+
     def get_config(self, *, hide_secrets: bool = True) -> MarimoConfig:
         """Return this session's configured marimo settings."""
         return self._config_manager.get_config(hide_secrets=hide_secrets)
@@ -377,8 +469,16 @@ class Session:
         self.update_runtime_config(updated)
         return updated
 
-    def sync(self, workspace: Workspace) -> None:
+    def sync(self, workspace: Workspace) -> bool:
         """Synchronize the live app with the current notebook document."""
+        if self._requires_restart:
+            return False
+        previous_document = self._app_file_manager.document_snapshot()
+        if not self.attached:
+            current_source = self._app_file_manager.workspace_source_snapshot(workspace)
+            if self._app_file_manager.source_snapshot() != current_source:
+                self._requires_restart = True
+                return True
         previous_configs = {
             cell_id: config.asdict()
             for cell_id, config in self._app_file_manager.app.cell_manager.config_map().items()
@@ -401,6 +501,7 @@ class Session:
                 UpdateCellConfigCommand(configs={cell_id: config}),
                 from_consumer_id=None,
             )
+        return previous_document != self._app_file_manager.document_snapshot()
 
     def accept_kernel_message(self, message: KernelMessage) -> None:
         """Record and forward an operation received from the kernel."""
@@ -727,6 +828,99 @@ class Sessions:
         with self._lock:
             return self._sessions.get(notebook_uri)
 
+    async def read_session_outputs(
+        self,
+        notebook_uri: str,
+        location: SavedSessionLocation | None,
+    ) -> list[CellNotification]:
+        """Read the authoritative live or compatible saved display state."""
+        lock = self._lifecycle_lock(notebook_uri)
+        live_snapshot: NotebookSessionV1 | None = None
+        async with lock:
+            session = self.get(notebook_uri)
+            if session is not None and not session.requires_restart:
+                return _session_output_notifications(
+                    session.session_view,
+                    session.app.cell_manager.code_lookup(),
+                )
+
+            try:
+                notebook = find_notebook_document(
+                    self._server.workspace,
+                    notebook_uri,
+                )
+                app_file_manager = LspAppFileManager(
+                    server=self._server,
+                    notebook_uri=notebook_uri,
+                )
+                notebook_version = notebook.version
+            except KeyError:
+                return []
+
+            if session is not None:
+                live_snapshot = serialize_saved_session_view(
+                    session.session_view,
+                    cell_ids=session.app_file_manager.app.cell_manager.cell_ids(),
+                    marimo_version=session.marimo_version,
+                    header=session.app_file_manager.header,
+                )
+            source_session = session
+
+        cell_manager = app_file_manager.app.cell_manager
+        view = (
+            await asyncio.to_thread(
+                restore_saved_session_view,
+                live_snapshot,
+                codes=tuple(cell_manager.codes()),
+                cell_ids=tuple(cell_manager.cell_ids()),
+                marimo_version=(
+                    source_session.marimo_version
+                    if source_session is not None
+                    else None
+                ),
+                header=app_file_manager.header,
+            )
+            if live_snapshot is not None
+            else None
+        )
+
+        if view is None and location is not None:
+            view = await _read_saved_session(
+                self._saved_session_files,
+                location.cache_path,
+                app_file_manager,
+                location.marimo_version,
+            )
+
+        async with lock:
+            session = self.get(notebook_uri)
+            if session is not None and not session.requires_restart:
+                return _session_output_notifications(
+                    session.session_view,
+                    session.app.cell_manager.code_lookup(),
+                )
+            if session is not source_session:
+                return []
+            try:
+                current = find_notebook_document(
+                    self._server.workspace,
+                    notebook_uri,
+                )
+            except KeyError:
+                current = None
+            if (
+                view is None
+                or current is not notebook
+                or current.version != notebook_version
+            ):
+                return []
+
+            return _session_output_notifications(
+                view,
+                app_file_manager.app.cell_manager.code_lookup(),
+                stale=True,
+            )
+
     def cancel_scratchpad(self, notebook_uri: str, run_id: str) -> None:
         """Remember a cancellation and interrupt only its active scratchpad."""
         key = (notebook_uri, run_id)
@@ -761,16 +955,49 @@ class Sessions:
         """
         async with self._lifecycle_lock(notebook_uri):
             current = self.get(notebook_uri)
-            if current is not None and current.executable == executable:
+            if (
+                current is not None
+                and current.executable == executable
+                and not current.attached
+                and not current.requires_restart
+            ):
+                current.sync(self._server.workspace)
+            if (
+                current is not None
+                and current.executable == executable
+                and not current.requires_restart
+            ):
                 current.attach()
                 return current
 
             version = self._lifecycle_version(notebook_uri)
-            replacement = await self._create(
-                notebook_uri, executable, working_directory
-            )
+            if current is not None and current.executable == executable:
+                replacement = await self._create(
+                    notebook_uri,
+                    executable,
+                    working_directory,
+                    previous=current,
+                )
+            else:
+                replacement = await self._create(
+                    notebook_uri,
+                    executable,
+                    working_directory,
+                    saved_session_source=current,
+                )
             with self._lock:
-                if version != self._lifecycle_version(notebook_uri):
+                try:
+                    source_changed = (
+                        replacement.app_file_manager.document_snapshot()
+                        != replacement.app_file_manager.workspace_document_snapshot(
+                            self._server.workspace
+                        )
+                    )
+                # Any invalid workspace snapshot makes the launched kernel
+                # unsafe to publish, regardless of the parser's exception.
+                except Exception:  # noqa: BLE001
+                    source_changed = True
+                if version != self._lifecycle_version(notebook_uri) or source_changed:
                     superseded = True
                 else:
                     superseded = False
@@ -796,8 +1023,13 @@ class Sessions:
         working_directory: str,
         *,
         previous: Session | None = None,
+        saved_session_source: Session | None = None,
     ) -> Session:
-        app_file_manager = previous.app_file_manager if previous else None
+        app_file_manager = (
+            previous.app_file_manager
+            if previous is not None and not previous.requires_restart
+            else None
+        )
         config_manager = previous.config_manager if previous else None
         if app_file_manager is None:
             app_file_manager = LspAppFileManager(
@@ -837,8 +1069,8 @@ class Sessions:
                 kernel,
                 app_file_manager.path,
             )
-            session_view, keep_previous_view = await _initial_session_view(
-                previous,
+            session_view, saved_session_pending = await _initial_session_view(
+                _session_view_source(previous, saved_session_source),
                 kernel,
                 self._saved_session_files,
                 saved_session_target,
@@ -855,7 +1087,7 @@ class Sessions:
                 started_at=previous.started_at if previous else None,
                 saved_session_files=self._saved_session_files,
                 saved_session_target=saved_session_target,
-                saved_session_pending=keep_previous_view,
+                saved_session_pending=saved_session_pending,
             )
             session.set_on_kernel_failure(_raise_kernel_failure)
             for message in pending_messages:
@@ -900,11 +1132,22 @@ class Sessions:
                     current.working_directory,
                     previous=current,
                 )
-                if not current.attached:
+                if not current.attached and not current.requires_restart:
                     replacement.detach(notify=False)
 
             with self._lock:
-                if version != self._lifecycle_version(notebook_uri):
+                try:
+                    source_changed = (
+                        replacement.app_file_manager.document_snapshot()
+                        != replacement.app_file_manager.workspace_document_snapshot(
+                            self._server.workspace
+                        )
+                    )
+                # Any invalid workspace snapshot makes the launched kernel
+                # unsafe to publish, regardless of the parser's exception.
+                except Exception:  # noqa: BLE001
+                    source_changed = True
+                if version != self._lifecycle_version(notebook_uri) or source_changed:
                     superseded = True
                 else:
                     superseded = False
@@ -948,26 +1191,53 @@ class Sessions:
         except KeyError:
             pass
         else:
-            session.attach(notify=False)
+            if not session.requires_restart:
+                session.attach(notify=False)
         self._notify_changed()
 
     def attach(self, notebook_uri: str, workspace: Workspace) -> None:
         """Attach and synchronize an existing session."""
-        session = self.get(notebook_uri)
+        with self._lock:
+            self._invalidate_lifecycle(notebook_uri)
+            session = self._sessions.get(notebook_uri)
         if session is None:
             return
         session.sync(workspace)
-        session.attach()
+        if not session.requires_restart:
+            session.attach()
 
     def sync(self, notebook_uri: str, workspace: Workspace) -> None:
         """Synchronize an existing session with its notebook document."""
-        session = self.get(notebook_uri)
-        if session is not None:
-            session.sync(workspace)
+        with self._lock:
+            session = self._sessions.get(notebook_uri)
+        if session is None:
+            return
+        previous_document = session.app_file_manager.document_snapshot()
+        previous_requires_restart = session.requires_restart
+        changed = False
+        try:
+            changed = session.sync(workspace)
+        finally:
+            try:
+                changed = (
+                    changed
+                    or previous_requires_restart != session.requires_restart
+                    or previous_document != session.app_file_manager.document_snapshot()
+                )
+            # A failed source comparison must still invalidate an in-flight
+            # launch; publishing the older graph would be worse than retrying.
+            except Exception:  # noqa: BLE001
+                changed = True
+            if changed:
+                with self._lock:
+                    if self._sessions.get(notebook_uri) is session:
+                        self._invalidate_lifecycle(notebook_uri)
 
     def detach(self, notebook_uri: str) -> None:
         """Detach an existing session without stopping its kernel."""
-        session = self.get(notebook_uri)
+        with self._lock:
+            self._invalidate_lifecycle(notebook_uri)
+            session = self._sessions.get(notebook_uri)
         if session is not None:
             session.detach()
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -18,6 +18,7 @@ from marimo_lsp.api import (
     ApiContext,
     KernelSessionMismatchError,
     KernelSessionRequiredError,
+    SessionNotFoundError,
     _restore_unknown_app_options,
     delete_cell,
     deserialize,
@@ -153,6 +154,7 @@ async def test_run_correlated_interrupt_records_scratchpad_cancellation() -> Non
 async def test_send_stdin_targets_one_exact_kernel_session() -> None:
     session_id = SessionId("00000000-0000-4000-8000-000000000001")
     session = MagicMock(session_id=session_id)
+    session.requires_restart = False
     sessions = MagicMock()
     sessions.get.return_value = session
 
@@ -166,6 +168,27 @@ async def test_send_stdin_targets_one_exact_kernel_session() -> None:
     )
 
     session.put_input.assert_called_once_with("answer")
+
+
+@pytest.mark.asyncio
+async def test_send_stdin_rejects_an_invalidated_live_graph() -> None:
+    session_id = SessionId("00000000-0000-4000-8000-000000000001")
+    session = MagicMock(session_id=session_id)
+    session.requires_restart = True
+    sessions = MagicMock()
+    sessions.get.return_value = session
+
+    with pytest.raises(KernelSessionMismatchError):
+        await send_stdin(
+            _context(sessions),
+            KernelCommand(
+                notebook_uri=NOTEBOOK_URI,
+                session_id=session_id,
+                inner=StdinRequest(text="stale"),
+            ),
+        )
+
+    session.put_input.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -377,6 +400,7 @@ if __name__ == "__main__":
     app.run()
 """
     session = MagicMock()
+    session.requires_restart = False
     session.filename = "/workspace/report.py"
     session.app.to_ir.return_value = MarimoConvert.from_py(source).to_ir()
     sessions = MagicMock()
@@ -392,6 +416,25 @@ if __name__ == "__main__":
 
     assert "title: Report" in markdown
     assert "```python {.marimo}\nx = 1\n```" in markdown
+
+
+@pytest.mark.asyncio
+async def test_export_rejects_an_invalidated_live_graph() -> None:
+    session = MagicMock()
+    session.requires_restart = True
+    sessions = MagicMock()
+    sessions.get.return_value = session
+
+    with pytest.raises(SessionNotFoundError):
+        await export_as_markdown(
+            _context(sessions),
+            NotebookCommand(
+                notebook_uri=NOTEBOOK_URI,
+                inner=ExportAsMarkdownRequest(),
+            ),
+        )
+
+    session.app.to_ir.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -664,6 +707,7 @@ async def test_list_sql_schemas_is_forwarded_to_the_kernel() -> None:
     )
     session_id = SessionId("00000000-0000-4000-8000-000000000001")
     session = MagicMock(session_id=session_id)
+    session.requires_restart = False
     sessions = MagicMock()
     sessions.get.return_value = session
 
@@ -692,6 +736,7 @@ async def test_list_sql_tables_is_forwarded_to_the_kernel() -> None:
     )
     session_id = SessionId("00000000-0000-4000-8000-000000000001")
     session = MagicMock(session_id=session_id)
+    session.requires_restart = False
     sessions = MagicMock()
     sessions.get.return_value = session
 

--- a/tests/test_saved_session_api.py
+++ b/tests/test_saved_session_api.py
@@ -1,0 +1,448 @@
+# Copyright 2026 Marimo. All rights reserved.
+
+"""Tests for replaying marimo session output notifications."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import cast
+from unittest.mock import AsyncMock, MagicMock
+
+import lsprotocol.types as lsp
+import msgspec
+import pytest
+from marimo import __version__
+from marimo._messaging.cell_output import CellChannel, CellOutput
+from marimo._messaging.notification import CellNotification
+from marimo._runtime.commands import ExecuteCellsCommand
+from marimo._session.state.session_view import SessionView
+from marimo._types.ids import CellId_t
+
+from marimo_lsp.api import ApiContext, handle_api_command, read_session_outputs
+from marimo_lsp.models import (
+    NotebookCommand,
+    ReadSessionOutputsRequest,
+    SavedSessionLocation,
+)
+from marimo_lsp.saved_sessions import serialize_saved_session_view
+from marimo_lsp.sessions import Session, Sessions
+
+NOTEBOOK_URI = "file:///workspace/notebook.py"
+CELL_URI = f"{NOTEBOOK_URI}#cell"
+SAVED_ID = CellId_t("saved")
+CURRENT_ID = CellId_t("current")
+CODE = "answer = 42\nanswer"
+CACHE_PATH = "/workspace/__marimo__/session/notebook.py.json"
+
+
+def _metadata(value: dict[str, object]) -> lsp.LSPObject:
+    return cast("lsp.LSPObject", value)
+
+
+def _workspace(*, code: str = CODE) -> MagicMock:
+    notebook = lsp.NotebookDocument(
+        uri=NOTEBOOK_URI,
+        notebook_type="marimo-notebook",
+        version=1,
+        cells=[
+            lsp.NotebookCell(
+                kind=lsp.NotebookCellKind.Code,
+                document=CELL_URI,
+                metadata=_metadata({"marimoRuntime": {"stableId": str(CURRENT_ID)}}),
+            )
+        ],
+        metadata=_metadata({"marimo": {"header": None}}),
+    )
+    workspace = MagicMock()
+    workspace.notebook_documents = {NOTEBOOK_URI: notebook}
+    workspace.text_documents = {CELL_URI: MagicMock(source=code, language_id="python")}
+    return workspace
+
+
+def _view(
+    cell_id: CellId_t,
+    *,
+    output: str | dict[str, float] = "42",
+) -> SessionView:
+    view = SessionView()
+    view.add_control_request(ExecuteCellsCommand(cell_ids=[cell_id], codes=[CODE]))
+    view.add_notification(
+        CellNotification(
+            cell_id=cell_id,
+            status="idle",
+            output=CellOutput(
+                channel=CellChannel.OUTPUT,
+                mimetype="text/plain",
+                data=output,
+            ),
+            console=[],
+            timestamp=1,
+        )
+    )
+    return view
+
+
+def _saved_contents() -> str:
+    snapshot = serialize_saved_session_view(
+        _view(SAVED_ID),
+        cell_ids=[SAVED_ID],
+        marimo_version=__version__,
+        header=None,
+    )
+    assert snapshot is not None
+    return json.dumps(snapshot)
+
+
+def _request(
+    location: SavedSessionLocation | None,
+) -> NotebookCommand[ReadSessionOutputsRequest]:
+    return NotebookCommand(
+        notebook_uri=NOTEBOOK_URI,
+        inner=ReadSessionOutputsRequest(location=location),
+    )
+
+
+@pytest.mark.asyncio
+async def test_reads_sidecar_into_marimo_cell_notifications() -> None:
+    files = MagicMock()
+    files.read = AsyncMock(return_value=_saved_contents())
+    files.replace = AsyncMock()
+    kernels = MagicMock()
+    server = MagicMock(workspace=_workspace())
+    sessions = Sessions(server, kernels=kernels, saved_session_files=files)
+
+    result = await read_session_outputs(
+        ApiContext(ls=server, sessions=sessions),
+        _request(
+            SavedSessionLocation(
+                cache_path=CACHE_PATH,
+                marimo_version=__version__,
+            )
+        ),
+    )
+
+    [notification] = result.notifications
+    assert isinstance(notification, CellNotification)
+    assert notification.cell_id == CURRENT_ID
+    assert notification.output is not None
+    assert notification.output.data == "42"
+    assert notification.stale_inputs is True
+    files.read.assert_awaited_once_with(CACHE_PATH)
+    kernels.launch.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_live_session_view_is_authoritative() -> None:
+    files = MagicMock()
+    files.read = AsyncMock(return_value=_saved_contents())
+    files.replace = AsyncMock()
+    server = MagicMock(workspace=_workspace())
+    sessions = Sessions(server, kernels=MagicMock(), saved_session_files=files)
+    session = MagicMock(spec=Session)
+    session.requires_restart = False
+    session.session_view = _view(CURRENT_ID, output="live")
+    session.app.cell_manager.cell_ids.return_value = [CURRENT_ID]
+    session.app.cell_manager.code_lookup.return_value = {CURRENT_ID: CODE}
+    sessions._sessions[NOTEBOOK_URI] = session
+
+    result = await read_session_outputs(
+        ApiContext(ls=server, sessions=sessions),
+        _request(
+            SavedSessionLocation(
+                cache_path=CACHE_PATH,
+                marimo_version=__version__,
+            )
+        ),
+    )
+
+    [notification] = result.notifications
+    assert isinstance(notification, CellNotification)
+    assert notification.output is not None
+    assert notification.output.data == "live"
+    assert notification.stale_inputs is not True
+    files.read.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_live_session_output_is_stale_when_source_changed() -> None:
+    server = MagicMock(workspace=_workspace(code="value = 2"))
+    sessions = Sessions(server, kernels=MagicMock())
+    session = MagicMock(spec=Session)
+    session.requires_restart = False
+    session.session_view = _view(CURRENT_ID, output="live")
+    session.app.cell_manager.code_lookup.return_value = {CURRENT_ID: "value = 2"}
+    sessions._sessions[NOTEBOOK_URI] = session
+
+    result = await read_session_outputs(
+        ApiContext(ls=server, sessions=sessions),
+        _request(None),
+    )
+
+    [notification] = result.notifications
+    assert notification.output is not None
+    assert notification.output.data == "live"
+    assert notification.stale_inputs is True
+
+
+@pytest.mark.asyncio
+async def test_live_in_flight_cell_is_replayed_before_it_has_output() -> None:
+    server = MagicMock(workspace=_workspace())
+    sessions = Sessions(server, kernels=MagicMock())
+    session = MagicMock(spec=Session)
+    session.requires_restart = False
+    view = SessionView()
+    view.add_control_request(ExecuteCellsCommand(cell_ids=[CURRENT_ID], codes=[CODE]))
+    view.add_notification(
+        CellNotification(
+            cell_id=CURRENT_ID,
+            status="running",
+            run_id="surviving-run",
+            output=None,
+            console=[],
+            timestamp=1,
+        )
+    )
+    session.session_view = view
+    session.app.cell_manager.code_lookup.return_value = {CURRENT_ID: CODE}
+    sessions._sessions[NOTEBOOK_URI] = session
+
+    result = await read_session_outputs(
+        ApiContext(ls=server, sessions=sessions),
+        _request(None),
+    )
+
+    [notification] = result.notifications
+    assert notification.status == "running"
+    assert notification.run_id == "surviving-run"
+    assert notification.output is None
+
+
+@pytest.mark.asyncio
+async def test_invalidated_live_view_is_rebased_without_waiting_for_disk() -> None:
+    files = MagicMock()
+    files.read = AsyncMock(return_value=None)
+    files.replace = AsyncMock()
+    server = MagicMock(workspace=_workspace())
+    sessions = Sessions(server, kernels=MagicMock(), saved_session_files=files)
+    session = MagicMock(spec=Session)
+    session.requires_restart = True
+    session.marimo_version = __version__
+    session.session_view = _view(SAVED_ID, output="not yet flushed")
+    session.app_file_manager.header = None
+    session.app_file_manager.app.cell_manager.cell_ids.return_value = [SAVED_ID]
+    sessions._sessions[NOTEBOOK_URI] = session
+
+    result = await read_session_outputs(
+        ApiContext(ls=server, sessions=sessions),
+        _request(None),
+    )
+
+    [notification] = result.notifications
+    assert notification.cell_id == CURRENT_ID
+    assert notification.output is not None
+    assert notification.output.data == "not yet flushed"
+    assert notification.stale_inputs is True
+    files.read.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_no_live_session_or_location_is_empty() -> None:
+    files = MagicMock()
+    files.read = AsyncMock(return_value=_saved_contents())
+    files.replace = AsyncMock()
+    server = MagicMock(workspace=_workspace())
+    sessions = Sessions(server, kernels=MagicMock(), saved_session_files=files)
+
+    result = await read_session_outputs(
+        ApiContext(ls=server, sessions=sessions),
+        _request(None),
+    )
+
+    assert result.notifications == []
+    files.read.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("contents", "version", "code"),
+    [
+        (None, __version__, CODE),
+        ("{", __version__, CODE),
+        (_saved_contents(), "0.0.0", CODE),
+        (_saved_contents(), __version__, "answer = 43"),
+    ],
+)
+async def test_unavailable_or_incompatible_sidecar_is_empty(
+    contents: str | None,
+    version: str,
+    code: str,
+) -> None:
+    files = MagicMock()
+    files.read = AsyncMock(return_value=contents)
+    files.replace = AsyncMock()
+    server = MagicMock(workspace=_workspace(code=code))
+    sessions = Sessions(server, kernels=MagicMock(), saved_session_files=files)
+
+    result = await read_session_outputs(
+        ApiContext(ls=server, sessions=sessions),
+        _request(
+            SavedSessionLocation(
+                cache_path=CACHE_PATH,
+                marimo_version=version,
+            )
+        ),
+    )
+
+    assert result.notifications == []
+
+
+@pytest.mark.asyncio
+async def test_read_discards_output_when_document_reopens() -> None:
+    workspace = _workspace()
+
+    async def reopen(_target: str) -> str:
+        workspace.notebook_documents[NOTEBOOK_URI] = _workspace().notebook_documents[
+            NOTEBOOK_URI
+        ]
+        return _saved_contents()
+
+    files = MagicMock()
+    files.read = AsyncMock(side_effect=reopen)
+    files.replace = AsyncMock()
+    server = MagicMock(workspace=workspace)
+    sessions = Sessions(server, kernels=MagicMock(), saved_session_files=files)
+
+    result = await read_session_outputs(
+        ApiContext(ls=server, sessions=sessions),
+        _request(
+            SavedSessionLocation(
+                cache_path=CACHE_PATH,
+                marimo_version=__version__,
+            )
+        ),
+    )
+
+    assert result.notifications == []
+
+
+@pytest.mark.asyncio
+async def test_read_discards_output_when_the_open_document_changes() -> None:
+    workspace = _workspace()
+
+    async def edit(_target: str) -> str:
+        notebook = workspace.notebook_documents[NOTEBOOK_URI]
+        notebook.version = 2
+        workspace.text_documents[CELL_URI].source = "answer = 43"
+        return _saved_contents()
+
+    files = MagicMock()
+    files.read = AsyncMock(side_effect=edit)
+    files.replace = AsyncMock()
+    server = MagicMock(workspace=workspace)
+    sessions = Sessions(server, kernels=MagicMock(), saved_session_files=files)
+
+    result = await read_session_outputs(
+        ApiContext(ls=server, sessions=sessions),
+        _request(
+            SavedSessionLocation(
+                cache_path=CACHE_PATH,
+                marimo_version=__version__,
+            )
+        ),
+    )
+
+    assert result.notifications == []
+
+
+@pytest.mark.asyncio
+async def test_read_does_not_block_a_new_live_session() -> None:
+    read_started = asyncio.Event()
+    finish_read = asyncio.Event()
+
+    async def read(_target: str) -> str:
+        read_started.set()
+        await finish_read.wait()
+        return _saved_contents()
+
+    files = MagicMock()
+    files.read = AsyncMock(side_effect=read)
+    files.replace = AsyncMock()
+    server = MagicMock(workspace=_workspace())
+    sessions = Sessions(server, kernels=MagicMock(), saved_session_files=files)
+    pending = asyncio.ensure_future(
+        read_session_outputs(
+            ApiContext(ls=server, sessions=sessions),
+            _request(
+                SavedSessionLocation(
+                    cache_path=CACHE_PATH,
+                    marimo_version=__version__,
+                )
+            ),
+        )
+    )
+    await read_started.wait()
+
+    live = MagicMock(spec=Session)
+    live.requires_restart = False
+    live.session_view = _view(CURRENT_ID, output="live")
+    live.app.cell_manager.cell_ids.return_value = [CURRENT_ID]
+    live.app.cell_manager.code_lookup.return_value = {CURRENT_ID: CODE}
+
+    async def install() -> None:
+        async with sessions._lifecycle_lock(NOTEBOOK_URI):
+            sessions._sessions[NOTEBOOK_URI] = live
+
+    await asyncio.wait_for(install(), timeout=0.1)
+    finish_read.set()
+
+    result = await pending
+    [notification] = result.notifications
+    assert notification.output is not None
+    assert notification.output.data == "live"
+    assert notification.stale_inputs is not True
+
+
+@pytest.mark.asyncio
+async def test_callback_store_receives_opaque_host_path() -> None:
+    windows_path = r"C:\workspace\__marimo__\session\notebook.py.json"
+    files = MagicMock()
+    files.read = AsyncMock(return_value=_saved_contents())
+    files.replace = AsyncMock()
+    server = MagicMock(workspace=_workspace())
+    sessions = Sessions(server, kernels=MagicMock(), saved_session_files=files)
+
+    result = await read_session_outputs(
+        ApiContext(ls=server, sessions=sessions),
+        _request(
+            SavedSessionLocation(
+                cache_path=windows_path,
+                marimo_version=__version__,
+            )
+        ),
+    )
+
+    assert len(result.notifications) == 1
+    files.read.assert_awaited_once_with(windows_path)
+
+
+@pytest.mark.asyncio
+async def test_non_finite_notification_uses_marimo_wire_normalization() -> None:
+    server = MagicMock(workspace=_workspace())
+    sessions = Sessions(server, kernels=MagicMock())
+    session = MagicMock(spec=Session)
+    session.requires_restart = False
+    session.session_view = _view(CURRENT_ID, output={"value": float("nan")})
+    session.app.cell_manager.cell_ids.return_value = [CURRENT_ID]
+    session.app.cell_manager.code_lookup.return_value = {CURRENT_ID: CODE}
+    sessions._sessions[NOTEBOOK_URI] = session
+
+    wire = await handle_api_command(
+        server,
+        sessions,
+        "read-session-outputs",
+        msgspec.to_builtins(_request(None)),
+    )
+
+    encoded = json.dumps(wire, allow_nan=False)
+    assert json.loads(encoded)["notifications"][0]["output"]["data"] == {"value": None}

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -36,7 +36,13 @@ from marimo_lsp.saved_sessions import (
     decode_saved_session_view,
     serialize_saved_session_view,
 )
-from marimo_lsp.sessions import Session, Sessions, _OperationSink
+from marimo_lsp.sessions import (
+    Session,
+    Sessions,
+    _initial_session_view,
+    _OperationSink,
+    _SessionViewSource,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -64,11 +70,22 @@ def _make_session() -> tuple[Session, Mock]:
     session._scratchpad_run_id = None
     session._closed = False
     session._activated = True
+    session._requires_restart = False
     session._saved_session_pending = False
     session._saved_session_writer = None
     session._saved_session_location = None
     session._state_lock = threading.RLock()
+    session._operation_sink = _OperationSink(Mock(), "file:///test.py", SESSION_ID)
     return session, ipc_queue_manager
+
+
+def _mark_replacement_source_current(session: Mock) -> None:
+    source = object()
+    document = object()
+    session.app_file_manager.source_snapshot.return_value = source
+    session.app_file_manager.workspace_source_snapshot.return_value = source
+    session.app_file_manager.document_snapshot.return_value = document
+    session.app_file_manager.workspace_document_snapshot.return_value = document
 
 
 def test_ui_element_updates_use_marimo_ipc_batching_route() -> None:
@@ -147,6 +164,128 @@ def test_sync_does_not_notify_kernel_when_configs_are_unchanged() -> None:
 
     session.sync(Mock())
 
+    queue_manager.control_queue.put.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("previous_codes", "current_codes", "expected"),
+    [
+        ({}, {}, "reuse"),
+        ({}, {CellId_t("new"): "value = 1"}, "restart"),
+        ({CellId_t("old"): "value = 1"}, {}, "restart"),
+        (
+            {CellId_t("old"): "value = 1"},
+            {CellId_t("old"): "value = 1"},
+            "reuse",
+        ),
+        (
+            {CellId_t("old"): "value = 1"},
+            {CellId_t("new"): "value = 1"},
+            "restart",
+        ),
+        (
+            {CellId_t("cell"): "value = 1"},
+            {CellId_t("cell"): "value = 2"},
+            "restart",
+        ),
+    ],
+)
+def test_detached_sync_requires_a_fresh_graph_when_source_identity_changes(
+    previous_codes: dict[CellId_t, str],
+    current_codes: dict[CellId_t, str],
+    expected: str,
+) -> None:
+    session, queue_manager = _make_session()
+    if previous_codes:
+        [cell_id] = previous_codes
+        session.session_view.add_control_request(
+            ExecuteCellsCommand(
+                cell_ids=[cell_id],
+                codes=[previous_codes[cell_id]],
+            )
+        )
+        session.session_view.add_notification(
+            CellNotification(
+                cell_id=cell_id,
+                status="idle",
+                output=CellOutput(
+                    channel=CellChannel.OUTPUT,
+                    mimetype="text/plain",
+                    data="old output",
+                ),
+                console=[],
+                timestamp=1,
+            )
+        )
+
+    cell_manager = Mock()
+    cell_manager.config_map.return_value = {}
+    session._app_file_manager = Mock()
+    session._app_file_manager.app.cell_manager = cell_manager
+    session._app_file_manager.source_snapshot.return_value = previous_codes
+    session._app_file_manager.workspace_source_snapshot.return_value = current_codes
+    session._operation_sink.detach()
+
+    session.sync(Mock())
+
+    assert session.requires_restart is (expected == "restart")
+    assert session.session_view.last_executed_code == previous_codes
+    assert session._app_file_manager.sync.called is (expected == "reuse")
+    queue_manager.control_queue.put.assert_not_called()
+
+
+def test_detached_sync_accepts_header_change_without_restarting_graph() -> None:
+    session, queue_manager = _make_session()
+    source = object()
+    session._app_file_manager = Mock()
+    session._app_file_manager.source_snapshot.return_value = source
+    session._app_file_manager.workspace_source_snapshot.return_value = source
+    session._app_file_manager.document_snapshot.side_effect = [
+        ("old header", source),
+        ("new header", source),
+    ]
+    session._app_file_manager.app.cell_manager.config_map.side_effect = [{}, {}]
+    session._operation_sink.detach()
+
+    changed = session.sync(Mock())
+
+    assert changed
+    assert not session.requires_restart
+    session._app_file_manager.sync.assert_called_once()
+    queue_manager.control_queue.put.assert_not_called()
+
+
+def test_attached_sync_preserves_session_view_cell_ids() -> None:
+    session, queue_manager = _make_session()
+    old_id = CellId_t("old")
+    session.session_view.add_control_request(
+        ExecuteCellsCommand(cell_ids=[old_id], codes=["value = 1"])
+    )
+    session.session_view.add_notification(
+        CellNotification(
+            cell_id=old_id,
+            status="idle",
+            output=CellOutput(
+                channel=CellChannel.OUTPUT,
+                mimetype="text/plain",
+                data="old output",
+            ),
+            console=[],
+            timestamp=1,
+        )
+    )
+
+    cell_manager = Mock()
+    cell_manager.config_map.side_effect = [{}, {}]
+    session._app_file_manager = Mock()
+    session._app_file_manager.app.cell_manager = cell_manager
+
+    session.sync(Mock())
+
+    assert list(session.session_view.cell_notifications) == [old_id]
+    assert session.session_view.last_executed_code == {old_id: "value = 1"}
+    assert not session.requires_restart
+    cell_manager.code_lookup.assert_not_called()
     queue_manager.control_queue.put.assert_not_called()
 
 
@@ -571,6 +710,7 @@ async def test_start_reuses_session_with_same_executable() -> None:
     sessions = Sessions(Mock(), kernels=Mock())
     current = Mock(spec=Session)
     current.executable = "/usr/bin/python"
+    current.requires_restart = False
     sessions._sessions["file:///test.py"] = current
     sessions._create = AsyncMock()
 
@@ -586,6 +726,7 @@ async def test_start_reuses_same_executable_despite_new_working_directory() -> N
     sessions = Sessions(Mock(), kernels=Mock())
     current = Mock(spec=Session)
     current.executable = "/usr/bin/python"
+    current.requires_restart = False
     sessions._sessions["file:///test.py"] = current
     sessions._create = AsyncMock()
 
@@ -599,6 +740,86 @@ async def test_start_reuses_same_executable_despite_new_working_directory() -> N
 
 
 @pytest.mark.asyncio
+async def test_start_replaces_a_live_graph_invalidated_while_detached() -> None:
+    sessions = Sessions(Mock(), kernels=Mock())
+    current = Mock(spec=Session)
+    current.executable = "/usr/bin/python"
+    current.requires_restart = True
+    replacement = Mock(spec=Session)
+    _mark_replacement_source_current(replacement)
+    replacement.describe.return_value = Mock()
+    sessions._sessions["file:///test.py"] = current
+    sessions._create = AsyncMock(return_value=replacement)
+    sessions._notify_changed = Mock()
+
+    result = await sessions.start(
+        "file:///test.py",
+        "/usr/bin/python",
+        "/workspace",
+    )
+
+    assert result is replacement
+    sessions._create.assert_awaited_once_with(
+        "file:///test.py",
+        "/usr/bin/python",
+        "/workspace",
+        previous=current,
+    )
+    current.close.assert_called_once_with()
+    replacement.activate.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_start_checks_a_detached_graph_before_reusing_it() -> None:
+    server = Mock()
+    sessions = Sessions(server, kernels=Mock())
+    current = Mock(spec=Session)
+    current.executable = "/usr/bin/python"
+    current.attached = False
+    current.requires_restart = False
+    current.sync.side_effect = lambda _workspace: setattr(
+        current, "requires_restart", True
+    )
+    replacement = Mock(spec=Session)
+    _mark_replacement_source_current(replacement)
+    sessions._sessions["file:///test.py"] = current
+    sessions._create = AsyncMock(return_value=replacement)
+    sessions._notify_changed = Mock()
+
+    result = await sessions.start(
+        "file:///test.py",
+        "/usr/bin/python",
+        "/workspace",
+    )
+
+    assert result is replacement
+    current.sync.assert_called_once_with(server.workspace)
+    current.attach.assert_not_called()
+    sessions._create.assert_awaited_once_with(
+        "file:///test.py",
+        "/usr/bin/python",
+        "/workspace",
+        previous=current,
+    )
+
+
+def test_attach_keeps_an_invalidated_live_graph_quarantined() -> None:
+    sessions = Sessions(Mock(), kernels=Mock())
+    current = Mock(spec=Session)
+    current.requires_restart = False
+    current.sync.side_effect = lambda _workspace: setattr(
+        current, "requires_restart", True
+    )
+    sessions._sessions["file:///test.py"] = current
+    workspace = Mock()
+
+    sessions.attach("file:///test.py", workspace)
+
+    current.sync.assert_called_once_with(workspace)
+    current.attach.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_start_replaces_session_after_replacement_starts() -> None:
     events: list[str] = []
     sessions = Sessions(Mock(), kernels=Mock())
@@ -606,6 +827,7 @@ async def test_start_replaces_session_after_replacement_starts() -> None:
     current.executable = "/old/python"
     current.close.side_effect = lambda: events.append("old closed")
     replacement = Mock(spec=Session)
+    _mark_replacement_source_current(replacement)
     replacement.describe.return_value = Mock()
     replacement.activate.side_effect = lambda: events.append("new activated")
     sessions._sessions["file:///test.py"] = current
@@ -618,6 +840,12 @@ async def test_start_replaces_session_after_replacement_starts() -> None:
 
     assert result is replacement
     assert sessions.get("file:///test.py") is replacement
+    sessions._create.assert_awaited_once_with(
+        "file:///test.py",
+        "/new/python",
+        "/workspace",
+        saved_session_source=current,
+    )
     current.close.assert_called_once_with()
     sessions._notify_changed.assert_called_once_with()
     replacement.activate.assert_called_once_with()
@@ -645,7 +873,9 @@ async def test_concurrent_starts_share_one_kernel_launch() -> None:
     launch_started = asyncio.Event()
     finish_launch = asyncio.Event()
     replacement = Mock(spec=Session)
+    _mark_replacement_source_current(replacement)
     replacement.executable = "/usr/bin/python"
+    replacement.requires_restart = False
     replacement.describe.return_value = Mock()
 
     async def create(*_args: object, **_kwargs: object) -> Session:
@@ -671,6 +901,67 @@ async def test_concurrent_starts_share_one_kernel_launch() -> None:
     assert await first is replacement
     assert await second is replacement
     sessions._create.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_source_neutral_change_does_not_cancel_kernel_start() -> None:
+    sessions = Sessions(Mock(), kernels=Mock())
+    launch_started = asyncio.Event()
+    finish_launch = asyncio.Event()
+    replacement = Mock(spec=Session)
+    _mark_replacement_source_current(replacement)
+
+    async def create(*_args: object, **_kwargs: object) -> Session:
+        launch_started.set()
+        await finish_launch.wait()
+        return replacement
+
+    sessions._create = AsyncMock(side_effect=create)
+    sessions._notify_changed = Mock()
+    start = asyncio.create_task(
+        sessions.start("file:///test.py", "/usr/bin/python", "/workspace")
+    )
+    await launch_started.wait()
+
+    # Output and execution-summary changes use notebookDocument/didChange too,
+    # but they do not change the graph captured by the launched kernel.
+    sessions.sync("file:///test.py", Mock())
+    finish_launch.set()
+
+    assert await start is replacement
+    replacement.activate.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_invalid_source_after_launch_closes_replacement() -> None:
+    sessions = Sessions(Mock(), kernels=Mock())
+    replacement = Mock(spec=Session)
+    replacement.app_file_manager.document_snapshot.return_value = object()
+    replacement.app_file_manager.workspace_document_snapshot.side_effect = ValueError(
+        "invalid notebook metadata"
+    )
+    sessions._create = AsyncMock(return_value=replacement)
+
+    with pytest.raises(KernelOpenError, match="changed while its kernel was starting"):
+        await sessions.start("file:///test.py", "/usr/bin/python", "/workspace")
+
+    assert sessions.get("file:///test.py") is None
+    replacement.close.assert_called_once_with()
+
+
+def test_sync_failure_after_source_change_invalidates_kernel_start() -> None:
+    sessions = Sessions(Mock(), kernels=Mock())
+    session = Mock(spec=Session)
+    session.requires_restart = False
+    session.app_file_manager.document_snapshot.side_effect = ["before", "after"]
+    session.sync.side_effect = RuntimeError("kernel send failed")
+    sessions._sessions["file:///test.py"] = session
+    previous = sessions._lifecycle_version("file:///test.py")
+
+    with pytest.raises(RuntimeError, match="kernel send failed"):
+        sessions.sync("file:///test.py", Mock())
+
+    assert sessions._lifecycle_version("file:///test.py") == previous + 1
 
 
 @pytest.mark.asyncio
@@ -701,6 +992,41 @@ async def test_close_during_start_discards_launched_kernel() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("event", ["open", "change", "close"])
+async def test_document_lifecycle_change_during_start_discards_launched_kernel(
+    event: str,
+) -> None:
+    sessions = Sessions(Mock(), kernels=Mock())
+    launch_started = asyncio.Event()
+    finish_launch = asyncio.Event()
+    replacement = Mock(spec=Session)
+
+    async def create(*_args: object, **_kwargs: object) -> Session:
+        launch_started.set()
+        await finish_launch.wait()
+        return replacement
+
+    sessions._create = AsyncMock(side_effect=create)
+    start = asyncio.create_task(
+        sessions.start("file:///test.py", "/usr/bin/python", "/workspace")
+    )
+    await launch_started.wait()
+
+    if event == "open":
+        sessions.attach("file:///test.py", Mock())
+    elif event == "change":
+        sessions.sync("file:///test.py", Mock())
+    else:
+        sessions.detach("file:///test.py")
+    finish_launch.set()
+
+    with pytest.raises(KernelOpenError, match="changed while its kernel was starting"):
+        await start
+    assert sessions.get("file:///test.py") is None
+    replacement.close.assert_called_once_with()
+
+
+@pytest.mark.asyncio
 async def test_session_creation_failure_closes_launched_kernel() -> None:
     kernel = Mock()
     kernels = Mock()
@@ -712,6 +1038,7 @@ async def test_session_creation_failure_closes_launched_kernel() -> None:
     previous.config_manager.get_config.side_effect = RuntimeError("bad config")
     previous.session_view = Mock()
     previous.started_at = 42
+    previous.requires_restart = False
 
     with pytest.raises(RuntimeError, match="bad config"):
         await sessions._create(
@@ -759,6 +1086,7 @@ async def test_startup_message_handoff_preserves_order(
     previous.session_view = Mock()
     previous.started_at = 42
     previous.marimo_version = "1.2.3-rc1+build.7"
+    previous.requires_restart = False
     loop_thread = threading.get_ident()
     observed: list[tuple[KernelMessage, int]] = []
     third_delivered = asyncio.Event()
@@ -815,6 +1143,7 @@ async def test_session_creation_drops_view_without_known_matching_versions(
     previous.session_view = SessionView()
     previous.started_at = 42
     previous.marimo_version = previous_version
+    previous.requires_restart = False
 
     created = await sessions._create(
         "file:///test.py",
@@ -847,6 +1176,7 @@ async def test_session_creation_binds_the_selected_kernel_cache_path() -> None:
     previous.session_view = SessionView()
     previous.started_at = 42
     previous.marimo_version = "1.2.3"
+    previous.requires_restart = False
 
     created = await sessions._create(
         "file:///workspace/notebook.py",
@@ -867,6 +1197,7 @@ async def test_session_creation_binds_the_selected_kernel_cache_path() -> None:
 @pytest.mark.asyncio
 async def test_session_creation_restores_the_selected_kernel_cache_before_writing(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     cell_id = CellId_t("cell")
     restored = SessionView()
@@ -901,6 +1232,18 @@ async def test_session_creation_restores_the_selected_kernel_cache_before_writin
     kernel.locate_saved_session = AsyncMock(return_value=str(tmp_path / "session.json"))
     kernels = Mock()
     kernels.launch = AsyncMock(return_value=kernel)
+    current_app_file_manager = Mock()
+    current_app_file_manager.path = str(tmp_path / "notebook.py")
+    current_app_file_manager.header = None
+    current_app_file_manager.app.cell_manager.codes.return_value = ["value = 1"]
+    current_app_file_manager.app.cell_manager.cell_ids.return_value = [cell_id]
+    current_app_file_manager.app.cell_manager.code_map.return_value = {
+        cell_id: "value = 1"
+    }
+    monkeypatch.setattr(
+        "marimo_lsp.sessions.LspAppFileManager",
+        Mock(return_value=current_app_file_manager),
+    )
     sessions = Sessions(Mock(), kernels=kernels, saved_session_files=files)
     previous = Mock(spec=Session)
     previous.app_file_manager = Mock()
@@ -915,7 +1258,8 @@ async def test_session_creation_restores_the_selected_kernel_cache_before_writin
     previous.config_manager.get_config.return_value = DEFAULT_CONFIG
     previous.session_view = SessionView()
     previous.started_at = 42
-    previous.marimo_version = "1.2.3"
+    previous.marimo_version = "1.2.4"
+    previous.requires_restart = True
 
     created = await sessions._create(
         "file:///workspace/notebook.py",
@@ -955,6 +1299,146 @@ async def test_session_creation_restores_the_selected_kernel_cache_before_writin
         is not None
     )
     created.close()
+
+
+@pytest.mark.asyncio
+async def test_session_creation_rebases_an_unflushed_invalidated_view(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    previous_id = CellId_t("previous")
+    current_id = CellId_t("current")
+    code = "value = 1"
+    previous_view = SessionView()
+    previous_view.add_control_request(
+        ExecuteCellsCommand(cell_ids=[previous_id], codes=[code])
+    )
+    previous_view.add_notification(
+        CellNotification(
+            cell_id=previous_id,
+            status="idle",
+            output=CellOutput(
+                channel=CellChannel.OUTPUT,
+                mimetype="text/plain",
+                data="not yet flushed",
+            ),
+            console=[],
+            timestamp=1,
+        )
+    )
+    files = Mock()
+    files.read = AsyncMock(return_value=None)
+    files.replace = AsyncMock()
+    kernel = Mock()
+    kernel.marimo_version = "1.2.4"
+    kernel.locate_saved_session = AsyncMock(return_value=str(tmp_path / "session.json"))
+    kernels = Mock()
+    kernels.launch = AsyncMock(return_value=kernel)
+    current_app_file_manager = Mock()
+    current_app_file_manager.path = str(tmp_path / "notebook.py")
+    current_app_file_manager.header = None
+    current_app_file_manager.app.cell_manager.codes.return_value = [code]
+    current_app_file_manager.app.cell_manager.cell_ids.return_value = [current_id]
+    current_app_file_manager.app.cell_manager.code_map.return_value = {current_id: code}
+    monkeypatch.setattr(
+        "marimo_lsp.sessions.LspAppFileManager",
+        Mock(return_value=current_app_file_manager),
+    )
+    sessions = Sessions(Mock(), kernels=kernels, saved_session_files=files)
+    previous = Mock(spec=Session)
+    previous.app_file_manager = Mock()
+    previous.app_file_manager.path = str(tmp_path / "notebook.py")
+    previous.app_file_manager.header = None
+    previous.app_file_manager.app.cell_manager.cell_ids.return_value = [previous_id]
+    previous.config_manager = Mock()
+    previous.config_manager.get_config.return_value = DEFAULT_CONFIG
+    previous.session_view = previous_view
+    previous.started_at = 42
+    previous.marimo_version = "1.2.4"
+    previous.requires_restart = True
+
+    created = await sessions._create(
+        "file:///workspace/notebook.py",
+        "/usr/bin/python",
+        "/workspace",
+        previous=previous,
+    )
+
+    notification = created.session_view.cell_notifications[current_id]
+    assert notification.output is not None
+    assert notification.output.data == "not yet flushed"
+    assert created.app_file_manager is current_app_file_manager
+    files.read.assert_not_awaited()
+
+    writer = created._saved_session_writer
+    assert writer is not None
+    assert await writer.flush_once()
+    replace_args = files.replace.await_args
+    assert replace_args is not None
+    written = replace_args.args[1]
+    rebased = decode_saved_session_view(
+        written,
+        codes=(code,),
+        cell_ids=(current_id,),
+        marimo_version="1.2.4",
+        header=None,
+    )
+    assert rebased is not None
+    rebased_output = rebased.cell_notifications[current_id].output
+    assert rebased_output is not None
+    assert rebased_output.data == "not yet flushed"
+    created.close()
+
+
+@pytest.mark.asyncio
+async def test_saved_session_source_rebases_across_executables() -> None:
+    previous_id = CellId_t("previous")
+    current_id = CellId_t("current")
+    code = "value = 1"
+    source = Mock(spec=Session)
+    source.marimo_version = "1.2.4"
+    source.session_view = SessionView()
+    source.session_view.add_control_request(
+        ExecuteCellsCommand(cell_ids=[previous_id], codes=[code])
+    )
+    source.session_view.add_notification(
+        CellNotification(
+            cell_id=previous_id,
+            status="idle",
+            output=CellOutput(
+                channel=CellChannel.OUTPUT,
+                mimetype="text/plain",
+                data="from another executable",
+            ),
+            console=[],
+            timestamp=1,
+        )
+    )
+    source.app_file_manager.header = None
+    source.app_file_manager.app.cell_manager.cell_ids.return_value = [previous_id]
+    current = Mock()
+    current.header = None
+    current.app.cell_manager.codes.return_value = [code]
+    current.app.cell_manager.cell_ids.return_value = [current_id]
+    kernel = Mock(marimo_version="1.2.4")
+    files = Mock()
+    files.read = AsyncMock(return_value=None)
+
+    restored, pending = await _initial_session_view(
+        _SessionViewSource(source, reuse_live_view=False),
+        kernel,
+        files,
+        "/workspace/session.json",
+        current,
+    )
+
+    assert restored is not None
+    output = restored.cell_notifications[current_id].output
+    assert output is not None
+    assert output.data == "from another executable"
+    assert restored.last_executed_code == {current_id: code}
+    assert pending
+    files.read.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -1021,6 +1505,7 @@ async def test_terminal_error_during_startup_handoff_aborts_session() -> None:
     previous.config_manager.get_config.return_value = DEFAULT_CONFIG
     previous.session_view = Mock()
     previous.started_at = 42
+    previous.requires_restart = False
 
     with pytest.raises(KernelOpenError, match="bridge exited"):
         await sessions._create(
@@ -1041,10 +1526,12 @@ async def test_restart_replaces_kernel_without_reloading_closed_notebook() -> No
     current.executable = "/usr/bin/python"
     current.working_directory = "/workspace"
     current.attached = False
+    current.requires_restart = False
     current.session_view = Mock()
     current.started_at = 42
     current.close.side_effect = lambda: events.append("old closed")
     replacement = Mock(spec=Session)
+    _mark_replacement_source_current(replacement)
     replacement.activate.side_effect = lambda: events.append("new activated")
     sessions._sessions["file:///test.py"] = current
     sessions._create = AsyncMock(return_value=replacement)
@@ -1073,9 +1560,41 @@ async def test_restart_replaces_kernel_without_reloading_closed_notebook() -> No
 
 
 @pytest.mark.asyncio
+async def test_restart_rebases_an_invalidated_live_graph_snapshot() -> None:
+    sessions = Sessions(Mock(), kernels=Mock())
+    current = Mock(spec=Session)
+    current.executable = "/usr/bin/python"
+    current.working_directory = "/workspace"
+    current.attached = False
+    current.requires_restart = True
+    replacement = Mock(spec=Session)
+    _mark_replacement_source_current(replacement)
+    sessions._sessions["file:///test.py"] = current
+    sessions._create = AsyncMock(return_value=replacement)
+    sessions._notify_changed = Mock()
+
+    result = await sessions.restart(
+        "file:///test.py",
+        executable="/usr/bin/python",
+        working_directory="/workspace",
+    )
+
+    assert result is replacement
+    sessions._create.assert_awaited_once_with(
+        "file:///test.py",
+        "/usr/bin/python",
+        "/workspace",
+        previous=current,
+    )
+    replacement.detach.assert_not_called()
+    current.close.assert_called_once_with()
+
+
+@pytest.mark.asyncio
 async def test_restore_uses_requested_working_directory() -> None:
     sessions = Sessions(Mock(), kernels=Mock())
     replacement = Mock(spec=Session)
+    _mark_replacement_source_current(replacement)
     sessions._create = AsyncMock(return_value=replacement)
     sessions._notify_changed = Mock()
 


### PR DESCRIPTION
marimo restores cached display state by decoding its sidecar into a
`SessionView` and replaying cell notifications. The language server now exposes
that same replay boundary, preferring a surviving live view and otherwise
reading a compatible sidecar through its existing host-file adapter.

The extension asks the selected environment only for its exact marimo version
and cache path. Session contents stay inside the language server, and reading
them does not start a kernel.

File-backed sessions can outlive the VS Code document whose cell IDs they were
created with. An incompatible live graph stays detached while its display state
is remapped through marimo's cache format onto the reopened document. A
replacement kernel receives that rebased view, including output that had not
reached disk yet.

Cold and rebased snapshots carry marimo's lazy-edit stale state. A surviving
live view preserves its recorded staleness instead.

Source-changing notebook events and document close invalidate an in-flight
replacement before it can publish a graph built from an older document. Output
and execution-summary changes do not cancel the kernel they belong to.
