### PR TITLE
Report marimo versions from launched kernels

### DIFF
--- a/extension/resources/wasm/kernel.py
+++ b/extension/resources/wasm/kernel.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import atexit
 import collections
 import contextlib
+import json
 import os
 import queue
 import signal
@@ -55,6 +56,11 @@ if TYPE_CHECKING:
 _write_lock = threading.Lock()
 _decoder = msgspec.json.Decoder(ToBridge)
 KERNEL_READY_TIMEOUT = 10.0
+_KERNEL_LAUNCH_CODE = """\
+import json, runpy, marimo
+print(json.dumps({"marimo_version": marimo.__version__}), flush=True)
+runpy.run_module("marimo._ipc.launch_kernel", run_name="__main__")
+"""
 
 
 def _read_frame() -> ToBridge | None:
@@ -111,8 +117,8 @@ class _Bridge:
 
         # Piped standard streams make CreateProcess hand the kernel real
         # handles, so its fds 0-2 are valid from birth.
-        process = subprocess.Popen(
-            [sys.executable, "-m", "marimo._ipc.launch_kernel"],
+        process = subprocess.Popen(  # noqa: S603 -- selected Python launches marimo
+            [sys.executable, "-c", _KERNEL_LAUNCH_CODE],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
@@ -127,6 +133,21 @@ class _Bridge:
         # Drain stderr before waiting for readiness so a noisy child cannot
         # fill its pipe and deadlock startup.
         threading.Thread(target=self._forward_stderr, daemon=True).start()
+        version_line = self._wait_for_kernel_ready()
+        try:
+            version_payload = json.loads(version_line)
+        except json.JSONDecodeError as error:
+            msg = f"Invalid kernel version response: {version_line!r}"
+            raise RuntimeError(self._with_stderr_tail(msg)) from error
+        marimo_version = (
+            version_payload.get("marimo_version")
+            if isinstance(version_payload, dict)
+            else None
+        )
+        if not isinstance(marimo_version, str):
+            msg = f"Invalid kernel version response: {version_line!r}"
+            raise TypeError(self._with_stderr_tail(msg))
+
         ready = self._wait_for_kernel_ready()
         if ready != "KERNEL_READY":
             msg = f"Expected KERNEL_READY, received {ready!r}"
@@ -138,7 +159,7 @@ class _Bridge:
         # during startup.
         threading.Thread(target=self._watch_kernel_exit, daemon=True).start()
         threading.Thread(target=self._forward_operations, daemon=True).start()
-        _write_frame(Ready())
+        _write_frame(Ready(marimo_version=marimo_version))
 
     def _with_stderr_tail(self, message: str) -> str:
         with self._stderr_lock:

--- a/extension/resources/wasm/protocol.py
+++ b/extension/resources/wasm/protocol.py
@@ -28,6 +28,7 @@ MAX_FRAME_SIZE = 64 * 1024 * 1024
 class Ready(msgspec.Struct, tag="ready", tag_field="type", rename="camel"):
     """The kernel bridge is ready."""
 
+    marimo_version: str | None = None
     version: Literal[1] = VERSION
 
 

--- a/src/marimo_lsp/kernels/__init__.py
+++ b/src/marimo_lsp/kernels/__init__.py
@@ -21,6 +21,7 @@ class Kernel(typing.Protocol):
 
     executable: str
     working_directory: str
+    marimo_version: str | None
 
     def send(self, request: CommandMessage) -> None:
         """Send a command to the kernel."""
@@ -57,3 +58,8 @@ class Kernels(typing.Protocol):
 
 class KernelOpenError(RuntimeError):
     """A kernel failed before it became ready."""
+
+
+def normalize_marimo_version(version: str | None) -> str | None:
+    """Return a version only when marimo can identify it."""
+    return None if version == "unknown" else version

--- a/src/marimo_lsp/kernels/manager.py
+++ b/src/marimo_lsp/kernels/manager.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import json
 import subprocess
 import typing
 from pathlib import Path
@@ -15,6 +16,7 @@ from marimo._session.managers import KernelManagerImpl
 from marimo._session.model import SessionMode
 from marimo._session.queue import ProcessLike
 
+from marimo_lsp.kernels import normalize_marimo_version
 from marimo_lsp.loggers import get_logger
 
 if typing.TYPE_CHECKING:
@@ -26,6 +28,13 @@ if typing.TYPE_CHECKING:
 
 
 logger = get_logger()
+
+_KERNEL_LAUNCH_CODE = """\
+import json, runpy, marimo
+print(json.dumps({"marimo_version": marimo.__version__}), flush=True)
+runpy.run_module("marimo._ipc.launch_kernel", run_name="__main__")
+"""
+_MAX_STARTUP_STDERR_CHARS = 16_000
 
 
 class InvalidWorkingDirectoryError(ValueError):
@@ -45,14 +54,61 @@ def _validate_working_directory(path: Path) -> None:
         raise InvalidWorkingDirectoryError(path, "is not a directory")
 
 
+def _with_stderr_tail(
+    process: subprocess.Popen[bytes],
+    message: str,
+) -> str:
+    """Include stderr from a kernel process that has stopped."""
+    if process.poll() is None or process.stderr is None:
+        return message
+    stderr = process.stderr.read().decode("utf-8", errors="replace").strip()
+    if not stderr:
+        return message
+    return f"{message} Stderr: {stderr[-_MAX_STARTUP_STDERR_CHARS:]}"
+
+
+def _parse_kernel_version(version_line: str) -> str | None:
+    try:
+        version_payload = json.loads(version_line)
+    except json.JSONDecodeError as error:
+        msg = f"Invalid kernel version response: {version_line!r}"
+        raise RuntimeError(msg) from error
+    marimo_version = (
+        version_payload.get("marimo_version")
+        if isinstance(version_payload, dict)
+        else None
+    )
+    if not isinstance(marimo_version, str):
+        msg = f"Invalid kernel version response: {version_line!r}"
+        raise TypeError(msg)
+    return normalize_marimo_version(marimo_version)
+
+
+def _require_kernel_ready(
+    process: subprocess.Popen[bytes],
+    ready_line: str,
+) -> None:
+    if ready_line == "KERNEL_READY":
+        return
+    exit_code = process.poll()
+    if exit_code is not None and exit_code != 0:
+        msg = f"Kernel failed to start (exit code {exit_code})"
+        logger.error(msg)
+        raise RuntimeError(msg)
+
+    msg = f"Invalid kernel response. Expected 'KERNEL_READY', got: {ready_line!r}."
+    logger.error(msg)
+    raise RuntimeError(msg)
+
+
 def launch_kernel(
     executable: str,
     args: ipc.KernelArgs,
     cwd: str | None = None,
 ) -> Process:
     """Launch kernel as a subprocess."""
-    cmd = [executable, "-m", "marimo._ipc.launch_kernel"]
-    logger.info(f"Launching kernel subprocess: {' '.join(cmd)}")
+    cmd = [executable, "-c", _KERNEL_LAUNCH_CODE]
+    logger.info(f"Launching kernel subprocess: {executable} -c <kernel bootstrap>")
     logger.debug(f"Connection info: {args.connection_info}")
     if cwd:
         logger.debug(f"Setting kernel working directory to: {cwd}")
@@ -64,39 +120,36 @@ def launch_kernel(
         stderr=subprocess.PIPE,
         cwd=cwd,
     )
+    owner = Process(inner=process)
+    try:
+        assert process.stdin, "Expect subprocess stdin pipe"
+        assert process.stdout, "Expect subprocess stdout pipe"
+        assert process.stderr, "Expect subprocess stderr pipe"
 
-    assert process.stdin, "Expect subprocess stdin pipe"
-    assert process.stdout, "Expect subprocess stdout pipe"
-    assert process.stderr, "Expect subprocess stderr pipe"
+        # Send over stdin
+        process.stdin.write(args.encode_json())
+        process.stdin.flush()
+        process.stdin.close()
 
-    # Send over stdin
-    process.stdin.write(args.encode_json())
-    process.stdin.flush()
-    process.stdin.close()
+        logger.debug("Waiting for marimo version from kernel subprocess")
 
-    logger.debug("Waiting for KERNEL_READY signal from kernel subprocess")
+        version_line = process.stdout.readline().decode("utf-8").strip()
+        marimo_version = _parse_kernel_version(version_line)
 
-    # Wait for "KERNEL_READY" message
-    ready_line = process.stdout.readline().decode("utf-8").strip()
-    if ready_line != "KERNEL_READY":
-        exit_code = process.poll()
-        stderr = process.stderr.read().decode("utf-8", errors="replace")
+        # Wait for "KERNEL_READY" message
+        ready_line = process.stdout.readline().decode("utf-8").strip()
+        _require_kernel_ready(process, ready_line)
+    except BaseException as error:
+        owner.terminate()
+        if isinstance(error, (RuntimeError, TypeError)):
+            message = _with_stderr_tail(process, str(error))
+            if message != str(error):
+                raise type(error)(message) from error
+        raise
 
-        if exit_code is not None and exit_code != 0:
-            msg = f"Kernel failed to start (exit code {exit_code}): {stderr}"
-            logger.error(msg)
-            raise RuntimeError(msg)
-
-        msg = (
-            f"Invalid kernel response. Expected 'KERNEL_READY', got: '{ready_line}'. "
-            f"Stderr: {stderr}"
-        )
-        logger.error(msg)
-        process.terminate()
-        raise RuntimeError(msg)
-
+    owner.marimo_version = marimo_version
     logger.info(f"Kernel subprocess started successfully with PID: {process.pid}")
-    return Process(inner=process)
+    return owner
 
 
 class Manager(KernelManagerImpl):
@@ -139,6 +192,7 @@ class Manager(KernelManagerImpl):
         self.executable = executable
         self.connection_info = connection_info
         self.working_directory = working_directory
+        self.marimo_version: str | None = None
 
     def start_kernel(self) -> None:
         """Start an instance of the marimo kernel using ZeroMQ IPC."""
@@ -157,6 +211,7 @@ class Manager(KernelManagerImpl):
             ),
             cwd=str(working_directory),
         )
+        self.marimo_version = self.kernel_task.marimo_version
 
 
 class Process(ProcessLike):
@@ -168,9 +223,14 @@ class Process(ProcessLike):
     # Timeout in seconds to wait for graceful termination before force killing
     TERMINATE_TIMEOUT = 2.0
 
-    def __init__(self, inner: subprocess.Popen[bytes]) -> None:
+    def __init__(
+        self,
+        inner: subprocess.Popen[bytes],
+        marimo_version: str | None = None,
+    ) -> None:
         """Initialize with a subprocess.Popen instance."""
         self.inner = inner
+        self.marimo_version = marimo_version
 
     @property
     def pid(self) -> int | None:

--- a/src/marimo_lsp/kernels/native.py
+++ b/src/marimo_lsp/kernels/native.py
@@ -43,10 +43,12 @@ class NativeKernel:
         self._listener_thread: threading.Thread | None = None
         self.executable = manager.executable
         self.working_directory = manager.working_directory
+        self.marimo_version: str | None = None
 
     def start(self, receive: Callable[[KernelMessage], None]) -> None:
         """Start the kernel process and operation listener."""
         self._manager.start_kernel()
+        self.marimo_version = self._manager.marimo_version
 
         def listen() -> None:
             stream_queue = self._queue_manager.stream_queue

--- a/src/marimo_lsp/sessions.py
+++ b/src/marimo_lsp/sessions.py
@@ -33,7 +33,7 @@ from marimo._session.state.session_view import SessionView
 from marimo._types.ids import SessionId
 
 from marimo_lsp.app_file_manager import LspAppFileManager, sync_app_with_workspace
-from marimo_lsp.kernels import KernelOpenError
+from marimo_lsp.kernels import KernelOpenError, normalize_marimo_version
 from marimo_lsp.loggers import get_logger
 from marimo_lsp.models import KernelNotification, ListSessionsResponse, SessionInfo
 
@@ -218,6 +218,11 @@ class Session:
     def working_directory(self) -> str:
         """Return the configured kernel working directory."""
         return self._kernel.working_directory
+
+    @property
+    def marimo_version(self) -> str | None:
+        """Return the exact version reported by the launched kernel."""
+        return normalize_marimo_version(self._kernel.marimo_version)
 
     @property
     def attached(self) -> bool:
@@ -668,6 +673,16 @@ class Sessions:
             receive=receive,
         )
         try:
+            previous_version = normalize_marimo_version(
+                previous.marimo_version if previous is not None else None
+            )
+            kernel_version = normalize_marimo_version(kernel.marimo_version)
+            keep_previous_view = (
+                previous is not None
+                and previous_version is not None
+                and kernel_version is not None
+                and previous_version == kernel_version
+            )
             session = Session(
                 session_id=session_id,
                 notebook_uri=notebook_uri,
@@ -675,7 +690,7 @@ class Sessions:
                 kernel=kernel,
                 app_file_manager=app_file_manager,
                 config_manager=config_manager,
-                session_view=previous.session_view if previous else None,
+                session_view=previous.session_view if keep_previous_view else None,
                 started_at=previous.started_at if previous else None,
             )
             session.set_on_kernel_failure(_raise_kernel_failure)
@@ -710,7 +725,9 @@ class Sessions:
             version = self._lifecycle_version(notebook_uri)
             if current is None:
                 replacement = await self._create(
-                    notebook_uri, executable, working_directory
+                    notebook_uri,
+                    executable,
+                    working_directory,
                 )
             else:
                 replacement = await self._create(

--- a/src/marimo_lsp/wasm/kernels.py
+++ b/src/marimo_lsp/wasm/kernels.py
@@ -13,7 +13,7 @@ from marimo._config.settings import GLOBAL_SETTINGS
 from marimo._messaging.types import KernelMessage
 from marimo._runtime.commands import AppMetadata
 
-from marimo_lsp.kernels import KernelOpenError
+from marimo_lsp.kernels import KernelOpenError, normalize_marimo_version
 from marimo_lsp.loggers import get_logger
 from marimo_lsp.wasm.protocol import (
     Close,
@@ -88,6 +88,7 @@ class WasmKernel:
         self._closed = False
         self.executable = executable
         self.working_directory = working_directory
+        self.marimo_version: str | None = None
 
     def accept(self, chunk: bytes) -> None:
         """Decode operations received from the kernel bridge."""
@@ -95,6 +96,7 @@ class WasmKernel:
             return
         for message in self._decoder.feed(chunk):
             if isinstance(message, Ready):
+                self.marimo_version = normalize_marimo_version(message.marimo_version)
                 if not self._ready.done():
                     self._ready.set_result(None)
             elif isinstance(message, Operation):

--- a/src/marimo_lsp/wasm/protocol.py
+++ b/src/marimo_lsp/wasm/protocol.py
@@ -26,6 +26,7 @@ MAX_FRAME_SIZE = 64 * 1024 * 1024
 class Ready(msgspec.Struct, tag="ready", tag_field="type", rename="camel"):
     """The kernel bridge is ready."""
 
+    marimo_version: str | None = None
     version: Literal[1] = VERSION
 
 

--- a/tests/test_native_kernel.py
+++ b/tests/test_native_kernel.py
@@ -10,7 +10,7 @@ from unittest.mock import Mock
 
 import pytest
 
-from marimo_lsp.kernels.manager import Manager
+from marimo_lsp.kernels.manager import Manager, launch_kernel
 from marimo_lsp.kernels.native import NativeKernels
 
 if TYPE_CHECKING:
@@ -32,7 +32,8 @@ def _manager(notebook: Path, working_directory: str) -> Manager:
 def test_supplied_working_directory_reaches_launch_kernel(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    launch = Mock(return_value=Mock())
+    launched = Mock(marimo_version="1.2.3-rc1+build.7")
+    launch = Mock(return_value=launched)
     monkeypatch.setattr("marimo_lsp.kernels.manager.launch_kernel", launch)
     selected = tmp_path / "selected"
     selected.mkdir()
@@ -41,6 +42,131 @@ def test_supplied_working_directory_reaches_launch_kernel(
     manager.start_kernel()
 
     assert launch.call_args.kwargs["cwd"] == str(selected)
+    assert manager.marimo_version == "1.2.3-rc1+build.7"
+
+
+def test_kernel_reports_exact_marimo_version_from_launched_process(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    process = Mock()
+    process.stdout.readline.side_effect = [
+        b'{"marimo_version":"1.2.3-rc1+build.7"}\n',
+        b"KERNEL_READY\n",
+    ]
+    popen = Mock(return_value=process)
+    monkeypatch.setattr("marimo_lsp.kernels.manager.subprocess.Popen", popen)
+    args = Mock()
+    args.encode_json.return_value = b"{}"
+
+    kernel_process = launch_kernel("/python", args, cwd="/workspace")
+
+    assert kernel_process.marimo_version == "1.2.3-rc1+build.7"
+    command = popen.call_args.args[0]
+    assert command[:2] == ["/python", "-c"]
+    assert "runpy.run_module" in command[2]
+    assert popen.call_args.kwargs["cwd"] == "/workspace"
+
+
+def test_kernel_treats_unknown_marimo_version_as_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    process = Mock()
+    process.stdout.readline.side_effect = [
+        b'{"marimo_version":"unknown"}\n',
+        b"KERNEL_READY\n",
+    ]
+    monkeypatch.setattr(
+        "marimo_lsp.kernels.manager.subprocess.Popen",
+        Mock(return_value=process),
+    )
+    args = Mock()
+    args.encode_json.return_value = b"{}"
+
+    kernel_process = launch_kernel("/python", args)
+
+    assert kernel_process.marimo_version is None
+
+
+@pytest.mark.parametrize(
+    ("version_line", "error_type"),
+    [
+        (b"", RuntimeError),
+        (b"not-json\n", RuntimeError),
+        (b'{"marimo_version": 123}\n', TypeError),
+    ],
+)
+def test_invalid_kernel_version_response_cleans_up_process(
+    version_line: bytes,
+    error_type: type[Exception],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    process = Mock()
+    process.stdout.readline.return_value = version_line
+    process.stderr.read.return_value = b"bootstrap failed"
+    process.poll.side_effect = [None, 1]
+    monkeypatch.setattr(
+        "marimo_lsp.kernels.manager.subprocess.Popen",
+        Mock(return_value=process),
+    )
+    args = Mock()
+    args.encode_json.return_value = b"{}"
+
+    with pytest.raises(error_type, match="bootstrap failed"):
+        launch_kernel("/python", args)
+
+    process.terminate.assert_called_once_with()
+    process.wait.assert_called_once()
+
+
+def test_invalid_ready_response_cleans_up_process(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    process = Mock()
+    process.stdout.readline.side_effect = [
+        b'{"marimo_version":"1.2.3"}\n',
+        b"NOT_READY\n",
+    ]
+    process.stderr.read.return_value = b"kernel failed"
+    process.poll.side_effect = [None, None, 1]
+    monkeypatch.setattr(
+        "marimo_lsp.kernels.manager.subprocess.Popen",
+        Mock(return_value=process),
+    )
+    args = Mock()
+    args.encode_json.return_value = b"{}"
+
+    with pytest.raises(RuntimeError, match="kernel failed"):
+        launch_kernel("/python", args)
+
+    process.terminate.assert_called_once_with()
+    process.wait.assert_called_once()
+
+
+@pytest.mark.parametrize("failure", ["write", "decode"])
+def test_unexpected_bootstrap_failure_cleans_up_process(
+    failure: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    process = Mock()
+    process.poll.return_value = None
+    if failure == "write":
+        process.stdin.write.side_effect = BrokenPipeError("closed pipe")
+        error_type = BrokenPipeError
+    else:
+        process.stdout.readline.return_value = b"\xff\n"
+        error_type = UnicodeDecodeError
+    monkeypatch.setattr(
+        "marimo_lsp.kernels.manager.subprocess.Popen",
+        Mock(return_value=process),
+    )
+    args = Mock()
+    args.encode_json.return_value = b"{}"
+
+    with pytest.raises(error_type):
+        launch_kernel("/python", args)
+
+    process.terminate.assert_called_once_with()
+    process.wait.assert_called_once()
 
 
 @pytest.mark.parametrize("kind", ["relative", "missing", "file"])

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -570,6 +570,7 @@ async def test_startup_message_handoff_preserves_order(
     second = KernelMessage(b'{"op": "second"}')
     third = KernelMessage(b'{"op": "third"}')
     kernel = Mock()
+    kernel.marimo_version = "1.2.3-rc1+build.7"
     receive_callback: list[Callable[[KernelMessage], None]] = []
 
     async def launch(**kwargs: object) -> object:
@@ -595,6 +596,7 @@ async def test_startup_message_handoff_preserves_order(
     previous.config_manager.get_config.return_value = DEFAULT_CONFIG
     previous.session_view = Mock()
     previous.started_at = 42
+    previous.marimo_version = "1.2.3-rc1+build.7"
     loop_thread = threading.get_ident()
     observed: list[tuple[KernelMessage, int]] = []
     third_delivered = asyncio.Event()
@@ -606,12 +608,14 @@ async def test_startup_message_handoff_preserves_order(
 
     monkeypatch.setattr(Session, "accept_kernel_message", accept)
 
-    await sessions._create(
+    created = await sessions._create(
         "file:///test.py",
         "/usr/bin/python",
         "/workspace",
         previous=previous,
     )
+    assert created.marimo_version == "1.2.3-rc1+build.7"
+    assert created.session_view is previous.session_view
     threading.Thread(target=receive_callback[0], args=(third,), daemon=True).start()
     await asyncio.wait_for(third_delivered.wait(), timeout=1)
 
@@ -620,6 +624,47 @@ async def test_startup_message_handoff_preserves_order(
         (second, loop_thread),
         (third, loop_thread),
     ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("previous_version", "kernel_version"),
+    [
+        ("1.2.3", "1.2.4"),
+        (None, None),
+        (None, "1.2.4"),
+        ("1.2.3", None),
+        ("unknown", "unknown"),
+    ],
+)
+async def test_session_creation_drops_view_without_known_matching_versions(
+    previous_version: str | None,
+    kernel_version: str | None,
+) -> None:
+    kernel = Mock()
+    kernel.marimo_version = kernel_version
+    kernels = Mock()
+    kernels.launch = AsyncMock(return_value=kernel)
+    sessions = Sessions(Mock(), kernels=kernels)
+    previous = Mock(spec=Session)
+    previous.app_file_manager = Mock()
+    previous.config_manager = Mock()
+    previous.config_manager.get_config.return_value = DEFAULT_CONFIG
+    previous.session_view = SessionView()
+    previous.started_at = 42
+    previous.marimo_version = previous_version
+
+    created = await sessions._create(
+        "file:///test.py",
+        "/usr/bin/python",
+        "/workspace",
+        previous=previous,
+    )
+
+    assert created.marimo_version == (
+        None if kernel_version == "unknown" else kernel_version
+    )
+    assert created.session_view is not previous.session_view
 
 
 @pytest.mark.asyncio

--- a/tests/test_wasm_bridge.py
+++ b/tests/test_wasm_bridge.py
@@ -174,7 +174,10 @@ def test_bridge_launches_kernel_subprocess_over_marimo_ipc(
     """
     bridge_module = _load_bridge_module(monkeypatch)
     process = Mock()
-    process.stdout.readline.return_value = b"KERNEL_READY\n"
+    process.stdout.readline.side_effect = [
+        b'{"marimo_version":"1.2.3-rc1+build.7"}\n',
+        b"KERNEL_READY\n",
+    ]
     process.stderr = None
     popen = Mock(return_value=process)
     write_frame = Mock()
@@ -187,7 +190,8 @@ def test_bridge_launches_kernel_subprocess_over_marimo_ipc(
 
         popen.assert_called_once()
         command = popen.call_args.args[0]
-        assert command == [sys.executable, "-m", "marimo._ipc.launch_kernel"]
+        assert command[:2] == [sys.executable, "-c"]
+        assert "runpy.run_module" in command[2]
         assert popen.call_args.kwargs["cwd"] == str(tmp_path)
         assert popen.call_args.kwargs["stdin"] is bridge_module.subprocess.PIPE
         assert popen.call_args.kwargs["stdout"] is bridge_module.subprocess.PIPE
@@ -195,7 +199,9 @@ def test_bridge_launches_kernel_subprocess_over_marimo_ipc(
         sent = KernelLaunchArgs.decode_json(process.stdin.write.call_args.args[0])
         assert sent.connection_info is not None
         assert sent.parent_pid == os.getpid()
-        write_frame.assert_any_call(bridge_module.Ready())
+        write_frame.assert_any_call(
+            bridge_module.Ready(marimo_version="1.2.3-rc1+build.7")
+        )
     finally:
         bridge.close()
 

--- a/tests/test_wasm_kernel.py
+++ b/tests/test_wasm_kernel.py
@@ -83,8 +83,12 @@ async def _begin_launch():
 async def _launch_kernel():
     callbacks, kernels, launch, messages = await _begin_launch()
     process_id = callbacks.spawns[0][0]
-    kernels.accept(process_id, encode(Ready()))
+    kernels.accept(
+        process_id,
+        encode(Ready(marimo_version="1.2.3-rc1+build.7")),
+    )
     kernel = await launch
+    assert kernel.marimo_version == "1.2.3-rc1+build.7"
     return callbacks, kernels, kernel, messages
 
 
@@ -98,6 +102,32 @@ async def test_wasm_launch_fails_before_publishing_unready_kernel() -> None:
     with pytest.raises(KernelOpenError, match="failed to start"):
         await launch
     assert callbacks.closes == snapshot([process_id])
+
+
+@pytest.mark.asyncio
+async def test_wasm_launch_accepts_legacy_ready_without_version() -> None:
+    callbacks, kernels, launch, _messages = await _begin_launch()
+    process_id = callbacks.spawns[0][0]
+    payload = b'{"type":"ready","version":1}'
+
+    kernels.accept(
+        process_id,
+        len(payload).to_bytes(4, byteorder="big") + payload,
+    )
+
+    kernel = await launch
+    assert kernel.marimo_version is None
+
+
+@pytest.mark.asyncio
+async def test_wasm_launch_treats_unknown_marimo_version_as_unavailable() -> None:
+    callbacks, kernels, launch, _messages = await _begin_launch()
+    process_id = callbacks.spawns[0][0]
+
+    kernels.accept(process_id, encode(Ready(marimo_version="unknown")))
+
+    kernel = await launch
+    assert kernel.marimo_version is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
An executable path can change in place, and inspecting it from the client is
not proof of the process that launched. Native and WASM bootstraps therefore
report `marimo.__version__` from the child that immediately becomes the kernel.

A restarted session keeps its `SessionView` only when both kernels report the
same exact version. Unknown or mismatched versions start with an empty view.
