### PR TITLE
Restore and persist marimo session outputs

### DIFF
--- a/extension/resources/wasm/kernel.py
+++ b/extension/resources/wasm/kernel.py
@@ -57,6 +57,21 @@ _decoder = msgspec.json.Decoder(ToBridge)
 KERNEL_READY_TIMEOUT = 10.0
 
 
+def _session_cache_path(notebook_path: str | None) -> str | None:
+    if not notebook_path:
+        return None
+    try:
+        # Optional persistence must not prevent an older marimo from starting.
+        from marimo._session.state.serialize import (  # noqa: PLC0415
+            get_session_cache_file,
+        )
+
+        path = Path(notebook_path)
+        return str(get_session_cache_file(path).absolute()) if path.is_file() else None
+    except Exception:  # noqa: BLE001
+        return None
+
+
 def _read_frame() -> ToBridge | None:
     header = sys.stdin.buffer.read(HEADER_SIZE)
     if not header:
@@ -138,7 +153,14 @@ class _Bridge:
         # during startup.
         threading.Thread(target=self._watch_kernel_exit, daemon=True).start()
         threading.Thread(target=self._forward_operations, daemon=True).start()
-        _write_frame(Ready())
+        _write_frame(
+            Ready(
+                marimo_version=__import__("marimo").__version__,
+                session_cache_path=_session_cache_path(
+                    kernel_args.app_metadata.filename
+                ),
+            )
+        )
 
     def _with_stderr_tail(self, message: str) -> str:
         with self._stderr_lock:

--- a/extension/resources/wasm/protocol.py
+++ b/extension/resources/wasm/protocol.py
@@ -28,6 +28,8 @@ MAX_FRAME_SIZE = 64 * 1024 * 1024
 class Ready(msgspec.Struct, tag="ready", tag_field="type", rename="camel"):
     """The kernel bridge is ready."""
 
+    marimo_version: str | None = None
+    session_cache_path: str | None = None
     version: Literal[1] = VERSION
 
 

--- a/extension/src/__tests__/__utils__/TestMarimoClient.ts
+++ b/extension/src/__tests__/__utils__/TestMarimoClient.ts
@@ -197,7 +197,11 @@ function makeTestMarimoClientValue(
         options.execute ??
         ((request) =>
           Effect.succeed(
-            request.method === "list-sessions" ? { sessions: [] } : null,
+            request.method === "list-sessions"
+              ? { sessions: [] }
+              : request.method === "read-notebook-outputs"
+                ? { cells: [] }
+                : null,
           )),
       kernelNotifications: options.kernelNotifications ?? Stream.never,
       documentAnalysis: options.documentAnalysis ?? Stream.never,

--- a/extension/src/commands/__tests__/refreshPackages.test.ts
+++ b/extension/src/commands/__tests__/refreshPackages.test.ts
@@ -20,6 +20,7 @@ const NOTEBOOK_URI = notebookId("file:///test/notebook.py");
 const controller: NotebookController = {
   id: "script",
   drive: () => () => Effect.void,
+  presentOutputs: () => Effect.void,
   resolveExecutable: () => Effect.succeed("/unused/python"),
 };
 

--- a/extension/src/features/__tests__/AutoExport.test.ts
+++ b/extension/src/features/__tests__/AutoExport.test.ts
@@ -30,6 +30,7 @@ import {
 const controller: NotebookController = {
   id: "test-controller",
   drive: () => () => Effect.void,
+  presentOutputs: () => Effect.void,
   resolveExecutable: () => Effect.succeed("/usr/bin/python"),
 };
 const SESSION_ID = kernelSessionId("00000000-0000-4000-8000-000000000001");

--- a/extension/src/kernel/CellExecutions.ts
+++ b/extension/src/kernel/CellExecutions.ts
@@ -26,6 +26,7 @@ import {
   type NotebookCellId,
   type NotebookId,
 } from "../schemas/MarimoNotebookDocument.ts";
+import type { CellOutputReplay } from "../schemas/Models.gen.ts";
 import type { CellOperationNotification } from "../types.ts";
 import {
   type CellSource,
@@ -55,6 +56,7 @@ export interface NotebookExecutions {
   readonly apply: (
     operation: CellOperationNotification,
   ) => Effect.Effect<void, RunCorrelationError>;
+  readonly restoreOutput: (replay: CellOutputReplay) => Effect.Effect<void>;
   readonly interrupt: Effect.Effect<void>;
   readonly invalidate: Effect.Effect<void>;
   readonly remove: (cellId: NotebookCellId) => Effect.Effect<void>;
@@ -210,6 +212,7 @@ export class CellExecutions extends Context.Service<CellExecutions>()(
 
         const executions: NotebookExecutions = {
           apply: session.apply,
+          restoreOutput: session.restoreOutput,
           interrupt: session.interrupt,
           invalidate: session.invalidate,
           remove: session.remove,

--- a/extension/src/kernel/DocumentExecutionSession.ts
+++ b/extension/src/kernel/DocumentExecutionSession.ts
@@ -20,6 +20,7 @@ import {
   type NotebookCellId,
   type NotebookId,
 } from "../schemas/MarimoNotebookDocument.ts";
+import type { CellOutputReplay } from "../schemas/Models.gen.ts";
 import type { CellOperationNotification } from "../types.ts";
 import {
   acceptKernelState,
@@ -445,6 +446,30 @@ const isCellStale = (
     }),
   );
 
+const restoreOutput = (
+  state: DocumentExecutionState,
+  replay: CellOutputReplay,
+): DocumentExecutionState => {
+  const cellId = extractCellIdFromCellMessage(replay.notification);
+  if (HashSet.has(state.removedCells, cellId)) return state;
+  const cell = getCell(state, cellId);
+  const runtime = transitionCell(cell.run.state, replay.notification);
+  const acceptedSource =
+    replay.kind === "saved" || runtime.staleInputs
+      ? AcceptedSource.Invalidated()
+      : replay.executedSource === null
+        ? AcceptedSource.Unknown()
+        : AcceptedSource.Accepted({ source: replay.executedSource });
+  return restoreCell(state, cellId, {
+    ...cell,
+    run: {
+      ...cell.run,
+      state: runtime,
+      acceptedSource,
+    },
+  });
+};
+
 /** Execution state and presentation for one exact notebook document session. */
 export class DocumentExecutionSession {
   private state: DocumentExecutionState;
@@ -628,6 +653,16 @@ export class DocumentExecutionSession {
           onSome: Effect.fail,
         });
       }).pipe(Effect.annotateLogs({ notebookId: this.options.notebook.id })),
+    );
+
+  readonly restoreOutput = (replay: CellOutputReplay) =>
+    this.ordering.withPermit(
+      Effect.gen({ self: this }, function* () {
+        if (this.closed) return;
+        const cellId = extractCellIdFromCellMessage(replay.notification);
+        this.state = restoreOutput(this.state, replay);
+        yield* this.publishStale([cellId]);
+      }),
     );
 
   private release(result: DocumentTransition) {

--- a/extension/src/kernel/NotebookControllers.ts
+++ b/extension/src/kernel/NotebookControllers.ts
@@ -37,6 +37,7 @@ import {
 } from "./PythonController.ts";
 import { createSandboxController } from "./SandboxController.ts";
 import { VsCodeCellDrive } from "./VsCodeCellDrive.ts";
+import { VsCodeNotebookOutputPresenter } from "./VsCodeNotebookOutputPresenter.ts";
 
 export interface NotebookController extends RuntimeNotebookController {
   readonly selectedNotebookChanges: Stream.Stream<{
@@ -158,6 +159,7 @@ export const NotebookControllersLive = Layer.effectDiscard(
   }),
 ).pipe(
   Layer.provide(VsCodeCellDrive.layer),
+  Layer.provide(VsCodeNotebookOutputPresenter.layer),
   Layer.provide(Uv.layer),
   Layer.provide(OutputChannel.layer),
   Layer.provide(Config.layer),

--- a/extension/src/kernel/NotebookRuntime.ts
+++ b/extension/src/kernel/NotebookRuntime.ts
@@ -33,6 +33,7 @@ import {
 } from "../notebook/NotebookDocumentSessions.ts";
 import { NotebookEditorRegistry } from "../notebook/NotebookEditorRegistry.ts";
 import { NotebookRenderer } from "../notebook/NotebookRenderer.ts";
+import { readNotebookOutputs } from "../notebook/readNotebookOutputs.ts";
 import { NotebookDatasources } from "../panel/datasources/NotebookDatasources.ts";
 import { LiveSessions } from "../panel/sessions/LiveSessions.ts";
 import { NotebookVariables } from "../panel/variables/NotebookVariables.ts";
@@ -49,7 +50,10 @@ import {
   type NotebookCellId,
   type NotebookId,
 } from "../schemas/MarimoNotebookDocument.ts";
-import type { KernelSessionId } from "../schemas/Models.gen.ts";
+import type {
+  CellOutputReplay,
+  KernelSessionId,
+} from "../schemas/Models.gen.ts";
 import type {
   CellOperationNotification,
   KernelNotification,
@@ -95,6 +99,10 @@ export interface NotebookController {
   readonly id: string;
   readonly executable?: string;
   readonly drive: (notebook: MarimoNotebookDocument) => Drive;
+  readonly presentOutputs: (
+    notebook: MarimoNotebookDocument,
+    replays: ReadonlyArray<CellOutputReplay>,
+  ) => Effect.Effect<void>;
   readonly resolveExecutable: (
     notebook: MarimoNotebookDocument,
   ) => Effect.Effect<string, ExecutableResolutionError | UnsavedNotebookError>;
@@ -928,6 +936,49 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
               }),
             );
             yield* updateKernelContext();
+
+            const documentSession = documentSessions.current(notebookId);
+            if (Option.isNone(documentSession)) return;
+            const session = documentSession.value;
+            const notebook = MarimoNotebookDocument.from(session.document);
+            yield* readNotebookOutputs(notebook, marimo).pipe(
+              Effect.flatMap(({ cells }) => {
+                if (cells.length === 0 || session.document.isClosed) {
+                  return Effect.void;
+                }
+                return executor
+                  .submitScoped(
+                    notebookId,
+                    Effect.gen(function* () {
+                      const state = yield* stateForDocumentSession(session);
+                      const selected = yield* Ref.get(state.controller);
+                      if (!Option.contains(selected, controller)) return;
+
+                      const notebookExecutions = yield* executions.open(
+                        session,
+                        {
+                          getDrive: Effect.succeed(
+                            Option.some(controller.drive(notebook)),
+                          ),
+                        },
+                      );
+                      yield* Effect.forEach(
+                        cells,
+                        notebookExecutions.restoreOutput,
+                        { discard: true },
+                      );
+                      yield* controller.presentOutputs(notebook, cells);
+                    }),
+                  )
+                  .pipe(Scope.provide(session.scope));
+              }),
+              Effect.catchCause((cause) =>
+                Effect.logDebug("Notebook output replay unavailable").pipe(
+                  Effect.annotateLogs({ cause, notebookUri: notebookId }),
+                ),
+              ),
+              Effect.forkIn(session.scope),
+            );
           });
         },
         controllerChanges: Stream.fromPubSub(controllerSelections),

--- a/extension/src/kernel/PythonController.ts
+++ b/extension/src/kernel/PythonController.ts
@@ -17,10 +17,12 @@ import { EnvironmentValidator } from "../python/EnvironmentValidator.ts";
 import { findVenvPath } from "../python/findVenvPath.ts";
 import { Uv } from "../python/Uv.ts";
 import { MarimoNotebookDocument } from "../schemas/MarimoNotebookDocument.ts";
+import type { CellOutputReplay } from "../schemas/Models.gen.ts";
 import type { Drive } from "./CellExecutions.ts";
 import { makeControllerSelectionChanges } from "./ControllerSelectionChanges.ts";
 import { NotebookRuntime } from "./NotebookRuntime.ts";
 import { VsCodeCellDrive } from "./VsCodeCellDrive.ts";
+import { VsCodeNotebookOutputPresenter } from "./VsCodeNotebookOutputPresenter.ts";
 
 const NotebookControllerId = Brand.nominal<NotebookControllerId>();
 export type NotebookControllerId = Brand.Branded<string, "ControllerId">;
@@ -34,6 +36,7 @@ export const createPythonController = Effect.fn("createPythonController")(
     const uv = yield* Uv;
     const code = yield* VsCode;
     const cellDrive = yield* VsCodeCellDrive;
+    const outputPresenter = yield* VsCodeNotebookOutputPresenter;
     const config = yield* Config;
     const notebooks = yield* NotebookRuntime;
     const validator = yield* EnvironmentValidator;
@@ -255,6 +258,15 @@ export const createPythonController = Effect.fn("createPythonController")(
               controller.createNotebookCellExecution(cell.rawNotebookCell),
           },
         }),
+      (notebook, replays) =>
+        outputPresenter.present(
+          notebook,
+          {
+            createNotebookCellExecution: (cell) =>
+              controller.createNotebookCellExecution(cell),
+          },
+          replays,
+        ),
     );
   },
 );
@@ -263,6 +275,10 @@ export class PythonController {
   readonly _tag = "PythonController";
   #inner: Omit<vscode.NotebookController, "dispose">;
   readonly drive: (notebook: MarimoNotebookDocument) => Drive;
+  readonly presentOutputs: (
+    notebook: MarimoNotebookDocument,
+    replays: ReadonlyArray<CellOutputReplay>,
+  ) => Effect.Effect<void>;
   /** The python interpreter this controller's environment runs on. */
   executable: string;
   /**
@@ -282,11 +298,16 @@ export class PythonController {
       selected: boolean;
     }>,
     drive: (notebook: MarimoNotebookDocument) => Drive,
+    presentOutputs: (
+      notebook: MarimoNotebookDocument,
+      replays: ReadonlyArray<CellOutputReplay>,
+    ) => Effect.Effect<void>,
   ) {
     this.#inner = inner;
     this.executable = executable;
     this.selectedNotebookChanges = selectedNotebookChanges;
     this.drive = drive;
+    this.presentOutputs = presentOutputs;
   }
   static getId(env: py.Environment) {
     return NotebookControllerId(`marimo-${env.path}`);

--- a/extension/src/kernel/SandboxController.ts
+++ b/extension/src/kernel/SandboxController.ts
@@ -21,16 +21,19 @@ import { SemVerFromString } from "../schemas/SemVerFromString.ts";
 import { makeControllerSelectionChanges } from "./ControllerSelectionChanges.ts";
 import {
   ExecutableResolutionError,
+  type NotebookController,
   NotebookRuntime,
   UnsavedNotebookError,
 } from "./NotebookRuntime.ts";
 import { VsCodeCellDrive } from "./VsCodeCellDrive.ts";
+import { VsCodeNotebookOutputPresenter } from "./VsCodeNotebookOutputPresenter.ts";
 
 export const createSandboxController = Effect.fn("createSandboxController")(
   function* () {
     const uv = yield* Uv;
     const code = yield* VsCode;
     const cellDrive = yield* VsCodeCellDrive;
+    const outputPresenter = yield* VsCodeNotebookOutputPresenter;
     const marimo = yield* MarimoClient;
     const notebooks = yield* NotebookRuntime;
     const python = yield* PythonExtension;
@@ -213,6 +216,19 @@ export const createSandboxController = Effect.fn("createSandboxController")(
     const selectedNotebookChanges =
       yield* makeControllerSelectionChanges(controller);
 
+    const presentOutputs: NotebookController["presentOutputs"] = (
+      notebook,
+      replays,
+    ) =>
+      outputPresenter.present(
+        notebook,
+        {
+          createNotebookCellExecution: (cell) =>
+            controller.createNotebookCellExecution(cell),
+        },
+        replays,
+      );
+
     return {
       id: controller.id,
       resolveExecutable: (notebook: MarimoNotebookDocument) =>
@@ -235,6 +251,7 @@ export const createSandboxController = Effect.fn("createSandboxController")(
               controller.createNotebookCellExecution(cell.rawNotebookCell),
           },
         }),
+      presentOutputs,
       selectedNotebookChanges,
       updateNotebookAffinity(
         notebook: vscode.NotebookDocument,

--- a/extension/src/kernel/VsCodeCellDrive.ts
+++ b/extension/src/kernel/VsCodeCellDrive.ts
@@ -39,6 +39,7 @@ interface PresentedRun {
   readonly execution: vscode.NotebookCellExecution;
   readonly projection: CellOutputProjection;
   readonly notebook: vscode.NotebookDocument;
+  started: boolean;
 }
 
 const resourceKey = (cell: CellRef, runId: RunId): string =>
@@ -113,7 +114,8 @@ export class VsCodeCellDrive extends Context.Service<VsCodeCellDrive>()(
         state: CellRuntimeState,
         final: boolean,
       ) =>
-        withResource(cell, runId, ({ notebook, projection }) => {
+        withResource(cell, runId, ({ notebook, projection, started }) => {
+          if (!started) return Effect.void;
           const outputs = buildKeyedCellOutputs(
             cell.cellId,
             state,
@@ -218,11 +220,15 @@ export class VsCodeCellDrive extends Context.Service<VsCodeCellDrive>()(
                 execution,
                 projection: new CellOutputProjection(execution),
                 notebook: binding.notebook.rawNotebookDocument,
+                started: false,
               });
             }),
           StartRun: ({ runId, at }) =>
-            withResource(cell, runId, ({ execution }) =>
-              Effect.sync(() => execution.start(Option.getOrUndefined(at))),
+            withResource(cell, runId, (resource) =>
+              Effect.sync(() => {
+                resource.execution.start(Option.getOrUndefined(at));
+                resource.started = true;
+              }),
             ),
           RenderOutputs: ({ runId, state, final }) =>
             renderOutputs(cell, runId, state, final),

--- a/extension/src/kernel/VsCodeNotebookOutputPresenter.ts
+++ b/extension/src/kernel/VsCodeNotebookOutputPresenter.ts
@@ -1,0 +1,89 @@
+import { createCellRuntimeState } from "@marimo-team/frontend/unstable_internal/core/cells/types.ts";
+import { Context, Effect, Layer } from "effect";
+import type * as vscode from "vscode";
+
+import { VsCode } from "../platform/VsCode.ts";
+import {
+  findNotebookCell,
+  MarimoNotebookDocument,
+  NotebookCellId,
+} from "../schemas/MarimoNotebookDocument.ts";
+import type { CellOutputReplay } from "../schemas/Models.gen.ts";
+import { transitionCell } from "./CellRunReducer.ts";
+import { buildCellOutputs } from "./VsCodeCellOutputs.ts";
+
+interface CellController {
+  readonly createNotebookCellExecution: (
+    cell: vscode.NotebookCell,
+  ) => vscode.NotebookCellExecution;
+}
+
+/** Presents a SessionView snapshot without claiming a successful run. */
+export class VsCodeNotebookOutputPresenter extends Context.Service<VsCodeNotebookOutputPresenter>()(
+  "VsCodeNotebookOutputPresenter",
+  {
+    make: Effect.gen(function* () {
+      const code = yield* VsCode;
+
+      const present = Effect.fn("VsCodeNotebookOutputPresenter.present")(
+        function* (
+          notebook: MarimoNotebookDocument,
+          controller: CellController,
+          replays: ReadonlyArray<CellOutputReplay>,
+        ) {
+          yield* Effect.forEach(
+            replays,
+            (replay) =>
+              Effect.gen(function* () {
+                const { notification } = replay;
+                const cellId = NotebookCellId(notification.cell_id);
+                const cell = yield* findNotebookCell(notebook, cellId);
+                if (cell.outputs.length > 0) return;
+
+                const state = transitionCell(
+                  createCellRuntimeState(),
+                  notification,
+                );
+                const outputs = buildCellOutputs(
+                  cellId,
+                  state,
+                  code,
+                  notebook.rawNotebookDocument,
+                );
+                if (outputs.length === 0) return;
+
+                const execution = yield* Effect.try(() =>
+                  controller.createNotebookCellExecution(cell.rawNotebookCell),
+                );
+                yield* Effect.acquireUseRelease(
+                  Effect.succeed(execution),
+                  (current) =>
+                    Effect.sync(() => current.start(Date.now())).pipe(
+                      Effect.andThen(
+                        Effect.tryPromise(() => current.replaceOutput(outputs)),
+                      ),
+                    ),
+                  (current) => Effect.sync(() => current.end(undefined)),
+                );
+              }).pipe(
+                Effect.catchCause((cause) =>
+                  Effect.logWarning("Failed to replay cell output").pipe(
+                    Effect.annotateLogs({
+                      cause,
+                      cellId: replay.notification.cell_id,
+                      notebookUri: notebook.id,
+                    }),
+                  ),
+                ),
+              ),
+            { discard: true },
+          );
+        },
+      );
+
+      return { present };
+    }),
+  },
+) {
+  static readonly layer = Layer.effect(this, this.make);
+}

--- a/extension/src/kernel/__tests__/CellExecutions.test.ts
+++ b/extension/src/kernel/__tests__/CellExecutions.test.ts
@@ -39,6 +39,7 @@ import {
   MarimoNotebookDocument,
   type NotebookCellId,
 } from "../../schemas/MarimoNotebookDocument.ts";
+import type { CellOutputReplay } from "../../schemas/Models.gen.ts";
 import type { CellRuntimeState } from "../../types.ts";
 
 const TestNotebookRuntime = makeTestNotebookRuntime();
@@ -1592,6 +1593,7 @@ describe("NotebookExecutions", () => {
         );
         yield* Effect.yieldNow;
         cellData.value = "x = 2";
+        expect(editor.notebook.cellAt(0).document.getText()).toBe("x = 2");
         yield* ctx.vscode.notebookChange({
           notebook: editor.notebook,
           metadata: undefined,
@@ -1876,6 +1878,128 @@ describe("NotebookExecutions", () => {
 
         yield* acknowledgeSubmission(notebook, id, "x = 1", "run-2");
         expect(HashSet.has(yield* notebook.staleCells.current, id)).toBe(false);
+      }).pipe(Effect.provide(ctx.layer));
+    }),
+  );
+
+  it.effect(
+    "marks saved output stale without inventing a live run",
+    Effect.fn(function* () {
+      const editor = TestVsCode.makeNotebookEditor("/test/notebook.py", {
+        data: {
+          cells: [
+            {
+              kind: 1,
+              value: "x = 1",
+              languageId: "python",
+              metadata: MarimoNotebookCell.createMetadata({
+                marimoRuntime: { stableId: "cell-1" },
+              }),
+            },
+          ],
+        },
+      });
+      const ctx = yield* withTestCtx({ initialDocuments: [editor.notebook] });
+
+      yield* Effect.gen(function* () {
+        const executions = yield* CellExecutions;
+        const commands: CellCommand[] = [];
+        const drive: Drive = (_cell, command) =>
+          Effect.sync(() => commands.push(command));
+        const { notebook } = yield* openNotebook(
+          executions,
+          editor.notebook,
+          Effect.succeed(Option.some(drive)),
+        );
+        const id = Option.getOrThrow(
+          MarimoNotebookDocument.from(editor.notebook).cellAt(0).id,
+        );
+        const replay: CellOutputReplay = {
+          kind: "saved",
+          notification: {
+            op: "cell-op",
+            cell_id: id,
+            status: "idle",
+            output: {
+              channel: "output",
+              mimetype: "text/plain",
+              data: "cached",
+            },
+            stale_inputs: true,
+          },
+        };
+
+        yield* notebook.restoreOutput(replay);
+
+        expect(HashSet.has(yield* notebook.staleCells.current, id)).toBe(true);
+        expect(commands).toEqual([]);
+      }).pipe(Effect.provide(ctx.layer));
+    }),
+  );
+
+  it.effect(
+    "restores live output with its executed source",
+    Effect.fn(function* () {
+      const cellData = {
+        kind: 1,
+        value: "x = 1",
+        languageId: "python",
+        metadata: MarimoNotebookCell.createMetadata({
+          marimoRuntime: { stableId: "cell-1" },
+        }),
+      };
+      const editor = TestVsCode.makeNotebookEditor("/test/notebook.py", {
+        data: { cells: [cellData] },
+      });
+      const ctx = yield* withTestCtx({ initialDocuments: [editor.notebook] });
+
+      yield* Effect.gen(function* () {
+        const executions = yield* CellExecutions;
+        const { notebook } = yield* openNotebook(executions, editor.notebook);
+        const id = Option.getOrThrow(
+          MarimoNotebookDocument.from(editor.notebook).cellAt(0).id,
+        );
+
+        yield* notebook.restoreOutput({
+          kind: "live",
+          executedSource: "x = 1",
+          notification: {
+            op: "cell-op",
+            cell_id: id,
+            status: "idle",
+            output: {
+              channel: "output",
+              mimetype: "text/plain",
+              data: "1",
+            },
+            stale_inputs: false,
+          },
+        });
+        expect(HashSet.has(yield* notebook.staleCells.current, id)).toBe(false);
+
+        const becomesStale = yield* notebook.staleCells.changes.pipe(
+          Stream.filter((stale) => HashSet.has(stale, id)),
+          Stream.runHead,
+          Effect.forkChild,
+        );
+        yield* Effect.yieldNow;
+        cellData.value = "x = 2";
+        yield* ctx.vscode.notebookChange({
+          notebook: editor.notebook,
+          metadata: undefined,
+          cellChanges: [
+            {
+              cell: editor.notebook.cellAt(0),
+              document: editor.notebook.cellAt(0).document,
+              metadata: undefined,
+              outputs: [],
+              executionSummary: undefined,
+            },
+          ],
+          contentChanges: [],
+        });
+
+        expect(Option.isSome(yield* Fiber.join(becomesStale))).toBe(true);
       }).pipe(Effect.provide(ctx.layer));
     }),
   );

--- a/extension/src/kernel/__tests__/NotebookRuntime.test.ts
+++ b/extension/src/kernel/__tests__/NotebookRuntime.test.ts
@@ -20,7 +20,12 @@ import { TestPythonExtension } from "../../__mocks__/TestPythonExtension.ts";
 import { TestTelemetryLive } from "../../__mocks__/TestTelemetry.ts";
 import { TestVsCode } from "../../__mocks__/TestVsCode.ts";
 import { makeTestMarimoClient } from "../../__tests__/__utils__/TestMarimoClient.ts";
-import { kernelSessionId, notebookId } from "../../lib/__tests__/branded.ts";
+import {
+  cellId,
+  kernelSessionId,
+  notebookId,
+} from "../../lib/__tests__/branded.ts";
+import type { CellOutputReplay } from "../../schemas/Models.gen.ts";
 import type { MarimoApiCall } from "../../types.ts";
 import {
   type NotebookController,
@@ -449,6 +454,7 @@ it.effect(
     const controller: NotebookController = {
       id: "marimo-/usr/bin/python",
       drive: () => () => Effect.void,
+      presentOutputs: () => Effect.void,
       resolveExecutable: () => Effect.succeed("/usr/bin/python"),
     };
 
@@ -472,6 +478,7 @@ it.effect(
     const controller: NotebookController = {
       id: "marimo-/usr/bin/python",
       drive: () => () => Effect.void,
+      presentOutputs: () => Effect.void,
       resolveExecutable: () => Effect.succeed("/usr/bin/python"),
     };
 
@@ -489,6 +496,67 @@ it.effect(
           execution.args[0] === "marimo.notebook.hasKernel",
       );
       expect(contexts.at(-1)?.args[1]).toBe(false);
+    }).pipe(Effect.provide(layer));
+  }),
+);
+
+it.effect(
+  "restores notebook output without starting a kernel",
+  Effect.fn(function* () {
+    const editor = TestVsCode.makeNotebookEditor("/test/notebook.py");
+    const requests = yield* Ref.make<ReadonlyArray<MarimoApiCall>>([]);
+    const presented = yield* Deferred.make<ReadonlyArray<CellOutputReplay>>();
+    const replay: CellOutputReplay = {
+      kind: "saved",
+      notification: {
+        op: "cell-op",
+        cell_id: cellId("cell-1"),
+        status: "idle",
+        output: {
+          channel: "output",
+          mimetype: "text/plain",
+          data: "42",
+        },
+        stale_inputs: true,
+      },
+    };
+    const { layer, vscode } = yield* makeTestLayer(
+      {
+        execute: (request) =>
+          Ref.update(requests, (current) => [...current, request]).pipe(
+            Effect.as(
+              request.method === "read-notebook-outputs"
+                ? { cells: [replay] }
+                : null,
+            ),
+          ),
+      },
+      { initialDocuments: [editor.notebook] },
+    );
+    const controller: NotebookController = {
+      id: "marimo-/usr/bin/python",
+      drive: () => () => Effect.void,
+      presentOutputs: (_notebook, cells) => Deferred.succeed(presented, cells),
+      resolveExecutable: () => Effect.succeed("/usr/bin/python"),
+    };
+
+    yield* Effect.gen(function* () {
+      const notebooks = yield* NotebookRuntime;
+      yield* vscode.openNotebook(editor.notebook);
+      yield* Effect.yieldNow;
+      const id = notebookId(editor.notebook.uri.toString());
+      yield* notebooks.forDocument(editor.notebook);
+      yield* notebooks.attachController(id, controller);
+
+      const restored = yield* Deferred.await(presented);
+      expect(restored).toEqual([replay]);
+      expect(Option.isNone(yield* notebooks.getRuntimeSession(id))).toBe(true);
+      const methods = (yield* Ref.get(requests)).map(
+        (request) => request.method,
+      );
+      expect(methods).toContain("read-notebook-outputs");
+      expect(methods).not.toContain("execute-cells");
+      expect(methods).not.toContain("restart-session");
     }).pipe(Effect.provide(layer));
   }),
 );
@@ -595,6 +663,7 @@ it.effect(
     const controller: NotebookController = {
       id: "marimo-/usr/bin/python",
       drive: () => () => Effect.void,
+      presentOutputs: () => Effect.void,
       resolveExecutable: () => Effect.succeed("/usr/bin/python"),
     };
 

--- a/extension/src/kernel/__tests__/NotebookRuntimeOperations.test.ts
+++ b/extension/src/kernel/__tests__/NotebookRuntimeOperations.test.ts
@@ -155,6 +155,7 @@ const withTestCtx = Effect.fn(function* (
               controller.createNotebookCellExecution(cell.rawNotebookCell),
           },
         }),
+      () => Effect.void,
     );
   }).pipe(Effect.provide(vscode.layer));
 

--- a/extension/src/kernel/__tests__/VsCodeCellDrive.test.ts
+++ b/extension/src/kernel/__tests__/VsCodeCellDrive.test.ts
@@ -9,7 +9,7 @@ import {
   MarimoNotebookDocument,
 } from "../../schemas/MarimoNotebookDocument.ts";
 import type { CellRuntimeState } from "../../types.ts";
-import { CellCommand } from "../CellRunReducer.ts";
+import { CellCommand, runIdFromWire } from "../CellRunReducer.ts";
 import { VsCodeCellDrive } from "../VsCodeCellDrive.ts";
 
 const errorState = (): CellRuntimeState => ({
@@ -23,6 +23,91 @@ const errorState = (): CellRuntimeState => ({
 });
 
 describe("VsCodeCellDrive", () => {
+  it.effect(
+    "does not update outputs before the execution starts",
+    Effect.fn(function* () {
+      const editor = TestVsCode.makeNotebookEditor("/test/notebook.py", {
+        data: {
+          cells: [
+            {
+              kind: 1,
+              value: "x = 1",
+              languageId: "python",
+              outputs: [
+                {
+                  items: [
+                    {
+                      mime: "text/plain",
+                      data: new TextEncoder().encode("saved"),
+                    },
+                  ],
+                },
+              ],
+              metadata: MarimoNotebookCell.createMetadata({
+                marimoRuntime: { stableId: "cell-1" },
+              }),
+            },
+          ],
+        },
+      });
+      const code = yield* TestVsCode.make({
+        initialDocuments: [editor.notebook],
+      });
+      const notebook = MarimoNotebookDocument.from(editor.notebook);
+      const cellId = Option.getOrThrow(notebook.cellAt(0).id);
+      const runId = Option.getOrThrow(runIdFromWire("run-1"));
+      const events: string[] = [];
+      const execution: vscode.NotebookCellExecution = {
+        cell: editor.notebook.cellAt(0),
+        executionOrder: undefined,
+        token: {
+          isCancellationRequested: false,
+          onCancellationRequested: () => ({ dispose() {} }),
+        },
+        start: () => events.push("start"),
+        end: () => {},
+        clearOutput: async () => {
+          events.push("clear");
+        },
+        appendOutput: async () => {
+          events.push("append");
+        },
+        replaceOutput: async () => {},
+        appendOutputItems: async () => {},
+        replaceOutputItems: async () => {},
+      };
+      const drive = (yield* VsCodeCellDrive.make.pipe(
+        Effect.provide(code.layer),
+      )).bind({
+        notebook,
+        controller: { createNotebookCellExecution: () => execution },
+      });
+      const cell = { notebookId: notebook.id, cellId };
+
+      yield* drive(cell, CellCommand.OpenRun({ runId }));
+      yield* drive(
+        cell,
+        CellCommand.RenderOutputs({
+          runId,
+          state: errorState(),
+          final: false,
+        }),
+      );
+      expect(events).toEqual([]);
+
+      yield* drive(cell, CellCommand.StartRun({ runId, at: Option.none() }));
+      yield* drive(
+        cell,
+        CellCommand.RenderOutputs({
+          runId,
+          state: errorState(),
+          final: false,
+        }),
+      );
+      expect(events).toEqual(["start", "clear", "append"]);
+    }),
+  );
+
   it.effect(
     "presents an untracked error in one execution lifecycle",
     Effect.fn(function* () {

--- a/extension/src/kernel/__tests__/VsCodeNotebookOutputPresenter.test.ts
+++ b/extension/src/kernel/__tests__/VsCodeNotebookOutputPresenter.test.ts
@@ -1,0 +1,129 @@
+import { expect, it } from "@effect/vitest";
+import { Effect } from "effect";
+import type * as vscode from "vscode";
+
+import { TestVsCode } from "../../__mocks__/TestVsCode.ts";
+import {
+  MarimoNotebookCell,
+  MarimoNotebookDocument,
+  NotebookCellId,
+} from "../../schemas/MarimoNotebookDocument.ts";
+import type { CellOutputReplay } from "../../schemas/Models.gen.ts";
+import { VsCodeNotebookOutputPresenter } from "../VsCodeNotebookOutputPresenter.ts";
+
+const savedReplay: CellOutputReplay = {
+  kind: "saved",
+  notification: {
+    op: "cell-op",
+    cell_id: NotebookCellId("cell-1"),
+    status: "idle",
+    output: {
+      channel: "output",
+      mimetype: "text/html",
+      data: "<b>42</b>",
+    },
+    stale_inputs: true,
+  },
+};
+
+const editor = (outputs: vscode.NotebookCellOutput[] = []) =>
+  TestVsCode.makeNotebookEditor("/test/notebook.py", {
+    data: {
+      cells: [
+        {
+          kind: 2,
+          value: "1 + 1",
+          languageId: "python",
+          outputs,
+          metadata: MarimoNotebookCell.createMetadata({
+            marimoRuntime: { stableId: "cell-1" },
+          }),
+        },
+      ],
+    },
+  });
+
+it.effect(
+  "presents saved output without completing a run",
+  Effect.fn(function* () {
+    const notebookEditor = editor();
+    const code = yield* TestVsCode.make({
+      initialDocuments: [notebookEditor.notebook],
+    });
+    const events: string[] = [];
+    const rendered: vscode.NotebookCellOutput[][] = [];
+    const execution: vscode.NotebookCellExecution = {
+      cell: notebookEditor.notebook.cellAt(0),
+      executionOrder: undefined,
+      token: {
+        isCancellationRequested: false,
+        onCancellationRequested: () => ({ dispose() {} }),
+      },
+      start: () => events.push("start"),
+      end: (success) => events.push(`end:${String(success)}`),
+      replaceOutput: async (outputs) => {
+        events.push("replace");
+        rendered.push(Array.isArray(outputs) ? [...outputs] : [outputs]);
+      },
+      appendOutput: async () => {},
+      clearOutput: async () => {},
+      replaceOutputItems: async () => {},
+      appendOutputItems: async () => {},
+    };
+    const presenter = yield* VsCodeNotebookOutputPresenter.make.pipe(
+      Effect.provide(code.layer),
+    );
+
+    yield* presenter.present(
+      MarimoNotebookDocument.from(notebookEditor.notebook),
+      { createNotebookCellExecution: () => execution },
+      [savedReplay],
+    );
+
+    expect(events).toEqual(["start", "replace", "end:undefined"]);
+    const rich = rendered
+      .flat()
+      .flatMap((output) => output.items)
+      .find((item) => item.mime === "application/vnd.marimo.ui+json");
+    expect(rich).toBeDefined();
+    expect(JSON.parse(new TextDecoder().decode(rich?.data))).toMatchObject({
+      state: { staleInputs: true },
+    });
+  }),
+);
+
+it.effect(
+  "does not overwrite output already owned by the notebook",
+  Effect.fn(function* () {
+    const notebookEditor = editor([
+      {
+        items: [
+          {
+            mime: "text/plain",
+            data: new TextEncoder().encode("current"),
+          },
+        ],
+      },
+    ]);
+    const code = yield* TestVsCode.make({
+      initialDocuments: [notebookEditor.notebook],
+    });
+    const presenter = yield* VsCodeNotebookOutputPresenter.make.pipe(
+      Effect.provide(code.layer),
+    );
+    let executions = 0;
+
+    yield* presenter.present(
+      MarimoNotebookDocument.from(notebookEditor.notebook),
+      {
+        createNotebookCellExecution: () => {
+          executions += 1;
+          throw new Error("should not create an execution");
+        },
+      },
+      [savedReplay],
+    );
+
+    expect(executions).toBe(0);
+  }),
+);

--- a/extension/src/kernel/__tests__/operations.test.ts
+++ b/extension/src/kernel/__tests__/operations.test.ts
@@ -25,6 +25,7 @@ const alert: NotificationOf<"missing-package-alert"> = {
 const controller: NotebookController = {
   id: "test-controller",
   drive: () => () => Effect.void,
+  presentOutputs: () => Effect.void,
   resolveExecutable: () => Effect.die("not implemented"),
 };
 

--- a/extension/src/notebook/__tests__/NotebookDependencies.test.ts
+++ b/extension/src/notebook/__tests__/NotebookDependencies.test.ts
@@ -48,6 +48,7 @@ function makeController(options: {
   return {
     ...options,
     drive: () => () => Effect.void,
+    presentOutputs: () => Effect.void,
     resolveExecutable: () =>
       Effect.succeed(options.executable ?? "/unused/python"),
   };

--- a/extension/src/notebook/__tests__/readNotebookOutputs.test.ts
+++ b/extension/src/notebook/__tests__/readNotebookOutputs.test.ts
@@ -1,0 +1,30 @@
+import * as NodePath from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { createTestNotebookDocument, Uri } from "../../__mocks__/TestVsCode.ts";
+import { MarimoNotebookDocument } from "../../schemas/MarimoNotebookDocument.ts";
+import { conventionalSessionCachePath } from "../readNotebookOutputs.ts";
+
+describe("conventionalSessionCachePath", () => {
+  it("resolves a sidecar in a remote extension host", () => {
+    const document = createTestNotebookDocument(
+      Uri.from({
+        scheme: "vscode-remote",
+        authority: "ssh-remote+host",
+        path: "/workspace/notebook.py",
+      }),
+    );
+
+    expect(
+      conventionalSessionCachePath(MarimoNotebookDocument.from(document)),
+    ).toBe(
+      NodePath.join(
+        NodePath.dirname(document.uri.fsPath),
+        "__marimo__",
+        "session",
+        "notebook.py.json",
+      ),
+    );
+  });
+});

--- a/extension/src/notebook/readNotebookOutputs.ts
+++ b/extension/src/notebook/readNotebookOutputs.ts
@@ -1,0 +1,38 @@
+import * as NodePath from "node:path";
+
+import { Context } from "effect";
+
+import { MarimoClient } from "../lsp/MarimoClient.ts";
+import type { MarimoNotebookDocument } from "../schemas/MarimoNotebookDocument.ts";
+
+type MarimoClientService = Context.Service.Shape<typeof MarimoClient>;
+
+/** Ask the LSP to replay live output or a conventional cold sidecar. */
+export const readNotebookOutputs = (
+  notebook: MarimoNotebookDocument,
+  marimo: MarimoClientService,
+) => {
+  const sessionCachePath = conventionalSessionCachePath(notebook);
+  return marimo.readNotebookOutputs({
+    notebookUri: notebook.id,
+    inner: { sessionCachePath },
+  });
+};
+
+export const conventionalSessionCachePath = (
+  notebook: MarimoNotebookDocument,
+): string | null => {
+  if (
+    notebook.isUntitled ||
+    !["file", "vscode-remote"].includes(notebook.uri.scheme) ||
+    NodePath.extname(notebook.uri.fsPath).toLowerCase() !== ".py"
+  ) {
+    return null;
+  }
+  return NodePath.join(
+    NodePath.dirname(notebook.uri.fsPath),
+    "__marimo__",
+    "session",
+    `${NodePath.basename(notebook.uri.fsPath)}.json`,
+  );
+};

--- a/extension/src/schemas/Models.gen.ts
+++ b/extension/src/schemas/Models.gen.ts
@@ -15,6 +15,12 @@ const MarimoNotification = Schema.declare<MarimoNotification>(
     typeof value.op === "string",
 );
 
+type CellOperationNotification = Extract<MarimoNotification, { op: "cell-op" }>;
+const CellOperationNotification = Schema.declare<CellOperationNotification>(
+  (value): value is CellOperationNotification =>
+    Schema.is(MarimoNotification)(value) && value.op === "cell-op",
+);
+
 type VariablesNotification = Extract<MarimoNotification, { op: "variables" }>;
 const VariablesNotification = Schema.declare<VariablesNotification>(
   (value): value is VariablesNotification =>
@@ -420,6 +426,41 @@ export const SetDisplayThemeRequest = Schema.Struct({
   theme: Schema.Literals(["dark", "light"]),
 }).annotate({ identifier: "SetDisplayThemeRequest" });
 export type SetDisplayThemeRequest = typeof SetDisplayThemeRequest.Type;
+
+/**
+ * Resolve outputs for an opened notebook without starting a kernel.
+ */
+export const ReadNotebookOutputsRequest = Schema.Struct({
+  sessionCachePath: Schema.NullOr(Schema.String).pipe(
+    Schema.withDecodingDefault(Effect.sync(() => null)),
+  ),
+}).annotate({ identifier: "ReadNotebookOutputsRequest" });
+export type ReadNotebookOutputsRequest = typeof ReadNotebookOutputsRequest.Type;
+
+/**
+ * One cell projected from an authoritative live SessionView.
+ */
+export const LiveCellReplay = Schema.Struct({
+  kind: Schema.Literal("live"),
+  notification: CellOperationNotification,
+  executedSource: Schema.NullOr(Schema.String),
+}).annotate({ identifier: "LiveCellReplay" });
+export type LiveCellReplay = typeof LiveCellReplay.Type;
+
+/**
+ * One cell restored from a compatible saved-session sidecar.
+ */
+export const SavedCellReplay = Schema.Struct({
+  kind: Schema.Literal("saved"),
+  notification: CellOperationNotification,
+}).annotate({ identifier: "SavedCellReplay" });
+export type SavedCellReplay = typeof SavedCellReplay.Type;
+
+export const CellOutputReplay = Schema.Union([
+  LiveCellReplay,
+  SavedCellReplay,
+]).annotate({ identifier: "CellOutputReplay" });
+export type CellOutputReplay = typeof CellOutputReplay.Type;
 
 /**
  * Serializable HTTP request representation.
@@ -1393,6 +1434,20 @@ export const SetDisplayThemePayload = Schema.Struct({
   theme: Schema.Literals(["dark", "light"]),
 });
 
+/**
+ * Cell outputs replayed from live memory or a saved-session sidecar.
+ */
+export const ReadNotebookOutputsResponse = Schema.Struct({
+  cells: Schema.Array(CellOutputReplay),
+}).annotate({ identifier: "ReadNotebookOutputsResponse" });
+export type ReadNotebookOutputsResponse =
+  typeof ReadNotebookOutputsResponse.Type;
+
+export const ReadNotebookOutputsPayload = Schema.Struct({
+  notebookUri: NotebookIdFromString,
+  inner: ReadNotebookOutputsRequest,
+});
+
 export const ExportAsHTMLRequest = Schema.Struct({
   download: Schema.Boolean,
   files: Schema.Array(Schema.String),
@@ -1520,6 +1575,10 @@ export type MarimoApiCall =
   | {
       readonly method: "set-display-theme";
       readonly params: typeof SetDisplayThemePayload.Encoded;
+    }
+  | {
+      readonly method: "read-notebook-outputs";
+      readonly params: typeof ReadNotebookOutputsPayload.Encoded;
     }
   | {
       readonly method: "export-as-html";
@@ -1717,6 +1776,13 @@ export const makeApiClient = <E, R>(execute: Execute<E, R>) => ({
       { method: "set-display-theme", params },
       SetDisplayThemePayload,
       SetDisplayThemeResponse,
+    ),
+  readNotebookOutputs: (params: typeof ReadNotebookOutputsPayload.Encoded) =>
+    dispatch(
+      execute,
+      { method: "read-notebook-outputs", params },
+      ReadNotebookOutputsPayload,
+      ReadNotebookOutputsResponse,
     ),
   exportAsHtml: (params: typeof ExportAsHtmlPayload.Encoded) =>
     dispatch(

--- a/extension/src/wasm/WasmBridgeRuntime.ts
+++ b/extension/src/wasm/WasmBridgeRuntime.ts
@@ -1,3 +1,6 @@
+import * as NodeFs from "node:fs";
+import * as NodePath from "node:path";
+
 import { Processes } from "./Processes.ts";
 
 interface WasmBridge {
@@ -22,6 +25,7 @@ export interface WasmModule {
   readonly create_bridge: (
     writeMessage: (messageJson: string) => void,
     processes: object,
+    savedSessions: object,
   ) => WasmBridge;
   readonly destroy: () => void;
 }
@@ -83,9 +87,42 @@ export class WasmBridgeRuntime {
       },
       close: (processId: string) => this.#processes.close(processId),
     };
+    const savedSessions = {
+      read: async (target: string) => {
+        if (!NodePath.isAbsolute(target)) {
+          throw new TypeError("Saved session path must be absolute");
+        }
+        try {
+          return await NodeFs.promises.readFile(target, "utf8");
+        } catch (error) {
+          if (
+            typeof error === "object" &&
+            error !== null &&
+            "code" in error &&
+            error.code === "ENOENT"
+          ) {
+            return null;
+          }
+          throw error;
+        }
+      },
+      write: async (target: string, contents: string) => {
+        if (!NodePath.isAbsolute(target)) {
+          throw new TypeError("Saved session path must be absolute");
+        }
+        await NodeFs.promises.mkdir(NodePath.dirname(target), {
+          recursive: true,
+        });
+        await NodeFs.promises.writeFile(target, contents, "utf8");
+      },
+    };
 
     try {
-      const bridge = wasmModule.create_bridge(writeMessage, processCallbacks);
+      const bridge = wasmModule.create_bridge(
+        writeMessage,
+        processCallbacks,
+        savedSessions,
+      );
       this.#state = { status: "running", bridge };
     } catch (error) {
       this.#processes.closeAll();

--- a/extension/tests/helpers.cjs
+++ b/extension/tests/helpers.cjs
@@ -301,6 +301,7 @@ function cellOutputText(cell) {
 module.exports = {
   activateExtension,
   createTestContext,
+  ensureSharedVenv,
   selectKernel,
   runCell,
   editCell,

--- a/extension/tests/saved-session-output.test.cjs
+++ b/extension/tests/saved-session-output.test.cjs
@@ -1,0 +1,204 @@
+// @ts-check
+/// <reference types="mocha" />
+
+const NodeAssert = require("node:assert");
+const NodeChildProcess = require("node:child_process");
+const NodeFs = require("node:fs/promises");
+const NodePath = require("node:path");
+const NodeUtil = require("node:util");
+const tinyspy = require("tinyspy");
+const vscode = require("vscode");
+
+const {
+  cellOutputText,
+  createTestContext,
+  ensureSharedVenv,
+  selectKernel,
+} = require("./helpers.cjs");
+
+const execFile = NodeUtil.promisify(NodeChildProcess.execFile);
+
+const SOURCE = `import marimo
+
+app = marimo.App()
+
+
+@app.cell
+def _():
+    import time
+    print(f"live output {time.time_ns()}")
+    return
+
+
+if __name__ == "__main__":
+    app.run()
+`;
+
+const WRITE_SAVED_SESSION = String.raw`
+import json
+import pathlib
+import sys
+
+sys.pycache_prefix = None
+
+from marimo._messaging.cell_output import CellChannel, CellOutput
+from marimo._messaging.notification import CellNotification
+from marimo._runtime.commands import ExecuteCellsCommand
+from marimo._session.notebook.file_manager import AppFileManager
+from marimo._session.state.serialize import (
+    _script_metadata_hash,
+    get_session_cache_file,
+    serialize_session_view,
+)
+from marimo._session.state.session_view import SessionView
+
+notebook_path = pathlib.Path(sys.argv[1])
+app = AppFileManager(notebook_path).app
+cell_ids = tuple(app.cell_manager.cell_ids())
+codes = tuple(app.cell_manager.codes())
+view = SessionView()
+view.add_control_request(ExecuteCellsCommand(cell_ids=cell_ids, codes=codes))
+view.add_notification(
+    CellNotification(
+        cell_id=cell_ids[0],
+        status="idle",
+        output=CellOutput(
+            channel=CellChannel.OUTPUT,
+            mimetype="text/plain",
+            data="saved output",
+        ),
+        console=[],
+        timestamp=1,
+    )
+)
+snapshot = serialize_session_view(
+    view,
+    cell_ids=cell_ids,
+    script_metadata_hash=_script_metadata_hash(notebook_path),
+    drop_virtual_file_outputs=True,
+)
+cache_path = get_session_cache_file(notebook_path)
+cache_path.parent.mkdir(parents=True, exist_ok=True)
+cache_path.write_text(json.dumps(snapshot, indent=2), encoding="utf-8")
+`;
+
+const READ_SAVED_SESSION = String.raw`
+import json
+import pathlib
+import sys
+
+import marimo
+from marimo._messaging.notebook.document import NotebookDocument
+from marimo._session.notebook.file_manager import AppFileManager
+from marimo._session.state.serialize import (
+    _script_metadata_hash,
+    get_session_cache_file,
+    SessionCacheKey,
+    SessionCacheManager,
+)
+from marimo._session.state.session_view import SessionView
+from marimo._utils.lists import as_list
+
+notebook_path = pathlib.Path(sys.argv[1])
+app = AppFileManager(notebook_path).app
+cell_ids = tuple(app.cell_manager.cell_ids())
+codes = tuple(app.cell_manager.codes())
+view = SessionCacheManager(
+    session_view=SessionView(),
+    document=NotebookDocument([]),
+    path=notebook_path,
+    interval=1,
+).read_session_view(
+    SessionCacheKey(
+        codes=codes,
+        marimo_version=marimo.__version__,
+        cell_ids=cell_ids,
+        script_metadata_hash=_script_metadata_hash(notebook_path),
+    )
+)
+notification = view.cell_notifications[cell_ids[0]]
+print(json.dumps(str(as_list(notification.console)[0].data)))
+`;
+
+/** @param {import("vscode").NotebookDocument} notebook */
+async function runFirstCell(notebook) {
+  await vscode.commands.executeCommand("notebook.cell.execute", {
+    ranges: [{ start: 0, end: 1 }],
+    document: notebook.uri,
+  });
+}
+
+suite("saved session output", function () {
+  this.timeout(60_000);
+
+  test("restores cold output without starting a kernel", async function () {
+    await using ctx = createTestContext();
+    const uri = await ctx.writeTempFile(SOURCE);
+    const python = await ensureSharedVenv();
+    await execFile(python, ["-c", WRITE_SAVED_SESSION, uri.fsPath]);
+
+    const notebook = await ctx.openNotebook(uri);
+    await selectKernel(notebook);
+    await ctx.waitUntil(() =>
+      NodeAssert.match(cellOutputText(notebook.cellAt(0)), /saved output/),
+    );
+    NodeAssert.strictEqual(
+      notebook.cellAt(0).executionSummary?.success,
+      undefined,
+    );
+
+    const information = tinyspy.spyOn(
+      vscode.window,
+      "showInformationMessage",
+      async () => undefined,
+    );
+    try {
+      // oxlint-disable-next-line marimo/no-marimo-command-id-literals -- external VS Code seam
+      await vscode.commands.executeCommand("marimo.restartKernel");
+      NodeAssert.strictEqual(
+        information.calls.at(-1)?.[0],
+        "This notebook does not have a live kernel",
+      );
+    } finally {
+      information.restore();
+    }
+
+    await runFirstCell(notebook);
+    await ctx.waitUntil(() => {
+      const output = cellOutputText(notebook.cellAt(0));
+      NodeAssert.match(output, /live output/);
+      NodeAssert.doesNotMatch(output, /saved output/);
+      NodeAssert.strictEqual(
+        notebook.cellAt(0).executionSummary?.success,
+        true,
+      );
+    });
+  });
+
+  test("writes output in a sidecar accepted by marimo", async function () {
+    await using ctx = createTestContext();
+    const uri = await ctx.writeTempFile(SOURCE);
+    const python = await ensureSharedVenv();
+    const cachePath = NodePath.join(
+      NodePath.dirname(uri.fsPath),
+      "__marimo__",
+      "session",
+      `${NodePath.basename(uri.fsPath)}.json`,
+    );
+    const notebook = await ctx.openNotebook(uri);
+    await selectKernel(notebook);
+
+    await runFirstCell(notebook);
+    await ctx.waitUntil(async () => {
+      const contents = await NodeFs.readFile(cachePath, "utf8");
+      NodeAssert.match(contents, /live output/);
+    });
+
+    const { stdout } = await execFile(python, [
+      "-c",
+      READ_SAVED_SESSION,
+      uri.fsPath,
+    ]);
+    NodeAssert.match(stdout, /live output/);
+  });
+});

--- a/scripts/codegen/effect_schemas.py
+++ b/scripts/codegen/effect_schemas.py
@@ -45,6 +45,15 @@ const MarimoNotification = Schema.declare<MarimoNotification>(
     typeof value.op === "string",
 );
 
+type CellOperationNotification = Extract<
+  MarimoNotification,
+  { op: "cell-op" }
+>;
+const CellOperationNotification = Schema.declare<CellOperationNotification>(
+  (value): value is CellOperationNotification =>
+    Schema.is(MarimoNotification)(value) && value.op === "cell-op",
+);
+
 type VariablesNotification = Extract<MarimoNotification, { op: "variables" }>;
 const VariablesNotification = Schema.declare<VariablesNotification>(
   (value): value is VariablesNotification =>
@@ -90,6 +99,8 @@ CONCRETE: list[tuple[str, type | object]] = [
     ("ExecuteScratchRequest", models.ExecuteScratchRequest),
     ("UpdateConfigurationRequest", models.UpdateConfigurationRequest),
     ("SetDisplayThemeRequest", models.SetDisplayThemeRequest),
+    ("ReadNotebookOutputsRequest", models.ReadNotebookOutputsRequest),
+    ("CellOutputReplay", models.CellOutputReplay),
 ]
 
 
@@ -361,7 +372,11 @@ class Emitter:
             tag = _ts_string(str(t.tag))
             lines.append(f"{indent}{_prop(t.tag_field)}: Schema.Literal({tag}),")
         for field in t.fields:
-            if t.cls is models.KernelNotification and field.name == "notification":
+            if t.cls in {models.LiveCellReplay, models.SavedCellReplay} and (
+                field.name == "notification"
+            ):
+                expr = "CellOperationNotification"
+            elif t.cls is models.KernelNotification and field.name == "notification":
                 expr = "MarimoNotification"
             elif t.cls is models.DocumentAnalysis and field.name == "analysis":
                 expr = "VariablesNotification"

--- a/src/marimo_lsp/__init__.py
+++ b/src/marimo_lsp/__init__.py
@@ -13,8 +13,14 @@ def main() -> None:
     # Keep native runtime imports out of the importable package so the WASM
     # entrypoint can provide its own kernel adapter.
     from marimo_lsp.kernels.native import NativeKernels  # noqa: PLC0415
+    from marimo_lsp.saved_session_store import (  # noqa: PLC0415
+        LocalSavedSessionFiles,
+    )
 
-    server = create_server(kernels=NativeKernels())
+    server = create_server(
+        kernels=NativeKernels(),
+        saved_session_files=LocalSavedSessionFiles(),
+    )
     logger = get_logger()
     logger.setLevel(logging.DEBUG)
     logger.addHandler(lsp_handler(server))

--- a/src/marimo_lsp/api.py
+++ b/src/marimo_lsp/api.py
@@ -26,6 +26,7 @@ from marimo._export.requests import (
     MarkdownExportRequest,
 )
 from marimo._export.serialization import serialize_notebook_snapshot
+from marimo._messaging.msgspec_encoder import encode_json_bytes
 from marimo._runtime.commands import (
     ExecuteScratchpadCommand,
     InvokeFunctionCommand,
@@ -74,6 +75,8 @@ from marimo_lsp.models import (
     NotebookCommand,
     NotebookDocument,
     PackageCommand,
+    ReadNotebookOutputsRequest,
+    ReadNotebookOutputsResponse,
     RestartSessionRequest,
     ScriptSource,
     SerializeResponse,
@@ -809,6 +812,24 @@ async def set_display_theme(
         )
         session.update_runtime_config(updated)
     return SetDisplayThemeResponse(success=True)
+
+
+@marimo_api("read-notebook-outputs")
+async def read_notebook_outputs(
+    ctx: ApiContext,
+    args: NotebookCommand[ReadNotebookOutputsRequest],
+) -> ReadNotebookOutputsResponse:
+    """Replay the live SessionView, falling back to a compatible sidecar."""
+    replay = await ctx.sessions.read_notebook_outputs(
+        args.notebook_uri,
+        session_cache_path=args.inner.session_cache_path,
+    )
+    # Match marimo's websocket JSON normalization before pygls serializes the
+    # response (for example, non-finite output numbers become JSON null).
+    return msgspec.json.decode(
+        encode_json_bytes(replay),
+        type=ReadNotebookOutputsResponse,
+    )
 
 
 @marimo_api("export-as-html")

--- a/src/marimo_lsp/app_file_manager.py
+++ b/src/marimo_lsp/app_file_manager.py
@@ -49,8 +49,17 @@ class LspAppFileManager:
         self._server = server
         self._notebook_uri = notebook_uri
         self.app = sync_app_with_workspace(
-            workspace=server.workspace, notebook_uri=notebook_uri, app=None
+            workspace=server.workspace,
+            notebook_uri=notebook_uri,
+            app=None,
         )
+        self.header: str | None = None
+        self.sync_header(server.workspace)
+
+    def sync_header(self, workspace: Workspace) -> None:
+        """Synchronize the notebook header used by saved sessions."""
+        notebook = find_notebook_document(workspace, self._notebook_uri)
+        self.header = decode_notebook_document_metadata(notebook).header
 
     @property
     def filename(self) -> str | None:

--- a/src/marimo_lsp/kernels/__init__.py
+++ b/src/marimo_lsp/kernels/__init__.py
@@ -21,6 +21,8 @@ class Kernel(typing.Protocol):
 
     executable: str
     working_directory: str
+    marimo_version: str | None
+    session_cache_path: str | None
 
     def send(self, request: CommandMessage) -> None:
         """Send a command to the kernel."""

--- a/src/marimo_lsp/kernels/manager.py
+++ b/src/marimo_lsp/kernels/manager.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import json
 import subprocess
 import typing
 from pathlib import Path
@@ -26,6 +27,24 @@ if typing.TYPE_CHECKING:
 
 
 logger = get_logger()
+
+_KERNEL_LAUNCH_CODE = """\
+import json, os, runpy, sys, marimo
+try:
+    from pathlib import Path
+    from marimo._session.state.serialize import get_session_cache_file
+    notebook = Path(sys.argv[1]) if len(sys.argv) > 1 and sys.argv[1] else None
+    cache = (
+        os.path.abspath(os.fspath(get_session_cache_file(notebook)))
+        if notebook is not None and notebook.is_file()
+        else None
+    )
+except Exception:
+    cache = None
+print(json.dumps({"marimo_version": marimo.__version__, "cache": cache}), flush=True)
+sys.argv[:] = [sys.argv[0]]
+runpy.run_module("marimo._ipc.launch_kernel", run_name="__main__")
+"""
 
 
 class InvalidWorkingDirectoryError(ValueError):
@@ -51,8 +70,13 @@ def launch_kernel(
     cwd: str | None = None,
 ) -> Process:
     """Launch kernel as a subprocess."""
-    cmd = [executable, "-m", "marimo._ipc.launch_kernel"]
-    logger.info(f"Launching kernel subprocess: {' '.join(cmd)}")
+    cmd = [
+        executable,
+        "-c",
+        _KERNEL_LAUNCH_CODE,
+        str(args.app_metadata.filename or ""),
+    ]
+    logger.info(f"Launching kernel subprocess: {executable} -c <kernel bootstrap>")
     logger.debug(f"Connection info: {args.connection_info}")
     if cwd:
         logger.debug(f"Setting kernel working directory to: {cwd}")
@@ -74,7 +98,21 @@ def launch_kernel(
     process.stdin.flush()
     process.stdin.close()
 
-    logger.debug("Waiting for KERNEL_READY signal from kernel subprocess")
+    logger.debug("Waiting for kernel metadata")
+
+    metadata_line = process.stdout.readline().decode("utf-8").strip()
+    try:
+        metadata = json.loads(metadata_line)
+        marimo_version = metadata["marimo_version"]
+        session_cache_path = metadata.get("cache")
+        if not isinstance(marimo_version, str):
+            raise TypeError  # noqa: TRY301
+        if session_cache_path is not None and not isinstance(session_cache_path, str):
+            raise TypeError  # noqa: TRY301
+    except (json.JSONDecodeError, KeyError, TypeError) as error:
+        process.terminate()
+        msg = f"Invalid kernel metadata: {metadata_line!r}"
+        raise RuntimeError(msg) from error
 
     # Wait for "KERNEL_READY" message
     ready_line = process.stdout.readline().decode("utf-8").strip()
@@ -96,7 +134,11 @@ def launch_kernel(
         raise RuntimeError(msg)
 
     logger.info(f"Kernel subprocess started successfully with PID: {process.pid}")
-    return Process(inner=process)
+    return Process(
+        inner=process,
+        marimo_version=marimo_version,
+        session_cache_path=session_cache_path,
+    )
 
 
 class Manager(KernelManagerImpl):
@@ -139,6 +181,8 @@ class Manager(KernelManagerImpl):
         self.executable = executable
         self.connection_info = connection_info
         self.working_directory = working_directory
+        self.marimo_version: str | None = None
+        self.session_cache_path: str | None = None
 
     def start_kernel(self) -> None:
         """Start an instance of the marimo kernel using ZeroMQ IPC."""
@@ -157,6 +201,8 @@ class Manager(KernelManagerImpl):
             ),
             cwd=str(working_directory),
         )
+        self.marimo_version = self.kernel_task.marimo_version
+        self.session_cache_path = self.kernel_task.session_cache_path
 
 
 class Process(ProcessLike):
@@ -168,9 +214,16 @@ class Process(ProcessLike):
     # Timeout in seconds to wait for graceful termination before force killing
     TERMINATE_TIMEOUT = 2.0
 
-    def __init__(self, inner: subprocess.Popen[bytes]) -> None:
+    def __init__(
+        self,
+        inner: subprocess.Popen[bytes],
+        marimo_version: str | None = None,
+        session_cache_path: str | None = None,
+    ) -> None:
         """Initialize with a subprocess.Popen instance."""
         self.inner = inner
+        self.marimo_version = marimo_version
+        self.session_cache_path = session_cache_path
 
     @property
     def pid(self) -> int | None:

--- a/src/marimo_lsp/kernels/native.py
+++ b/src/marimo_lsp/kernels/native.py
@@ -43,10 +43,14 @@ class NativeKernel:
         self._listener_thread: threading.Thread | None = None
         self.executable = manager.executable
         self.working_directory = manager.working_directory
+        self.marimo_version: str | None = None
+        self.session_cache_path: str | None = None
 
     def start(self, receive: Callable[[KernelMessage], None]) -> None:
         """Start the kernel process and operation listener."""
         self._manager.start_kernel()
+        self.marimo_version = self._manager.marimo_version
+        self.session_cache_path = self._manager.session_cache_path
 
         def listen() -> None:
             stream_queue = self._queue_manager.stream_queue

--- a/src/marimo_lsp/models.py
+++ b/src/marimo_lsp/models.py
@@ -15,6 +15,7 @@ import msgspec
 from marimo._config.config import MarimoConfig  # noqa: TC002
 from marimo._convert.common.format import DEFAULT_MARKDOWN_PREFIX
 from marimo._messaging.notification import (  # noqa: TC002
+    CellNotification,
     NotificationMessage,
     VariablesNotification,
 )
@@ -416,6 +417,13 @@ class SetDisplayThemeRequest(msgspec.Struct, rename="camel"):
     """The theme to set ('light' or 'dark')."""
 
 
+class ReadNotebookOutputsRequest(msgspec.Struct, rename="camel"):
+    """Resolve outputs for an opened notebook without starting a kernel."""
+
+    session_cache_path: str | None = None
+    """Conventional cold-cache path, or ``None`` for live-session replay only."""
+
+
 class ApiRequest(msgspec.Struct, rename="camel"):
     """A unified API request for all marimo internal methods."""
 
@@ -458,6 +466,40 @@ class SetDisplayThemeResponse(msgspec.Struct, rename="camel"):
     """Response for ``set-display-theme``."""
 
     success: bool
+
+
+class LiveCellReplay(
+    msgspec.Struct,
+    tag="live",
+    tag_field="kind",
+    rename="camel",
+    frozen=True,
+):
+    """One cell projected from an authoritative live SessionView."""
+
+    notification: CellNotification
+    executed_source: str | None
+
+
+class SavedCellReplay(
+    msgspec.Struct,
+    tag="saved",
+    tag_field="kind",
+    rename="camel",
+    frozen=True,
+):
+    """One cell restored from a compatible saved-session sidecar."""
+
+    notification: CellNotification
+
+
+type CellOutputReplay = LiveCellReplay | SavedCellReplay
+
+
+class ReadNotebookOutputsResponse(msgspec.Struct, rename="camel", frozen=True):
+    """Cell outputs replayed from live memory or a saved-session sidecar."""
+
+    cells: list[CellOutputReplay]
 
 
 ExecuteCellsRequest = core.ExecuteCellsRequest

--- a/src/marimo_lsp/saved_session_store.py
+++ b/src/marimo_lsp/saved_session_store.py
@@ -1,0 +1,79 @@
+# Copyright 2026 Marimo. All rights reserved.
+
+"""Host filesystem boundary for saved sessions."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable
+
+
+class SavedSessionFiles(Protocol):
+    """Write a saved session on the language server's host."""
+
+    async def read(self, target: str) -> str | None:
+        """Read a saved session when it exists."""
+        ...
+
+    async def write(self, target: str, contents: str) -> None:
+        """Write one complete saved session."""
+        ...
+
+
+class LocalSavedSessionFiles:
+    """Write through the native language server filesystem."""
+
+    async def read(self, target: str) -> str | None:
+        """Read a saved session when it exists."""
+        destination = Path(target)
+        if not destination.is_absolute():
+            msg = f"Saved session path must be absolute: {target}"
+            raise ValueError(msg)
+        try:
+            return await asyncio.to_thread(destination.read_text, encoding="utf-8")
+        except FileNotFoundError:
+            return None
+
+    async def write(self, target: str, contents: str) -> None:
+        """Write one complete saved session."""
+        destination = Path(target)
+        if not destination.is_absolute():
+            msg = f"Saved session path must be absolute: {target}"
+            raise ValueError(msg)
+
+        def write() -> None:
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            destination.write_text(contents, encoding="utf-8")
+
+        await asyncio.to_thread(write)
+
+
+class SavedSessionFileCallbacks(Protocol):
+    """Host callbacks supplied to the Pyodide language server."""
+
+    def read(self, target: str) -> Awaitable[str | None]:
+        """Read a saved session from the host when it exists."""
+        ...
+
+    def write(self, target: str, contents: str) -> Awaitable[None]:
+        """Write one complete saved session on the host."""
+        ...
+
+
+class CallbackSavedSessionFiles:
+    """Write through the extension host callback."""
+
+    def __init__(self, callbacks: SavedSessionFileCallbacks) -> None:
+        self._callbacks = callbacks
+
+    async def read(self, target: str) -> str | None:
+        """Read a saved session through the host."""
+        return await self._callbacks.read(target)
+
+    async def write(self, target: str, contents: str) -> None:
+        """Write one complete saved session through the host."""
+        await self._callbacks.write(target, contents)

--- a/src/marimo_lsp/saved_session_writer.py
+++ b/src/marimo_lsp/saved_session_writer.py
@@ -1,0 +1,81 @@
+# Copyright 2026 Marimo. All rights reserved.
+
+"""Periodically persist one live marimo SessionView."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import TYPE_CHECKING
+
+from marimo_lsp.loggers import get_logger
+from marimo_lsp.saved_sessions import serialize_saved_session
+
+if TYPE_CHECKING:
+    from marimo._session.state.session_view import SessionView
+
+    from marimo_lsp.app_file_manager import LspAppFileManager
+    from marimo_lsp.saved_session_store import SavedSessionFiles
+
+
+logger = get_logger()
+SESSION_CACHE_INTERVAL_SECONDS = 2
+
+
+class SavedSessionWriter:
+    """Mirror marimo's session-owned periodic cache writer."""
+
+    def __init__(  # noqa: PLR0913
+        self,
+        *,
+        view: SessionView,
+        app_file_manager: LspAppFileManager,
+        marimo_version: str,
+        target: str,
+        files: SavedSessionFiles,
+        interval: float = SESSION_CACHE_INTERVAL_SECONDS,
+    ) -> None:
+        self._view = view
+        self._app_file_manager = app_file_manager
+        self._marimo_version = marimo_version
+        self._target = target
+        self._files = files
+        self._interval = interval
+        self._task: asyncio.Task[None] | None = None
+
+    def start(self) -> None:
+        """Start the periodic writer."""
+        if self._task is None or self._task.done():
+            self._task = asyncio.create_task(self._run())
+
+    def stop(self) -> None:
+        """Stop the periodic writer."""
+        if self._task is not None:
+            self._task.cancel()
+            self._task = None
+
+    async def flush_once(self) -> bool:
+        """Write the current view when marimo marks it dirty."""
+        if not self._view.needs_export("session"):
+            return False
+        self._view.mark_auto_export_session()
+        cells = self._app_file_manager.app.cell_manager
+        snapshot = serialize_saved_session(
+            self._view,
+            cell_ids=cells.cell_ids(),
+            marimo_version=self._marimo_version,
+            header=self._app_file_manager.header,
+        )
+        await self._files.write(self._target, json.dumps(snapshot, indent=2))
+        return True
+
+    async def _run(self) -> None:
+        while True:
+            try:
+                await self.flush_once()
+                await asyncio.sleep(self._interval)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("Stopped saved-session writer after write failure")
+                return

--- a/src/marimo_lsp/saved_sessions.py
+++ b/src/marimo_lsp/saved_sessions.py
@@ -1,0 +1,142 @@
+# Copyright 2026 Marimo. All rights reserved.
+
+"""Compatibility helpers for marimo saved-session snapshots."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, cast
+
+import msgspec
+from marimo._messaging.notebook.document import NotebookDocument
+from marimo._messaging.notification import CellNotification
+from marimo._session.state.serialize import (
+    SessionCacheKey,
+    SessionCacheManager,
+    deserialize_session,
+    serialize_session_view,
+)
+from marimo._session.state.session_view import SessionView
+from marimo._utils.code import hash_code
+from marimo._utils.inline_script_metadata import read_pyproject_from_script
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from marimo._schemas.session import NotebookSessionV1
+    from marimo._types.ids import CellId_t
+
+
+def _script_metadata_hash(header: str | None) -> str | None:
+    try:
+        project = read_pyproject_from_script(header or "")
+    except Exception:  # noqa: BLE001 - match marimo's filename helper
+        return None
+    if project is None:
+        return None
+    return hash_code(
+        json.dumps(
+            project,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        )
+    )
+
+
+def serialize_saved_session(
+    view: SessionView,
+    *,
+    cell_ids: Iterable[CellId_t],
+    marimo_version: str,
+    header: str | None,
+) -> NotebookSessionV1:
+    """Serialize a view with the selected kernel's cache identity."""
+    snapshot = serialize_session_view(
+        view,
+        cell_ids=tuple(cell_ids),
+        script_metadata_hash=_script_metadata_hash(header),
+        drop_virtual_file_outputs=True,
+    )
+    snapshot["metadata"]["marimo_version"] = marimo_version
+    return snapshot
+
+
+def decode_saved_session_outputs(
+    contents: str,
+    *,
+    codes: Iterable[str],
+    cell_ids: Iterable[CellId_t],
+    header: str | None,
+) -> list[CellNotification]:
+    """Return cold display notifications from a compatible V1 snapshot."""
+    try:
+        decoded = json.loads(contents)
+        if not isinstance(decoded, dict) or decoded.get("version") != "1":
+            return []
+        metadata = decoded.get("metadata")
+        if not isinstance(metadata, dict):
+            return []
+        marimo_version = metadata.get("marimo_version")
+        if not isinstance(marimo_version, str):
+            return []
+        view = decode_saved_session_view(
+            contents,
+            codes=codes,
+            cell_ids=cell_ids,
+            marimo_version=marimo_version,
+            header=header,
+        )
+        if view is None:
+            return []
+        return [
+            msgspec.structs.replace(notification, stale_inputs=True)
+            for notification in view.notifications
+            if isinstance(notification, CellNotification)
+            and (notification.output is not None or bool(notification.console))
+        ]
+    except Exception:  # noqa: BLE001 - malformed snapshots are cache misses
+        return []
+
+
+def decode_saved_session_view(
+    contents: str,
+    *,
+    codes: Iterable[str],
+    cell_ids: Iterable[CellId_t],
+    marimo_version: str,
+    header: str | None,
+) -> SessionView | None:
+    """Restore a compatible snapshot into the current cell IDs."""
+    try:
+        notebook_session = cast("NotebookSessionV1", json.loads(contents))
+        current_codes = tuple(codes)
+        current_cell_ids = tuple(cell_ids)
+        if len(current_codes) != len(current_cell_ids):
+            return None
+        manager = SessionCacheManager(
+            session_view=SessionView(),
+            document=NotebookDocument([]),
+            path=None,
+            interval=1,
+        )
+        key = SessionCacheKey(
+            codes=current_codes,
+            marimo_version=marimo_version,
+            cell_ids=current_cell_ids,
+            script_metadata_hash=_script_metadata_hash(header),
+        )
+        if not manager.is_cache_hit(notebook_session, key):
+            return None
+        cell_ids_by_hash = {
+            hash_code(code): cell_id
+            for code, cell_id in zip(
+                current_codes,
+                current_cell_ids,
+                strict=True,
+            )
+            if code
+        }
+        return deserialize_session(notebook_session, cell_ids_by_hash)
+    except Exception:  # noqa: BLE001 - malformed snapshots are cache misses
+        return None

--- a/src/marimo_lsp/server.py
+++ b/src/marimo_lsp/server.py
@@ -25,9 +25,14 @@ logger = get_logger()
 
 if typing.TYPE_CHECKING:
     from marimo_lsp.kernels import Kernels
+    from marimo_lsp.saved_session_store import SavedSessionFiles
 
 
-def create_server(*, kernels: Kernels) -> LanguageServer:  # noqa: C901, PLR0915
+def create_server(  # noqa: C901, PLR0915
+    *,
+    kernels: Kernels,
+    saved_session_files: SavedSessionFiles | None = None,
+) -> LanguageServer:
     """Create the marimo LSP server."""
     server = LanguageServer(
         name="marimo-lsp",
@@ -47,7 +52,11 @@ def create_server(*, kernels: Kernels) -> LanguageServer:  # noqa: C901, PLR0915
             save=True,
         ),
     )
-    sessions = Sessions(server, kernels=kernels)
+    sessions = Sessions(
+        server,
+        kernels=kernels,
+        saved_session_files=saved_session_files,
+    )
     graph_registry = GraphUpdaterRegistry(server)
 
     # Register atexit handler to ensure kernel processes are cleaned up

--- a/src/marimo_lsp/sessions.py
+++ b/src/marimo_lsp/sessions.py
@@ -35,7 +35,20 @@ from marimo._types.ids import SessionId
 from marimo_lsp.app_file_manager import LspAppFileManager, sync_app_with_workspace
 from marimo_lsp.kernels import KernelOpenError
 from marimo_lsp.loggers import get_logger
-from marimo_lsp.models import KernelNotification, ListSessionsResponse, SessionInfo
+from marimo_lsp.models import (
+    CellOutputReplay,
+    KernelNotification,
+    ListSessionsResponse,
+    LiveCellReplay,
+    ReadNotebookOutputsResponse,
+    SavedCellReplay,
+    SessionInfo,
+)
+from marimo_lsp.saved_session_writer import SavedSessionWriter
+from marimo_lsp.saved_sessions import (
+    decode_saved_session_outputs,
+    decode_saved_session_view,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -55,6 +68,7 @@ if TYPE_CHECKING:
     from pygls.workspace import Workspace
 
     from marimo_lsp.kernels import Kernel, Kernels
+    from marimo_lsp.saved_session_store import SavedSessionFiles
 
 
 logger = get_logger()
@@ -177,6 +191,7 @@ class Session:
         config_manager: MarimoConfigManager,
         on_change: typing.Callable[[], None] | None = None,
         session_view: SessionView | None = None,
+        saved_session_files: SavedSessionFiles | None = None,
         started_at: float | None = None,
     ) -> None:
         self.session_id = session_id
@@ -207,6 +222,20 @@ class Session:
         self._state_lock = threading.RLock()
 
         self._kernel = kernel
+        self._instantiated = False
+        self._saved_session_writer = None
+        if (
+            saved_session_files is not None
+            and kernel.marimo_version is not None
+            and kernel.session_cache_path is not None
+        ):
+            self._saved_session_writer = SavedSessionWriter(
+                view=self.session_view,
+                app_file_manager=self._app_file_manager,
+                marimo_version=kernel.marimo_version,
+                target=kernel.session_cache_path,
+                files=saved_session_files,
+            )
         logger.info(f"Started session {session_id}")
 
     @property
@@ -254,6 +283,34 @@ class Session:
         self.update_runtime_config(updated)
         return updated
 
+    def output_replay(self) -> list[CellOutputReplay]:
+        """Project the authoritative live view for a newly attached client."""
+        codes = self._app_file_manager.app.cell_manager.code_map()
+        cells: list[CellOutputReplay] = []
+        for cell_id, notification in self.session_view.cell_notifications.items():
+            if cell_id not in codes:
+                continue
+            if (
+                notification.output is None
+                and not notification.console
+                and notification.status not in {"queued", "running"}
+            ):
+                continue
+            executed_source = self.session_view.last_executed_code.get(cell_id)
+            stale = notification.stale_inputs is True or (
+                executed_source != codes[cell_id]
+            )
+            cells.append(
+                LiveCellReplay(
+                    notification=msgspec.structs.replace(
+                        notification,
+                        stale_inputs=stale,
+                    ),
+                    executed_source=executed_source,
+                )
+            )
+        return cells
+
     def sync(self, workspace: Workspace) -> None:
         """Synchronize the live app with the current notebook document."""
         previous_configs = {
@@ -265,6 +322,7 @@ class Session:
             notebook_uri=self._notebook_uri,
             app=self._app_file_manager.app,
         )
+        self._app_file_manager.sync_header(workspace)
         current_configs = {
             cell_id: config.asdict()
             for cell_id, config in self._app_file_manager.app.cell_manager.config_map().items()
@@ -455,6 +513,10 @@ class Session:
             self._notebook_uri = notebook_uri
             self._operation_sink.move(notebook_uri)
             self._app_file_manager.move(notebook_uri)
+            # The target belongs to the filename reported at kernel startup.
+            if self._saved_session_writer is not None:
+                self._saved_session_writer.stop()
+                self._saved_session_writer = None
         if notify:
             self._on_change()
 
@@ -465,6 +527,8 @@ class Session:
         http_request: HTTPRequest | None,
     ) -> None:
         """Instantiate the notebook."""
+        if self._instantiated:
+            return
         codes = request.codes or self._app_file_manager.app.cell_manager.code_map()
 
         del http_request  # Unused in language-server sessions.
@@ -484,6 +548,9 @@ class Session:
             ),
             from_consumer_id=None,
         )
+        self._instantiated = True
+        if self._saved_session_writer is not None:
+            self._saved_session_writer.start()
 
     def activate(self) -> None:
         """Release operations after this session becomes authoritative."""
@@ -497,6 +564,8 @@ class Session:
         self._idle.set()
         self._on_change = lambda: None
         logger.info(f"Closing session {self.session_id}")
+        if self._saved_session_writer is not None:
+            self._saved_session_writer.stop()
         self._kernel.close()
         self._operation_sink.detach()
 
@@ -509,9 +578,11 @@ class Sessions:
         server: LanguageServer,
         *,
         kernels: Kernels,
+        saved_session_files: SavedSessionFiles | None = None,
     ) -> None:
         self._server = server
         self._kernels = kernels
+        self._saved_session_files = saved_session_files
         self._sessions: dict[str, Session] = {}
         self._lock = threading.RLock()
         self._lifecycle_locks: dict[str, asyncio.Lock] = {}
@@ -561,6 +632,48 @@ class Sessions:
         """Return the live session for a notebook, if one exists."""
         with self._lock:
             return self._sessions.get(notebook_uri)
+
+    async def read_notebook_outputs(
+        self,
+        notebook_uri: str,
+        *,
+        session_cache_path: str | None,
+    ) -> ReadNotebookOutputsResponse:
+        """Prefer a live SessionView and otherwise decode the supplied cache."""
+        session = self.get(notebook_uri)
+        if session is not None:
+            return ReadNotebookOutputsResponse(cells=session.output_replay())
+        if self._saved_session_files is None or session_cache_path is None:
+            return ReadNotebookOutputsResponse(cells=[])
+
+        try:
+            app_file_manager = LspAppFileManager(
+                server=self._server,
+                notebook_uri=notebook_uri,
+            )
+            contents = await self._saved_session_files.read(session_cache_path)
+            # A session created while the file was being read is authoritative.
+            session = self.get(notebook_uri)
+            if session is not None:
+                return ReadNotebookOutputsResponse(cells=session.output_replay())
+            if contents is None:
+                return ReadNotebookOutputsResponse(cells=[])
+            cells = app_file_manager.app.cell_manager
+            notifications = decode_saved_session_outputs(
+                contents,
+                codes=cells.codes(),
+                cell_ids=cells.cell_ids(),
+                header=app_file_manager.header,
+            )
+            return ReadNotebookOutputsResponse(
+                cells=[
+                    SavedCellReplay(notification=notification)
+                    for notification in notifications
+                ]
+            )
+        except Exception:
+            logger.exception("Ignored unreadable saved session")
+            return ReadNotebookOutputsResponse(cells=[])
 
     def cancel_scratchpad(self, notebook_uri: str, run_id: str) -> None:
         """Remember a cancellation and interrupt only its active scratchpad."""
@@ -624,7 +737,7 @@ class Sessions:
             replacement.activate()
             return replacement
 
-    async def _create(
+    async def _create(  # noqa: C901
         self,
         notebook_uri: str,
         executable: str,
@@ -668,6 +781,28 @@ class Sessions:
             receive=receive,
         )
         try:
+            session_view = previous.session_view if previous else None
+            if (
+                session_view is None
+                and self._saved_session_files is not None
+                and kernel.marimo_version is not None
+                and kernel.session_cache_path is not None
+            ):
+                try:
+                    contents = await self._saved_session_files.read(
+                        kernel.session_cache_path
+                    )
+                    if contents is not None:
+                        cells = app_file_manager.app.cell_manager
+                        session_view = decode_saved_session_view(
+                            contents,
+                            codes=cells.codes(),
+                            cell_ids=cells.cell_ids(),
+                            marimo_version=kernel.marimo_version,
+                            header=app_file_manager.header,
+                        )
+                except Exception:
+                    logger.exception("Ignored unreadable saved session")
             session = Session(
                 session_id=session_id,
                 notebook_uri=notebook_uri,
@@ -675,7 +810,8 @@ class Sessions:
                 kernel=kernel,
                 app_file_manager=app_file_manager,
                 config_manager=config_manager,
-                session_view=previous.session_view if previous else None,
+                session_view=session_view,
+                saved_session_files=self._saved_session_files,
                 started_at=previous.started_at if previous else None,
             )
             session.set_on_kernel_failure(_raise_kernel_failure)

--- a/src/marimo_lsp/wasm/__init__.py
+++ b/src/marimo_lsp/wasm/__init__.py
@@ -12,6 +12,10 @@ import typing
 import msgspec
 
 from marimo_lsp.loggers import get_logger, lsp_handler
+from marimo_lsp.saved_session_store import (
+    CallbackSavedSessionFiles,
+    SavedSessionFileCallbacks,
+)
 from marimo_lsp.server import create_server
 from marimo_lsp.wasm.kernels import ProcessCallbacks, WasmKernels
 
@@ -44,9 +48,18 @@ class WasmServer:
         self,
         write_message: Callable[[str], None],
         process_callbacks: ProcessCallbacks,
+        saved_session_callbacks: SavedSessionFileCallbacks | None = None,
     ) -> None:
         self._kernels = WasmKernels(process_callbacks)
-        self._server: LanguageServer = create_server(kernels=self._kernels)
+        files = (
+            CallbackSavedSessionFiles(saved_session_callbacks)
+            if saved_session_callbacks is not None
+            else None
+        )
+        self._server: LanguageServer = create_server(
+            kernels=self._kernels,
+            saved_session_files=files,
+        )
         self._server.protocol.set_writer(
             _MessageWriter(write_message),
             include_headers=False,
@@ -109,6 +122,11 @@ class WasmServer:
 def create_bridge(
     write_message: Callable[[str], None],
     process_callbacks: ProcessCallbacks,
+    saved_session_callbacks: SavedSessionFileCallbacks | None = None,
 ) -> WasmServer:
     """Create the message boundary exported to JavaScript."""
-    return WasmServer(write_message, process_callbacks)
+    return WasmServer(
+        write_message,
+        process_callbacks,
+        saved_session_callbacks,
+    )

--- a/src/marimo_lsp/wasm/kernels.py
+++ b/src/marimo_lsp/wasm/kernels.py
@@ -88,6 +88,8 @@ class WasmKernel:
         self._closed = False
         self.executable = executable
         self.working_directory = working_directory
+        self.marimo_version: str | None = None
+        self.session_cache_path: str | None = None
 
     def accept(self, chunk: bytes) -> None:
         """Decode operations received from the kernel bridge."""
@@ -95,6 +97,8 @@ class WasmKernel:
             return
         for message in self._decoder.feed(chunk):
             if isinstance(message, Ready):
+                self.marimo_version = message.marimo_version
+                self.session_cache_path = message.session_cache_path
                 if not self._ready.done():
                     self._ready.set_result(None)
             elif isinstance(message, Operation):

--- a/src/marimo_lsp/wasm/protocol.py
+++ b/src/marimo_lsp/wasm/protocol.py
@@ -26,6 +26,8 @@ MAX_FRAME_SIZE = 64 * 1024 * 1024
 class Ready(msgspec.Struct, tag="ready", tag_field="type", rename="camel"):
     """The kernel bridge is ready."""
 
+    marimo_version: str | None = None
+    session_cache_path: str | None = None
     version: Literal[1] = VERSION
 
 

--- a/tests/test_saved_session_writer.py
+++ b/tests/test_saved_session_writer.py
@@ -1,0 +1,80 @@
+# Copyright 2026 Marimo. All rights reserved.
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, cast
+
+import pytest
+from marimo._messaging.cell_output import CellChannel, CellOutput
+from marimo._messaging.notification import CellNotification
+from marimo._runtime.commands import ExecuteCellsCommand
+from marimo._session.state.session_view import SessionView
+from marimo._types.ids import CellId_t
+
+from marimo_lsp.saved_session_writer import SavedSessionWriter
+
+if TYPE_CHECKING:
+    from marimo_lsp.app_file_manager import LspAppFileManager
+
+
+class RecordingFiles:
+    def __init__(self) -> None:
+        self.writes: list[tuple[str, str]] = []
+
+    async def read(self, target: str) -> str | None:
+        del target
+        return None
+
+    async def write(self, target: str, contents: str) -> None:
+        self.writes.append((target, contents))
+
+
+@pytest.mark.asyncio
+async def test_writes_a_dirty_view_in_marimo_format() -> None:
+    cell_id = CellId_t("cell")
+    view = SessionView()
+    view.add_control_request(
+        ExecuteCellsCommand(cell_ids=[cell_id], codes=["answer = 42"])
+    )
+    view.add_notification(
+        CellNotification(
+            cell_id=cell_id,
+            status="idle",
+            output=CellOutput(
+                channel=CellChannel.OUTPUT,
+                mimetype="text/plain",
+                data="42",
+            ),
+            console=[],
+            timestamp=1,
+        )
+    )
+    manager = cast(
+        "LspAppFileManager",
+        SimpleNamespace(
+            header=None,
+            app=SimpleNamespace(
+                cell_manager=SimpleNamespace(cell_ids=lambda: (cell_id,))
+            ),
+        ),
+    )
+    files = RecordingFiles()
+    writer = SavedSessionWriter(
+        view=view,
+        app_file_manager=manager,
+        marimo_version="1.2.3",
+        target="/workspace/__marimo__/session/notebook.py.json",
+        files=files,
+    )
+
+    assert await writer.flush_once()
+    assert not await writer.flush_once()
+
+    [(target, contents)] = files.writes
+    snapshot = json.loads(contents)
+    assert target.endswith("notebook.py.json")
+    assert snapshot["version"] == "1"
+    assert snapshot["metadata"]["marimo_version"] == "1.2.3"
+    assert snapshot["cells"][0]["outputs"][0]["data"] == {"text/plain": "42"}

--- a/tests/test_saved_sessions.py
+++ b/tests/test_saved_sessions.py
@@ -1,0 +1,118 @@
+# Copyright 2026 Marimo. All rights reserved.
+
+"""Behavior tests for cold saved-session decoding."""
+
+from __future__ import annotations
+
+import json
+
+from marimo import __version__
+from marimo._messaging.cell_output import CellChannel, CellOutput
+from marimo._messaging.notification import CellNotification
+from marimo._runtime.commands import ExecuteCellsCommand
+from marimo._session.state.serialize import serialize_session_view
+from marimo._session.state.session_view import SessionView
+from marimo._types.ids import CellId_t
+from marimo._utils.code import hash_code
+from marimo._utils.inline_script_metadata import read_pyproject_from_script
+
+from marimo_lsp.saved_sessions import decode_saved_session_outputs
+
+SAVED_ID = CellId_t("saved")
+CURRENT_ID = CellId_t("current")
+CODE = "answer = 42\nanswer"
+HEADER = """# /// script
+# dependencies = ["polars"]
+# ///
+"""
+
+
+def _script_metadata_hash(header: str) -> str:
+    project = read_pyproject_from_script(header)
+    assert project is not None
+    return hash_code(
+        json.dumps(
+            project,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        )
+    )
+
+
+def _contents() -> str:
+    view = SessionView()
+    view.add_control_request(ExecuteCellsCommand(cell_ids=[SAVED_ID], codes=[CODE]))
+    view.add_notification(
+        CellNotification(
+            cell_id=SAVED_ID,
+            status="idle",
+            output=CellOutput(
+                channel=CellChannel.OUTPUT,
+                mimetype="text/plain",
+                data="42",
+            ),
+            console=[],
+            timestamp=12.5,
+        )
+    )
+    snapshot = serialize_session_view(
+        view,
+        cell_ids=[SAVED_ID],
+        script_metadata_hash=_script_metadata_hash(HEADER),
+        drop_virtual_file_outputs=True,
+    )
+    snapshot["metadata"]["marimo_version"] = __version__
+    return json.dumps(snapshot)
+
+
+def test_decodes_compatible_output_into_current_cell() -> None:
+    notifications = decode_saved_session_outputs(
+        _contents(),
+        codes=[CODE],
+        cell_ids=[CURRENT_ID],
+        header=HEADER,
+    )
+
+    [notification] = notifications
+    assert notification.cell_id == CURRENT_ID
+    assert notification.status == "idle"
+    assert notification.stale_inputs is True
+    assert notification.output is not None
+    assert notification.output.data == "42"
+
+
+def test_ignores_output_for_changed_code() -> None:
+    assert (
+        decode_saved_session_outputs(
+            _contents(),
+            codes=["answer = 43\nanswer"],
+            cell_ids=[CURRENT_ID],
+            header=HEADER,
+        )
+        == []
+    )
+
+
+def test_ignores_output_for_changed_script_metadata() -> None:
+    assert (
+        decode_saved_session_outputs(
+            _contents(),
+            codes=[CODE],
+            cell_ids=[CURRENT_ID],
+            header=HEADER.replace("polars", "pandas"),
+        )
+        == []
+    )
+
+
+def test_ignores_malformed_snapshot() -> None:
+    assert (
+        decode_saved_session_outputs(
+            "not json",
+            codes=[CODE],
+            cell_ids=[CURRENT_ID],
+            header=HEADER,
+        )
+        == []
+    )

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -12,6 +12,8 @@ from unittest.mock import ANY, AsyncMock, Mock
 
 import pytest
 from marimo._config.config import DEFAULT_CONFIG, MarimoConfig, RuntimeConfig
+from marimo._messaging.cell_output import CellChannel, CellOutput
+from marimo._messaging.notification import CellNotification
 from marimo._messaging.types import KernelMessage
 from marimo._runtime.commands import (
     CodeCompletionCommand,
@@ -26,7 +28,7 @@ from marimo._types.ids import CellId_t, RequestId, SessionId, UIElementId
 
 from marimo_lsp.kernels import KernelOpenError
 from marimo_lsp.kernels.native import NativeKernel
-from marimo_lsp.models import SessionInfo
+from marimo_lsp.models import LiveCellReplay, SavedCellReplay, SessionInfo
 from marimo_lsp.sessions import Session, Sessions, _OperationSink
 
 if TYPE_CHECKING:
@@ -75,6 +77,95 @@ def test_control_requests_update_live_session_snapshot() -> None:
 
     assert session.session_view.ui_values == {UIElementId("slider"): 1}
     assert session.session_view.needs_export("html")
+
+
+def test_live_output_replay_carries_execution_source_and_staleness() -> None:
+    session, _queue_manager = _make_session()
+    cell_id = CellId_t("cell-1")
+    session._app_file_manager = Mock()
+    session._app_file_manager.app.cell_manager.code_map.return_value = {
+        cell_id: "edited = True"
+    }
+    session.session_view.last_executed_code[cell_id] = "edited = False"
+    session.session_view.add_notification(
+        CellNotification(
+            cell_id=cell_id,
+            status="idle",
+            output=CellOutput(
+                channel=CellChannel.OUTPUT,
+                mimetype="text/plain",
+                data="old output",
+            ),
+        )
+    )
+
+    [replay] = session.output_replay()
+
+    assert isinstance(replay, LiveCellReplay)
+    assert replay.executed_source == "edited = False"
+    assert replay.notification.stale_inputs is True
+    assert replay.notification.output is not None
+    assert replay.notification.output.data == "old output"
+
+
+@pytest.mark.asyncio
+async def test_live_output_replay_wins_without_reading_the_sidecar() -> None:
+    files = Mock(read=AsyncMock())
+    sessions = Sessions(Mock(), kernels=Mock(), saved_session_files=files)
+    session = Mock(output_replay=Mock(return_value=[]))
+    sessions._sessions["file:///notebook.py"] = session
+
+    replay = await sessions.read_notebook_outputs(
+        "file:///notebook.py",
+        session_cache_path="/workspace/__marimo__/session/notebook.py.json",
+    )
+
+    assert replay.cells == []
+    session.output_replay.assert_called_once_with()
+    files.read.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_cold_output_replay_uses_the_canonical_lsp_app(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cell_id = CellId_t("cell-1")
+    notification = CellNotification(
+        cell_id=cell_id,
+        status="idle",
+        output=CellOutput(
+            channel=CellChannel.OUTPUT,
+            mimetype="text/plain",
+            data="saved output",
+        ),
+    )
+    app_file_manager = Mock(header="# header")
+    app_file_manager.app.cell_manager.codes.return_value = ["mo.md('hello')"]
+    app_file_manager.app.cell_manager.cell_ids.return_value = [cell_id]
+    monkeypatch.setattr(
+        "marimo_lsp.sessions.LspAppFileManager",
+        Mock(return_value=app_file_manager),
+    )
+    decode = Mock(return_value=[notification])
+    monkeypatch.setattr("marimo_lsp.sessions.decode_saved_session_outputs", decode)
+    files = Mock(read=AsyncMock(return_value="{}"))
+    sessions = Sessions(Mock(), kernels=Mock(), saved_session_files=files)
+
+    replay = await sessions.read_notebook_outputs(
+        "file:///notebook.py",
+        session_cache_path="/workspace/__marimo__/session/notebook.py.json",
+    )
+
+    [cell] = replay.cells
+    assert isinstance(cell, SavedCellReplay)
+    assert cell.notification.output is not None
+    assert cell.notification.output.data == "saved output"
+    decode.assert_called_once_with(
+        "{}",
+        codes=["mo.md('hello')"],
+        cell_ids=[cell_id],
+        header="# header",
+    )
 
 
 def test_sync_forwards_changed_document_configs_to_the_kernel() -> None:

--- a/tests/test_wasm_bridge.py
+++ b/tests/test_wasm_bridge.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING
 from unittest.mock import Mock
 
 import pytest
+from marimo import __version__ as marimo_version
 from marimo._ast.app_config import _AppConfig
 from marimo._config.config import DEFAULT_CONFIG
 from marimo._runtime.commands import AppMetadata, ExecuteCellsCommand
@@ -195,7 +196,13 @@ def test_bridge_launches_kernel_subprocess_over_marimo_ipc(
         sent = KernelLaunchArgs.decode_json(process.stdin.write.call_args.args[0])
         assert sent.connection_info is not None
         assert sent.parent_pid == os.getpid()
-        write_frame.assert_any_call(bridge_module.Ready())
+        ready = next(
+            call.args[0]
+            for call in write_frame.call_args_list
+            if isinstance(call.args[0], bridge_module.Ready)
+        )
+        assert ready.marimo_version == marimo_version
+        assert ready.session_cache_path is None
     finally:
         bridge.close()
 

--- a/tests/test_wasm_kernel.py
+++ b/tests/test_wasm_kernel.py
@@ -83,9 +83,27 @@ async def _begin_launch():
 async def _launch_kernel():
     callbacks, kernels, launch, messages = await _begin_launch()
     process_id = callbacks.spawns[0][0]
-    kernels.accept(process_id, encode(Ready()))
+    kernels.accept(
+        process_id,
+        encode(
+            Ready(
+                marimo_version="1.2.3",
+                session_cache_path="/workspace/session.json",
+            )
+        ),
+    )
     kernel = await launch
     return callbacks, kernels, kernel, messages
+
+
+@pytest.mark.asyncio
+async def test_wasm_kernel_owns_selected_marimo_cache_identity() -> None:
+    _callbacks, _kernels, kernel, _messages = await _launch_kernel()
+
+    assert kernel.marimo_version == "1.2.3"
+    assert kernel.session_cache_path == "/workspace/session.json"
+
+    kernel.close()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
marimo keeps notebook display state in a session sidecar. The extension now reads and writes the same V1 format.

Opening a notebook does not start a kernel. The LSP restores a compatible sidecar with marimo's cache reader, or replays the in-memory SessionView when a managed session already exists. VS Code presents restored output without marking the cell successful.

After execution starts, the selected kernel reports its marimo version and cache path. The LSP Session owns periodic persistence; Pyodide delegates only host file access because its filesystem is virtual. The end-to-end tests verify both directions with marimo's reader and serializer.

Closes #761