### PR TITLE
Persist marimo session outputs

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -20,7 +20,7 @@
     "check": "vp check && node ./scripts/check-css-variables.mjs",
     "fix": "vp fmt && vp check --fix",
     "test": "vp test",
-    "pretest:extension": "pnpm run build:extension",
+    "pretest:extension": "node scripts/run-turbo.mjs build:wasm-lsp:bundle build:extension",
     "test:extension": "vscode-test",
     "embed-sdist": "node scripts/embed-sdist.mjs",
     "build:wasm-lsp": "node scripts/run-turbo.mjs build:wasm-lsp:bundle",

--- a/extension/resources/wasm/kernel.py
+++ b/extension/resources/wasm/kernel.py
@@ -41,9 +41,11 @@ from protocol import (
     FromBridge,
     Input,
     Interrupt,
+    LocateSessionCache,
     Log,
     Operation,
     Ready,
+    SessionCacheLocation,
     Start,
     ToBridge,
     encode,
@@ -61,6 +63,24 @@ import json, runpy, marimo
 print(json.dumps({"marimo_version": marimo.__version__}), flush=True)
 runpy.run_module("marimo._ipc.launch_kernel", run_name="__main__")
 """
+
+
+def _locate_session_cache(notebook_path: str | None) -> str | None:
+    if not notebook_path:
+        return None
+    try:
+        # Older selected environments may not provide this private helper;
+        # importing it eagerly would make optional persistence block startup.
+        from marimo._session.state.serialize import (  # noqa: PLC0415
+            get_session_cache_file,
+        )
+
+        path = Path(notebook_path)
+        if not path.is_file():
+            return None
+        return str(get_session_cache_file(path).absolute())
+    except Exception:  # noqa: BLE001 - cache support must not block startup
+        return None
 
 
 def _read_frame() -> ToBridge | None:
@@ -159,7 +179,15 @@ class _Bridge:
         # during startup.
         threading.Thread(target=self._watch_kernel_exit, daemon=True).start()
         threading.Thread(target=self._forward_operations, daemon=True).start()
-        _write_frame(Ready(marimo_version=marimo_version))
+        _write_frame(
+            Ready(
+                marimo_version=marimo_version,
+                session_cache_path=_locate_session_cache(
+                    kernel_args.app_metadata.filename
+                ),
+                can_locate_session_cache=True,
+            )
+        )
 
     def _with_stderr_tail(self, message: str) -> str:
         with self._stderr_lock:
@@ -239,6 +267,13 @@ class _Bridge:
             self._queues.put_input(message.text)
         elif isinstance(message, Interrupt):
             self.interrupt()
+        elif isinstance(message, LocateSessionCache):
+            _write_frame(
+                SessionCacheLocation(
+                    request_id=message.request_id,
+                    path=_locate_session_cache(message.notebook_path),
+                )
+            )
         elif isinstance(message, Close):
             self.close()
             return False

--- a/extension/resources/wasm/protocol.py
+++ b/extension/resources/wasm/protocol.py
@@ -29,6 +29,21 @@ class Ready(msgspec.Struct, tag="ready", tag_field="type", rename="camel"):
     """The kernel bridge is ready."""
 
     marimo_version: str | None = None
+    session_cache_path: str | None = None
+    can_locate_session_cache: bool = False
+    version: Literal[1] = VERSION
+
+
+class SessionCacheLocation(
+    msgspec.Struct,
+    tag="session-cache-location",
+    tag_field="type",
+    rename="camel",
+):
+    """A cache path resolved by the selected Python."""
+
+    request_id: str
+    path: str | None
     version: Literal[1] = VERSION
 
 
@@ -53,7 +68,7 @@ class Log(msgspec.Struct, tag="log", tag_field="type", rename="camel"):
     version: Literal[1] = VERSION
 
 
-FromBridge: TypeAlias = Ready | Operation | Error | Log
+FromBridge: TypeAlias = Ready | SessionCacheLocation | Operation | Error | Log
 
 
 class KernelLaunchArgs(ipc.KernelArgs):
@@ -94,13 +109,26 @@ class Interrupt(msgspec.Struct, tag="interrupt", tag_field="type", rename="camel
     version: Literal[1] = VERSION
 
 
+class LocateSessionCache(
+    msgspec.Struct,
+    tag="locate-session-cache",
+    tag_field="type",
+    rename="camel",
+):
+    """Resolve marimo's cache path for a renamed notebook."""
+
+    request_id: str
+    notebook_path: str
+    version: Literal[1] = VERSION
+
+
 class Close(msgspec.Struct, tag="close", tag_field="type", rename="camel"):
     """Close the kernel."""
 
     version: Literal[1] = VERSION
 
 
-ToBridge: TypeAlias = Start | Control | Input | Interrupt | Close
+ToBridge: TypeAlias = Start | Control | Input | Interrupt | LocateSessionCache | Close
 
 Message = TypeVar("Message")
 

--- a/extension/src/wasm/WasmBridgeRuntime.ts
+++ b/extension/src/wasm/WasmBridgeRuntime.ts
@@ -1,3 +1,7 @@
+import * as NodeCrypto from "node:crypto";
+import * as NodeFs from "node:fs";
+import * as NodePath from "node:path";
+
 import { Processes } from "./Processes.ts";
 
 interface WasmBridge {
@@ -22,8 +26,17 @@ export interface WasmModule {
   readonly create_bridge: (
     writeMessage: (messageJson: string) => void,
     processes: object,
+    savedSessions: object,
   ) => WasmBridge;
   readonly destroy: () => void;
+}
+
+interface SavedSessionReplacement {
+  readonly target: string;
+  readonly temporary: string;
+  descriptor: number | undefined;
+  writing: Promise<void> | undefined;
+  discarded: boolean;
 }
 
 type RuntimeState =
@@ -42,10 +55,175 @@ function takeBytes(value: Uint8Array | BytesProxy): Uint8Array {
   return converted;
 }
 
+export class SavedSessionFiles {
+  readonly #replacements = new Map<string, SavedSessionReplacement>();
+  #closed = false;
+
+  async read(target: string): Promise<string | null> {
+    this.#assertOpen();
+    this.#assertTarget(target);
+    try {
+      return await NodeFs.promises.readFile(target, "utf8");
+    } catch (error) {
+      if (
+        typeof error === "object" &&
+        error !== null &&
+        "code" in error &&
+        error.code === "ENOENT"
+      ) {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  create(target: string): string {
+    this.#assertOpen();
+    this.#assertTarget(target);
+    const directory = NodePath.dirname(target);
+    NodeFs.mkdirSync(directory, { recursive: true });
+    const replacement = NodeCrypto.randomUUID();
+    const temporary = NodePath.join(
+      directory,
+      `.${NodePath.basename(target)}.${replacement}.tmp`,
+    );
+    try {
+      let mode: number | undefined;
+      try {
+        mode = NodeFs.statSync(target).mode & 0o777;
+      } catch (error) {
+        if (
+          typeof error !== "object" ||
+          error === null ||
+          !("code" in error) ||
+          error.code !== "ENOENT"
+        ) {
+          throw error;
+        }
+      }
+      const descriptor = NodeFs.openSync(temporary, "wx", mode);
+      try {
+        if (mode !== undefined && process.platform !== "win32") {
+          NodeFs.fchmodSync(descriptor, mode);
+        }
+      } catch (error) {
+        NodeFs.closeSync(descriptor);
+        throw error;
+      }
+      this.#replacements.set(replacement, {
+        target,
+        temporary,
+        descriptor,
+        writing: undefined,
+        discarded: false,
+      });
+    } catch (error) {
+      NodeFs.rmSync(temporary, { force: true });
+      throw error;
+    }
+    return replacement;
+  }
+
+  write(replacement: string, contents: string): Promise<void> {
+    this.#assertOpen();
+    const pending = this.#requireReplacement(replacement);
+    const descriptor = pending.descriptor;
+    if (pending.writing !== undefined || descriptor === undefined) {
+      throw new Error("Saved session replacement is already being written");
+    }
+    const write = new Promise<void>((resolve, reject) => {
+      NodeFs.writeFile(descriptor, contents, { encoding: "utf8" }, (error) => {
+        if (error === null) resolve();
+        else reject(error);
+      });
+    }).finally(() => {
+      pending.writing = undefined;
+      if (pending.discarded) {
+        this.#discardReplacement(replacement, pending);
+      }
+    });
+    pending.writing = write;
+    return write;
+  }
+
+  commit(replacement: string): void {
+    this.#assertOpen();
+    const pending = this.#requireReplacement(replacement);
+    if (pending.writing !== undefined || pending.descriptor === undefined) {
+      throw new Error("Saved session replacement is not ready to commit");
+    }
+    try {
+      NodeFs.fsyncSync(pending.descriptor);
+      NodeFs.closeSync(pending.descriptor);
+      pending.descriptor = undefined;
+      NodeFs.renameSync(pending.temporary, pending.target);
+      this.#replacements.delete(replacement);
+    } catch (error) {
+      this.#discardReplacement(replacement, pending);
+      throw error;
+    }
+  }
+
+  discard(replacement: string): void {
+    const pending = this.#replacements.get(replacement);
+    if (pending === undefined) return;
+    if (pending.writing !== undefined) {
+      pending.discarded = true;
+      return;
+    }
+    this.#discardReplacement(replacement, pending);
+  }
+
+  close(): void {
+    if (this.#closed) return;
+    this.#closed = true;
+    for (const [replacement, pending] of [...this.#replacements]) {
+      if (pending.writing !== undefined) {
+        pending.discarded = true;
+      } else {
+        this.#discardReplacement(replacement, pending);
+      }
+    }
+  }
+
+  #assertOpen(): void {
+    if (this.#closed) {
+      throw new Error("Saved session files are closed");
+    }
+  }
+
+  #assertTarget(target: string): void {
+    if (!NodePath.isAbsolute(target)) {
+      throw new TypeError("Saved session path must be absolute");
+    }
+  }
+
+  #requireReplacement(replacement: string): SavedSessionReplacement {
+    const pending = this.#replacements.get(replacement);
+    if (pending === undefined) {
+      throw new Error("Unknown saved session replacement");
+    }
+    return pending;
+  }
+
+  #discardReplacement(
+    replacement: string,
+    pending: SavedSessionReplacement,
+  ): void {
+    if (pending.descriptor !== undefined) {
+      NodeFs.closeSync(pending.descriptor);
+      pending.descriptor = undefined;
+    }
+    NodeFs.rmSync(pending.temporary, { force: true });
+    this.#replacements.delete(replacement);
+  }
+}
+
 /** Owns the Pyodide bridge and its selected-Python process lifecycle. */
 export class WasmBridgeRuntime {
   readonly #module: WasmModule;
   readonly #processes: Processes;
+  readonly #savedSessions = new SavedSessionFiles();
   #state: RuntimeState = { status: "starting" };
 
   constructor(
@@ -85,9 +263,14 @@ export class WasmBridgeRuntime {
     };
 
     try {
-      const bridge = wasmModule.create_bridge(writeMessage, processCallbacks);
+      const bridge = wasmModule.create_bridge(
+        writeMessage,
+        processCallbacks,
+        this.#savedSessions,
+      );
       this.#state = { status: "running", bridge };
     } catch (error) {
+      this.#savedSessions.close();
       this.#processes.closeAll();
       this.#module.destroy();
       this.#state = { status: "closed" };
@@ -115,6 +298,7 @@ export class WasmBridgeRuntime {
       state.bridge.close();
     } finally {
       try {
+        this.#savedSessions.close();
         // Also release any process that was not tracked by the Python bridge.
         this.#processes.closeAll();
       } finally {

--- a/extension/src/wasm/__tests__/WasmBridgeRuntime.test.ts
+++ b/extension/src/wasm/__tests__/WasmBridgeRuntime.test.ts
@@ -1,0 +1,126 @@
+import * as NodeFs from "node:fs";
+import * as NodeOs from "node:os";
+import * as NodePath from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  SavedSessionFiles,
+  type WasmModule,
+  WasmBridgeRuntime,
+} from "../WasmBridgeRuntime.ts";
+
+describe("SavedSessionFiles", () => {
+  it("keeps the prior target until the staged write is committed", async () => {
+    const directory = NodeFs.mkdtempSync(
+      NodePath.join(NodeOs.tmpdir(), "marimo-saved-session-"),
+    );
+    try {
+      const target = NodePath.join(directory, "session.json");
+      NodeFs.writeFileSync(target, "old");
+      if (process.platform !== "win32") NodeFs.chmodSync(target, 0o666);
+      const files = new SavedSessionFiles();
+
+      const replacement = files.create(target);
+      await files.write(replacement, "new");
+
+      expect(NodeFs.readFileSync(target, "utf8")).toBe("old");
+      files.commit(replacement);
+      expect(NodeFs.readFileSync(target, "utf8")).toBe("new");
+      await expect(files.read(target)).resolves.toBe("new");
+      if (process.platform !== "win32") {
+        expect(NodeFs.statSync(target).mode & 0o777).toBe(0o666);
+      }
+    } finally {
+      NodeFs.rmSync(directory, { force: true, recursive: true });
+    }
+  });
+
+  it("discards a temp whose asynchronous write is still pending", async () => {
+    const directory = NodeFs.mkdtempSync(
+      NodePath.join(NodeOs.tmpdir(), "marimo-saved-session-"),
+    );
+    try {
+      const files = new SavedSessionFiles();
+      const replacement = files.create(
+        NodePath.join(directory, "session.json"),
+      );
+      const temporary = NodeFs.readdirSync(directory).map((name) =>
+        NodePath.join(directory, name),
+      )[0];
+      expect(temporary).toBeDefined();
+      if (temporary === undefined) throw new Error("Missing replacement file");
+
+      const write = files.write(replacement, "output");
+      files.discard(replacement);
+      await write;
+
+      expect(NodeFs.existsSync(temporary)).toBe(false);
+    } finally {
+      NodeFs.rmSync(directory, { force: true, recursive: true });
+    }
+  });
+
+  it("rejects new replacements after close", () => {
+    const files = new SavedSessionFiles();
+
+    files.close();
+    files.close();
+
+    expect(() =>
+      files.create(NodePath.join(NodeOs.tmpdir(), "session.json")),
+    ).toThrow("closed");
+  });
+
+  it("discards replacements that finish after close", async () => {
+    const directory = NodeFs.mkdtempSync(
+      NodePath.join(NodeOs.tmpdir(), "marimo-saved-session-"),
+    );
+    try {
+      const target = NodePath.join(directory, "session.json");
+      const files = new SavedSessionFiles();
+      const replacement = files.create(target);
+      const write = files.write(replacement, "output");
+
+      files.close();
+      await write;
+
+      expect(NodeFs.readdirSync(directory)).toEqual([]);
+      expect(NodeFs.existsSync(target)).toBe(false);
+    } finally {
+      NodeFs.rmSync(directory, { force: true, recursive: true });
+    }
+  });
+});
+
+describe("WasmBridgeRuntime", () => {
+  it("closes the saved-session store before destroying the bridge", () => {
+    let savedSessions: SavedSessionFiles | undefined;
+    const calls: Array<string> = [];
+    const module: WasmModule = {
+      create_bridge: (_writeMessage, _processes, files) => {
+        if (!(files instanceof SavedSessionFiles)) {
+          throw new TypeError("Expected saved-session files");
+        }
+        savedSessions = files;
+        return {
+          handle_message: async () => undefined,
+          handle_kernel_bytes: () => undefined,
+          handle_kernel_exit: () => undefined,
+          close: () => calls.push("bridge.close"),
+          destroy: () => calls.push("bridge.destroy"),
+        };
+      },
+      destroy: () => calls.push("module.destroy"),
+    };
+    const runtime = new WasmBridgeRuntime(module, () => undefined);
+
+    runtime.close();
+
+    expect(calls).toEqual(["bridge.close", "bridge.destroy", "module.destroy"]);
+    expect(savedSessions).toBeDefined();
+    expect(() =>
+      savedSessions?.create(NodePath.join(NodeOs.tmpdir(), "session.json")),
+    ).toThrow("closed");
+  });
+});

--- a/extension/tests/helpers.cjs
+++ b/extension/tests/helpers.cjs
@@ -300,6 +300,7 @@ function cellOutputText(cell) {
 
 module.exports = {
   activateExtension,
+  ensureSharedVenv,
   createTestContext,
   selectKernel,
   runCell,

--- a/extension/tests/saved-session-write.test.cjs
+++ b/extension/tests/saved-session-write.test.cjs
@@ -1,0 +1,284 @@
+// @ts-check
+/// <reference types="mocha" />
+
+const NodeAssert = require("node:assert");
+const NodeChildProcess = require("node:child_process");
+const NodeFs = require("node:fs/promises");
+const NodeUtil = require("node:util");
+const vscode = require("vscode");
+
+const {
+  createTestContext,
+  ensureSharedVenv,
+  selectKernel,
+} = require("./helpers.cjs");
+
+const execFile = NodeUtil.promisify(NodeChildProcess.execFile);
+
+const SOURCE = `# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "marimo",
+# ]
+# ///
+
+import marimo
+
+app = marimo.App()
+
+
+@app.cell
+def _():
+    import time
+    print(f"live output {time.time_ns()}")
+    return
+
+
+@app.cell
+def _():
+    40 + 2
+    return
+
+
+if __name__ == "__main__":
+    app.run()
+`;
+
+const LOCATE_MARIMO_SAVED_SESSION = String.raw`
+import pathlib
+import sys
+
+from marimo._session.state.serialize import get_session_cache_file
+
+print(get_session_cache_file(pathlib.Path(sys.argv[1])).absolute())
+`;
+
+const READ_MARIMO_SAVED_SESSION = String.raw`
+import json
+import pathlib
+import sys
+
+import marimo
+from marimo._messaging.notebook.document import NotebookDocument
+from marimo._session.notebook.file_manager import AppFileManager
+from marimo._session.state.serialize import (
+    _script_metadata_hash,
+    SessionCacheKey,
+    SessionCacheManager,
+)
+from marimo._session.state.session_view import SessionView
+from marimo._utils.lists import as_list
+
+notebook_path = pathlib.Path(sys.argv[1])
+app = AppFileManager(notebook_path).app
+cell_ids = tuple(app.cell_manager.cell_ids())
+codes = tuple(app.cell_manager.codes())
+manager = SessionCacheManager(
+    session_view=SessionView(),
+    document=NotebookDocument([]),
+    path=notebook_path,
+    interval=1,
+)
+view = manager.read_session_view(
+    SessionCacheKey(
+        codes=codes,
+        marimo_version=marimo.__version__,
+        cell_ids=cell_ids,
+        script_metadata_hash=_script_metadata_hash(notebook_path),
+    )
+)
+payload = []
+for cell_id in cell_ids:
+    notification = view.cell_notifications.get(cell_id)
+    payload.append(
+        {
+            "output": (
+                None
+                if notification is None or notification.output is None
+                else str(notification.output.data)
+            ),
+            "console": (
+                []
+                if notification is None
+                else [str(item.data) for item in as_list(notification.console)]
+            ),
+        }
+    )
+print(json.dumps(payload))
+`;
+
+const WRITE_MARIMO_SAVED_SESSION = String.raw`
+import json
+import pathlib
+import sys
+
+from marimo._messaging.cell_output import CellChannel, CellOutput
+from marimo._messaging.notification import CellNotification
+from marimo._runtime.commands import ExecuteCellsCommand
+from marimo._session.notebook.file_manager import AppFileManager
+from marimo._session.state.serialize import (
+    _script_metadata_hash,
+    get_session_cache_file,
+    serialize_session_view,
+)
+from marimo._session.state.session_view import SessionView
+
+notebook_path = pathlib.Path(sys.argv[1])
+app = AppFileManager(notebook_path).app
+cell_ids = tuple(app.cell_manager.cell_ids())
+codes = tuple(app.cell_manager.codes())
+view = SessionView()
+view.add_control_request(ExecuteCellsCommand(cell_ids=cell_ids, codes=codes))
+for cell_id, output in zip(cell_ids, ("cli first", "cli second"), strict=True):
+    view.add_notification(
+        CellNotification(
+            cell_id=cell_id,
+            status="idle",
+            output=CellOutput(
+                channel=CellChannel.OUTPUT,
+                mimetype="text/plain",
+                data=output,
+            ),
+            console=[],
+            timestamp=1,
+        )
+    )
+snapshot = serialize_session_view(
+    view,
+    cell_ids=cell_ids,
+    script_metadata_hash=_script_metadata_hash(notebook_path),
+    drop_virtual_file_outputs=True,
+)
+cache_path = get_session_cache_file(notebook_path)
+cache_path.parent.mkdir(parents=True, exist_ok=True)
+cache_path.write_text(json.dumps(snapshot, indent=2), encoding="utf-8")
+`;
+
+/**
+ * @param {import("vscode").NotebookDocument} notebook
+ * @param {ReturnType<typeof createTestContext>} ctx
+ */
+async function runAllCells(notebook, ctx) {
+  const priorEndTimes = Array.from(
+    { length: notebook.cellCount },
+    (_, index) => notebook.cellAt(index).executionSummary?.timing?.endTime,
+  );
+  await vscode.commands.executeCommand("notebook.cell.execute", {
+    ranges: [{ start: 0, end: notebook.cellCount }],
+    document: notebook.uri,
+  });
+  await ctx.waitUntil(() => {
+    for (let index = 0; index < notebook.cellCount; index += 1) {
+      const summary = notebook.cellAt(index).executionSummary;
+      NodeAssert.strictEqual(summary?.success, true);
+      NodeAssert.notStrictEqual(summary.timing?.endTime, priorEndTimes[index]);
+    }
+  });
+}
+
+/**
+ * @param {import("vscode").NotebookDocument} notebook
+ * @param {number} index
+ * @param {ReturnType<typeof createTestContext>} ctx
+ */
+async function runCell(notebook, index, ctx) {
+  const priorEndTime = notebook.cellAt(index).executionSummary?.timing?.endTime;
+  await vscode.commands.executeCommand("notebook.cell.execute", {
+    ranges: [{ start: index, end: index + 1 }],
+    document: notebook.uri,
+  });
+  await ctx.waitUntil(() => {
+    const summary = notebook.cellAt(index).executionSummary;
+    NodeAssert.strictEqual(summary?.success, true);
+    NodeAssert.notStrictEqual(summary.timing?.endTime, priorEndTime);
+  });
+}
+
+/** @param {import("vscode").Uri} notebook */
+async function savedSessionPath(notebook) {
+  const python = await ensureSharedVenv();
+  const { stdout } = await execFile(python, [
+    "-c",
+    LOCATE_MARIMO_SAVED_SESSION,
+    notebook.fsPath,
+  ]);
+  return stdout.trim();
+}
+
+/** @param {import("vscode").Uri} notebook */
+async function readMarimoSavedSession(notebook) {
+  const python = await ensureSharedVenv();
+  const { stdout } = await execFile(python, [
+    "-c",
+    READ_MARIMO_SAVED_SESSION,
+    notebook.fsPath,
+  ]);
+  return stdout;
+}
+
+/** @param {import("vscode").Uri} notebook */
+async function writeMarimoSavedSession(notebook) {
+  const python = await ensureSharedVenv();
+  await execFile(python, ["-c", WRITE_MARIMO_SAVED_SESSION, notebook.fsPath]);
+}
+
+suite("saved session output", function () {
+  this.timeout(60_000);
+
+  test("run all writes a sidecar accepted by marimo", async function () {
+    await using ctx = createTestContext();
+    const uri = await ctx.writeTempFile(SOURCE);
+    const notebook = await ctx.openNotebook(uri);
+    await selectKernel(notebook);
+    const cachePath = await savedSessionPath(uri);
+    await NodeAssert.rejects(NodeFs.access(cachePath));
+
+    await runAllCells(notebook, ctx);
+    await ctx.waitUntil(async () => {
+      const payload = JSON.parse(await NodeFs.readFile(cachePath, "utf8"));
+      NodeAssert.strictEqual(payload.version, "1");
+      NodeAssert.strictEqual(payload.cells.length, 2);
+      NodeAssert.match(JSON.stringify(payload), /live output/);
+      NodeAssert.match(JSON.stringify(payload), /42/);
+    });
+    const first = await NodeFs.readFile(cachePath, "utf8");
+    const readByMarimo = await readMarimoSavedSession(uri);
+    NodeAssert.match(readByMarimo, /live output/);
+    NodeAssert.match(readByMarimo, /42/);
+
+    await runAllCells(notebook, ctx);
+    await ctx.waitUntil(async () =>
+      NodeAssert.notStrictEqual(
+        await NodeFs.readFile(cachePath, "utf8"),
+        first,
+      ),
+    );
+  });
+
+  test("a partial run preserves untouched marimo output", async function () {
+    await using ctx = createTestContext();
+    const uri = await ctx.writeTempFile(SOURCE);
+    await writeMarimoSavedSession(uri);
+    const cachePath = await savedSessionPath(uri);
+    const initial = await NodeFs.readFile(cachePath, "utf8");
+    const notebook = await ctx.openNotebook(uri);
+    await selectKernel(notebook);
+
+    const before = JSON.parse(await readMarimoSavedSession(uri));
+    NodeAssert.strictEqual(before[0].output, "cli first");
+    NodeAssert.strictEqual(before[1].output, "cli second");
+
+    await runCell(notebook, 1, ctx);
+    await ctx.waitUntil(async () =>
+      NodeAssert.notStrictEqual(
+        await NodeFs.readFile(cachePath, "utf8"),
+        initial,
+      ),
+    );
+
+    const after = JSON.parse(await readMarimoSavedSession(uri));
+    NodeAssert.strictEqual(after[0].output, "cli first");
+    NodeAssert.notStrictEqual(after[1].output, "cli second");
+    NodeAssert.match(after[1].output, /42/);
+  });
+});

--- a/src/marimo_lsp/app_file_manager.py
+++ b/src/marimo_lsp/app_file_manager.py
@@ -48,8 +48,23 @@ class LspAppFileManager:
     def __init__(self, *, server: LanguageServer, notebook_uri: str) -> None:
         self._server = server
         self._notebook_uri = notebook_uri
+        self.app = InternalApp(App())
+        self._header: str | None = None
+        self.sync(server.workspace)
+
+    @property
+    def header(self) -> str | None:
+        """Return the latest synchronized notebook header."""
+        return self._header
+
+    def sync(self, workspace: Workspace) -> None:
+        """Synchronize app state and source metadata from the LSP document."""
+        notebook = find_notebook_document(workspace, self._notebook_uri)
+        self._header = decode_notebook_document_metadata(notebook).header
         self.app = sync_app_with_workspace(
-            workspace=server.workspace, notebook_uri=notebook_uri, app=None
+            workspace=workspace,
+            notebook_uri=self._notebook_uri,
+            app=self.app,
         )
 
     @property

--- a/src/marimo_lsp/kernels/__init__.py
+++ b/src/marimo_lsp/kernels/__init__.py
@@ -23,6 +23,10 @@ class Kernel(typing.Protocol):
     working_directory: str
     marimo_version: str | None
 
+    async def locate_saved_session(self, notebook_path: str) -> str | None:
+        """Resolve marimo's cache path in this kernel's environment."""
+        ...
+
     def send(self, request: CommandMessage) -> None:
         """Send a command to the kernel."""
         ...

--- a/src/marimo_lsp/kernels/manager.py
+++ b/src/marimo_lsp/kernels/manager.py
@@ -30,8 +30,24 @@ if typing.TYPE_CHECKING:
 logger = get_logger()
 
 _KERNEL_LAUNCH_CODE = """\
-import json, runpy, marimo
-print(json.dumps({"marimo_version": marimo.__version__}), flush=True)
+import json, os, runpy, sys, marimo
+try:
+    from pathlib import Path
+    from marimo._session.state.serialize import get_session_cache_file
+    _notebook_path = sys.argv[1] if len(sys.argv) > 1 else ""
+    _notebook = Path(_notebook_path) if _notebook_path else None
+    _session_cache_path = (
+        os.path.abspath(os.fspath(get_session_cache_file(_notebook)))
+        if _notebook is not None and _notebook.is_file()
+        else None
+    )
+except Exception:
+    _session_cache_path = None
+print(json.dumps({
+    "marimo_version": marimo.__version__,
+    "session_cache_path": _session_cache_path,
+}), flush=True)
+sys.argv[:] = [sys.argv[0]]
 runpy.run_module("marimo._ipc.launch_kernel", run_name="__main__")
 """
 _MAX_STARTUP_STDERR_CHARS = 16_000
@@ -67,7 +83,7 @@ def _with_stderr_tail(
     return f"{message} Stderr: {stderr[-_MAX_STARTUP_STDERR_CHARS:]}"
 
 
-def _parse_kernel_version(version_line: str) -> str | None:
+def _parse_kernel_metadata(version_line: str) -> tuple[str | None, str | None]:
     try:
         version_payload = json.loads(version_line)
     except json.JSONDecodeError as error:
@@ -81,7 +97,13 @@ def _parse_kernel_version(version_line: str) -> str | None:
     if not isinstance(marimo_version, str):
         msg = f"Invalid kernel version response: {version_line!r}"
         raise TypeError(msg)
-    return normalize_marimo_version(marimo_version)
+    session_cache_path = version_payload.get("session_cache_path")
+    if (
+        not isinstance(session_cache_path, str)
+        or not Path(session_cache_path).is_absolute()
+    ):
+        session_cache_path = None
+    return normalize_marimo_version(marimo_version), session_cache_path
 
 
 def _require_kernel_ready(
@@ -107,7 +129,12 @@ def launch_kernel(
     cwd: str | None = None,
 ) -> Process:
     """Launch kernel as a subprocess."""
-    cmd = [executable, "-c", _KERNEL_LAUNCH_CODE]
+    cmd = [
+        executable,
+        "-c",
+        _KERNEL_LAUNCH_CODE,
+        str(args.app_metadata.filename or ""),
+    ]
     logger.info(f"Launching kernel subprocess: {executable} -c <kernel bootstrap>")
     logger.debug(f"Connection info: {args.connection_info}")
     if cwd:
@@ -134,7 +161,7 @@ def launch_kernel(
         logger.debug("Waiting for marimo version from kernel subprocess")
 
         version_line = process.stdout.readline().decode("utf-8").strip()
-        marimo_version = _parse_kernel_version(version_line)
+        marimo_version, session_cache_path = _parse_kernel_metadata(version_line)
 
         # Wait for "KERNEL_READY" message
         ready_line = process.stdout.readline().decode("utf-8").strip()
@@ -148,6 +175,7 @@ def launch_kernel(
         raise
 
     owner.marimo_version = marimo_version
+    owner.session_cache_path = session_cache_path
     logger.info(f"Kernel subprocess started successfully with PID: {process.pid}")
     return owner
 
@@ -193,6 +221,7 @@ class Manager(KernelManagerImpl):
         self.connection_info = connection_info
         self.working_directory = working_directory
         self.marimo_version: str | None = None
+        self.session_cache_path: str | None = None
 
     def start_kernel(self) -> None:
         """Start an instance of the marimo kernel using ZeroMQ IPC."""
@@ -212,6 +241,7 @@ class Manager(KernelManagerImpl):
             cwd=str(working_directory),
         )
         self.marimo_version = self.kernel_task.marimo_version
+        self.session_cache_path = self.kernel_task.session_cache_path
 
 
 class Process(ProcessLike):
@@ -227,10 +257,12 @@ class Process(ProcessLike):
         self,
         inner: subprocess.Popen[bytes],
         marimo_version: str | None = None,
+        session_cache_path: str | None = None,
     ) -> None:
         """Initialize with a subprocess.Popen instance."""
         self.inner = inner
         self.marimo_version = marimo_version
+        self.session_cache_path = session_cache_path
 
     @property
     def pid(self) -> int | None:

--- a/src/marimo_lsp/kernels/native.py
+++ b/src/marimo_lsp/kernels/native.py
@@ -6,9 +6,11 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import json
 import queue
 import threading
 import typing
+from pathlib import Path
 
 from marimo._ipc import QueueManager as IpcQueues
 from marimo._session.managers import IPCQueueManagerImpl as IpcQueueManager
@@ -27,6 +29,18 @@ if typing.TYPE_CHECKING:
 
 
 logger = get_logger()
+
+_LOCATE_SAVED_SESSION_CODE = """\
+import json, os, sys
+from pathlib import Path
+from marimo._session.state.serialize import get_session_cache_file
+path = Path(sys.argv[1])
+print(json.dumps(
+    os.path.abspath(os.fspath(get_session_cache_file(path)))
+    if path.is_file()
+    else None
+))
+"""
 
 
 class NativeKernel:
@@ -65,6 +79,40 @@ class NativeKernel:
 
         self._listener_thread = threading.Thread(target=listen, daemon=True)
         self._listener_thread.start()
+
+    async def locate_saved_session(self, notebook_path: str) -> str | None:
+        """Resolve a renamed notebook through the selected Python."""
+        if (
+            notebook_path == self._manager.app_metadata.filename
+            and self._manager.session_cache_path is not None
+        ):
+            return self._manager.session_cache_path
+        process = await asyncio.create_subprocess_exec(
+            self.executable,
+            "-c",
+            _LOCATE_SAVED_SESSION_CODE,
+            notebook_path,
+            cwd=self.working_directory,
+            stdin=asyncio.subprocess.DEVNULL,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        try:
+            stdout, _ = await process.communicate()
+        except asyncio.CancelledError:
+            if process.returncode is None:
+                process.terminate()
+            await process.wait()
+            raise
+        if process.returncode != 0:
+            return None
+        try:
+            path = json.loads(stdout)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            return None
+        if not isinstance(path, str) or not Path(path).is_absolute():
+            return None
+        return path
 
     def send(self, request: CommandMessage) -> None:
         """Send a command over marimo IPC."""

--- a/src/marimo_lsp/saved_session_store.py
+++ b/src/marimo_lsp/saved_session_store.py
@@ -1,0 +1,178 @@
+# Copyright 2026 Marimo. All rights reserved.
+
+"""Atomically replace saved-session sidecars on the LSP host."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import stat
+import threading
+from contextlib import suppress
+from pathlib import Path
+from typing import TYPE_CHECKING, Protocol
+from uuid import uuid4
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable
+
+
+class SavedSessionFiles(Protocol):
+    """The narrow host-filesystem boundary needed by saved sessions."""
+
+    async def read(self, target: str) -> str | None:
+        """Read target when it exists."""
+        ...
+
+    async def replace(self, target: str, contents: str) -> None:
+        """Atomically replace target with contents."""
+        ...
+
+
+def _local_target(target: str) -> Path:
+    destination = Path(target)
+    if not destination.is_absolute():
+        msg = f"Saved session path must be absolute: {target}"
+        raise ValueError(msg)
+    return destination
+
+
+def _create_local(destination: Path) -> tuple[str, int]:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        destination_mode = stat.S_IMODE(destination.stat().st_mode)
+    except FileNotFoundError:
+        destination_mode = None
+
+    while True:
+        temporary = destination.parent / (f".{destination.name}.{uuid4().hex}.tmp")
+        try:
+            descriptor = os.open(
+                temporary,
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                0o666,
+            )
+        except FileExistsError:
+            continue
+        try:
+            if destination_mode is not None and os.name != "nt":
+                os.fchmod(descriptor, destination_mode)
+        except BaseException:
+            os.close(descriptor)
+            temporary.unlink(missing_ok=True)
+            raise
+        return str(temporary), descriptor
+
+
+def _write_local(
+    temporary: str,
+    descriptor: int,
+    contents: str,
+    abandoned: threading.Event,
+) -> None:
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as output:
+            output.write(contents)
+    except BaseException:
+        Path(temporary).unlink(missing_ok=True)
+        raise
+    finally:
+        if abandoned.is_set():
+            Path(temporary).unlink(missing_ok=True)
+
+
+class LocalSavedSessionFiles:
+    """Saved-session files for a native language-server process."""
+
+    async def read(self, target: str) -> str | None:
+        """Read through the native language-server filesystem."""
+        destination = _local_target(target)
+        try:
+            return await asyncio.to_thread(destination.read_text, encoding="utf-8")
+        except FileNotFoundError:
+            return None
+
+    async def replace(self, target: str, contents: str) -> None:
+        """Replace through a shielded thread without exposing a partial file."""
+        destination = _local_target(target)
+        temporary, descriptor = _create_local(destination)
+        abandoned = threading.Event()
+        task = asyncio.create_task(
+            asyncio.to_thread(
+                _write_local,
+                temporary,
+                descriptor,
+                contents,
+                abandoned,
+            )
+        )
+        try:
+            await asyncio.shield(task)
+        except asyncio.CancelledError:
+            abandoned.set()
+            task.add_done_callback(_consume_background_result)
+            with suppress(OSError):
+                os.unlink(temporary)  # noqa: PTH108 - avoid pathlib in async code
+            raise
+        except BaseException:
+            with suppress(OSError):
+                os.unlink(temporary)  # noqa: PTH108 - avoid pathlib in async code
+            raise
+        else:
+            try:
+                os.replace(temporary, destination)  # noqa: PTH105 - atomic boundary
+            except BaseException:
+                with suppress(OSError):
+                    os.unlink(temporary)  # noqa: PTH108 - async cleanup
+                raise
+
+
+def _consume_background_result(task: asyncio.Task[None]) -> None:
+    """Retrieve a shielded worker result after its caller was cancelled."""
+    with suppress(BaseException):
+        task.result()
+
+
+class SavedSessionFileCallbacks(Protocol):
+    """Host callbacks supplied to the Pyodide language server."""
+
+    def read(self, target: str) -> Awaitable[str | None]:
+        """Read one host file when it exists."""
+        ...
+
+    def create(self, target: str) -> str:
+        """Create one opaque replacement owned by the host."""
+        ...
+
+    def write(self, replacement: str, contents: str) -> Awaitable[None]:
+        """Write one host-owned replacement."""
+        ...
+
+    def commit(self, replacement: str) -> None:
+        """Commit one host-owned replacement."""
+        ...
+
+    def discard(self, replacement: str) -> None:
+        """Discard one host-owned replacement."""
+        ...
+
+
+class CallbackSavedSessionFiles:
+    """Adapt JavaScript host callbacks to saved-session files."""
+
+    def __init__(self, callbacks: SavedSessionFileCallbacks) -> None:
+        self._callbacks = callbacks
+
+    async def read(self, target: str) -> str | None:
+        """Read through the host filesystem callback."""
+        return await self._callbacks.read(target)
+
+    async def replace(self, target: str, contents: str) -> None:
+        """Atomically replace through the host filesystem callback."""
+        replacement = self._callbacks.create(target)
+        try:
+            await self._callbacks.write(replacement, contents)
+            self._callbacks.commit(replacement)
+        except BaseException:
+            self._callbacks.discard(replacement)
+            raise

--- a/src/marimo_lsp/saved_session_writer.py
+++ b/src/marimo_lsp/saved_session_writer.py
@@ -1,0 +1,132 @@
+# Copyright 2026 Marimo. All rights reserved.
+
+"""Persist a live marimo SessionView using marimo's cache lifecycle."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import TYPE_CHECKING
+
+from marimo_lsp.loggers import get_logger
+from marimo_lsp.saved_sessions import serialize_saved_session_view
+
+if TYPE_CHECKING:
+    from marimo._session.state.session_view import SessionView
+
+    from marimo_lsp.app_file_manager import LspAppFileManager
+    from marimo_lsp.saved_session_store import SavedSessionFiles
+
+
+logger = get_logger()
+
+SESSION_CACHE_INTERVAL_SECONDS = 2
+
+
+class SavedSessionWriter:
+    """Periodically persist one authoritative language-server session."""
+
+    def __init__(  # noqa: PLR0913
+        self,
+        *,
+        view: SessionView,
+        app_file_manager: LspAppFileManager,
+        marimo_version: str,
+        target: str,
+        files: SavedSessionFiles,
+        interval: float = SESSION_CACHE_INTERVAL_SECONDS,
+        pending: bool = False,
+    ) -> None:
+        self._view = view
+        self._app_file_manager = app_file_manager
+        self._marimo_version = marimo_version
+        self._target = target
+        self._files = files
+        self._interval = interval
+        self._pending = pending
+        self._writing = False
+        self._generation = 0
+        self._task: asyncio.Task[None] | None = None
+
+    @property
+    def running(self) -> bool:
+        """Return whether the periodic writer is active."""
+        return self._task is not None and not self._task.done()
+
+    def start(self) -> None:
+        """Start polling, if it is not already active."""
+        if self.running:
+            return
+        generation = self._generation
+        self._task = asyncio.create_task(self._run(generation))
+
+    def stop(self) -> bool:
+        """Stop polling and return whether the next writer must retry."""
+        self._generation += 1
+        if self._writing:
+            self._pending = True
+        task = self._task
+        self._task = None
+        if task is not None and not task.done():
+            task.cancel()
+        return self._pending
+
+    async def flush_once(self) -> bool:
+        """Write one dirty snapshot. Exposed for lifecycle tests."""
+        if not self._pending and not self._view.needs_export("session"):
+            return False
+        return await self._write(self._generation)
+
+    async def _run(self, generation: int) -> None:
+        while generation == self._generation:
+            try:
+                await self.flush_once()
+                await asyncio.sleep(self._interval)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("Stopped saved-session writer after write failure")
+                return
+
+    async def _write(self, generation: int) -> bool:
+        cell_manager = self._app_file_manager.app.cell_manager
+        cell_ids = tuple(cell_manager.cell_ids())
+        codes = tuple(cell_manager.codes())
+        if len(cell_ids) != len(codes) or any(
+            code
+            and (
+                self._view.last_executed_code.get(cell_id) != code
+                or cell_id not in self._view.cell_notifications
+            )
+            for cell_id, code in zip(cell_ids, codes, strict=False)
+        ):
+            return False
+
+        self._pending = False
+        self._writing = True
+        self._view.mark_auto_export_session()
+        try:
+            snapshot = serialize_saved_session_view(
+                self._view,
+                cell_ids=cell_ids,
+                marimo_version=self._marimo_version,
+                header=self._app_file_manager.header,
+            )
+            if snapshot is None:
+                self._pending = True
+                msg = "Unable to serialize saved session"
+                raise RuntimeError(msg)  # noqa: TRY301 - retain retry state
+            contents = json.dumps(snapshot, indent=2)
+            await self._files.replace(self._target, contents)
+            if generation != self._generation:
+                return False
+        except asyncio.CancelledError:
+            self._pending = True
+            raise
+        except BaseException:
+            self._pending = True
+            raise
+        else:
+            return True
+        finally:
+            self._writing = False

--- a/src/marimo_lsp/saved_sessions.py
+++ b/src/marimo_lsp/saved_sessions.py
@@ -1,0 +1,139 @@
+# Copyright 2026 Marimo. All rights reserved.
+
+"""Read and write marimo saved-session data."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, cast
+
+from marimo._messaging.notebook.document import NotebookDocument
+from marimo._session.state.serialize import (
+    SessionCacheKey,
+    SessionCacheManager,
+    deserialize_session,
+    serialize_session_view,
+)
+from marimo._session.state.session_view import SessionView
+from marimo._utils.code import hash_code
+from marimo._utils.inline_script_metadata import read_pyproject_from_script
+
+from marimo_lsp.kernels import normalize_marimo_version
+from marimo_lsp.loggers import get_logger
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from marimo._schemas.session import NotebookSessionV1
+    from marimo._types.ids import CellId_t
+
+
+logger = get_logger()
+# TODO: Replace this adapter when marimo exposes content-based session I/O.
+# SessionCacheManager currently couples the wire format to local paths and the
+# marimo version imported by this language-server process.
+
+
+def _script_metadata_hash(header: str | None) -> str | None:
+    try:
+        project = read_pyproject_from_script(header or "")
+    except Exception:  # noqa: BLE001 - parity with marimo's filename helper
+        return None
+    if project is None:
+        return None
+    return hash_code(
+        json.dumps(
+            project,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        )
+    )
+
+
+def serialize_saved_session_view(
+    view: SessionView,
+    *,
+    cell_ids: Iterable[CellId_t],
+    marimo_version: str | None,
+    header: str | None,
+) -> NotebookSessionV1 | None:
+    """Serialize a live view with the selected kernel's cache identity."""
+    try:
+        marimo_version = normalize_marimo_version(marimo_version)
+        if marimo_version is None:
+            return None
+        notebook_session = serialize_session_view(
+            view,
+            cell_ids=tuple(cell_ids),
+            drop_virtual_file_outputs=True,
+            script_metadata_hash=_script_metadata_hash(header),
+        )
+        # The SessionView belongs to the selected kernel. Cache compatibility
+        # therefore uses that kernel's version, not marimo-base's version.
+        notebook_session["metadata"]["marimo_version"] = marimo_version
+    except Exception:
+        logger.exception("Ignored unserializable saved session")
+        return None
+    return notebook_session
+
+
+def decode_saved_session_view(
+    contents: str,
+    *,
+    codes: Iterable[str],
+    cell_ids: Iterable[CellId_t],
+    marimo_version: str | None,
+    header: str | None,
+) -> SessionView | None:
+    """Decode a compatible marimo session sidecar, if one can be proven."""
+    marimo_version = normalize_marimo_version(marimo_version)
+    if marimo_version is None:
+        return None
+
+    current_codes = tuple(codes)
+    current_cell_ids = tuple(cell_ids)
+    code_hashes = tuple(hash_code(code) for code in current_codes if code)
+    if (
+        len(current_codes) != len(current_cell_ids)
+        or len(current_cell_ids) != len(set(current_cell_ids))
+        or len(code_hashes) != len(set(code_hashes))
+    ):
+        return None
+
+    manager = SessionCacheManager(
+        session_view=SessionView(),
+        document=NotebookDocument([]),
+        path=None,
+        interval=1,
+    )
+    try:
+        decoded = json.loads(contents)
+        if not isinstance(decoded, dict) or decoded.get("version") != "1":
+            return None
+        # Delegate field and output compatibility to marimo. In particular,
+        # its V1 reader skips future output tags instead of rejecting the
+        # otherwise-compatible session.
+        notebook_session = cast("NotebookSessionV1", decoded)
+        key = SessionCacheKey(
+            codes=current_codes,
+            marimo_version=marimo_version,
+            cell_ids=current_cell_ids,
+            script_metadata_hash=_script_metadata_hash(header),
+        )
+        if not manager.is_cache_hit(notebook_session, key):
+            return None
+
+        code_hash_to_cell_id = {
+            hash_code(code): cell_id
+            for code, cell_id in zip(
+                current_codes,
+                current_cell_ids,
+                strict=True,
+            )
+            if code
+        }
+        return deserialize_session(notebook_session, code_hash_to_cell_id)
+    except Exception:
+        logger.exception("Ignored malformed saved session")
+        return None

--- a/src/marimo_lsp/server.py
+++ b/src/marimo_lsp/server.py
@@ -19,6 +19,7 @@ from marimo_lsp.completions import get_completions
 from marimo_lsp.diagnostics import GraphUpdaterRegistry
 from marimo_lsp.loggers import get_logger
 from marimo_lsp.models import ApiRequest, ConvertRequest
+from marimo_lsp.saved_session_store import LocalSavedSessionFiles, SavedSessionFiles
 from marimo_lsp.sessions import Sessions
 
 logger = get_logger()
@@ -27,9 +28,19 @@ if typing.TYPE_CHECKING:
     from marimo_lsp.kernels import Kernels
 
 
-def create_server(*, kernels: Kernels) -> LanguageServer:  # noqa: C901, PLR0915
+class MarimoLanguageServer(LanguageServer):
+    """Language server with explicit ownership of its live Sessions."""
+
+    sessions: Sessions
+
+
+def create_server(  # noqa: C901, PLR0915
+    *,
+    kernels: Kernels,
+    saved_session_files: SavedSessionFiles | None = None,
+) -> MarimoLanguageServer:
     """Create the marimo LSP server."""
-    server = LanguageServer(
+    server = MarimoLanguageServer(
         name="marimo-lsp",
         version=importlib.metadata.version("marimo-lsp"),
         notebook_document_sync=lsp.NotebookDocumentSyncOptions(
@@ -47,7 +58,11 @@ def create_server(*, kernels: Kernels) -> LanguageServer:  # noqa: C901, PLR0915
             save=True,
         ),
     )
-    sessions = Sessions(server, kernels=kernels)
+    sessions = server.sessions = Sessions(
+        server,
+        kernels=kernels,
+        saved_session_files=saved_session_files or LocalSavedSessionFiles(),
+    )
     graph_registry = GraphUpdaterRegistry(server)
 
     # Register atexit handler to ensure kernel processes are cleaned up

--- a/src/marimo_lsp/sessions.py
+++ b/src/marimo_lsp/sessions.py
@@ -32,10 +32,13 @@ from marimo._runtime.commands import (
 from marimo._session.state.session_view import SessionView
 from marimo._types.ids import SessionId
 
-from marimo_lsp.app_file_manager import LspAppFileManager, sync_app_with_workspace
+from marimo_lsp.app_file_manager import LspAppFileManager
 from marimo_lsp.kernels import KernelOpenError, normalize_marimo_version
 from marimo_lsp.loggers import get_logger
 from marimo_lsp.models import KernelNotification, ListSessionsResponse, SessionInfo
+from marimo_lsp.saved_session_store import LocalSavedSessionFiles
+from marimo_lsp.saved_session_writer import SavedSessionWriter
+from marimo_lsp.saved_sessions import decode_saved_session_view
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -55,6 +58,7 @@ if TYPE_CHECKING:
     from pygls.workspace import Workspace
 
     from marimo_lsp.kernels import Kernel, Kernels
+    from marimo_lsp.saved_session_store import SavedSessionFiles
 
 
 logger = get_logger()
@@ -73,6 +77,78 @@ def _notification_name(message: KernelMessage) -> str:
         return deserialize_kernel_notification_name(message)
     except Exception:  # noqa: BLE001
         return "<undecodable>"
+
+
+async def _locate_saved_session(
+    kernel: Kernel,
+    notebook_path: str | None,
+) -> str | None:
+    """Resolve an optional cache path without making kernel startup fail."""
+    if notebook_path is None:
+        return None
+    try:
+        return await kernel.locate_saved_session(notebook_path)
+    except Exception:
+        logger.exception("Unable to locate saved session")
+        return None
+
+
+async def _read_saved_session(
+    files: SavedSessionFiles,
+    target: str | None,
+    app_file_manager: LspAppFileManager,
+    marimo_version: str | None,
+) -> SessionView | None:
+    """Read one compatible view before its authoritative Session starts."""
+    if target is None or marimo_version is None:
+        return None
+    try:
+        contents = await files.read(target)
+        if contents is None:
+            return None
+        cell_manager = app_file_manager.app.cell_manager
+        return await asyncio.to_thread(
+            decode_saved_session_view,
+            contents,
+            codes=tuple(cell_manager.codes()),
+            cell_ids=tuple(cell_manager.cell_ids()),
+            marimo_version=marimo_version,
+            header=app_file_manager.header,
+        )
+    except Exception:
+        logger.exception("Unable to read saved session")
+        return None
+
+
+async def _initial_session_view(
+    previous: Session | None,
+    kernel: Kernel,
+    files: SavedSessionFiles,
+    target: str | None,
+    app_file_manager: LspAppFileManager,
+) -> tuple[SessionView | None, bool]:
+    """Reuse a compatible live view, otherwise restore the selected cache."""
+    previous_version = normalize_marimo_version(
+        previous.marimo_version if previous is not None else None
+    )
+    kernel_version = normalize_marimo_version(kernel.marimo_version)
+    reuse_previous = (
+        previous is not None
+        and previous_version is not None
+        and kernel_version is not None
+        and previous_version == kernel_version
+    )
+    if reuse_previous:
+        return previous.session_view, True
+    return (
+        await _read_saved_session(
+            files,
+            target,
+            app_file_manager,
+            kernel_version,
+        ),
+        False,
+    )
 
 
 class _OperationSink:
@@ -178,6 +254,9 @@ class Session:
         on_change: typing.Callable[[], None] | None = None,
         session_view: SessionView | None = None,
         started_at: float | None = None,
+        saved_session_files: SavedSessionFiles | None = None,
+        saved_session_target: str | None = None,
+        saved_session_pending: bool = False,
     ) -> None:
         self.session_id = session_id
         self._notebook_uri = notebook_uri
@@ -185,6 +264,11 @@ class Session:
         self._config_manager = config_manager
         # Used by exporters and scratchpad snapshots.
         self.session_view = session_view if session_view is not None else SessionView()
+        # A new or disk-restored view must not overwrite the sidecar before a
+        # kernel request supplies current code hashes. A reused live view is
+        # retried because its previous writer may have been interrupted.
+        if not saved_session_pending:
+            self.session_view.mark_auto_export_session()
 
         self._operation_sink = _OperationSink(
             server,
@@ -192,6 +276,7 @@ class Session:
             session_id,
             activated=False,
         )
+        self._activated = False
         self._closed = False
         self._runtime_config = config_manager.get_config(hide_secrets=False)
         self.started_at = started_at if started_at is not None else time.time()
@@ -207,7 +292,40 @@ class Session:
         self._state_lock = threading.RLock()
 
         self._kernel = kernel
+        self._saved_session_files = (
+            saved_session_files
+            if saved_session_files is not None
+            else LocalSavedSessionFiles()
+        )
+        self._saved_session_pending = saved_session_pending
+        self._saved_session_writer = self._make_saved_session_writer(
+            saved_session_target
+        )
+        self._saved_session_location: asyncio.Task[None] | None = None
         logger.info(f"Started session {session_id}")
+
+    def _make_saved_session_writer(
+        self,
+        target: str | None,
+    ) -> SavedSessionWriter | None:
+        if self.marimo_version is None or target is None:
+            return None
+        writer = SavedSessionWriter(
+            view=self.session_view,
+            app_file_manager=self._app_file_manager,
+            marimo_version=self.marimo_version,
+            target=target,
+            files=self._saved_session_files,
+            pending=self._saved_session_pending,
+        )
+        self._saved_session_pending = False
+        return writer
+
+    def _stop_saved_session_writer(self) -> None:
+        writer = self._saved_session_writer
+        self._saved_session_writer = None
+        if writer is not None:
+            self._saved_session_pending |= writer.stop()
 
     @property
     def executable(self) -> str:
@@ -265,11 +383,7 @@ class Session:
             cell_id: config.asdict()
             for cell_id, config in self._app_file_manager.app.cell_manager.config_map().items()
         }
-        sync_app_with_workspace(
-            workspace=workspace,
-            notebook_uri=self._notebook_uri,
-            app=self._app_file_manager.app,
-        )
+        self._app_file_manager.sync(workspace)
         current_configs = {
             cell_id: config.asdict()
             for cell_id, config in self._app_file_manager.app.cell_manager.config_map().items()
@@ -456,10 +570,19 @@ class Session:
 
     def move(self, notebook_uri: str, *, notify: bool = True) -> None:
         """Move this session to a renamed notebook URI."""
+        self._stop_saved_session_writer()
+        if self._saved_session_location is not None:
+            self._saved_session_location.cancel()
+            self._saved_session_location = None
         with self._state_lock:
             self._notebook_uri = notebook_uri
             self._operation_sink.move(notebook_uri)
             self._app_file_manager.move(notebook_uri)
+        notebook_path = self._app_file_manager.path
+        if notebook_path is not None:
+            self._saved_session_location = asyncio.create_task(
+                self._relocate_saved_session(notebook_path)
+            )
         if notify:
             self._on_change()
 
@@ -492,18 +615,53 @@ class Session:
 
     def activate(self) -> None:
         """Release operations after this session becomes authoritative."""
+        self._activated = True
         self._operation_sink.activate()
+        if self._saved_session_writer is not None:
+            self._saved_session_writer.start()
+
+    async def _relocate_saved_session(self, notebook_path: str) -> None:
+        """Rebind persistence after a notebook rename."""
+        try:
+            target = await self._kernel.locate_saved_session(notebook_path)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("Unable to locate saved session after notebook move")
+            return
+        if self._closed or self._app_file_manager.path != notebook_path:
+            return
+        self._saved_session_writer = self._make_saved_session_writer(target)
+        if self._activated and self._saved_session_writer is not None:
+            self._saved_session_writer.start()
 
     def close(self) -> None:
         """Close the session and its owned kernel resources."""
         if self._closed:
             return
         self._closed = True
-        self._idle.set()
-        self._on_change = lambda: None
-        logger.info(f"Closing session {self.session_id}")
-        self._kernel.close()
-        self._operation_sink.detach()
+        try:
+            if self._saved_session_location is not None:
+                try:
+                    self._saved_session_location.cancel()
+                except RuntimeError:
+                    logger.exception("Unable to cancel saved-session relocation")
+                self._saved_session_location = None
+            try:
+                self._stop_saved_session_writer()
+            except RuntimeError:
+                logger.exception("Unable to stop saved-session writer")
+            try:
+                self._idle.set()
+            except RuntimeError:
+                logger.exception("Unable to release idle-session waiters")
+            self._on_change = lambda: None
+            logger.info(f"Closing session {self.session_id}")
+        finally:
+            try:
+                self._kernel.close()
+            finally:
+                self._operation_sink.detach()
 
 
 class Sessions:
@@ -514,9 +672,11 @@ class Sessions:
         server: LanguageServer,
         *,
         kernels: Kernels,
+        saved_session_files: SavedSessionFiles | None = None,
     ) -> None:
         self._server = server
         self._kernels = kernels
+        self._saved_session_files = saved_session_files or LocalSavedSessionFiles()
         self._sessions: dict[str, Session] = {}
         self._lock = threading.RLock()
         self._lifecycle_locks: dict[str, asyncio.Lock] = {}
@@ -673,15 +833,16 @@ class Sessions:
             receive=receive,
         )
         try:
-            previous_version = normalize_marimo_version(
-                previous.marimo_version if previous is not None else None
+            saved_session_target = await _locate_saved_session(
+                kernel,
+                app_file_manager.path,
             )
-            kernel_version = normalize_marimo_version(kernel.marimo_version)
-            keep_previous_view = (
-                previous is not None
-                and previous_version is not None
-                and kernel_version is not None
-                and previous_version == kernel_version
+            session_view, keep_previous_view = await _initial_session_view(
+                previous,
+                kernel,
+                self._saved_session_files,
+                saved_session_target,
+                app_file_manager,
             )
             session = Session(
                 session_id=session_id,
@@ -690,8 +851,11 @@ class Sessions:
                 kernel=kernel,
                 app_file_manager=app_file_manager,
                 config_manager=config_manager,
-                session_view=previous.session_view if keep_previous_view else None,
+                session_view=session_view,
                 started_at=previous.started_at if previous else None,
+                saved_session_files=self._saved_session_files,
+                saved_session_target=saved_session_target,
+                saved_session_pending=keep_previous_view,
             )
             session.set_on_kernel_failure(_raise_kernel_failure)
             for message in pending_messages:

--- a/src/marimo_lsp/wasm/__init__.py
+++ b/src/marimo_lsp/wasm/__init__.py
@@ -12,13 +12,15 @@ import typing
 import msgspec
 
 from marimo_lsp.loggers import get_logger, lsp_handler
-from marimo_lsp.server import create_server
+from marimo_lsp.saved_session_store import (
+    CallbackSavedSessionFiles,
+    SavedSessionFileCallbacks,
+)
+from marimo_lsp.server import MarimoLanguageServer, create_server
 from marimo_lsp.wasm.kernels import ProcessCallbacks, WasmKernels
 
 if typing.TYPE_CHECKING:
     from collections.abc import Callable
-
-    from pygls.lsp.server import LanguageServer
 
     from marimo_lsp.loggers import LspLoggingHandler
 
@@ -44,9 +46,13 @@ class WasmServer:
         self,
         write_message: Callable[[str], None],
         process_callbacks: ProcessCallbacks,
+        saved_session_callbacks: SavedSessionFileCallbacks,
     ) -> None:
         self._kernels = WasmKernels(process_callbacks)
-        self._server: LanguageServer = create_server(kernels=self._kernels)
+        self._server: MarimoLanguageServer = create_server(
+            kernels=self._kernels,
+            saved_session_files=CallbackSavedSessionFiles(saved_session_callbacks),
+        )
         self._server.protocol.set_writer(
             _MessageWriter(write_message),
             include_headers=False,
@@ -86,6 +92,7 @@ class WasmServer:
             return
         self._closed = True
         try:
+            self._server.sessions.close_all()
             self._kernels.close_all()
             self._server.shutdown()
         finally:
@@ -109,6 +116,11 @@ class WasmServer:
 def create_bridge(
     write_message: Callable[[str], None],
     process_callbacks: ProcessCallbacks,
+    saved_session_callbacks: SavedSessionFileCallbacks,
 ) -> WasmServer:
     """Create the message boundary exported to JavaScript."""
-    return WasmServer(write_message, process_callbacks)
+    return WasmServer(
+        write_message,
+        process_callbacks,
+        saved_session_callbacks,
+    )

--- a/src/marimo_lsp/wasm/kernels.py
+++ b/src/marimo_lsp/wasm/kernels.py
@@ -24,9 +24,11 @@ from marimo_lsp.wasm.protocol import (
     Input,
     Interrupt,
     KernelLaunchArgs,
+    LocateSessionCache,
     Log,
     Operation,
     Ready,
+    SessionCacheLocation,
     Start,
     ToBridge,
     encode,
@@ -76,6 +78,7 @@ class WasmKernel:
         process_id: str,
         executable: str,
         working_directory: str,
+        notebook_path: str | None,
         receive: Callable[[KernelMessage], None],
         on_close: Callable[[], None],
     ) -> None:
@@ -85,6 +88,10 @@ class WasmKernel:
         self._on_close = on_close
         self._decoder = Decoder(FromBridge)
         self._ready = asyncio.get_running_loop().create_future()
+        self._locations: dict[str, asyncio.Future[str | None]] = {}
+        self._notebook_path = notebook_path
+        self._initial_session_cache_path: str | None = None
+        self._can_locate_session_cache = False
         self._closed = False
         self.executable = executable
         self.working_directory = working_directory
@@ -97,8 +104,16 @@ class WasmKernel:
         for message in self._decoder.feed(chunk):
             if isinstance(message, Ready):
                 self.marimo_version = normalize_marimo_version(message.marimo_version)
+                # The path belongs to the native host. Pyodide's POSIX pathlib
+                # cannot validate Windows paths, so keep it opaque here.
+                self._initial_session_cache_path = message.session_cache_path
+                self._can_locate_session_cache = message.can_locate_session_cache
                 if not self._ready.done():
                     self._ready.set_result(None)
+            elif isinstance(message, SessionCacheLocation):
+                future = self._locations.get(message.request_id)
+                if future is not None and not future.done():
+                    future.set_result(message.path)
             elif isinstance(message, Operation):
                 self._receive(KernelMessage(bytes(message.message)))
             elif isinstance(message, Error):
@@ -128,6 +143,28 @@ class WasmKernel:
         """Wait until the kernel bridge reports readiness."""
         await self._ready
 
+    async def locate_saved_session(self, notebook_path: str) -> str | None:
+        """Resolve a renamed notebook through the selected-Python bridge."""
+        if self._closed:
+            return None
+        if notebook_path == self._notebook_path:
+            return self._initial_session_cache_path
+        if not self._can_locate_session_cache:
+            return None
+        request_id = str(uuid4())
+        future: asyncio.Future[str | None] = asyncio.get_running_loop().create_future()
+        self._locations[request_id] = future
+        try:
+            self._write(
+                LocateSessionCache(
+                    request_id=request_id,
+                    notebook_path=notebook_path,
+                )
+            )
+            return await future
+        finally:
+            self._locations.pop(request_id, None)
+
     def abort(self) -> None:
         """Release a kernel bridge that failed before readiness."""
         self._release(close_process=True)
@@ -153,6 +190,10 @@ class WasmKernel:
         if self._closed:
             return
         self._closed = True
+        for future in self._locations.values():
+            if not future.done():
+                future.cancel()
+        self._locations.clear()
         try:
             if request_close:
                 self._write(Close())
@@ -210,6 +251,7 @@ class WasmKernels:
             process_id=process_id,
             executable=executable,
             working_directory=working_directory,
+            notebook_path=app_file_manager.path,
             receive=receive,
             on_close=forget,
         )

--- a/src/marimo_lsp/wasm/protocol.py
+++ b/src/marimo_lsp/wasm/protocol.py
@@ -27,6 +27,21 @@ class Ready(msgspec.Struct, tag="ready", tag_field="type", rename="camel"):
     """The kernel bridge is ready."""
 
     marimo_version: str | None = None
+    session_cache_path: str | None = None
+    can_locate_session_cache: bool = False
+    version: Literal[1] = VERSION
+
+
+class SessionCacheLocation(
+    msgspec.Struct,
+    tag="session-cache-location",
+    tag_field="type",
+    rename="camel",
+):
+    """A cache path resolved by the selected Python."""
+
+    request_id: str
+    path: str | None
     version: Literal[1] = VERSION
 
 
@@ -51,7 +66,7 @@ class Log(msgspec.Struct, tag="log", tag_field="type", rename="camel"):
     version: Literal[1] = VERSION
 
 
-FromBridge: TypeAlias = Ready | Operation | Error | Log
+FromBridge: TypeAlias = Ready | SessionCacheLocation | Operation | Error | Log
 
 
 class KernelLaunchArgs(ipc.KernelArgs):
@@ -92,13 +107,26 @@ class Interrupt(msgspec.Struct, tag="interrupt", tag_field="type", rename="camel
     version: Literal[1] = VERSION
 
 
+class LocateSessionCache(
+    msgspec.Struct,
+    tag="locate-session-cache",
+    tag_field="type",
+    rename="camel",
+):
+    """Resolve marimo's cache path for a renamed notebook."""
+
+    request_id: str
+    notebook_path: str
+    version: Literal[1] = VERSION
+
+
 class Close(msgspec.Struct, tag="close", tag_field="type", rename="camel"):
     """Close the kernel."""
 
     version: Literal[1] = VERSION
 
 
-ToBridge: TypeAlias = Start | Control | Input | Interrupt | Close
+ToBridge: TypeAlias = Start | Control | Input | Interrupt | LocateSessionCache | Close
 
 Message = TypeVar("Message")
 

--- a/tests/test_app_file_manager.py
+++ b/tests/test_app_file_manager.py
@@ -11,7 +11,11 @@ import lsprotocol.types as lsp
 import msgspec
 import pytest
 
-from marimo_lsp.app_file_manager import find_notebook_document, sync_app_with_workspace
+from marimo_lsp.app_file_manager import (
+    LspAppFileManager,
+    find_notebook_document,
+    sync_app_with_workspace,
+)
 
 
 def _lsp_object(d: dict[str, object] | None) -> lsp.LSPObject | None:
@@ -90,6 +94,18 @@ def _make_workspace_with_metadata(
 
 
 class TestSyncAppWithWorkspace:
+    def test_manager_keeps_the_synchronized_notebook_header(self) -> None:
+        uri = "file:///test/notebook.py"
+        workspace = _make_workspace_with_metadata(
+            uri,
+            metadata={"marimo": {"header": "# /// script\n# ///"}},
+        )
+        server = MagicMock(workspace=workspace)
+
+        manager = LspAppFileManager(server=server, notebook_uri=uri)
+
+        assert manager.header == "# /// script\n# ///"
+
     def test_extracts_app_options_from_metadata(self) -> None:
         """App config should come from namespaced notebook metadata."""
         uri = "file:///test/notebook.py"

--- a/tests/test_native_kernel.py
+++ b/tests/test_native_kernel.py
@@ -6,12 +6,12 @@ import asyncio
 import threading
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
 from marimo_lsp.kernels.manager import Manager, launch_kernel
-from marimo_lsp.kernels.native import NativeKernels
+from marimo_lsp.kernels.native import NativeKernel, NativeKernels
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -32,7 +32,10 @@ def _manager(notebook: Path, working_directory: str) -> Manager:
 def test_supplied_working_directory_reaches_launch_kernel(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    launched = Mock(marimo_version="1.2.3-rc1+build.7")
+    launched = Mock(
+        marimo_version="1.2.3-rc1+build.7",
+        session_cache_path=str(tmp_path / "session.json"),
+    )
     launch = Mock(return_value=launched)
     monkeypatch.setattr("marimo_lsp.kernels.manager.launch_kernel", launch)
     selected = tmp_path / "selected"
@@ -43,6 +46,49 @@ def test_supplied_working_directory_reaches_launch_kernel(
 
     assert launch.call_args.kwargs["cwd"] == str(selected)
     assert manager.marimo_version == "1.2.3-rc1+build.7"
+    assert manager.session_cache_path == str(tmp_path / "session.json")
+
+
+@pytest.mark.asyncio
+async def test_native_kernel_reuses_the_startup_cache_path() -> None:
+    manager = Mock(
+        executable="/python",
+        working_directory="/workspace",
+        app_metadata=Mock(filename="/workspace/notebook.py"),
+        session_cache_path="/workspace/__marimo__/session/notebook.py.json",
+    )
+    kernel = NativeKernel(Mock(), manager)
+
+    assert (
+        await kernel.locate_saved_session("/workspace/notebook.py")
+        == "/workspace/__marimo__/session/notebook.py.json"
+    )
+
+
+@pytest.mark.asyncio
+async def test_native_kernel_resolves_a_renamed_notebook_in_selected_python(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = Mock(
+        executable="/python",
+        working_directory="/workspace",
+        app_metadata=Mock(filename="/workspace/notebook.py"),
+        session_cache_path="/workspace/__marimo__/session/notebook.py.json",
+    )
+    kernel = NativeKernel(Mock(), manager)
+    process = Mock(returncode=0)
+    process.communicate = AsyncMock(
+        return_value=(b'"/workspace/__marimo__/session/renamed.py.json"', b"")
+    )
+    launch = AsyncMock(return_value=process)
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", launch)
+
+    located = await kernel.locate_saved_session("/workspace/renamed.py")
+
+    assert located == "/workspace/__marimo__/session/renamed.py.json"
+    assert launch.call_args.args[:2] == ("/python", "-c")
+    assert launch.call_args.args[3] == "/workspace/renamed.py"
+    assert launch.call_args.kwargs["cwd"] == "/workspace"
 
 
 def test_kernel_reports_exact_marimo_version_from_launched_process(
@@ -50,20 +96,29 @@ def test_kernel_reports_exact_marimo_version_from_launched_process(
 ) -> None:
     process = Mock()
     process.stdout.readline.side_effect = [
-        b'{"marimo_version":"1.2.3-rc1+build.7"}\n',
+        (
+            b'{"marimo_version":"1.2.3-rc1+build.7",'
+            b'"session_cache_path":"/workspace/__marimo__/session/notebook.py.json"}\n'
+        ),
         b"KERNEL_READY\n",
     ]
     popen = Mock(return_value=process)
     monkeypatch.setattr("marimo_lsp.kernels.manager.subprocess.Popen", popen)
     args = Mock()
+    args.app_metadata.filename = "/workspace/notebook.py"
     args.encode_json.return_value = b"{}"
 
     kernel_process = launch_kernel("/python", args, cwd="/workspace")
 
     assert kernel_process.marimo_version == "1.2.3-rc1+build.7"
+    assert (
+        kernel_process.session_cache_path
+        == "/workspace/__marimo__/session/notebook.py.json"
+    )
     command = popen.call_args.args[0]
     assert command[:2] == ["/python", "-c"]
     assert "runpy.run_module" in command[2]
+    assert command[3] == "/workspace/notebook.py"
     assert popen.call_args.kwargs["cwd"] == "/workspace"
 
 

--- a/tests/test_saved_session_store.py
+++ b/tests/test_saved_session_store.py
@@ -1,0 +1,168 @@
+# Copyright 2026 Marimo. All rights reserved.
+
+from __future__ import annotations
+
+import asyncio
+import os
+import stat
+import threading
+from pathlib import Path
+from typing import Self
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from marimo_lsp.saved_session_store import (
+    CallbackSavedSessionFiles,
+    LocalSavedSessionFiles,
+)
+
+
+@pytest.mark.asyncio
+async def test_local_store_replaces_the_target_atomically(tmp_path: Path) -> None:
+    target = tmp_path / "__marimo__" / "session" / "notebook.py.json"
+    target.parent.mkdir(parents=True)
+    target.write_text("old", encoding="utf-8")
+    files = LocalSavedSessionFiles()
+
+    await files.replace(str(target), "new")
+
+    assert target.read_text(encoding="utf-8") == "new"
+    assert not list(target.parent.glob("*.tmp"))
+
+
+@pytest.mark.asyncio
+async def test_local_store_preserves_existing_target_permissions(
+    tmp_path: Path,
+) -> None:
+    if os.name == "nt":
+        pytest.skip("POSIX file permissions")
+    target = tmp_path / "session.json"
+    target.write_text("old", encoding="utf-8")
+    target.chmod(0o640)
+
+    await LocalSavedSessionFiles().replace(str(target), "new")
+
+    assert stat.S_IMODE(target.stat().st_mode) == 0o640
+
+
+@pytest.mark.asyncio
+async def test_local_store_reads_an_existing_target(tmp_path: Path) -> None:
+    target = tmp_path / "session.json"
+    target.write_text("saved", encoding="utf-8")
+    files = LocalSavedSessionFiles()
+
+    assert await files.read(str(target)) == "saved"
+    assert await files.read(str(tmp_path / "missing.json")) is None
+
+
+@pytest.mark.asyncio
+async def test_local_store_discards_a_stage_completed_after_cancellation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target = tmp_path / "__marimo__" / "session" / "notebook.py.json"
+    staged = threading.Event()
+    release = threading.Event()
+    original_fdopen = os.fdopen
+    original_unlink = Path.unlink
+
+    class BlockingOutput:
+        def __init__(self, descriptor: int) -> None:
+            self._descriptor = descriptor
+
+        def __enter__(self) -> Self:
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            os.close(self._descriptor)
+
+        def write(self, _contents: str) -> None:
+            staged.set()
+            release.wait()
+
+    def blocking_fdopen(
+        descriptor: int,
+        *args: object,
+        **kwargs: object,
+    ) -> object:
+        del args, kwargs
+        return BlockingOutput(descriptor)
+
+    def unavailable_while_open(
+        path: Path,
+        *,
+        missing_ok: bool = False,
+    ) -> None:
+        if not release.is_set():
+            raise PermissionError(path)
+        original_unlink(path, missing_ok=missing_ok)
+
+    monkeypatch.setattr(os, "fdopen", blocking_fdopen)
+    monkeypatch.setattr(Path, "unlink", unavailable_while_open)
+    task = asyncio.create_task(LocalSavedSessionFiles().replace(str(target), "new"))
+    await asyncio.to_thread(staged.wait)
+    temporary = list(target.parent.glob("*.tmp"))
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    release.set()
+    monkeypatch.setattr(os, "fdopen", original_fdopen)
+
+    for _ in range(100):
+        if temporary and not await asyncio.to_thread(temporary[0].exists):
+            break
+        await asyncio.sleep(0.01)
+
+    assert temporary
+    assert not await asyncio.to_thread(temporary[0].exists)
+    assert not await asyncio.to_thread(target.exists)
+
+
+@pytest.mark.asyncio
+async def test_callback_store_commits_only_after_the_host_write() -> None:
+    callbacks = Mock()
+    callbacks.create.return_value = "replacement"
+    callbacks.write = AsyncMock()
+    files = CallbackSavedSessionFiles(callbacks)
+
+    await files.replace("/workspace/session.json", "contents")
+
+    callbacks.write.assert_awaited_once_with("replacement", "contents")
+    callbacks.commit.assert_called_once_with("replacement")
+    callbacks.discard.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_callback_store_reads_through_the_host() -> None:
+    callbacks = Mock()
+    callbacks.read = AsyncMock(return_value="saved")
+    files = CallbackSavedSessionFiles(callbacks)
+
+    assert await files.read(r"C:\workspace\session.json") == "saved"
+
+    callbacks.read.assert_awaited_once_with(r"C:\workspace\session.json")
+
+
+@pytest.mark.asyncio
+async def test_callback_store_discards_a_cancelled_host_write() -> None:
+    started = asyncio.Event()
+
+    async def write(_temporary: str, _contents: str) -> None:
+        started.set()
+        await asyncio.Event().wait()
+
+    callbacks = Mock()
+    callbacks.create.return_value = "replacement"
+    callbacks.write.side_effect = write
+    files = CallbackSavedSessionFiles(callbacks)
+    task = asyncio.create_task(files.replace("/workspace/session.json", "contents"))
+    await started.wait()
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    callbacks.commit.assert_not_called()
+    callbacks.discard.assert_called_once_with("replacement")

--- a/tests/test_saved_session_writer.py
+++ b/tests/test_saved_session_writer.py
@@ -1,0 +1,382 @@
+# Copyright 2026 Marimo. All rights reserved.
+
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, cast
+
+import pytest
+from marimo._messaging.cell_output import CellChannel, CellOutput
+from marimo._messaging.notification import CellNotification
+from marimo._runtime.commands import ExecuteCellsCommand, UpdateUserConfigCommand
+from marimo._session.state.session_view import SessionView
+from marimo._types.ids import CellId_t
+
+from marimo_lsp.saved_session_writer import SavedSessionWriter
+from marimo_lsp.saved_sessions import decode_saved_session_view
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from marimo_lsp.app_file_manager import LspAppFileManager
+
+CELL_ID = CellId_t("cell")
+SECOND_CELL_ID = CellId_t("second")
+
+
+class RecordingFiles:
+    def __init__(self) -> None:
+        self.attempted: list[tuple[str, str]] = []
+        self.completed: list[tuple[str, str]] = []
+
+    async def read(self, target: str) -> str | None:
+        del target
+        return None
+
+    async def replace(self, target: str, contents: str) -> None:
+        self.attempted.append((target, contents))
+        self.completed.append((target, contents))
+
+
+def _view(output: str = "first") -> SessionView:
+    view = SessionView()
+    view.add_control_request(
+        ExecuteCellsCommand(cell_ids=[CELL_ID], codes=["value = 1"])
+    )
+    view.add_notification(
+        CellNotification(
+            cell_id=CELL_ID,
+            status="idle",
+            output=CellOutput(
+                channel=CellChannel.OUTPUT,
+                mimetype="text/plain",
+                data=output,
+            ),
+            console=[],
+            timestamp=1,
+        )
+    )
+    return view
+
+
+def _manager(
+    header: str | None = None,
+    cell_ids: tuple[CellId_t, ...] = (CELL_ID,),
+    codes: tuple[str, ...] = ("value = 1",),
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        header=header,
+        app=SimpleNamespace(
+            cell_manager=SimpleNamespace(
+                cell_ids=lambda: cell_ids,
+                codes=lambda: codes,
+            )
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_writer_uses_upstream_format_and_selected_version(
+    tmp_path: Path,
+) -> None:
+    view = _view()
+    files = RecordingFiles()
+    target = str(tmp_path / "session.json")
+    writer = SavedSessionWriter(
+        view=view,
+        app_file_manager=cast("LspAppFileManager", _manager()),
+        marimo_version="1.2.3-rc1+build.7",
+        target=target,
+        files=files,
+    )
+
+    assert await writer.flush_once()
+    assert not await writer.flush_once()
+
+    payload = json.loads(files.completed[0][1])
+    assert payload["version"] == "1"
+    assert payload["metadata"]["marimo_version"] == "1.2.3-rc1+build.7"
+    assert payload["cells"][0]["outputs"][0]["data"] == {"text/plain": "first"}
+    assert files.completed[0][0] == target
+
+
+@pytest.mark.asyncio
+async def test_change_during_stage_remains_dirty_for_the_next_tick(
+    tmp_path: Path,
+) -> None:
+    view = _view()
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    class BlockingFiles(RecordingFiles):
+        async def replace(self, target: str, contents: str) -> None:
+            self.attempted.append((target, contents))
+            if len(self.attempted) == 1:
+                started.set()
+                await release.wait()
+            self.completed.append((target, contents))
+
+    files = BlockingFiles()
+    writer = SavedSessionWriter(
+        view=view,
+        app_file_manager=cast("LspAppFileManager", _manager()),
+        marimo_version="1.2.3",
+        target=str(tmp_path / "session.json"),
+        files=files,
+    )
+    first = asyncio.create_task(writer.flush_once())
+    await started.wait()
+
+    view.add_notification(
+        CellNotification(
+            cell_id=CELL_ID,
+            status="idle",
+            output=CellOutput(
+                channel=CellChannel.OUTPUT,
+                mimetype="text/plain",
+                data="second",
+            ),
+            console=[],
+            timestamp=2,
+        )
+    )
+    release.set()
+
+    assert await first
+    assert view.needs_export("session")
+    assert await writer.flush_once()
+    assert len(files.completed) == 2
+    assert json.loads(files.completed[1][1])["cells"][0]["outputs"][0]["data"] == {
+        "text/plain": "second"
+    }
+
+
+@pytest.mark.asyncio
+async def test_partial_run_retains_an_untouched_restored_output(
+    tmp_path: Path,
+) -> None:
+    view = SessionView()
+    for cell_id, output in ((CELL_ID, "old first"), (SECOND_CELL_ID, "old second")):
+        view.add_notification(
+            CellNotification(
+                cell_id=cell_id,
+                status="idle",
+                output=CellOutput(
+                    channel=CellChannel.OUTPUT,
+                    mimetype="text/plain",
+                    data=output,
+                ),
+                console=[],
+                timestamp=1,
+            )
+        )
+    view.mark_auto_export_session()
+    view.add_control_request(
+        ExecuteCellsCommand(
+            cell_ids=[CELL_ID, SECOND_CELL_ID],
+            codes=["first = 1", "second = 2"],
+        )
+    )
+    view.add_notification(
+        CellNotification(
+            cell_id=CELL_ID,
+            status="idle",
+            output=CellOutput(
+                channel=CellChannel.OUTPUT,
+                mimetype="text/plain",
+                data="new first",
+            ),
+            console=[],
+            timestamp=2,
+        )
+    )
+    files = RecordingFiles()
+    writer = SavedSessionWriter(
+        view=view,
+        app_file_manager=cast(
+            "LspAppFileManager",
+            _manager(
+                cell_ids=(CELL_ID, SECOND_CELL_ID),
+                codes=("first = 1", "second = 2"),
+            ),
+        ),
+        marimo_version="1.2.3",
+        target=str(tmp_path / "session.json"),
+        files=files,
+    )
+
+    assert await writer.flush_once()
+
+    payload = json.loads(files.completed[0][1])
+    assert payload["cells"][0]["outputs"][0]["data"] == {"text/plain": "new first"}
+    assert payload["cells"][1]["outputs"][0]["data"] == {"text/plain": "old second"}
+
+
+@pytest.mark.asyncio
+async def test_restored_view_waits_for_the_current_notebook_graph(
+    tmp_path: Path,
+) -> None:
+    view = _view()
+    view.last_executed_code.clear()
+    view.mark_auto_export_session()
+    view.add_control_request(UpdateUserConfigCommand(config={}))
+    files = RecordingFiles()
+    writer = SavedSessionWriter(
+        view=view,
+        app_file_manager=cast("LspAppFileManager", _manager()),
+        marimo_version="1.2.3",
+        target=str(tmp_path / "session.json"),
+        files=files,
+    )
+
+    assert not await writer.flush_once()
+    assert files.attempted == []
+
+    view.add_control_request(
+        ExecuteCellsCommand(cell_ids=[CELL_ID], codes=["value = 1"])
+    )
+
+    assert await writer.flush_once()
+    assert json.loads(files.completed[0][1])["cells"][0]["code_hash"] is not None
+
+
+@pytest.mark.asyncio
+async def test_writer_waits_for_a_notification_for_each_nonempty_cell(
+    tmp_path: Path,
+) -> None:
+    view = SessionView()
+    view.add_control_request(
+        ExecuteCellsCommand(cell_ids=[CELL_ID], codes=["value = 1"])
+    )
+    files = RecordingFiles()
+    writer = SavedSessionWriter(
+        view=view,
+        app_file_manager=cast("LspAppFileManager", _manager()),
+        marimo_version="1.2.3",
+        target=str(tmp_path / "session.json"),
+        files=files,
+    )
+
+    assert not await writer.flush_once()
+    assert files.attempted == []
+
+    view.add_notification(
+        CellNotification(
+            cell_id=CELL_ID,
+            status="idle",
+            output=None,
+            console=[],
+            timestamp=1,
+        )
+    )
+
+    assert await writer.flush_once()
+    restored = decode_saved_session_view(
+        files.completed[0][1],
+        codes=("value = 1",),
+        cell_ids=(CELL_ID,),
+        marimo_version="1.2.3",
+        header=None,
+    )
+    assert restored is not None
+
+
+@pytest.mark.asyncio
+async def test_pending_restored_view_waits_for_instantiation(
+    tmp_path: Path,
+) -> None:
+    view = _view()
+    view.last_executed_code.clear()
+    view.mark_auto_export_session()
+    files = RecordingFiles()
+    writer = SavedSessionWriter(
+        view=view,
+        app_file_manager=cast("LspAppFileManager", _manager()),
+        marimo_version="1.2.3",
+        target=str(tmp_path / "session.json"),
+        files=files,
+        pending=True,
+    )
+
+    assert not await writer.flush_once()
+    assert writer.stop()
+    assert files.attempted == []
+
+    view.add_control_request(
+        ExecuteCellsCommand(cell_ids=[CELL_ID], codes=["value = 1"])
+    )
+
+    assert await writer.flush_once()
+
+
+@pytest.mark.asyncio
+async def test_stop_discards_an_in_flight_stage_and_retries_on_restart(
+    tmp_path: Path,
+) -> None:
+    view = _view()
+    started = asyncio.Event()
+
+    class BlockingFiles(RecordingFiles):
+        async def replace(self, target: str, contents: str) -> None:
+            self.attempted.append((target, contents))
+            if len(self.attempted) == 1:
+                started.set()
+                await asyncio.Event().wait()
+            self.completed.append((target, contents))
+
+    files = BlockingFiles()
+    writer = SavedSessionWriter(
+        view=view,
+        app_file_manager=cast("LspAppFileManager", _manager()),
+        marimo_version="1.2.3",
+        target=str(tmp_path / "session.json"),
+        files=files,
+        interval=0,
+    )
+    writer.start()
+    await started.wait()
+
+    assert writer.stop()
+    await asyncio.sleep(0)
+    writer.start()
+    for _ in range(100):
+        if files.completed:
+            break
+        await asyncio.sleep(0)
+    writer.stop()
+
+    assert len(files.attempted) == 2
+    assert files.completed == [files.attempted[1]]
+
+
+@pytest.mark.asyncio
+async def test_failed_write_remains_pending_for_a_lifecycle_restart(
+    tmp_path: Path,
+) -> None:
+    view = _view()
+
+    class FailOnceFiles(RecordingFiles):
+        async def replace(self, target: str, contents: str) -> None:
+            self.attempted.append((target, contents))
+            if len(self.attempted) == 1:
+                message = "unavailable"
+                raise OSError(message)
+            self.completed.append((target, contents))
+
+    files = FailOnceFiles()
+    writer = SavedSessionWriter(
+        view=view,
+        app_file_manager=cast("LspAppFileManager", _manager()),
+        marimo_version="1.2.3",
+        target=str(tmp_path / "session.json"),
+        files=files,
+    )
+
+    with pytest.raises(OSError, match="unavailable"):
+        await writer.flush_once()
+
+    assert writer.stop()
+    assert await writer.flush_once()
+    assert files.completed == [files.attempted[1]]

--- a/tests/test_saved_sessions.py
+++ b/tests/test_saved_sessions.py
@@ -1,0 +1,291 @@
+# Copyright 2026 Marimo. All rights reserved.
+
+"""Characterize marimo's saved-session format at the LSP boundary."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+from marimo import __version__
+from marimo._messaging.cell_output import CellChannel, CellOutput
+from marimo._messaging.notification import CellNotification
+from marimo._runtime.commands import ExecuteCellsCommand
+from marimo._session.state.serialize import (
+    get_session_cache_file,
+    serialize_session_view,
+)
+from marimo._session.state.session_view import SessionView
+from marimo._types.ids import CellId_t
+from marimo._utils.code import hash_code
+from marimo._utils.inline_script_metadata import read_pyproject_from_script
+
+from marimo_lsp.saved_sessions import (
+    decode_saved_session_view,
+    serialize_saved_session_view,
+)
+
+SAVED_ID = CellId_t("saved")
+CURRENT_ID = CellId_t("current")
+SECOND_ID = CellId_t("second")
+CODE = "answer = 42\nanswer"
+SECOND_CODE = "other = 7\nother"
+HEADER = """# /// script
+# dependencies = ["polars"]
+# ///
+"""
+
+
+def _script_metadata_hash(header: str) -> str:
+    project = read_pyproject_from_script(header)
+    assert project is not None
+    return hash_code(
+        json.dumps(
+            project,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        )
+    )
+
+
+def _view(*, code: str = CODE, output: str = "42") -> SessionView:
+    view = SessionView()
+    view.add_control_request(ExecuteCellsCommand(cell_ids=[SAVED_ID], codes=[code]))
+    view.add_notification(
+        CellNotification(
+            cell_id=SAVED_ID,
+            status="idle",
+            output=CellOutput(
+                channel=CellChannel.OUTPUT,
+                mimetype="text/plain",
+                data=output,
+            ),
+            console=[
+                CellOutput(
+                    channel=CellChannel.STDOUT,
+                    mimetype="text/plain",
+                    data="ready\n",
+                )
+            ],
+            timestamp=12.5,
+        )
+    )
+    return view
+
+
+def _contents(*, marimo_version: str = __version__) -> str:
+    snapshot = serialize_session_view(
+        _view(),
+        cell_ids=[SAVED_ID],
+        drop_virtual_file_outputs=True,
+        script_metadata_hash=_script_metadata_hash(HEADER),
+    )
+    snapshot["metadata"]["marimo_version"] = marimo_version
+    return json.dumps(snapshot)
+
+
+def _decode(contents: str | None = None, *, version: str | None = __version__):
+    return decode_saved_session_view(
+        contents if contents is not None else _contents(),
+        codes=(CODE,),
+        cell_ids=(CURRENT_ID,),
+        marimo_version=version,
+        header=HEADER,
+    )
+
+
+def test_upstream_cache_path_is_beside_the_notebook(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    notebook = tmp_path / "notebook.py"
+    monkeypatch.setattr(sys, "pycache_prefix", None)
+
+    assert get_session_cache_file(notebook) == (
+        tmp_path / "__marimo__" / "session" / "notebook.py.json"
+    )
+
+
+def test_upstream_cache_path_follows_pycache_prefix(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    notebook = tmp_path / "workspace" / "notebook.py"
+    prefix = tmp_path / "cache"
+    monkeypatch.setattr(sys, "pycache_prefix", str(prefix))
+
+    assert get_session_cache_file(notebook) == (
+        prefix
+        / Path(*notebook.parent.parts[1:])
+        / "__marimo__"
+        / "session"
+        / "notebook.py.json"
+    )
+
+
+def test_serializes_upstream_v1_with_selected_kernel_version() -> None:
+    snapshot = serialize_saved_session_view(
+        _view(),
+        cell_ids=[SAVED_ID],
+        marimo_version="1.2.3-rc1+build.7",
+        header=HEADER,
+    )
+
+    assert snapshot is not None
+    assert snapshot["version"] == "1"
+    assert snapshot["metadata"] == {
+        "marimo_version": "1.2.3-rc1+build.7",
+        "script_metadata_hash": _script_metadata_hash(HEADER),
+    }
+    assert snapshot["cells"][0]["code_hash"] == hash_code(CODE)
+    assert snapshot["cells"][0]["outputs"] == [
+        {"type": "data", "data": {"text/plain": "42"}}
+    ]
+
+
+@pytest.mark.parametrize("version", [None, "unknown"])
+def test_unknown_kernel_version_does_not_serialize_or_decode(
+    version: str | None,
+) -> None:
+    assert (
+        serialize_saved_session_view(
+            _view(),
+            cell_ids=[SAVED_ID],
+            marimo_version=version,
+            header=None,
+        )
+        is None
+    )
+    assert _decode(version=version) is None
+
+
+def test_decodes_compatible_outputs_by_code_hash() -> None:
+    restored = _decode()
+
+    assert restored is not None
+    assert set(restored.cell_notifications) == {CURRENT_ID}
+    notification = restored.cell_notifications[CURRENT_ID]
+    assert notification.status == "idle"
+    assert notification.timestamp == 0
+    assert notification.output is not None
+    assert notification.output.data == "42"
+    assert isinstance(notification.console, list)
+    [console] = notification.console
+    assert isinstance(console, CellOutput)
+    assert console.channel == CellChannel.STDOUT
+    assert console.data == "ready\n"
+    assert restored.last_executed_code == {}
+
+
+def test_upstream_reader_skips_future_output_types() -> None:
+    payload = json.loads(_contents())
+    payload["cells"][0]["outputs"].insert(
+        0,
+        {"type": "future-output", "data": "opaque"},
+    )
+
+    restored = _decode(json.dumps(payload))
+
+    assert restored is not None
+    output = restored.cell_notifications[CURRENT_ID].output
+    assert output is not None
+    assert output.data == "42"
+
+
+@pytest.mark.parametrize(
+    ("codes", "cell_ids", "version", "header"),
+    [
+        (("changed",), (CURRENT_ID,), __version__, HEADER),
+        ((CODE,), (CURRENT_ID,), "0.0.0", HEADER),
+        ((CODE,), (), __version__, HEADER),
+        ((CODE,), (CURRENT_ID,), __version__, HEADER.replace("polars", "pandas")),
+    ],
+    ids=["code", "version", "unaligned-key", "script-metadata"],
+)
+def test_rejects_incompatible_cache_keys(
+    codes: tuple[str, ...],
+    cell_ids: tuple[CellId_t, ...],
+    version: str,
+    header: str,
+) -> None:
+    assert (
+        decode_saved_session_view(
+            _contents(),
+            codes=codes,
+            cell_ids=cell_ids,
+            marimo_version=version,
+            header=header,
+        )
+        is None
+    )
+
+
+def test_duplicate_code_hashes_fail_closed() -> None:
+    payload = json.loads(_contents())
+    duplicate = json.loads(json.dumps(payload["cells"][0]))
+    duplicate["id"] = "saved-2"
+    duplicate["outputs"][0]["data"]["text/plain"] = "second"
+    payload["cells"].append(duplicate)
+
+    assert (
+        decode_saved_session_view(
+            json.dumps(payload),
+            codes=(CODE, CODE),
+            cell_ids=(CURRENT_ID, SECOND_ID),
+            marimo_version=__version__,
+            header=HEADER,
+        )
+        is None
+    )
+
+
+def test_duplicate_current_cell_ids_fail_closed() -> None:
+    payload = json.loads(_contents())
+    second = json.loads(json.dumps(payload["cells"][0]))
+    second["id"] = "saved-2"
+    second["code_hash"] = hash_code(SECOND_CODE)
+    payload["cells"].append(second)
+
+    assert (
+        decode_saved_session_view(
+            json.dumps(payload),
+            codes=(CODE, SECOND_CODE),
+            cell_ids=(CURRENT_ID, CURRENT_ID),
+            marimo_version=__version__,
+            header=HEADER,
+        )
+        is None
+    )
+
+
+def test_requested_code_can_keep_the_previous_display() -> None:
+    view = _view(code="old_code", output="old output")
+    view.add_control_request(
+        ExecuteCellsCommand(cell_ids=[SAVED_ID], codes=["new_code"])
+    )
+    snapshot = serialize_saved_session_view(
+        view,
+        cell_ids=[SAVED_ID],
+        marimo_version=__version__,
+        header=None,
+    )
+    assert snapshot is not None
+
+    restored = decode_saved_session_view(
+        json.dumps(snapshot),
+        codes=("new_code",),
+        cell_ids=(CURRENT_ID,),
+        marimo_version=__version__,
+        header=None,
+    )
+
+    assert restored is not None
+    output = restored.cell_notifications[CURRENT_ID].output
+    assert output is not None
+    assert output.data == "old output"
+
+
+@pytest.mark.parametrize("contents", ["not json", "{}"])
+def test_malformed_contents_fail_closed(contents: str) -> None:
+    assert _decode(contents) is None

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -6,31 +6,43 @@ from __future__ import annotations
 
 import asyncio
 import copy
+import json
 import threading
 from typing import TYPE_CHECKING, cast
-from unittest.mock import ANY, AsyncMock, Mock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 from marimo._config.config import DEFAULT_CONFIG, MarimoConfig, RuntimeConfig
+from marimo._messaging.cell_output import CellChannel, CellOutput
+from marimo._messaging.notification import CellNotification
 from marimo._messaging.types import KernelMessage
 from marimo._runtime.commands import (
     CodeCompletionCommand,
+    ExecuteCellsCommand,
     StopKernelCommand,
     UpdateCellConfigCommand,
     UpdateUIElementCommand,
     UpdateUserConfigCommand,
 )
 from marimo._session.managers import IPCQueueManagerImpl
+from marimo._session.requests import InstantiateNotebookRequest
 from marimo._session.state.session_view import SessionView
 from marimo._types.ids import CellId_t, RequestId, SessionId, UIElementId
 
 from marimo_lsp.kernels import KernelOpenError
 from marimo_lsp.kernels.native import NativeKernel
 from marimo_lsp.models import SessionInfo
+from marimo_lsp.saved_sessions import (
+    decode_saved_session_view,
+    serialize_saved_session_view,
+)
 from marimo_lsp.sessions import Session, Sessions, _OperationSink
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+    from pathlib import Path
+
+    from marimo_lsp.kernels import Kernel
 
 
 SESSION_ID = SessionId("00000000-0000-4000-8000-000000000001")
@@ -51,6 +63,10 @@ def _make_session() -> tuple[Session, Mock]:
     session._scratchpad_running = False
     session._scratchpad_run_id = None
     session._closed = False
+    session._activated = True
+    session._saved_session_pending = False
+    session._saved_session_writer = None
+    session._saved_session_location = None
     session._state_lock = threading.RLock()
     return session, ipc_queue_manager
 
@@ -86,16 +102,10 @@ def test_sync_forwards_changed_document_configs_to_the_kernel() -> None:
         {CellId_t("cell-1"): Mock(asdict=Mock(return_value={"disabled": False}))},
     ]
 
-    with pytest.MonkeyPatch.context() as monkeypatch:
-        sync = Mock()
-        monkeypatch.setattr("marimo_lsp.sessions.sync_app_with_workspace", sync)
-        session.sync(Mock())
+    workspace = Mock()
+    session.sync(workspace)
 
-    sync.assert_called_once_with(
-        workspace=ANY,
-        notebook_uri="file:///test.py",
-        app=session._app_file_manager.app,
-    )
+    session._app_file_manager.sync.assert_called_once_with(workspace)
     command = queue_manager.control_queue.put.call_args.args[0]
     assert isinstance(command, UpdateCellConfigCommand)
     assert command.configs == {CellId_t("cell-1"): {"disabled": False}}
@@ -116,9 +126,7 @@ def test_sync_forwards_each_changed_config_separately() -> None:
         },
     ]
 
-    with pytest.MonkeyPatch.context() as monkeypatch:
-        monkeypatch.setattr("marimo_lsp.sessions.sync_app_with_workspace", Mock())
-        session.sync(Mock())
+    session.sync(Mock())
 
     commands = [call.args[0] for call in queue_manager.control_queue.put.call_args_list]
     assert [command.configs for command in commands] == [
@@ -137,9 +145,7 @@ def test_sync_does_not_notify_kernel_when_configs_are_unchanged() -> None:
         {CellId_t("cell-1"): config},
     ]
 
-    with pytest.MonkeyPatch.context() as monkeypatch:
-        monkeypatch.setattr("marimo_lsp.sessions.sync_app_with_workspace", Mock())
-        session.sync(Mock())
+    session.sync(Mock())
 
     queue_manager.control_queue.put.assert_not_called()
 
@@ -229,6 +235,162 @@ def test_detached_session_keeps_auto_reload_paused_after_config_update() -> None
     assert isinstance(command, UpdateUserConfigCommand)
     runtime = cast("RuntimeConfig", command.config.get("runtime", {}))
     assert runtime.get("auto_reload") == "off"
+
+
+def test_saved_session_writer_outlives_client_attachment() -> None:
+    session, _queue_manager = _make_session()
+    session._config_manager = Mock()
+    session._runtime_config = DEFAULT_CONFIG
+    session._operation_sink = _OperationSink(Mock(), "file:///test.py", SESSION_ID)
+    writer = Mock()
+    session._saved_session_writer = writer
+
+    session.detach()
+
+    writer.stop.assert_not_called()
+
+    session.attach()
+
+    writer.start.assert_not_called()
+
+
+def test_saved_session_writer_starts_only_after_session_activation() -> None:
+    session, _queue_manager = _make_session()
+    session._activated = False
+    session._operation_sink = _OperationSink(
+        Mock(),
+        "file:///test.py",
+        SESSION_ID,
+        activated=False,
+    )
+    writer = Mock()
+    session._saved_session_writer = writer
+
+    session.activate()
+
+    writer.start.assert_called_once_with()
+
+
+def test_close_releases_kernel_after_event_loop_is_closed() -> None:
+    session, _queue_manager = _make_session()
+    session.session_id = SESSION_ID
+    session._operation_sink = Mock()
+    session._kernel = Mock()
+    session._saved_session_location = Mock()
+    session._saved_session_location.cancel.side_effect = RuntimeError(
+        "Event loop is closed"
+    )
+    session._saved_session_writer = Mock()
+    session._saved_session_writer.stop.side_effect = RuntimeError(
+        "Event loop is closed"
+    )
+    loop = asyncio.new_event_loop()
+    session._idle = asyncio.Event()
+    waiter = loop.create_task(session._idle.wait())
+    loop.run_until_complete(asyncio.sleep(0))
+    loop.close()
+
+    try:
+        session.close()
+        session.close()
+    finally:
+        coroutine = waiter.get_coro()
+        assert coroutine is not None
+        coroutine.close()
+        waiter._log_destroy_pending = False  # ty: ignore[unresolved-attribute]
+
+    session._kernel.close.assert_called_once_with()
+    session._operation_sink.detach.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_moving_a_session_relocates_its_writer() -> None:
+    session, _queue_manager = _make_session()
+    session._notebook_uri = "file:///old.py"
+    session._kernel.marimo_version = "1.2.3"
+    session._saved_session_files = Mock()
+    session._operation_sink = _OperationSink(Mock(), "file:///old.py", SESSION_ID)
+    app_file_manager = Mock()
+    app_file_manager.path = "/workspace/old.py"
+    app_file_manager.header = None
+    app_file_manager.app.cell_manager.cell_ids.return_value = []
+
+    def move(_notebook_uri: str) -> None:
+        app_file_manager.path = "/workspace/renamed.py"
+
+    app_file_manager.move.side_effect = move
+    session._app_file_manager = app_file_manager
+    kernel = Mock()
+    kernel.marimo_version = "1.2.3"
+    kernel.locate_saved_session = AsyncMock(
+        return_value="/workspace/__marimo__/session/renamed.py.json"
+    )
+    session._kernel = cast("Kernel", kernel)
+    old_writer = Mock()
+    old_writer.stop.return_value = False
+    session._saved_session_writer = old_writer
+    session.session_view.mark_auto_export_session()
+
+    session.move("file:///renamed.py")
+    assert session._saved_session_location is not None
+    await session._saved_session_location
+
+    old_writer.stop.assert_called_once_with()
+    kernel.locate_saved_session.assert_awaited_once_with("/workspace/renamed.py")
+    assert session._saved_session_writer is not None
+    assert (
+        session._saved_session_writer._target
+        == "/workspace/__marimo__/session/renamed.py.json"
+    )
+    assert session._saved_session_writer.running
+    session._saved_session_writer.stop()
+
+
+@pytest.mark.asyncio
+async def test_rapid_moves_preserve_an_in_flight_write_retry() -> None:
+    session, _queue_manager = _make_session()
+    session._notebook_uri = "file:///old.py"
+    session._activated = False
+    session._saved_session_files = Mock()
+    session._operation_sink = _OperationSink(Mock(), "file:///old.py", SESSION_ID)
+    app_file_manager = Mock()
+    app_file_manager.path = "/workspace/old.py"
+    app_file_manager.header = None
+    app_file_manager.app.cell_manager.cell_ids.return_value = []
+
+    def move(notebook_uri: str) -> None:
+        app_file_manager.path = {
+            "file:///first.py": "/workspace/first.py",
+            "file:///second.py": "/workspace/second.py",
+        }[notebook_uri]
+
+    app_file_manager.move.side_effect = move
+    session._app_file_manager = app_file_manager
+    first_started = asyncio.Event()
+
+    async def locate(path: str) -> str:
+        if path == "/workspace/first.py":
+            first_started.set()
+            await asyncio.Event().wait()
+        return "/workspace/__marimo__/session/second.py.json"
+
+    kernel = Mock()
+    kernel.marimo_version = "1.2.3"
+    kernel.locate_saved_session = AsyncMock(side_effect=locate)
+    session._kernel = cast("Kernel", kernel)
+    old_writer = Mock()
+    old_writer.stop.return_value = True
+    session._saved_session_writer = old_writer
+
+    session.move("file:///first.py")
+    await first_started.wait()
+    session.move("file:///second.py")
+    assert session._saved_session_location is not None
+    await session._saved_session_location
+
+    assert session._saved_session_writer is not None
+    assert session._saved_session_writer._pending
+    session._saved_session_writer.stop()
 
 
 def test_detached_operation_sink_drops_messages_until_reattached() -> None:
@@ -665,6 +827,178 @@ async def test_session_creation_drops_view_without_known_matching_versions(
         None if kernel_version == "unknown" else kernel_version
     )
     assert created.session_view is not previous.session_view
+
+
+@pytest.mark.asyncio
+async def test_session_creation_binds_the_selected_kernel_cache_path() -> None:
+    kernel = Mock()
+    kernel.marimo_version = "1.2.3"
+    kernel.locate_saved_session = AsyncMock(
+        return_value="/workspace/__marimo__/session/notebook.py.json"
+    )
+    kernels = Mock()
+    kernels.launch = AsyncMock(return_value=kernel)
+    sessions = Sessions(Mock(), kernels=kernels)
+    previous = Mock(spec=Session)
+    previous.app_file_manager = Mock()
+    previous.app_file_manager.path = "/workspace/notebook.py"
+    previous.config_manager = Mock()
+    previous.config_manager.get_config.return_value = DEFAULT_CONFIG
+    previous.session_view = SessionView()
+    previous.started_at = 42
+    previous.marimo_version = "1.2.3"
+
+    created = await sessions._create(
+        "file:///workspace/notebook.py",
+        "/usr/bin/python",
+        "/workspace",
+        previous=previous,
+    )
+
+    kernel.locate_saved_session.assert_awaited_once_with("/workspace/notebook.py")
+    assert created._saved_session_writer is not None
+    assert (
+        created._saved_session_writer._target
+        == "/workspace/__marimo__/session/notebook.py.json"
+    )
+    created.close()
+
+
+@pytest.mark.asyncio
+async def test_session_creation_restores_the_selected_kernel_cache_before_writing(
+    tmp_path: Path,
+) -> None:
+    cell_id = CellId_t("cell")
+    restored = SessionView()
+    restored.add_control_request(
+        ExecuteCellsCommand(cell_ids=[cell_id], codes=["value = 1"])
+    )
+    restored.add_notification(
+        CellNotification(
+            cell_id=cell_id,
+            status="idle",
+            output=CellOutput(
+                channel=CellChannel.OUTPUT,
+                mimetype="text/plain",
+                data="saved",
+            ),
+            console=[],
+            timestamp=1,
+        )
+    )
+    snapshot = serialize_saved_session_view(
+        restored,
+        cell_ids=[cell_id],
+        marimo_version="1.2.4",
+        header=None,
+    )
+    assert snapshot is not None
+    files = Mock()
+    files.read = AsyncMock(return_value=json.dumps(snapshot))
+    files.replace = AsyncMock()
+    kernel = Mock()
+    kernel.marimo_version = "1.2.4"
+    kernel.locate_saved_session = AsyncMock(return_value=str(tmp_path / "session.json"))
+    kernels = Mock()
+    kernels.launch = AsyncMock(return_value=kernel)
+    sessions = Sessions(Mock(), kernels=kernels, saved_session_files=files)
+    previous = Mock(spec=Session)
+    previous.app_file_manager = Mock()
+    previous.app_file_manager.path = str(tmp_path / "notebook.py")
+    previous.app_file_manager.header = None
+    previous.app_file_manager.app.cell_manager.codes.return_value = ["value = 1"]
+    previous.app_file_manager.app.cell_manager.cell_ids.return_value = [cell_id]
+    previous.app_file_manager.app.cell_manager.code_map.return_value = {
+        cell_id: "value = 1"
+    }
+    previous.config_manager = Mock()
+    previous.config_manager.get_config.return_value = DEFAULT_CONFIG
+    previous.session_view = SessionView()
+    previous.started_at = 42
+    previous.marimo_version = "1.2.3"
+
+    created = await sessions._create(
+        "file:///workspace/notebook.py",
+        "/usr/bin/python",
+        "/workspace",
+        previous=previous,
+    )
+
+    notification = created.session_view.cell_notifications[cell_id]
+    assert notification.output is not None
+    assert notification.output.data == "saved"
+    assert not created.session_view.needs_export("session")
+    files.read.assert_awaited_once_with(str(tmp_path / "session.json"))
+
+    created.detach()
+    writer = created._saved_session_writer
+    assert writer is not None
+    assert not await writer.flush_once()
+    files.replace.assert_not_awaited()
+
+    created.instantiate(
+        InstantiateNotebookRequest(auto_run=False, object_ids=[], values=[]),
+        http_request=None,
+    )
+    assert await writer.flush_once()
+    replace_args = files.replace.await_args
+    assert replace_args is not None
+    written = replace_args.args[1]
+    assert (
+        decode_saved_session_view(
+            written,
+            codes=("value = 1",),
+            cell_ids=(cell_id,),
+            marimo_version="1.2.4",
+            header=None,
+        )
+        is not None
+    )
+    created.close()
+
+
+@pytest.mark.asyncio
+async def test_fresh_session_does_not_write_until_the_view_changes(
+    tmp_path: Path,
+) -> None:
+    files = Mock()
+    files.read = AsyncMock(return_value=None)
+    files.replace = AsyncMock()
+    kernel = Mock()
+    kernel.marimo_version = "1.2.3"
+    kernel.locate_saved_session = AsyncMock(return_value=str(tmp_path / "session.json"))
+    kernels = Mock()
+    kernels.launch = AsyncMock(return_value=kernel)
+    server = Mock()
+    app_file_manager = Mock()
+    app_file_manager.path = str(tmp_path / "notebook.py")
+    app_file_manager.header = None
+    app_file_manager.app.cell_manager.codes.return_value = []
+    app_file_manager.app.cell_manager.cell_ids.return_value = []
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(
+            "marimo_lsp.sessions.LspAppFileManager",
+            Mock(return_value=app_file_manager),
+        )
+        sessions = Sessions(server, kernels=kernels, saved_session_files=files)
+        created = await sessions._create(
+            "file:///workspace/notebook.py",
+            "/usr/bin/python",
+            "/workspace",
+        )
+
+    writer = created._saved_session_writer
+    assert writer is not None
+    assert not await writer.flush_once()
+
+    created.put_control_request(
+        ExecuteCellsCommand(cell_ids=[], codes=[]),
+        from_consumer_id=None,
+    )
+
+    assert await writer.flush_once()
+    files.replace.assert_awaited_once()
+    created.close()
 
 
 @pytest.mark.asyncio

--- a/tests/test_wasm.py
+++ b/tests/test_wasm.py
@@ -17,6 +17,7 @@ async def test_wasm_server_handles_initialize_message() -> None:
     server = create_bridge(
         lambda message: messages.append(msgspec.json.decode(message)),
         Mock(),
+        Mock(),
     )
 
     await server.handle_message(
@@ -84,6 +85,7 @@ async def test_wasm_server_drives_async_api_handler() -> None:
     server = create_bridge(
         lambda message: messages.append(msgspec.json.decode(message)),
         Mock(),
+        Mock(),
     )
 
     await server.handle_message(
@@ -112,7 +114,7 @@ async def test_wasm_server_drives_async_api_handler() -> None:
 
 
 def test_wasm_server_close_releases_tracked_kernels() -> None:
-    server = create_bridge(Mock(), Mock())
+    server = create_bridge(Mock(), Mock(), Mock())
     kernel = Mock()
     server._kernels._kernels["kernel"] = kernel
 

--- a/tests/test_wasm_bridge.py
+++ b/tests/test_wasm_bridge.py
@@ -200,10 +200,41 @@ def test_bridge_launches_kernel_subprocess_over_marimo_ipc(
         assert sent.connection_info is not None
         assert sent.parent_pid == os.getpid()
         write_frame.assert_any_call(
-            bridge_module.Ready(marimo_version="1.2.3-rc1+build.7")
+            bridge_module.Ready(
+                marimo_version="1.2.3-rc1+build.7",
+                session_cache_path=str(
+                    tmp_path / "__marimo__" / "session" / "notebook.py.json"
+                ),
+                can_locate_session_cache=True,
+            )
         )
     finally:
         bridge.close()
+
+
+def test_bridge_resolves_cache_paths_in_the_selected_environment(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    bridge_module = _load_bridge_module(monkeypatch)
+    write_frame = Mock()
+    monkeypatch.setattr(bridge_module, "_write_frame", write_frame)
+    bridge = bridge_module._Bridge()
+    (tmp_path / "renamed.py").touch()
+
+    assert bridge.handle(
+        bridge_module.LocateSessionCache(
+            request_id="request",
+            notebook_path=str(tmp_path / "renamed.py"),
+        )
+    )
+
+    write_frame.assert_called_once_with(
+        bridge_module.SessionCacheLocation(
+            request_id="request",
+            path=str(tmp_path / "__marimo__" / "session" / "renamed.py.json"),
+        )
+    )
 
 
 class _BridgeProcess:
@@ -287,6 +318,7 @@ class _BridgeProcess:
 
 
 def _start_frame(working_directory: Path) -> Start:
+    (working_directory / "notebook.py").touch(exist_ok=True)
     return Start(
         working_directory=str(working_directory),
         kernel_args=KernelLaunchArgs(

--- a/tests/test_wasm_kernel.py
+++ b/tests/test_wasm_kernel.py
@@ -21,8 +21,10 @@ from marimo_lsp.wasm.protocol import (
     Decoder,
     Error,
     FromBridge,
+    LocateSessionCache,
     Operation,
     Ready,
+    SessionCacheLocation,
     ToBridge,
     encode,
 )
@@ -85,10 +87,20 @@ async def _launch_kernel():
     process_id = callbacks.spawns[0][0]
     kernels.accept(
         process_id,
-        encode(Ready(marimo_version="1.2.3-rc1+build.7")),
+        encode(
+            Ready(
+                marimo_version="1.2.3-rc1+build.7",
+                session_cache_path=("/workspace/__marimo__/session/notebook.py.json"),
+                can_locate_session_cache=True,
+            )
+        ),
     )
     kernel = await launch
     assert kernel.marimo_version == "1.2.3-rc1+build.7"
+    assert (
+        await kernel.locate_saved_session("/workspace/notebook.py")
+        == "/workspace/__marimo__/session/notebook.py.json"
+    )
     return callbacks, kernels, kernel, messages
 
 
@@ -117,6 +129,28 @@ async def test_wasm_launch_accepts_legacy_ready_without_version() -> None:
 
     kernel = await launch
     assert kernel.marimo_version is None
+    writes = len(callbacks.writes)
+
+    assert await kernel.locate_saved_session("/workspace/renamed.py") is None
+    assert len(callbacks.writes) == writes
+
+
+@pytest.mark.asyncio
+async def test_wasm_does_not_relocate_without_bridge_capability() -> None:
+    callbacks, kernels, launch, _messages = await _begin_launch()
+    process_id = callbacks.spawns[0][0]
+    payload = b'{"type":"ready","marimoVersion":"1.2.3","version":1}'
+
+    kernels.accept(
+        process_id,
+        len(payload).to_bytes(4, byteorder="big") + payload,
+    )
+
+    kernel = await launch
+    writes = len(callbacks.writes)
+
+    assert await kernel.locate_saved_session("/workspace/renamed.py") is None
+    assert len(callbacks.writes) == writes
 
 
 @pytest.mark.asyncio
@@ -128,6 +162,38 @@ async def test_wasm_launch_treats_unknown_marimo_version_as_unavailable() -> Non
 
     kernel = await launch
     assert kernel.marimo_version is None
+
+
+@pytest.mark.asyncio
+async def test_wasm_keeps_windows_saved_session_paths_opaque() -> None:
+    callbacks, kernels, launch, _messages = await _begin_launch()
+    process_id = callbacks.spawns[0][0]
+    initial = r"C:\workspace\__marimo__\session\notebook.py.json"
+    kernels.accept(
+        process_id,
+        encode(
+            Ready(
+                marimo_version="1.2.3",
+                session_cache_path=initial,
+                can_locate_session_cache=True,
+            )
+        ),
+    )
+    kernel = await launch
+
+    assert await kernel.locate_saved_session("/workspace/notebook.py") == initial
+
+    locate = asyncio.create_task(kernel.locate_saved_session(r"C:\workspace\moved.py"))
+    await asyncio.sleep(0)
+    request = Decoder(ToBridge).feed(callbacks.writes[-1][1])[0]
+    assert isinstance(request, LocateSessionCache)
+    moved = r"C:\workspace\__marimo__\session\moved.py.json"
+    kernels.accept(
+        process_id,
+        encode(SessionCacheLocation(request_id=request.request_id, path=moved)),
+    )
+
+    assert await locate == moved
 
 
 @pytest.mark.asyncio
@@ -213,6 +279,30 @@ async def test_wasm_kernel_forwards_lifecycle_and_messages() -> None:
             "operations": [KernelMessage(b'{"op":"ready"}')],
         }
     )
+
+
+@pytest.mark.asyncio
+async def test_wasm_kernel_resolves_a_moved_notebook_in_selected_python() -> None:
+    callbacks, kernels, kernel, _messages = await _launch_kernel()
+    process_id = callbacks.spawns[0][0]
+
+    locate = asyncio.create_task(kernel.locate_saved_session("/workspace/renamed.py"))
+    await asyncio.sleep(0)
+    request = Decoder(ToBridge).feed(callbacks.writes[-1][1])[0]
+    assert isinstance(request, LocateSessionCache)
+    assert request.notebook_path == "/workspace/renamed.py"
+
+    kernels.accept(
+        process_id,
+        encode(
+            SessionCacheLocation(
+                request_id=request.request_id,
+                path="/workspace/__marimo__/session/renamed.py.json",
+            )
+        ),
+    )
+
+    assert await locate == "/workspace/__marimo__/session/renamed.py.json"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
marimo's `SessionView` already tracks when its display state needs a session
export. Each authoritative LSP `Session` now owns the same two-second writer
lifecycle, instead of asking the extension to infer durability from VS Code
execution and document events.

The selected kernel reports both its exact marimo version and the cache path
computed by that environment. Native servers replace the sidecar locally. The
WASM server uses a narrow host-file adapter because Pyodide's filesystem cannot
write the Extension Host filesystem. Both routes stage beside the destination
and replace it atomically.

A session restores a compatible sidecar before the writer starts and waits for
`CreateNotebook` to establish the full current code map before acknowledging
dirty state. Partial runs therefore retain untouched cached outputs, while
restart, detach, and rename cannot replace a valid sidecar with unkeyed output.

The compatibility tests use marimo's V1 reader and serializer directly.
Extension Host coverage writes and rereads sidecars through the selected marimo
installation, including a partial run across the WASM boundary.
