### PR TITLE
Own extension commands at the LSP boundary

### DIFF
--- a/extension/scripts/test-wasm-lsp.mjs
+++ b/extension/scripts/test-wasm-lsp.mjs
@@ -155,22 +155,15 @@ const executed = response(2);
 send({
   jsonrpc: "2.0",
   id: 2,
-  method: "workspace/executeCommand",
+  method: "marimo/command",
   params: {
-    command: "marimo.api",
-    arguments: [
-      {
-        method: "execute-cells",
-        params: {
-          notebookUri,
-          executable: kernelPython,
-          workingDirectory: repositoryDir,
-          inner: {
-            cellIds: ["slider-cell", "value-cell"],
-            codes: [sliderCode, valueCode],
-          },
-        },
-      },
+    kind: "execute",
+    notebookUri,
+    executable: kernelPython,
+    workingDirectory: repositoryDir,
+    cells: [
+      { cellId: "slider-cell", code: sliderCode },
+      { cellId: "value-cell", code: valueCode },
     ],
   },
 });
@@ -186,9 +179,9 @@ NodeAssert.ok(
 );
 // Kernel-addressed commands name the exact live session; every kernel
 // notification carries the id.
-const sessionId = initialOutput.match(/"sessionId":"([^"]+)"/)?.[1];
+const kernelSessionId = initialOutput.match(/"sessionId":"([^"]+)"/)?.[1];
 NodeAssert.ok(
-  sessionId,
+  kernelSessionId,
   `Could not find kernel session ID in output:\n${initialOutput}`,
 );
 
@@ -200,19 +193,13 @@ for (let value = 1; value <= 100; value++) {
   send({
     jsonrpc: "2.0",
     id,
-    method: "workspace/executeCommand",
+    method: "marimo/command",
     params: {
-      command: "marimo.api",
-      arguments: [
-        {
-          method: "update-ui-element",
-          params: {
-            notebookUri,
-            sessionId,
-            inner: { objectIds: [sliderId], values: [value] },
-          },
-        },
-      ],
+      kind: "update-ui-element",
+      notebookUri,
+      kernelSessionId,
+      objectIds: [sliderId],
+      values: [value],
     },
   });
 }
@@ -223,25 +210,19 @@ const longRun = response(300);
 send({
   jsonrpc: "2.0",
   id: 300,
-  method: "workspace/executeCommand",
+  method: "marimo/command",
   params: {
-    command: "marimo.api",
-    arguments: [
+    kind: "execute",
+    notebookUri,
+    executable: kernelPython,
+    workingDirectory: repositoryDir,
+    cells: [
       {
-        method: "execute-cells",
-        params: {
-          notebookUri,
-          executable: kernelPython,
-          workingDirectory: repositoryDir,
-          inner: {
-            cellIds: ["value-cell"],
-            codes: [
-              'print("interrupt-started", flush=True)\n' +
-                "time.sleep(60)\n" +
-                "value = slider.value",
-            ],
-          },
-        },
+        cellId: "value-cell",
+        code:
+          'print("interrupt-started", flush=True)\n' +
+          "time.sleep(60)\n" +
+          "value = slider.value",
       },
     ],
   },
@@ -253,15 +234,11 @@ const interrupted = response(301);
 send({
   jsonrpc: "2.0",
   id: 301,
-  method: "workspace/executeCommand",
+  method: "marimo/command",
   params: {
-    command: "marimo.api",
-    arguments: [
-      {
-        method: "interrupt",
-        params: { notebookUri, inner: { sessionId } },
-      },
-    ],
+    kind: "interrupt",
+    notebookUri,
+    kernelSessionId,
   },
 });
 await interrupted;

--- a/extension/src/__mocks__/TestMarimoClient.ts
+++ b/extension/src/__mocks__/TestMarimoClient.ts
@@ -56,17 +56,9 @@ export const TestMarimoClientProcess = Layer.effect(
       },
       restart: Effect.void,
       ...makeMarimoCommands({
-        execute(request) {
-          const command = {
-            command: "marimo.api",
-            params: request,
-          } as const;
+        send(command) {
           return Effect.tryPromise({
-            try: () =>
-              conn.sendRequest("workspace/executeCommand", {
-                command: command.command,
-                arguments: [command.params],
-              }),
+            try: () => conn.sendRequest("marimo/command", command),
             catch: (cause) =>
               new MarimoCommandError({
                 command: Redacted.make(command),

--- a/extension/src/__tests__/__utils__/TestMarimoClient.ts
+++ b/extension/src/__tests__/__utils__/TestMarimoClient.ts
@@ -23,17 +23,21 @@ import {
   MarimoNotebookDocument,
   type NotebookId,
 } from "../../schemas/MarimoNotebookDocument.ts";
-import { KernelSessionIdFromString } from "../../schemas/Models.gen.ts";
+import {
+  Command,
+  KernelSessionIdFromString,
+} from "../../schemas/Models.gen.ts";
 import type {
   DocumentAnalysis,
   KernelNotification,
-  MarimoApiCall,
   MarimoSessionsChanged,
 } from "../../types.ts";
 
+export type TestCommand = typeof Command.Encoded;
+
 interface Options {
-  readonly execute?: (
-    request: MarimoApiCall,
+  readonly send?: (
+    request: TestCommand,
   ) => Effect.Effect<unknown, Schema.SchemaError>;
   readonly kernelNotifications?: Stream.Stream<KernelNotification>;
   readonly documentAnalysis?: Stream.Stream<DocumentAnalysis>;
@@ -81,42 +85,43 @@ export function makeTestNotebookRuntime(options: Options = {}) {
                 Option.fromNullishOr(controllers.get(notebookId)),
               ),
               executeScratchpad: () => Stream.empty,
-              updateUIElements: (inner) =>
+              updateUIElements: (fields) =>
                 client.updateUiElement({
+                  ...fields,
                   notebookUri: notebookId,
-                  sessionId: TEST_KERNEL_SESSION_ID,
-                  inner,
+                  kernelSessionId: TEST_KERNEL_SESSION_ID,
                 }),
-              updateModel: (inner) =>
+              updateModel: (fields) =>
                 client.setModelValue({
+                  ...fields,
                   notebookUri: notebookId,
-                  sessionId: TEST_KERNEL_SESSION_ID,
-                  inner,
+                  kernelSessionId: TEST_KERNEL_SESSION_ID,
                 }),
-              invokeFunction: (inner) =>
+              invokeFunction: (fields) =>
                 client.invokeFunction({
+                  ...fields,
                   notebookUri: notebookId,
-                  sessionId: TEST_KERNEL_SESSION_ID,
-                  inner,
+                  kernelSessionId: TEST_KERNEL_SESSION_ID,
                 }),
-              deleteCell: (inner) =>
+              deleteCell: (fields) =>
                 client.deleteCell({
+                  ...fields,
                   notebookUri: notebookId,
-                  sessionId: TEST_KERNEL_SESSION_ID,
-                  inner,
+                  kernelSessionId: TEST_KERNEL_SESSION_ID,
                 }),
               interrupt: client.interrupt({
                 notebookUri: notebookId,
-                inner: { sessionId: TEST_KERNEL_SESSION_ID },
+                kernelSessionId: TEST_KERNEL_SESSION_ID,
               }),
               restart: client
                 .restartSession({
                   notebookUri: notebookId,
-                  inner: { executable: "", workingDirectory: "" },
+                  executable: "",
+                  workingDirectory: "",
                 })
                 .pipe(Effect.as(undefined)),
               close: client
-                .closeSession({ notebookUri: notebookId, inner: {} })
+                .closeSession({ notebookUri: notebookId })
                 .pipe(Effect.asVoid),
             };
             handles.set(notebookId, handle);
@@ -128,13 +133,13 @@ export function makeTestNotebookRuntime(options: Options = {}) {
         ): Effect.Effect<NotebookDocumentHandle> => {
           const notebookId = MarimoNotebookDocument.from(document).id;
           return Effect.succeed({
-            executeCells: (inner, executable) =>
-              client.executeCells({
+            execute: (request, executable) =>
+              client.execute({
                 notebookUri: notebookId,
                 executable,
                 workingDirectory:
                   options.runtimeSession?.workingDirectory ?? process.cwd(),
-                inner,
+                cells: request.cells,
               }),
           });
         };
@@ -161,18 +166,16 @@ export function makeTestNotebookRuntime(options: Options = {}) {
             client
               .moveSession({
                 notebookUri: notebookId,
-                inner: { newNotebookUri: newNotebookId },
+                newNotebookUri: newNotebookId,
               })
               .pipe(Effect.asVoid),
           restoreSession: (notebookId, executable, workingDirectory) =>
             client
               .restartSession({
                 notebookUri: notebookId,
-                inner: {
-                  executable,
-                  workingDirectory,
-                  createIfMissing: true,
-                },
+                executable,
+                workingDirectory,
+                createIfMissing: true,
               })
               .pipe(Effect.asVoid),
           shutdownAll: client.shutdownAllSessions({}).pipe(Effect.asVoid),
@@ -193,13 +196,13 @@ function makeTestMarimoClientValue(
     channel: { name: "marimo-lsp-test", show() {} },
     restart: Effect.void,
     ...makeMarimoCommands({
-      execute:
-        options.execute ??
+      send:
+        options.send ??
         ((request) =>
           Effect.succeed(
-            request.method === "list-sessions"
+            request.kind === "list-sessions"
               ? { sessions: [] }
-              : request.method === "read-notebook-outputs"
+              : request.kind === "read-notebook-outputs"
                 ? { cells: [] }
                 : null,
           )),

--- a/extension/src/commands/__tests__/refreshPackages.test.ts
+++ b/extension/src/commands/__tests__/refreshPackages.test.ts
@@ -34,8 +34,8 @@ it.effect("refreshes dependencies for the active document session", () =>
     let requests = 0;
     const runtime = makeTestNotebookRuntime({
       initialControllers: [{ notebookUri: NOTEBOOK_URI, controller }],
-      execute: (request) =>
-        request.method === "get-dependency-tree"
+      send: (request) =>
+        request.kind === "get-dependency-tree"
           ? Effect.sync(() => {
               requests += 1;
               return {
@@ -47,7 +47,7 @@ it.effect("refreshes dependencies for the active document session", () =>
                 },
               };
             })
-          : Effect.die(`Unexpected method: ${request.method}`),
+          : Effect.die(`Unexpected command: ${request.kind}`),
     });
     const sessions = NotebookDocumentSessions.layer.pipe(
       Layer.provide(vscode.layer),

--- a/extension/src/commands/__tests__/showNotebookMenu.test.ts
+++ b/extension/src/commands/__tests__/showNotebookMenu.test.ts
@@ -30,8 +30,8 @@ const constantsLayer = Layer.succeed(
 );
 
 const runtimeLayer = makeTestNotebookRuntime({
-  execute: (request) =>
-    request.method === "get-configuration"
+  send: (request) =>
+    request.kind === "get-configuration"
       ? Effect.succeed({
           config: marimoConfigFixture({
             runtime: {
@@ -274,8 +274,8 @@ describe("showNotebookMenu", () => {
           },
         });
         const runtime = makeTestNotebookRuntime({
-          execute: (request) =>
-            request.method === "get-configuration"
+          send: (request) =>
+            request.kind === "get-configuration"
               ? Deferred.succeed(requestStarted, undefined).pipe(
                   Effect.andThen(Deferred.await(releaseRequest)),
                   Effect.andThen(

--- a/extension/src/commands/exportNotebookAsHtml.ts
+++ b/extension/src/commands/exportNotebookAsHtml.ts
@@ -53,14 +53,12 @@ const handler = Effect.fn("command.exportNotebookAsHtml")(function* (
     Effect.fn(function* () {
       // Call the LSP API to export the notebook
       const result = yield* marimo
-        .exportAsHtml({
+        .exportHtml({
           notebookUri: notebook.id,
-          inner: {
-            download: false,
-            files: [],
-            includeCode: true,
-            assetUrl: null,
-          },
+          download: false,
+          files: [],
+          includeCode: true,
+          assetUrl: null,
         })
         .pipe(
           Effect.andThen(Schema.decodeUnknownEffect(Schema.String)),

--- a/extension/src/commands/publishMarimoNotebookGist.ts
+++ b/extension/src/commands/publishMarimoNotebookGist.ts
@@ -51,9 +51,8 @@ export const publishMarimoNotebookGist = Effect.fn(
 
     // Try to export ipynb with outputs for GitHub rendering
     const ipynbResult = yield* marimo
-      .exportAsIpynb({
+      .exportIpynb({
         notebookUri: notebook.id,
-        inner: {},
       })
       .pipe(
         Effect.andThen(Schema.decodeUnknownEffect(Schema.String)),

--- a/extension/src/config/NotebookConfiguration.ts
+++ b/extension/src/config/NotebookConfiguration.ts
@@ -35,7 +35,6 @@ export class NotebookConfiguration extends Context.Service<NotebookConfiguration
         );
         const result = yield* marimo.getConfiguration({
           notebookUri: session.notebookId,
-          inner: {},
         });
         yield* Effect.logTrace("Configuration fetched").pipe(
           Effect.annotateLogs({ notebookUri: session.notebookId }),
@@ -81,7 +80,7 @@ export class NotebookConfiguration extends Context.Service<NotebookConfiguration
             );
             const config = yield* marimo.updateConfiguration({
               notebookUri: session.notebookId,
-              inner: { config: partialConfig },
+              config: partialConfig,
             });
             yield* ScopedCache.set(cache, cacheKey, config);
             yield* SubscriptionRef.set(current, Option.some(config));

--- a/extension/src/config/__tests__/ConfigContextManager.test.ts
+++ b/extension/src/config/__tests__/ConfigContextManager.test.ts
@@ -1,5 +1,5 @@
 import { expect, it } from "@effect/vitest";
-import { Deferred, Effect, Layer, Option, Ref, Schema } from "effect";
+import { Deferred, Effect, Layer, Option, Ref } from "effect";
 
 import {
   createTestNotebookDocument,
@@ -14,7 +14,6 @@ import {
 } from "../../lib/__tests__/branded.ts";
 import { NotebookDocumentSessions } from "../../notebook/NotebookDocumentSessions.ts";
 import { NotebookSessionResources } from "../../notebook/NotebookSessionResources.ts";
-import * as Api from "../../schemas/Models.gen.ts";
 import { ConfigContextManagerLive } from "../ConfigContextManager.ts";
 
 const NOTEBOOK_URI = notebookId("file:///test/notebook.py");
@@ -63,13 +62,10 @@ const withTestCtx = Effect.fn(function* () {
     runtime: { on_cell_change: "lazy", auto_reload: "autorun" },
   });
   const runtime = makeTestNotebookRuntime({
-    execute: Effect.fn(function* (request) {
-      if (request.method !== "get-configuration") {
-        return yield* Effect.die(`Unexpected method: ${request.method}`);
+    send: Effect.fn(function* (request) {
+      if (request.kind !== "get-configuration") {
+        return yield* Effect.die(`Unexpected command: ${request.kind}`);
       }
-      yield* Schema.decodeUnknownEffect(Api.GetConfigurationPayload)(
-        request.params,
-      );
       return { config };
     }),
   });
@@ -178,20 +174,17 @@ it.effect("keeps context writes ordered when the active session changes", () =>
       ],
     ]);
     const runtime = makeTestNotebookRuntime({
-      execute: Effect.fn(function* (request) {
-        if (request.method !== "get-configuration") {
-          return yield* Effect.die(`Unexpected method: ${request.method}`);
+      send: Effect.fn(function* (request) {
+        if (request.kind !== "get-configuration") {
+          return yield* Effect.die(`Unexpected command: ${request.kind}`);
         }
-        const params = yield* Schema.decodeUnknownEffect(
-          Api.GetConfigurationPayload,
-        )(request.params);
-        const config = configurations.get(params.notebookUri);
+        const config = configurations.get(notebookId(request.notebookUri));
         if (config === undefined) {
           return yield* Effect.die(
-            `Missing configuration for ${params.notebookUri}`,
+            `Missing configuration for ${request.notebookUri}`,
           );
         }
-        if (params.notebookUri === NOTEBOOK_URI_2) {
+        if (request.notebookUri === NOTEBOOK_URI_2) {
           signalSecondConfigurationLoaded();
         }
         return { config };

--- a/extension/src/config/__tests__/NotebookConfiguration.test.ts
+++ b/extension/src/config/__tests__/NotebookConfiguration.test.ts
@@ -1,14 +1,5 @@
 import { assert, describe, expect, it } from "@effect/vitest";
-import {
-  Deferred,
-  Effect,
-  Fiber,
-  Layer,
-  Option,
-  Schema,
-  Scope,
-  Stream,
-} from "effect";
+import { Deferred, Effect, Fiber, Layer, Option, Scope, Stream } from "effect";
 import { TestClock } from "effect/testing";
 
 import {
@@ -25,7 +16,6 @@ import {
 import { NotebookDocumentSessions } from "../../notebook/NotebookDocumentSessions.ts";
 import { NotebookSessionResources } from "../../notebook/NotebookSessionResources.ts";
 import type { NotebookId } from "../../schemas/MarimoNotebookDocument.ts";
-import * as Api from "../../schemas/Models.gen.ts";
 import type { MarimoConfig } from "../../types.ts";
 import { NotebookConfiguration } from "../NotebookConfiguration.ts";
 
@@ -116,44 +106,36 @@ const withTestCtx = Effect.fn(function* (
   const vscode = yield* TestVsCode.make({ initialDocuments });
 
   const runtime = makeTestNotebookRuntime({
-    execute: Effect.fn(function* (request) {
-      if (request.method === "get-configuration") {
-        const params = yield* Schema.decodeUnknownEffect(
-          Api.GetConfigurationPayload,
-        )(request.params);
-        const config = configStore.get(params.notebookUri);
+    send: Effect.fn(function* (request) {
+      if (request.kind === "get-configuration") {
+        const config = configStore.get(request.notebookUri);
         if (config === undefined) {
           return yield* Effect.die(
-            `Config not found for ${params.notebookUri}`,
+            `Config not found for ${request.notebookUri}`,
           );
         }
         if (options.beforeGetResponse) {
-          yield* options.beforeGetResponse(params.notebookUri);
+          yield* options.beforeGetResponse(request.notebookUri);
         }
         return { config };
       }
 
-      if (request.method === "update-configuration") {
-        const params = yield* Schema.decodeUnknownEffect(
-          Api.UpdateConfigurationPayload,
-        )(request.params);
+      if (request.kind === "update-configuration") {
         if (options.beforeUpdateResponse) {
-          yield* options.beforeUpdateResponse(params.notebookUri);
+          yield* options.beforeUpdateResponse(request.notebookUri);
         }
-        const existing = configStore.get(params.notebookUri);
+        const existing = configStore.get(request.notebookUri);
         if (existing === undefined) {
           return yield* Effect.die(
-            `Config not found for ${params.notebookUri}`,
+            `Config not found for ${request.notebookUri}`,
           );
         }
-        const config = mergeMarimoConfig(existing, params.inner.config);
-        configStore.set(params.notebookUri, config);
+        const config = mergeMarimoConfig(existing, request.config);
+        configStore.set(request.notebookUri, config);
         return config;
       }
 
-      return yield* Effect.die(
-        `Unexpected marimo.api method: ${request.method}`,
-      );
+      return yield* Effect.die(`Unexpected marimo command: ${request.kind}`);
     }),
   });
   const documentSessions = NotebookDocumentSessions.layer.pipe(

--- a/extension/src/features/AutoExport.ts
+++ b/extension/src/features/AutoExport.ts
@@ -239,25 +239,21 @@ export const AutoExportLive = Layer.effectDiscard(
     ) {
       const content = (() => {
         if (format === "html") {
-          return marimo.exportAsHtml({
+          return marimo.exportHtml({
             notebookUri: notebook.id,
-            inner: {
-              download: false,
-              files: [],
-              includeCode: true,
-              assetUrl: null,
-            },
+            download: false,
+            files: [],
+            includeCode: true,
+            assetUrl: null,
           });
         }
         if (format === "ipynb") {
-          return marimo.exportAsIpynb({
+          return marimo.exportIpynb({
             notebookUri: notebook.id,
-            inner: {},
           });
         }
-        return marimo.exportAsMarkdown({
+        return marimo.exportMarkdown({
           notebookUri: notebook.id,
-          inner: {},
         });
       })();
 

--- a/extension/src/features/__tests__/AutoExport.test.ts
+++ b/extension/src/features/__tests__/AutoExport.test.ts
@@ -12,7 +12,10 @@ import {
 import { TestClock } from "effect/testing";
 
 import { TestVsCode } from "../../__mocks__/TestVsCode.ts";
-import { makeTestNotebookRuntime } from "../../__tests__/__utils__/TestMarimoClient.ts";
+import {
+  makeTestNotebookRuntime,
+  type TestCommand,
+} from "../../__tests__/__utils__/TestMarimoClient.ts";
 import type { NotebookController } from "../../kernel/NotebookRuntime.ts";
 import { kernelSessionId } from "../../lib/__tests__/branded.ts";
 import { FileSystemError, VsCode } from "../../platform/VsCode.ts";
@@ -20,7 +23,7 @@ import {
   MarimoNotebookCell,
   MarimoNotebookDocument,
 } from "../../schemas/MarimoNotebookDocument.ts";
-import type { KernelNotification, MarimoApiCall } from "../../types.ts";
+import type { KernelNotification } from "../../types.ts";
 import {
   AUTO_EXPORT_INTERVAL,
   AutoExportLive,
@@ -38,12 +41,12 @@ const SESSION_ID = kernelSessionId("00000000-0000-4000-8000-000000000001");
 const withTestCtx = Effect.fn(function* (
   options: {
     readonly autoDownload?: ReadonlyArray<"html" | "ipynb" | "markdown">;
-    readonly execute?: (request: MarimoApiCall) => Effect.Effect<string>;
+    readonly send?: (request: TestCommand) => Effect.Effect<string>;
     readonly hasOutputs?: boolean;
     readonly hasRuntimeSession?: boolean;
   } = {},
 ) {
-  const calls = yield* Ref.make<ReadonlyArray<MarimoApiCall>>([]);
+  const calls = yield* Ref.make<ReadonlyArray<TestCommand>>([]);
   const writes = yield* Ref.make<ReadonlyMap<string, string>>(new Map());
   const directories = yield* Ref.make<ReadonlyArray<string>>([]);
   const operations = yield* PubSub.unbounded<KernelNotification>();
@@ -108,14 +111,14 @@ const withTestCtx = Effect.fn(function* (
         ? undefined
         : { executable: "/usr/bin/python", workingDirectory: "/test" },
     kernelNotifications: Stream.fromPubSub(operations),
-    execute: (request) =>
+    send: (request) =>
       Ref.update(calls, (current) => [...current, request]).pipe(
         Effect.andThen(
-          options.execute?.(request) ??
+          options.send?.(request) ??
             Effect.succeed(
-              request.method === "export-as-html"
+              request.kind === "export-html"
                 ? "<html>report</html>"
-                : request.method === "export-as-markdown"
+                : request.kind === "export-markdown"
                   ? "# Report"
                   : "{}",
             ),
@@ -166,8 +169,8 @@ describe("AutoExport", () => {
         yield* ctx.vscode.setActiveNotebookEditor(Option.some(ctx.editor));
         yield* TestClock.adjust(AUTO_EXPORT_INTERVAL);
 
-        expect((yield* Ref.get(ctx.calls)).map((call) => call.method)).toEqual([
-          "export-as-markdown",
+        expect((yield* Ref.get(ctx.calls)).map((call) => call.kind)).toEqual([
+          "export-markdown",
         ]);
         expect(Object.fromEntries(yield* Ref.get(ctx.writes))).toEqual({
           "file:///test/__marimo__/report.md": "# Report",
@@ -201,9 +204,9 @@ describe("AutoExport", () => {
         yield* ctx.vscode.setActiveNotebookEditor(Option.some(ctx.editor));
         yield* TestClock.adjust(AUTO_EXPORT_INTERVAL);
 
-        expect((yield* Ref.get(ctx.calls)).map((call) => call.method)).toEqual([
-          "export-as-html",
-          "export-as-ipynb",
+        expect((yield* Ref.get(ctx.calls)).map((call) => call.kind)).toEqual([
+          "export-html",
+          "export-ipynb",
         ]);
         expect(Object.fromEntries(yield* Ref.get(ctx.writes))).toEqual({
           "file:///test/__marimo__/report.html": "<html>report</html>",
@@ -222,11 +225,11 @@ describe("AutoExport", () => {
           notification: { op: "completed-run", run_id: null },
         });
         yield* TestClock.adjust(AUTO_EXPORT_INTERVAL);
-        expect((yield* Ref.get(ctx.calls)).map((call) => call.method)).toEqual([
-          "export-as-html",
-          "export-as-ipynb",
-          "export-as-html",
-          "export-as-ipynb",
+        expect((yield* Ref.get(ctx.calls)).map((call) => call.kind)).toEqual([
+          "export-html",
+          "export-ipynb",
+          "export-html",
+          "export-ipynb",
         ]);
       }).pipe(Effect.provide(ctx.layer));
     }),
@@ -242,9 +245,9 @@ describe("AutoExport", () => {
         yield* ctx.vscode.setActiveNotebookEditor(Option.some(ctx.editor));
         yield* TestClock.adjust(AUTO_EXPORT_INTERVAL);
 
-        expect((yield* Ref.get(ctx.calls)).map((call) => call.method)).toEqual([
-          "export-as-html",
-          "export-as-ipynb",
+        expect((yield* Ref.get(ctx.calls)).map((call) => call.kind)).toEqual([
+          "export-html",
+          "export-ipynb",
         ]);
       }).pipe(Effect.provide(ctx.layer));
     }),
@@ -258,8 +261,8 @@ describe("AutoExport", () => {
       yield* Effect.gen(function* () {
         yield* ctx.vscode.setActiveNotebookEditor(Option.some(ctx.editor));
         yield* TestClock.adjust(AUTO_EXPORT_INTERVAL);
-        expect((yield* Ref.get(ctx.calls)).map((call) => call.method)).toEqual([
-          "export-as-ipynb",
+        expect((yield* Ref.get(ctx.calls)).map((call) => call.kind)).toEqual([
+          "export-ipynb",
         ]);
 
         ctx.cellOutputs.push({
@@ -277,10 +280,10 @@ describe("AutoExport", () => {
         });
         yield* TestClock.adjust(AUTO_EXPORT_INTERVAL);
 
-        expect((yield* Ref.get(ctx.calls)).map((call) => call.method)).toEqual([
-          "export-as-ipynb",
-          "export-as-html",
-          "export-as-ipynb",
+        expect((yield* Ref.get(ctx.calls)).map((call) => call.kind)).toEqual([
+          "export-ipynb",
+          "export-html",
+          "export-ipynb",
         ]);
       }).pipe(Effect.provide(ctx.layer));
     }),
@@ -292,8 +295,8 @@ describe("AutoExport", () => {
       const exportStarted = yield* Deferred.make<void>();
       const releaseExport = yield* Deferred.make<void>();
       const ctx = yield* withTestCtx({
-        execute: (request) =>
-          request.method === "export-as-html"
+        send: (request) =>
+          request.kind === "export-html"
             ? Deferred.succeed(exportStarted, undefined).pipe(
                 Effect.andThen(Deferred.await(releaseExport)),
                 Effect.as("<html>old report</html>"),
@@ -335,11 +338,11 @@ describe("AutoExport", () => {
         yield* Fiber.join(firstTick);
         yield* TestClock.adjust(AUTO_EXPORT_INTERVAL);
 
-        expect((yield* Ref.get(ctx.calls)).map((call) => call.method)).toEqual([
-          "export-as-html",
-          "export-as-ipynb",
-          "export-as-html",
-          "export-as-ipynb",
+        expect((yield* Ref.get(ctx.calls)).map((call) => call.kind)).toEqual([
+          "export-html",
+          "export-ipynb",
+          "export-html",
+          "export-ipynb",
         ]);
       }).pipe(Effect.provide(ctx.layer));
     }),

--- a/extension/src/features/__tests__/ThemeSync.test.ts
+++ b/extension/src/features/__tests__/ThemeSync.test.ts
@@ -4,17 +4,19 @@ import { TestClock } from "effect/testing";
 
 import { TestTelemetryLive } from "../../__mocks__/TestTelemetry.ts";
 import { TestVsCode } from "../../__mocks__/TestVsCode.ts";
-import { makeTestMarimoClient } from "../../__tests__/__utils__/TestMarimoClient.ts";
+import {
+  makeTestMarimoClient,
+  type TestCommand,
+} from "../../__tests__/__utils__/TestMarimoClient.ts";
 import { NotebookEditorRegistry } from "../../notebook/NotebookEditorRegistry.ts";
 import { MarimoNotebookCell } from "../../schemas/MarimoNotebookDocument.ts";
-import type { MarimoApiCall } from "../../types.ts";
 import { ThemeSyncLive } from "../ThemeSync.ts";
 
 const withTestCtx = Effect.fn(function* (
   initialTheme: "light" | "dark" = "light",
 ) {
   const themeRef = yield* SubscriptionRef.make<"light" | "dark">(initialTheme);
-  const executions = yield* Ref.make<ReadonlyArray<MarimoApiCall>>([]);
+  const executions = yield* Ref.make<ReadonlyArray<TestCommand>>([]);
 
   const editor = TestVsCode.makeNotebookEditor("/test/notebook_mo.py", {
     data: {
@@ -43,7 +45,7 @@ const withTestCtx = Effect.fn(function* (
     Layer.provide(NotebookEditorRegistry.layer),
     Layer.provide(
       makeTestMarimoClient({
-        execute(request) {
+        send(request) {
           return Ref.update(executions, (current) => [
             ...current,
             request,
@@ -80,22 +82,16 @@ describe("ThemeSync", () => {
         expect(yield* Ref.get(ctx.executions)).toMatchInlineSnapshot(`
           [
             {
-              "method": "set-display-theme",
-              "params": {
-                "theme": "light",
-              },
+              "kind": "set-display-theme",
+              "theme": "light",
             },
             {
-              "method": "set-display-theme",
-              "params": {
-                "theme": "light",
-              },
+              "kind": "set-display-theme",
+              "theme": "light",
             },
             {
-              "method": "set-display-theme",
-              "params": {
-                "theme": "dark",
-              },
+              "kind": "set-display-theme",
+              "theme": "dark",
             },
           ]
         `);
@@ -119,8 +115,8 @@ describe("ThemeSync", () => {
         // set-display-theme updates all running sessions. The kernels must
         // get the change when no notebook is focused.
         expect(yield* Ref.get(ctx.executions)).toContainEqual({
-          method: "set-display-theme",
-          params: { theme: "dark" },
+          kind: "set-display-theme",
+          theme: "dark",
         });
       }).pipe(Effect.provide(ctx.layer));
     }),
@@ -138,16 +134,12 @@ describe("ThemeSync", () => {
         expect(yield* Ref.get(ctx.executions)).toMatchInlineSnapshot(`
           [
             {
-              "method": "set-display-theme",
-              "params": {
-                "theme": "dark",
-              },
+              "kind": "set-display-theme",
+              "theme": "dark",
             },
             {
-              "method": "set-display-theme",
-              "params": {
-                "theme": "dark",
-              },
+              "kind": "set-display-theme",
+              "theme": "dark",
             },
           ]
         `);

--- a/extension/src/kernel/NotebookRuntime.ts
+++ b/extension/src/kernel/NotebookRuntime.ts
@@ -77,11 +77,9 @@ type VsCodeService = Context.Service.Shape<typeof VsCode>;
 type CellExecutionsService = Context.Service.Shape<typeof CellExecutions>;
 type LiveSessionsShape = Context.Service.Shape<typeof LiveSessions>;
 
-type InnerRequest<K extends keyof MarimoClientService> =
+type CommandFields<K extends keyof MarimoClientService> =
   MarimoClientService[K] extends (params: infer Params) => unknown
-    ? Params extends { readonly inner: infer Request }
-      ? Request
-      : never
+    ? Omit<Params, "notebookUri" | "kernelSessionId">
     : never;
 
 type WithNoActiveKernel<T> =
@@ -150,16 +148,16 @@ export interface NotebookHandle {
     | UnsavedNotebookError
   >;
   readonly updateUIElements: (
-    request: InnerRequest<"updateUiElement">,
+    request: CommandFields<"updateUiElement">,
   ) => WithNoActiveKernel<ReturnType<MarimoClientService["updateUiElement"]>>;
   readonly updateModel: (
-    request: InnerRequest<"setModelValue">,
+    request: CommandFields<"setModelValue">,
   ) => WithNoActiveKernel<ReturnType<MarimoClientService["setModelValue"]>>;
   readonly invokeFunction: (
-    request: InnerRequest<"invokeFunction">,
+    request: CommandFields<"invokeFunction">,
   ) => WithNoActiveKernel<ReturnType<MarimoClientService["invokeFunction"]>>;
   readonly deleteCell: (
-    request: InnerRequest<"deleteCell">,
+    request: CommandFields<"deleteCell">,
   ) => WithNoActiveKernel<ReturnType<MarimoClientService["deleteCell"]>>;
   readonly interrupt: WithNoActiveKernel<
     ReturnType<MarimoClientService["interrupt"]>
@@ -170,8 +168,8 @@ export interface NotebookHandle {
 
 /** Operations scoped to one Notebook Document Session. */
 export interface NotebookDocumentHandle {
-  readonly executeCells: (
-    request: InnerRequest<"executeCells">,
+  readonly execute: (
+    request: Pick<CommandFields<"execute">, "cells">,
     executable: string,
   ) => Effect.Effect<
     null,
@@ -248,7 +246,7 @@ function isScratchpadOutput(
  * const documentHandle = yield* runtime.forDocument(rawNotebook);
  * const notebook = yield* runtime.forNotebook(notebookId);
  *
- * yield* documentHandle.executeCells(request, executable);
+ * yield* documentHandle.execute(request, executable);
  * yield* notebook.updateUIElements(update);
  * yield* notebook.interrupt;
  * ```
@@ -366,13 +364,13 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
             onSome: (text) =>
               marimo.sendStdin({
                 notebookUri: notebookId,
-                sessionId,
-                inner: { text },
+                kernelSessionId: sessionId,
+                text,
               }),
             onNone: () =>
               marimo.interrupt({
                 notebookUri: notebookId,
-                inner: { sessionId },
+                kernelSessionId: sessionId,
               }),
           }),
         );
@@ -381,7 +379,7 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
         session: NotebookDocumentSession,
         controller: Ref.Ref<Option.Option<NotebookController>>,
       ): NotebookDocumentHandle => ({
-        executeCells: (request, executable) =>
+        execute: (request, executable) =>
           stateForDocumentSession(session).pipe(
             Effect.andThen(
               executor
@@ -397,11 +395,11 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
                       executable,
                       notebook,
                     );
-                    const send = marimo.executeCells({
+                    const send = marimo.execute({
                       notebookUri: notebookId,
                       executable,
                       workingDirectory,
-                      inner: request,
+                      cells: request.cells,
                     });
                     const notebookExecutions = yield* executions.open(session, {
                       getDrive: Ref.get(controller).pipe(
@@ -411,17 +409,10 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
                       ),
                     });
                     const result = yield* notebookExecutions.submit(
-                      request.cellIds.flatMap((cellId, index) => {
-                        const source = request.codes[index];
-                        return source === undefined
-                          ? []
-                          : [
-                              {
-                                cellId: makeNotebookCellId(cellId),
-                                source,
-                              },
-                            ];
-                      }),
+                      request.cells.map(({ cellId, code }) => ({
+                        cellId: makeNotebookCellId(cellId),
+                        source: code,
+                      })),
                       send,
                     );
                     yield* liveSessions.refresh();
@@ -478,7 +469,7 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
                         marimo
                           .interrupt({
                             notebookUri: notebookId,
-                            inner: { runId },
+                            runId,
                           })
                           .pipe(
                             Effect.timeout("5 seconds"),
@@ -524,7 +515,8 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
                       notebookUri: notebookId,
                       executable,
                       workingDirectory,
-                      inner: { code: sourceCode, runId },
+                      code: sourceCode,
+                      runId,
                     });
                     yield* liveSessions.refresh();
                     yield* reconcileKernelSession(notebookId);
@@ -556,39 +548,39 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
         updateUIElements: (request) =>
           runInCurrentKernelSession(notebookId, (sessionId) =>
             marimo.updateUiElement({
+              ...request,
               notebookUri: notebookId,
-              sessionId,
-              inner: request,
+              kernelSessionId: sessionId,
             }),
           ),
         updateModel: (request) =>
           runInCurrentKernelSession(notebookId, (sessionId) =>
             marimo.setModelValue({
+              ...request,
               notebookUri: notebookId,
-              sessionId,
-              inner: request,
+              kernelSessionId: sessionId,
             }),
           ),
         invokeFunction: (request) =>
           runInCurrentKernelSession(notebookId, (sessionId) =>
             marimo.invokeFunction({
+              ...request,
               notebookUri: notebookId,
-              sessionId,
-              inner: request,
+              kernelSessionId: sessionId,
             }),
           ),
         deleteCell: (request) =>
           runInCurrentKernelSession(notebookId, (sessionId) =>
             marimo.deleteCell({
+              ...request,
               notebookUri: notebookId,
-              sessionId,
-              inner: request,
+              kernelSessionId: sessionId,
             }),
           ),
         interrupt: runInCurrentKernelSession(notebookId, (sessionId) =>
           marimo.interrupt({
             notebookUri: notebookId,
-            inner: { sessionId },
+            kernelSessionId: sessionId,
           }),
         ),
         restart: mutateKernelSession(

--- a/extension/src/kernel/PythonController.ts
+++ b/extension/src/kernel/PythonController.ts
@@ -76,10 +76,7 @@ export const createPythonController = Effect.fn("createPythonController")(
           const validEnv = yield* validator.validate(options.env);
 
           const documentHandle = yield* notebooks.forDocument(rawNotebook);
-          yield* documentHandle.executeCells(
-            request.value,
-            validEnv.executable,
-          );
+          yield* documentHandle.execute(request.value, validEnv.executable);
         }).pipe(
           Effect.withSpan("PythonController.execute", {
             attributes: {
@@ -108,7 +105,7 @@ export const createPythonController = Effect.fn("createPythonController")(
               yield* Effect.logError("Failed to execute command").pipe(
                 Effect.annotateLogs({
                   cause: Cause.fail(error),
-                  command: Redacted.value(error.command).command,
+                  command: Redacted.value(error.command).kind,
                 }),
               );
               const detail = extractPythonError(error.cause);

--- a/extension/src/kernel/SandboxController.ts
+++ b/extension/src/kernel/SandboxController.ts
@@ -116,7 +116,7 @@ export const createSandboxController = Effect.fn("createSandboxController")(
           );
 
           const documentHandle = yield* notebooks.forDocument(rawNotebook);
-          yield* documentHandle.executeCells(request.value, executable);
+          yield* documentHandle.execute(request.value, executable);
         }).pipe(
           // Handle the expected "unsaved notebook" path before logging, so a
           // normal save prompt isn't recorded as an error. (sandboxing only

--- a/extension/src/kernel/__tests__/NotebookRuntime.test.ts
+++ b/extension/src/kernel/__tests__/NotebookRuntime.test.ts
@@ -19,14 +19,16 @@ import {
 import { TestPythonExtension } from "../../__mocks__/TestPythonExtension.ts";
 import { TestTelemetryLive } from "../../__mocks__/TestTelemetry.ts";
 import { TestVsCode } from "../../__mocks__/TestVsCode.ts";
-import { makeTestMarimoClient } from "../../__tests__/__utils__/TestMarimoClient.ts";
+import {
+  makeTestMarimoClient,
+  type TestCommand,
+} from "../../__tests__/__utils__/TestMarimoClient.ts";
 import {
   cellId,
   kernelSessionId,
   notebookId,
 } from "../../lib/__tests__/branded.ts";
 import type { CellOutputReplay } from "../../schemas/Models.gen.ts";
-import type { MarimoApiCall } from "../../types.ts";
 import {
   type NotebookController,
   NotebookRuntime,
@@ -52,25 +54,25 @@ const makeTestLayer = Effect.fn(function* (
       attached: boolean;
     }
   >();
-  const execute = options.execute ?? (() => Effect.succeed(null));
+  const send = options.send ?? (() => Effect.succeed(null));
   const client = makeTestMarimoClient({
     ...options,
-    execute: (request) =>
+    send: (request) =>
       Effect.gen(function* () {
-        const result = yield* execute(request);
-        switch (request.method) {
+        const result = yield* send(request);
+        switch (request.kind) {
           case "list-sessions":
             return { sessions: [...serverSessions.values()] };
-          case "execute-cells": {
-            const notebookUri = notebookId(request.params.notebookUri);
+          case "execute": {
+            const notebookUri = notebookId(request.notebookUri);
             serverSessions.set(notebookUri, {
               sessionId: kernelSessionId(
                 "00000000-0000-4000-8000-000000000001",
               ),
               notebookUri,
-              filename: NodePath.basename(request.params.notebookUri),
-              executable: request.params.executable,
-              workingDirectory: request.params.workingDirectory,
+              filename: NodePath.basename(request.notebookUri),
+              executable: request.executable,
+              workingDirectory: request.workingDirectory,
               startedAt: 1,
               status: "idle",
               attached: true,
@@ -78,7 +80,7 @@ const makeTestLayer = Effect.fn(function* (
             break;
           }
           case "close-session":
-            serverSessions.delete(notebookId(request.params.notebookUri));
+            serverSessions.delete(notebookId(request.notebookUri));
             break;
           case "shutdown-all-sessions":
             serverSessions.clear();
@@ -102,13 +104,11 @@ const makeTestLayer = Effect.fn(function* (
 it.effect(
   "returns a stable handle that binds the notebook ID",
   Effect.fn(function* () {
-    const requests = yield* Ref.make<ReadonlyArray<MarimoApiCall>>([]);
+    const requests = yield* Ref.make<ReadonlyArray<TestCommand>>([]);
     const { layer, vscode } = yield* makeTestLayer({
-      execute: (request) =>
+      send: (request) =>
         Ref.update(requests, (current) => [...current, request]).pipe(
-          Effect.as(
-            request.method === "list-sessions" ? { sessions: [] } : null,
-          ),
+          Effect.as(request.kind === "list-sessions" ? { sessions: [] } : null),
         ),
     });
 
@@ -127,38 +127,30 @@ it.effect(
       expect(first).toBe(second);
 
       yield* document
-        .executeCells({ cellIds: [], codes: [] }, "/usr/bin/python")
+        .execute({ cells: [] }, "/usr/bin/python")
         .pipe(Effect.orDie);
       yield* first.interrupt.pipe(Effect.orDie);
 
       assert.deepStrictEqual(yield* Ref.get(requests), [
         {
-          method: "list-sessions",
-          params: {},
+          kind: "list-sessions",
         },
         {
-          method: "execute-cells",
-          params: {
-            notebookUri: id,
-            executable: "/usr/bin/python",
-            workingDirectory: process.cwd(),
-            inner: { cellIds: [], codes: [] },
-          },
+          kind: "execute",
+          notebookUri: id,
+          executable: "/usr/bin/python",
+          workingDirectory: process.cwd(),
+          cells: [],
         },
         {
-          method: "list-sessions",
-          params: {},
+          kind: "list-sessions",
         },
         {
-          method: "interrupt",
-          params: {
-            notebookUri: id,
-            inner: {
-              sessionId: kernelSessionId(
-                "00000000-0000-4000-8000-000000000001",
-              ),
-            },
-          },
+          kind: "interrupt",
+          notebookUri: id,
+          kernelSessionId: kernelSessionId(
+            "00000000-0000-4000-8000-000000000001",
+          ),
         },
       ]);
     }).pipe(Effect.provide(layer));
@@ -166,9 +158,89 @@ it.effect(
 );
 
 it.effect(
+  "keeps captured kernel identity authoritative over request fields",
+  Effect.fn(function* () {
+    const requests = yield* Ref.make<ReadonlyArray<TestCommand>>([]);
+    const { layer, vscode } = yield* makeTestLayer({
+      send: (request) =>
+        Ref.update(requests, (current) => [...current, request]).pipe(
+          Effect.as(null),
+        ),
+    });
+
+    yield* Effect.gen(function* () {
+      const runtime = yield* NotebookRuntime;
+      const editor = TestVsCode.makeNotebookEditor(
+        NodePath.join(process.cwd(), "notebook.py"),
+      );
+      const id = notebookId(editor.notebook.uri.toString());
+      const activeSessionId = kernelSessionId(
+        "00000000-0000-4000-8000-000000000001",
+      );
+      const foreignIdentity = {
+        notebookUri: notebookId("file:///foreign.py"),
+        kernelSessionId: kernelSessionId(
+          "00000000-0000-4000-8000-000000000002",
+        ),
+      };
+
+      yield* vscode.openNotebook(editor.notebook);
+      yield* Effect.yieldNow;
+      const document = yield* runtime.forDocument(editor.notebook);
+      yield* document.execute({ cells: [] }, "/usr/bin/python");
+      const notebook = yield* runtime.forNotebook(id);
+
+      yield* notebook.updateUIElements({
+        ...foreignIdentity,
+        objectIds: [],
+        values: [],
+      });
+      yield* notebook.updateModel({
+        ...foreignIdentity,
+        modelId: "model-1",
+        message: { method: "custom", content: {} },
+        buffers: [],
+      });
+      yield* notebook.invokeFunction({
+        ...foreignIdentity,
+        functionCallId: "call-1",
+        namespace: "namespace",
+        functionName: "function",
+        args: {},
+      });
+      yield* notebook.deleteCell({
+        ...foreignIdentity,
+        cellId: cellId("cell-1"),
+      });
+
+      const commands = (yield* Ref.get(requests)).filter((request) =>
+        [
+          "update-ui-element",
+          "set-model-value",
+          "invoke-function",
+          "delete-cell",
+        ].includes(request.kind),
+      );
+      expect(commands.map((request) => request.kind)).toEqual([
+        "update-ui-element",
+        "set-model-value",
+        "invoke-function",
+        "delete-cell",
+      ]);
+      for (const command of commands) {
+        expect(command).toMatchObject({
+          notebookUri: id,
+          kernelSessionId: activeSessionId,
+        });
+      }
+    }).pipe(Effect.provide(layer));
+  }),
+);
+
+it.effect(
   "orders kernel mutations behind admitted notebook work",
   Effect.fn(function* () {
-    const calls = yield* Ref.make<ReadonlyArray<MarimoApiCall>>([]);
+    const calls = yield* Ref.make<ReadonlyArray<TestCommand>>([]);
     const secondExecutionStarted = yield* Deferred.make<void>();
     const releaseSecondExecution = yield* Deferred.make<void>();
     let executionCount = 0;
@@ -178,17 +250,17 @@ it.effect(
     const id = notebookId(editor.notebook.uri.toString());
     const { layer } = yield* makeTestLayer(
       {
-        execute: (request) =>
+        send: (request) =>
           Effect.gen(function* () {
             yield* Ref.update(calls, (current) => [...current, request]);
-            if (request.method === "execute-cells") {
+            if (request.kind === "execute") {
               executionCount += 1;
               if (executionCount === 2) {
                 yield* Deferred.succeed(secondExecutionStarted, undefined);
                 yield* Deferred.await(releaseSecondExecution);
               }
             }
-            return request.method === "list-sessions" ? { sessions: [] } : null;
+            return request.kind === "list-sessions" ? { sessions: [] } : null;
           }),
       },
       { initialDocuments: [editor.notebook] },
@@ -197,13 +269,10 @@ it.effect(
     yield* Effect.gen(function* () {
       const runtime = yield* NotebookRuntime;
       const document = yield* runtime.forDocument(editor.notebook);
-      yield* document.executeCells(
-        { cellIds: [], codes: [] },
-        "/usr/bin/python",
-      );
+      yield* document.execute({ cells: [] }, "/usr/bin/python");
 
       const execution = yield* document
-        .executeCells({ cellIds: [], codes: [] }, "/usr/bin/python")
+        .execute({ cells: [] }, "/usr/bin/python")
         .pipe(Effect.forkChild);
       yield* Deferred.await(secondExecutionStarted);
 
@@ -214,7 +283,7 @@ it.effect(
       yield* Effect.yieldNow;
       expect(
         (yield* Ref.get(calls)).some(
-          (request) => request.method === "update-ui-element",
+          (request) => request.kind === "update-ui-element",
         ),
       ).toBe(false);
 
@@ -224,20 +293,19 @@ it.effect(
 
       const kernelCalls = (yield* Ref.get(calls)).filter(
         (request) =>
-          request.method === "execute-cells" ||
-          request.method === "update-ui-element",
+          request.kind === "execute" || request.kind === "update-ui-element",
       );
-      expect(kernelCalls.map((request) => request.method)).toEqual([
-        "execute-cells",
-        "execute-cells",
+      expect(kernelCalls.map((request) => request.kind)).toEqual([
+        "execute",
+        "execute",
         "update-ui-element",
       ]);
       expect(kernelCalls.at(-1)).toMatchObject({
-        method: "update-ui-element",
-        params: {
-          notebookUri: id,
-          sessionId: kernelSessionId("00000000-0000-4000-8000-000000000001"),
-        },
+        kind: "update-ui-element",
+        notebookUri: id,
+        kernelSessionId: kernelSessionId(
+          "00000000-0000-4000-8000-000000000001",
+        ),
       });
     }).pipe(Effect.provide(layer));
   }),
@@ -254,15 +322,14 @@ it.effect(
     const id = notebookId(first.notebook.uri.toString());
     const { layer, vscode } = yield* makeTestLayer(
       {
-        execute: (request) =>
-          request.method === "execute-cells" &&
-          request.params.executable === "/old-python"
+        send: (request) =>
+          request.kind === "execute" && request.executable === "/old-python"
             ? Deferred.succeed(requestStarted, undefined).pipe(
                 Effect.andThen(Deferred.await(releaseRequest)),
                 Effect.as(null),
               )
             : Effect.succeed(
-                request.method === "list-sessions" ? { sessions: [] } : null,
+                request.kind === "list-sessions" ? { sessions: [] } : null,
               ),
       },
       { initialDocuments: [first.notebook] },
@@ -272,7 +339,7 @@ it.effect(
       const runtime = yield* NotebookRuntime;
       const firstDocument = yield* runtime.forDocument(first.notebook);
       const pending = yield* firstDocument
-        .executeCells({ cellIds: [], codes: [] }, "/old-python")
+        .execute({ cells: [] }, "/old-python")
         .pipe(Effect.exit, Effect.forkChild);
       yield* Deferred.await(requestStarted);
 
@@ -281,10 +348,7 @@ it.effect(
       const replacementDocument = yield* runtime
         .forDocument(replacement.notebook)
         .pipe(Effect.retry(Schedule.recurs(100)), Effect.orDie);
-      yield* replacementDocument.executeCells(
-        { cellIds: [], codes: [] },
-        "/new-python",
-      );
+      yield* replacementDocument.execute({ cells: [] }, "/new-python");
 
       yield* Deferred.succeed(releaseRequest, undefined);
       expect(Exit.isFailure(yield* Fiber.join(pending))).toBe(true);
@@ -296,7 +360,7 @@ it.effect(
       );
 
       const ended = yield* firstDocument
-        .executeCells({ cellIds: [], codes: [] }, "/old-python")
+        .execute({ cells: [] }, "/old-python")
         .pipe(Effect.flip);
       expect(ended._tag).toBe("NoActiveKernelError");
     }).pipe(Effect.provide(layer));
@@ -321,13 +385,13 @@ it.effect("tracks RuntimeSession until a successful kernel close", () =>
           NodePath.join(temporary.path, "notebook.py"),
         );
         const id = notebookId(editor.notebook.uri.toString());
-        const requests = yield* Ref.make<ReadonlyArray<MarimoApiCall>>([]);
+        const requests = yield* Ref.make<ReadonlyArray<TestCommand>>([]);
         const { layer, vscode } = yield* makeTestLayer(
           {
-            execute: (request) =>
+            send: (request) =>
               Ref.update(requests, (current) => [...current, request]).pipe(
                 Effect.as(
-                  request.method === "list-sessions" ? { sessions: [] } : null,
+                  request.kind === "list-sessions" ? { sessions: [] } : null,
                 ),
               ),
           },
@@ -358,16 +422,10 @@ it.effect("tracks RuntimeSession until a successful kernel close", () =>
           const runtime = yield* NotebookRuntime;
           yield* Effect.yieldNow;
           const firstDocument = yield* runtime.forDocument(editor.notebook);
-          yield* firstDocument.executeCells(
-            { cellIds: [], codes: [] },
-            "/python-one",
-          );
+          yield* firstDocument.execute({ cells: [] }, "/python-one");
 
           configuredRoot = secondRoot;
-          yield* firstDocument.executeCells(
-            { cellIds: [], codes: [] },
-            "/python-one",
-          );
+          yield* firstDocument.execute({ cells: [] }, "/python-one");
           expect(yield* runtime.getRuntimeSession(id)).toEqual(
             Option.some({
               executable: "/python-one",
@@ -392,10 +450,7 @@ it.effect("tracks RuntimeSession until a successful kernel close", () =>
           yield* vscode.openNotebook(reopened.notebook);
           yield* Effect.yieldNow;
           const secondDocument = yield* runtime.forDocument(reopened.notebook);
-          yield* secondDocument.executeCells(
-            { cellIds: [], codes: [] },
-            "/python-two",
-          );
+          yield* secondDocument.execute({ cells: [] }, "/python-two");
           const notebook = yield* runtime.forNotebook(id);
           yield* notebook.close;
           expect(Option.isNone(yield* runtime.getRuntimeSession(id))).toBe(
@@ -403,17 +458,17 @@ it.effect("tracks RuntimeSession until a successful kernel close", () =>
           );
 
           configuredRoot = firstRoot;
-          yield* secondDocument.executeCells(
-            { cellIds: [], codes: [] },
-            "/python-two",
-          );
+          yield* secondDocument.execute({ cells: [] }, "/python-two");
 
           const launches = (yield* Ref.get(requests)).filter(
-            (request) => request.method === "execute-cells",
+            (request) => request.kind === "execute",
           );
-          expect(
-            launches.map((request) => request.params.workingDirectory),
-          ).toEqual([firstRoot, firstRoot, secondRoot, firstRoot]);
+          expect(launches.map((request) => request.workingDirectory)).toEqual([
+            firstRoot,
+            firstRoot,
+            secondRoot,
+            firstRoot,
+          ]);
         }).pipe(Effect.provide(layer));
       }),
     (temporary) => Effect.sync(() => temporary.remove()),
@@ -504,7 +559,7 @@ it.effect(
   "restores notebook output without starting a kernel",
   Effect.fn(function* () {
     const editor = TestVsCode.makeNotebookEditor("/test/notebook.py");
-    const requests = yield* Ref.make<ReadonlyArray<MarimoApiCall>>([]);
+    const requests = yield* Ref.make<ReadonlyArray<TestCommand>>([]);
     const presented = yield* Deferred.make<ReadonlyArray<CellOutputReplay>>();
     const replay: CellOutputReplay = {
       kind: "saved",
@@ -522,10 +577,10 @@ it.effect(
     };
     const { layer, vscode } = yield* makeTestLayer(
       {
-        execute: (request) =>
+        send: (request) =>
           Ref.update(requests, (current) => [...current, request]).pipe(
             Effect.as(
-              request.method === "read-notebook-outputs"
+              request.kind === "read-notebook-outputs"
                 ? { cells: [replay] }
                 : null,
             ),
@@ -551,12 +606,10 @@ it.effect(
       const restored = yield* Deferred.await(presented);
       expect(restored).toEqual([replay]);
       expect(Option.isNone(yield* notebooks.getRuntimeSession(id))).toBe(true);
-      const methods = (yield* Ref.get(requests)).map(
-        (request) => request.method,
-      );
-      expect(methods).toContain("read-notebook-outputs");
-      expect(methods).not.toContain("execute-cells");
-      expect(methods).not.toContain("restart-session");
+      const kinds = (yield* Ref.get(requests)).map((request) => request.kind);
+      expect(kinds).toContain("read-notebook-outputs");
+      expect(kinds).not.toContain("execute");
+      expect(kinds).not.toContain("restart-session");
     }).pipe(Effect.provide(layer));
   }),
 );

--- a/extension/src/kernel/__tests__/NotebookRuntimeOperations.test.ts
+++ b/extension/src/kernel/__tests__/NotebookRuntimeOperations.test.ts
@@ -11,7 +11,6 @@ import {
   PubSub,
   Queue,
   Ref,
-  Schema,
   Stream,
   SubscriptionRef,
 } from "effect";
@@ -24,7 +23,10 @@ import {
   NotebookRange,
   TestVsCode,
 } from "../../__mocks__/TestVsCode.ts";
-import { makeTestMarimoClient } from "../../__tests__/__utils__/TestMarimoClient.ts";
+import {
+  makeTestMarimoClient,
+  type TestCommand,
+} from "../../__tests__/__utils__/TestMarimoClient.ts";
 import { NOTEBOOK_TYPE, SCRATCH_CELL_ID } from "../../constants.ts";
 import { makeNotebookExecutor } from "../../kernel/NotebookExecutor.ts";
 import { NotebookRuntime } from "../../kernel/NotebookRuntime.ts";
@@ -44,13 +46,11 @@ import {
   MarimoNotebookDocument,
   type NotebookId,
 } from "../../schemas/MarimoNotebookDocument.ts";
-import * as Api from "../../schemas/Models.gen.ts";
 import type { KernelSessionId } from "../../schemas/Models.gen.ts";
 import type {
   CellOperationNotification,
   DocumentAnalysis,
   KernelNotification,
-  MarimoApiCall,
   MarimoSessionsChanged,
 } from "../../types.ts";
 
@@ -72,7 +72,7 @@ const withTestCtx = Effect.fn(function* (
   const inputRequested = yield* Latch.make();
 
   // Capture executeCommand calls
-  const executions = yield* SubscriptionRef.make<ReadonlyArray<MarimoApiCall>>(
+  const executions = yield* SubscriptionRef.make<ReadonlyArray<TestCommand>>(
     [],
   );
   const errorMessages = yield* Ref.make<ReadonlyArray<string>>([]);
@@ -167,30 +167,30 @@ const withTestCtx = Effect.fn(function* (
     Layer.provideMerge(NotebookDatasources.layer),
     Layer.provide(
       makeTestMarimoClient({
-        execute(request) {
+        send(request) {
           return Effect.gen(function* () {
             yield* SubscriptionRef.update(executions, (current) => [
               ...current,
               request,
             ]);
             if (
-              request.method === "execute-scratchpad" ||
-              request.method === "execute-cells"
+              request.kind === "execute-scratchpad" ||
+              request.kind === "execute"
             ) {
-              const id = notebookId(request.params.notebookUri);
+              const id = notebookId(request.notebookUri);
               serverSessions.set(id, {
                 sessionId: activeSessionId,
                 notebookUri: id,
-                filename: NodePath.basename(request.params.notebookUri),
-                executable: request.params.executable,
-                workingDirectory: request.params.workingDirectory,
+                filename: NodePath.basename(request.notebookUri),
+                executable: request.executable,
+                workingDirectory: request.workingDirectory,
                 startedAt: 1,
                 status: "idle",
                 attached: true,
               });
             }
-            if (request.method === "restart-session") {
-              const id = notebookId(request.params.notebookUri);
+            if (request.kind === "restart-session") {
+              const id = notebookId(request.notebookUri);
               const current = serverSessions.get(id);
               if (current !== undefined) {
                 serverSessions.set(id, {
@@ -199,7 +199,7 @@ const withTestCtx = Effect.fn(function* (
                 });
               }
             }
-            return request.method === "list-sessions"
+            return request.kind === "list-sessions"
               ? { sessions: [...serverSessions.values()] }
               : null;
           });
@@ -450,12 +450,10 @@ describe("NotebookRuntime cell identity", () => {
         yield* TestClock.adjust("10 millis");
 
         expect(yield* SubscriptionRef.get(ctx.executions)).toContainEqual({
-          method: "delete-cell",
-          params: {
-            notebookUri: ctx.notebookUri,
-            sessionId: ACTIVE_SESSION_ID,
-            inner: { cellId: "cell-1" },
-          },
+          kind: "delete-cell",
+          notebookUri: ctx.notebookUri,
+          kernelSessionId: ACTIVE_SESSION_ID,
+          cellId: "cell-1",
         });
       }).pipe(Effect.provide(ctx.layer));
     }),
@@ -495,9 +493,9 @@ describe("NotebookRuntime cell identity", () => {
         yield* TestClock.adjust("10 millis");
 
         const commands = yield* SubscriptionRef.get(ctx.executions);
-        expect(
-          commands.some((command) => command.method === "delete-cell"),
-        ).toBe(false);
+        expect(commands.some((command) => command.kind === "delete-cell")).toBe(
+          false,
+        );
       }).pipe(Effect.provide(ctx.layer));
     }),
   );
@@ -540,19 +538,17 @@ describe("NotebookRuntime stdin", () => {
         // Assert executeCommand was called with send-stdin
         const cmds = yield* SubscriptionRef.get(ctx.executions).pipe(
           Effect.filterOrFail(
-            (calls) => calls.some((call) => call.method === "send-stdin"),
+            (calls) => calls.some((call) => call.kind === "send-stdin"),
             () => "stdin response not sent" as const,
           ),
           Effect.eventually,
         );
-        const stdinCmd = cmds.find((c) => c.method === "send-stdin");
+        const stdinCmd = cmds.find((c) => c.kind === "send-stdin");
         expect(stdinCmd).toMatchObject({
-          method: "send-stdin",
-          params: {
-            notebookUri: ctx.notebookUri,
-            sessionId: ACTIVE_SESSION_ID,
-            inner: { text: "foo" },
-          },
+          kind: "send-stdin",
+          notebookUri: ctx.notebookUri,
+          kernelSessionId: ACTIVE_SESSION_ID,
+          text: "foo",
         });
       }).pipe(Effect.provide(ctx.layer));
     }),
@@ -590,24 +586,22 @@ describe("NotebookRuntime stdin", () => {
         yield* Queue.offer(ctx.inputQueue, Option.none());
         const cmds = yield* SubscriptionRef.changes(ctx.executions).pipe(
           Stream.filter((calls) =>
-            calls.some((call) => call.method === "interrupt"),
+            calls.some((call) => call.kind === "interrupt"),
           ),
           Stream.runHead,
           Effect.map(Option.getOrThrow),
         );
 
         // No send-stdin command should have been sent
-        const stdinCmd = cmds.find((c) => c.method === "send-stdin");
+        const stdinCmd = cmds.find((c) => c.kind === "send-stdin");
         expect(stdinCmd).toBeUndefined();
 
         // An interrupt should have been sent instead
-        const interruptCmd = cmds.find((c) => c.method === "interrupt");
+        const interruptCmd = cmds.find((c) => c.kind === "interrupt");
         expect(interruptCmd).toMatchObject({
-          method: "interrupt",
-          params: {
-            notebookUri: ctx.notebookUri,
-            inner: { sessionId: ACTIVE_SESSION_ID },
-          },
+          kind: "interrupt",
+          notebookUri: ctx.notebookUri,
+          kernelSessionId: ACTIVE_SESSION_ID,
         });
       }).pipe(Effect.provide(ctx.layer));
     }),
@@ -646,7 +640,7 @@ describe("NotebookRuntime stdin", () => {
 
         expect(
           (yield* SubscriptionRef.get(ctx.executions)).some(
-            (command) => command.method === "send-stdin",
+            (command) => command.kind === "send-stdin",
           ),
         ).toBe(false);
       }).pipe(Effect.provide(ctx.layer));
@@ -687,7 +681,7 @@ describe("NotebookRuntime stdin", () => {
 
         expect(
           (yield* SubscriptionRef.get(ctx.executions)).some(
-            (command) => command.method === "send-stdin",
+            (command) => command.kind === "send-stdin",
           ),
         ).toBe(false);
       }).pipe(Effect.provide(ctx.layer));
@@ -711,14 +705,8 @@ describe("NotebookRuntime scratch stream", () => {
           notebook.executeScratchpad("print('second')").pipe(Stream.runDrain),
         );
 
-        const scratchpadCalls = (calls: ReadonlyArray<MarimoApiCall>) =>
-          calls
-            .filter((call) => call.method === "execute-scratchpad")
-            .map((call) =>
-              Schema.decodeUnknownSync(Api.ExecuteScratchpadPayload)(
-                call.params,
-              ),
-            );
+        const scratchpadCalls = (calls: ReadonlyArray<TestCommand>) =>
+          calls.filter((call) => call.kind === "execute-scratchpad");
 
         // Wait until the first command is recorded. Do not count scheduler
         // drains. The scratchpad setup can need more than one drain.
@@ -737,8 +725,7 @@ describe("NotebookRuntime scratch stream", () => {
         expect(first_).toHaveLength(1);
         const firstCommand = first_[0];
         assert(
-          firstCommand !== undefined &&
-            typeof firstCommand.inner.runId === "string",
+          firstCommand !== undefined && typeof firstCommand.runId === "string",
         );
 
         yield* PubSub.publish(ctx.operationsPubSub, {
@@ -746,7 +733,7 @@ describe("NotebookRuntime scratch stream", () => {
           sessionId: ACTIVE_SESSION_ID,
           notification: {
             op: "completed-run",
-            run_id: firstCommand.inner.runId,
+            run_id: firstCommand.runId,
           },
         });
 
@@ -763,7 +750,7 @@ describe("NotebookRuntime scratch stream", () => {
         const secondCommand = commands[1];
         assert(
           secondCommand !== undefined &&
-            typeof secondCommand.inner.runId === "string",
+            typeof secondCommand.runId === "string",
         );
 
         yield* PubSub.publish(ctx.operationsPubSub, {
@@ -771,7 +758,7 @@ describe("NotebookRuntime scratch stream", () => {
           sessionId: ACTIVE_SESSION_ID,
           notification: {
             op: "completed-run",
-            run_id: secondCommand.inner.runId,
+            run_id: secondCommand.runId,
           },
         });
 
@@ -816,7 +803,7 @@ describe("NotebookRuntime scratch stream", () => {
         const executions = yield* SubscriptionRef.changes(ctx.executions).pipe(
           Stream.filter(
             (calls) =>
-              calls.filter((call) => call.method === "execute-scratchpad")
+              calls.filter((call) => call.kind === "execute-scratchpad")
                 .length === 2,
           ),
           Stream.runHead,
@@ -828,14 +815,11 @@ describe("NotebookRuntime scratch stream", () => {
           runId: string;
         }> = [];
         for (const command of executions) {
-          if (command.method === "execute-scratchpad") {
-            const params = yield* Schema.decodeUnknownEffect(
-              Api.ExecuteScratchpadPayload,
-            )(command.params);
-            assert(typeof params.inner.runId === "string");
+          if (command.kind === "execute-scratchpad") {
+            assert(typeof command.runId === "string");
             commands.push({
-              notebookUri: notebookId(params.notebookUri),
-              runId: params.inner.runId,
+              notebookUri: notebookId(command.notebookUri),
+              runId: command.runId,
             });
           }
         }
@@ -883,23 +867,21 @@ describe("NotebookRuntime scratch stream", () => {
           notebook.executeScratchpad("print('hi')").pipe(Stream.runCollect),
         );
 
-        // Wait for executeScratchpad to enqueue marimo.api with its generated
+        // Wait for executeScratchpad to enqueue its private command with its generated
         // runId instead of relying on a scheduler tick.
         const executions = yield* SubscriptionRef.changes(ctx.executions).pipe(
           Stream.filter((calls) =>
-            calls.some((call) => call.method === "execute-scratchpad"),
+            calls.some((call) => call.kind === "execute-scratchpad"),
           ),
           Stream.runHead,
           Effect.map(Option.getOrThrow),
         );
         const executeCmd = executions.find(
-          (c) => c.method === "execute-scratchpad",
+          (c) => c.kind === "execute-scratchpad",
         );
 
         assert(executeCmd !== undefined);
-        const { runId } = (yield* Schema.decodeUnknownEffect(
-          Api.ExecuteScratchpadPayload,
-        )(executeCmd.params)).inner;
+        const { runId } = executeCmd;
         expect(runId).toBeDefined();
 
         const cell = ctx.notebook.cellAt(0);
@@ -987,7 +969,7 @@ describe("NotebookRuntime scratch stream", () => {
         // tick.
         yield* SubscriptionRef.changes(ctx.executions).pipe(
           Stream.filter((calls) =>
-            calls.some((call) => call.method === "execute-scratchpad"),
+            calls.some((call) => call.kind === "execute-scratchpad"),
           ),
           Stream.runHead,
         );
@@ -999,20 +981,19 @@ describe("NotebookRuntime scratch stream", () => {
         const executions = yield* SubscriptionRef.get(ctx.executions);
 
         const executeCmd = executions.find(
-          (c) => c.method === "execute-scratchpad",
+          (c) => c.kind === "execute-scratchpad",
         );
         assert(executeCmd !== undefined);
-        const { runId } = (yield* Schema.decodeUnknownEffect(
-          Api.ExecuteScratchpadPayload,
-        )(executeCmd.params)).inner;
+        const { runId } = executeCmd;
 
         // The finalizer should have sent a run-correlated interrupt. The
         // server uses the id to remember cancellation during kernel startup.
-        const interruptCmd = executions.find((c) => c.method === "interrupt");
+        const interruptCmd = executions.find((c) => c.kind === "interrupt");
 
         expect(interruptCmd).toMatchObject({
-          method: "interrupt",
-          params: { inner: { runId }, notebookUri: ctx.notebookUri },
+          kind: "interrupt",
+          runId,
+          notebookUri: ctx.notebookUri,
         });
       }).pipe(Effect.provide(ctx.layer));
     }),
@@ -1039,16 +1020,14 @@ describe("NotebookRuntime scratch stream", () => {
         // makes a single `TestClock.adjust` flaky.
         const calls = yield* SubscriptionRef.changes(ctx.executions).pipe(
           Stream.filter((current) =>
-            current.some((call) => call.method === "execute-scratchpad"),
+            current.some((call) => call.kind === "execute-scratchpad"),
           ),
           Stream.runHead,
           Effect.map(Option.getOrThrow),
         );
-        const executeCmd = calls.find((c) => c.method === "execute-scratchpad");
+        const executeCmd = calls.find((c) => c.kind === "execute-scratchpad");
         assert(executeCmd !== undefined);
-        const { runId } = (yield* Schema.decodeUnknownEffect(
-          Api.ExecuteScratchpadPayload,
-        )(executeCmd.params)).inner;
+        const { runId } = executeCmd;
 
         // Our completed-run ends the stream normally.
         yield* PubSub.publish(ctx.operationsPubSub, {
@@ -1060,7 +1039,7 @@ describe("NotebookRuntime scratch stream", () => {
         yield* Fiber.join(streamFiber);
 
         const interruptCmd = (yield* SubscriptionRef.get(ctx.executions)).find(
-          (c) => c.method === "interrupt",
+          (c) => c.kind === "interrupt",
         );
         expect(interruptCmd).toBeUndefined();
       }).pipe(Effect.provide(ctx.layer));

--- a/extension/src/lib/__tests__/extractExecuteCodeRequest.test.ts
+++ b/extension/src/lib/__tests__/extractExecuteCodeRequest.test.ts
@@ -52,9 +52,10 @@ describe("extractExecuteCodeRequest", () => {
       const request = extractExecuteCodeRequest([cellA, cellB], LanguageId);
 
       expect(Option.isSome(request)).toBe(true);
-      const { codes, cellIds } = Option.getOrThrow(request);
-      expect(cellIds).toEqual(["cell-a", "cell-b"]);
-      expect(codes).toEqual(["x = 1", "y = x + 1"]);
+      expect(Option.getOrThrow(request).cells).toEqual([
+        { cellId: "cell-a", code: "x = 1" },
+        { cellId: "cell-b", code: "y = x + 1" },
+      ]);
     }).pipe(Effect.provide(Constants.layer)),
   );
 
@@ -75,8 +76,9 @@ describe("extractExecuteCodeRequest", () => {
       );
 
       expect(Option.isSome(request)).toBe(true);
-      const { cellIds } = Option.getOrThrow(request);
-      expect(cellIds).toEqual(["cell-a"]);
+      expect(
+        Option.getOrThrow(request).cells.map((cell) => cell.cellId),
+      ).toEqual(["cell-a"]);
     }).pipe(Effect.provide(Constants.layer)),
   );
 
@@ -106,8 +108,10 @@ describe("extractExecuteCodeRequest", () => {
       );
 
       expect(Option.getOrThrow(request)).toEqual({
-        codes: ["x = 1", 'print("RAN")'],
-        cellIds: ["cell-enabled", "cell-disabled"],
+        cells: [
+          { cellId: "cell-enabled", code: "x = 1" },
+          { cellId: "cell-disabled", code: 'print("RAN")' },
+        ],
       });
     }).pipe(Effect.provide(Constants.layer)),
   );
@@ -128,8 +132,7 @@ describe("extractExecuteCodeRequest", () => {
       const request = extractExecuteCodeRequest([disabled], LanguageId);
 
       expect(Option.getOrThrow(request)).toEqual({
-        codes: ['print("RAN")'],
-        cellIds: ["cell-disabled"],
+        cells: [{ cellId: "cell-disabled", code: 'print("RAN")' }],
       });
     }).pipe(Effect.provide(Constants.layer)),
   );

--- a/extension/src/lib/extractExecuteCodeRequest.ts
+++ b/extension/src/lib/extractExecuteCodeRequest.ts
@@ -10,11 +10,9 @@ export function extractExecuteCodeRequest(
   rawCells: Array<vscode.NotebookCell>,
   LanguageId: Context.Service.Shape<typeof Constants>["LanguageId"],
 ): Option.Option<{
-  codes: Array<string>;
-  cellIds: Array<NotebookCellId>;
+  cells: Array<{ cellId: NotebookCellId; code: string }>;
 }> {
-  const codes: Array<string> = [];
-  const cellIds: Array<NotebookCellId> = [];
+  const cells: Array<{ cellId: NotebookCellId; code: string }> = [];
 
   for (const rawCell of rawCells) {
     const cell = MarimoNotebookCell.from(rawCell);
@@ -25,13 +23,12 @@ export function extractExecuteCodeRequest(
     const code = getCellExecutableCode(cell, LanguageId);
     const cellId = cell.id.value;
 
-    codes.push(code);
-    cellIds.push(cellId);
+    cells.push({ cellId, code });
   }
 
-  if (codes.length === 0) {
+  if (cells.length === 0) {
     return Option.none();
   }
 
-  return Option.some({ codes, cellIds });
+  return Option.some({ cells });
 }

--- a/extension/src/lsp/MarimoClient.ts
+++ b/extension/src/lsp/MarimoClient.ts
@@ -31,7 +31,6 @@ import { Telemetry } from "../telemetry/Telemetry.ts";
 import type {
   DocumentAnalysis,
   KernelNotification,
-  MarimoApiCall,
   MarimoSessionsChanged,
 } from "../types.ts";
 
@@ -94,10 +93,7 @@ export class MarimoClientStartError extends Data.TaggedError(
 }> {}
 
 export class MarimoCommandError extends Data.TaggedError("MarimoCommandError")<{
-  readonly command: Redacted.Redacted<{
-    readonly command: "marimo.api";
-    readonly params: MarimoApiCall;
-  }>;
+  readonly command: Redacted.Redacted<typeof Api.Command.Encoded>;
   readonly cause: unknown;
   readonly mode: MarimoLspMode;
 }> {}
@@ -109,7 +105,9 @@ export class MarimoCommandError extends Data.TaggedError("MarimoCommandError")<{
  * transport without reproducing MarimoClient's named methods.
  */
 interface MarimoTransport<Error = never> {
-  readonly execute: (request: MarimoApiCall) => Effect.Effect<unknown, Error>;
+  readonly send: (
+    command: typeof Api.Command.Encoded,
+  ) => Effect.Effect<unknown, Error>;
   readonly kernelNotifications: Stream.Stream<KernelNotification>;
   readonly documentAnalysis?: Stream.Stream<DocumentAnalysis>;
   readonly sessionChanges?: Stream.Stream<MarimoSessionsChanged>;
@@ -120,7 +118,7 @@ export function makeMarimoCommands<Error>(transport: MarimoTransport<Error>) {
     kernelNotifications: transport.kernelNotifications,
     documentAnalysis: transport.documentAnalysis ?? Stream.never,
     sessionChanges: transport.sessionChanges ?? Stream.never,
-    ...Api.makeApiClient(transport.execute),
+    ...Api.makeCommandClient(transport.send),
   };
 }
 
@@ -401,19 +399,15 @@ export class MarimoClient extends Context.Service<MarimoClient>()(
       const transport: MarimoTransport<
         MarimoClientStartError | MarimoCommandError
       > = {
-        execute: Effect.fn(function* (request) {
+        send: Effect.fn(function* (command) {
           if (!client.isRunning()) {
             yield* startClient();
           }
-          const command = {
-            command: "marimo.api",
-            params: request,
-          } as const;
           return yield* Effect.tryPromise({
             try: (signal) =>
               client.sendRequest<unknown>(
-                "workspace/executeCommand",
-                { command: command.command, arguments: [command.params] },
+                "marimo/command",
+                command,
                 tokenFromSignal(signal),
               ),
             catch: (cause) =>
@@ -426,8 +420,8 @@ export class MarimoClient extends Context.Service<MarimoClient>()(
             Effect.tapError(() => Effect.forkDetach(notifyCustomLspFailure)),
             Effect.withSpan("lsp.executeCommand", {
               attributes: {
-                command: command.command,
-                method: request.method,
+                command: "marimo/command",
+                kind: command.kind,
               },
             }),
           );

--- a/extension/src/lsp/__tests__/MarimoClient.test.ts
+++ b/extension/src/lsp/__tests__/MarimoClient.test.ts
@@ -7,13 +7,10 @@ import { Effect, Exit, Option, Ref, Stream } from "effect";
 import { vi } from "vite-plus/test";
 
 import { TestVsCode } from "../../__mocks__/TestVsCode.ts";
+import type { TestCommand } from "../../__tests__/__utils__/TestMarimoClient.ts";
 import { MarimoLspServer } from "../../config/Config.ts";
 import { kernelSessionId, notebookId } from "../../lib/__tests__/branded.ts";
-import type {
-  DocumentAnalysis,
-  KernelNotification,
-  MarimoApiCall,
-} from "../../types.ts";
+import type { DocumentAnalysis, KernelNotification } from "../../types.ts";
 import {
   disposeLanguageClient,
   findMarimoLspExecutable,
@@ -140,53 +137,51 @@ it.effect(
 );
 
 it.effect(
-  "constructs marimo.api commands through named methods",
+  "constructs private commands through named methods",
   Effect.fn(function* () {
-    const calls = yield* Ref.make<ReadonlyArray<MarimoApiCall>>([]);
+    const calls = yield* Ref.make<ReadonlyArray<TestCommand>>([]);
     const responses: Record<string, unknown> = {
-      "execute-cells": null,
+      execute: null,
       "set-display-theme": { success: true },
     };
     const marimo = makeMarimoCommands({
-      execute: (request) =>
+      send: (request) =>
         Ref.update(calls, (current) => [...current, request]).pipe(
-          Effect.as(responses[request.method]),
+          Effect.as(responses[request.kind]),
         ),
       kernelNotifications: Stream.empty,
     });
 
-    yield* marimo.executeCells({
+    yield* marimo.execute({
       notebookUri: notebook,
       executable: "/python",
       workingDirectory: "/workspace",
-      inner: { cellIds: [], codes: [] },
+      cells: [],
     });
     yield* marimo.setDisplayTheme({ theme: "dark" });
 
     assert.deepStrictEqual(yield* Ref.get(calls), [
       {
-        method: "execute-cells",
-        params: {
-          notebookUri: notebook,
-          executable: "/python",
-          workingDirectory: "/workspace",
-          inner: { cellIds: [], codes: [] },
-        },
+        kind: "execute",
+        notebookUri: notebook,
+        executable: "/python",
+        workingDirectory: "/workspace",
+        cells: [],
       },
       {
-        method: "set-display-theme",
-        params: { theme: "dark" },
+        kind: "set-display-theme",
+        theme: "dark",
       },
     ]);
   }),
 );
 
-describe("generated api client", () => {
+describe("generated command client", () => {
   it.effect(
     "parses responses against the method's success schema",
     Effect.fn(function* () {
       const marimo = makeMarimoCommands({
-        execute: () =>
+        send: () =>
           Effect.succeed({
             tree: { name: "root", version: null, tags: [], dependencies: [] },
           }),
@@ -196,7 +191,6 @@ describe("generated api client", () => {
       const response = yield* marimo.getDependencyTree({
         notebookUri: notebook,
         source: { kind: "script" },
-        inner: {},
       });
 
       // Response is parsed, not asserted: `tree` is a typed DependencyTreeNode.
@@ -208,7 +202,7 @@ describe("generated api client", () => {
     "fails with ParseError when the server response violates the contract",
     Effect.fn(function* () {
       const marimo = makeMarimoCommands({
-        execute: () => Effect.succeed({ tree: "not-a-tree" }),
+        send: () => Effect.succeed({ tree: "not-a-tree" }),
         kernelNotifications: Stream.empty,
       });
 
@@ -216,7 +210,6 @@ describe("generated api client", () => {
         .getDependencyTree({
           notebookUri: notebook,
           source: { kind: "script" },
-          inner: {},
         })
         .pipe(Effect.exit);
 
@@ -233,7 +226,7 @@ describe("generated api client", () => {
     "rejects params the server would reject, before hitting the wire",
     Effect.fn(function* () {
       const marimo = makeMarimoCommands({
-        execute: () => Effect.die("should not reach the transport"),
+        send: () => Effect.die("should not reach the transport"),
         kernelNotifications: Stream.empty,
       });
 
@@ -242,12 +235,13 @@ describe("generated api client", () => {
           notebookUri: notebook,
           // @ts-expect-error -- deliberately malformed source
           source: { kind: "conda" },
-          inner: {},
         })
         .pipe(Effect.exit);
 
       assert.isTrue(Exit.isFailure(exit));
-      assert.include(String(exit), "PackageSource");
+      assert.include(String(exit), '["source"]');
+      assert.include(String(exit), 'readonly "kind": "venv"');
+      assert.include(String(exit), 'readonly "kind": "script"');
     }),
   );
 
@@ -255,7 +249,7 @@ describe("generated api client", () => {
     "requires tagged-union discriminators before hitting the wire",
     Effect.fn(function* () {
       const marimo = makeMarimoCommands({
-        execute: () => Effect.die("should not reach the transport"),
+        send: () => Effect.die("should not reach the transport"),
         kernelNotifications: Stream.empty,
       });
 
@@ -264,12 +258,13 @@ describe("generated api client", () => {
           notebookUri: notebook,
           // @ts-expect-error -- msgspec requires `kind` for union decoding
           source: { executable: "/usr/bin/python3" },
-          inner: {},
         })
         .pipe(Effect.exit);
 
       assert.isTrue(Exit.isFailure(exit));
-      assert.include(String(exit), "PackageSource");
+      assert.include(String(exit), '["source"]');
+      assert.include(String(exit), 'readonly "kind": "venv"');
+      assert.include(String(exit), 'readonly "kind": "script"');
     }),
   );
 });
@@ -390,7 +385,7 @@ it.effect(
   Effect.fn(function* () {
     let requestedNotification: string | undefined;
     const marimo = makeMarimoCommands({
-      execute: () => Effect.void,
+      send: () => Effect.void,
       // Stream.suspend defers to subscription time, so the assertion below
       // still observes that draining `kernelNotifications` evaluated the
       // transport.

--- a/extension/src/notebook/NotebookDependencies.ts
+++ b/extension/src/notebook/NotebookDependencies.ts
@@ -17,7 +17,8 @@ import { NotebookRuntime } from "../kernel/NotebookRuntime.ts";
 import { MarimoClient } from "../lsp/MarimoClient.ts";
 import type {
   DependencyTreeNode,
-  PackageSource,
+  ScriptSource,
+  VenvSource,
 } from "../schemas/Models.gen.ts";
 import { NotebookSession } from "./NotebookSession.ts";
 
@@ -29,6 +30,8 @@ export type NotebookDependencyState = Data.TaggedEnum<{
 }>;
 export const NotebookDependencyState =
   Data.taggedEnum<NotebookDependencyState>();
+
+type PackageSource = VenvSource | ScriptSource;
 
 function controllerSource(controller: NotebookController): PackageSource {
   return typeof controller.executable === "string"
@@ -64,7 +67,6 @@ export class NotebookDependencies extends Context.Service<NotebookDependencies>(
           .getDependencyTree({
             notebookUri: session.notebookId,
             source,
-            inner: {},
           })
           .pipe(
             Effect.map(({ tree }) => NotebookDependencyState.Loaded({ tree })),
@@ -91,10 +93,9 @@ export class NotebookDependencies extends Context.Service<NotebookDependencies>(
                 }),
                 Effect.andThen(
                   marimo
-                    .getPackageList({
+                    .listPackages({
                       notebookUri: session.notebookId,
                       source,
-                      inner: {},
                     })
                     .pipe(
                       Effect.map((packageList) =>

--- a/extension/src/notebook/NotebookSerializer.ts
+++ b/extension/src/notebook/NotebookSerializer.ts
@@ -302,7 +302,10 @@ function notebookDataToNotebookDocument(
   }: {
     LanguageId: Constants["Service"]["LanguageId"];
   },
-): Effect.Effect<typeof Api.SerializePayload.Encoded, Schema.SchemaError> {
+): Effect.Effect<
+  Omit<typeof Api.Serialize.Encoded, "kind">,
+  Schema.SchemaError
+> {
   const { cells, metadata = {} } = notebook;
   const sqlParser = new SQLParser();
   const markdownParser = new MarkdownParser();

--- a/extension/src/notebook/__tests__/NotebookDependencies.test.ts
+++ b/extension/src/notebook/__tests__/NotebookDependencies.test.ts
@@ -15,7 +15,10 @@ import {
   TestVsCode,
   Uri,
 } from "../../__mocks__/TestVsCode.ts";
-import { makeTestNotebookRuntime } from "../../__tests__/__utils__/TestMarimoClient.ts";
+import {
+  makeTestNotebookRuntime,
+  type TestCommand,
+} from "../../__tests__/__utils__/TestMarimoClient.ts";
 import type {
   NotebookController,
   NotebookControllerSelection,
@@ -23,7 +26,6 @@ import type {
 import { notebookId } from "../../lib/__tests__/branded.ts";
 import type { NotebookId } from "../../schemas/MarimoNotebookDocument.ts";
 import type { DependencyTreeNode } from "../../schemas/Models.gen.ts";
-import type { MarimoApiCall } from "../../types.ts";
 import {
   NotebookDependencies,
   type NotebookDependencyState,
@@ -60,8 +62,8 @@ const isTerminal = (state: NotebookDependencyState) =>
 const makeContext = Effect.fn(function* (options: {
   readonly notebookIds?: ReadonlyArray<NotebookId>;
   readonly controllers?: ReadonlyArray<NotebookControllerSelection>;
-  readonly execute: (
-    request: MarimoApiCall,
+  readonly send: (
+    request: TestCommand,
   ) => Effect.Effect<unknown, Schema.SchemaError>;
 }) {
   const notebookIds = options.notebookIds ?? [NOTEBOOK_URI];
@@ -69,12 +71,12 @@ const makeContext = Effect.fn(function* (options: {
     createTestNotebookDocument(Uri.parse(uri)),
   );
   const vscode = yield* TestVsCode.make({ initialDocuments: documents });
-  const requests: MarimoApiCall[] = [];
+  const requests: TestCommand[] = [];
   const runtime = makeTestNotebookRuntime({
     initialControllers: options.controllers,
-    execute: (request) =>
+    send: (request) =>
       Effect.sync(() => requests.push(request)).pipe(
-        Effect.andThen(options.execute(request)),
+        Effect.andThen(options.send(request)),
       ),
   });
   const sessions = NotebookDocumentSessions.layer.pipe(
@@ -136,7 +138,7 @@ describe("NotebookDependencies", () => {
             }),
           },
         ],
-        execute: () => Effect.succeed({ tree: TREE }),
+        send: () => Effect.succeed({ tree: TREE }),
       });
 
       const states = yield* collectUntilTerminal(OTHER_NOTEBOOK_URI).pipe(
@@ -146,14 +148,11 @@ describe("NotebookDependencies", () => {
       expect(states.at(-1)).toEqual({ _tag: "Loaded", tree: TREE });
       expect(ctx.requests).toEqual([
         {
-          method: "get-dependency-tree",
-          params: {
-            notebookUri: OTHER_NOTEBOOK_URI,
-            source: {
-              kind: "venv",
-              executable: "/other/.venv/bin/python",
-            },
-            inner: {},
+          kind: "get-dependency-tree",
+          notebookUri: OTHER_NOTEBOOK_URI,
+          source: {
+            kind: "venv",
+            executable: "/other/.venv/bin/python",
           },
         },
       ]);
@@ -169,7 +168,7 @@ describe("NotebookDependencies", () => {
       const controller = makeController({ id: "script" });
       const ctx = yield* makeContext({
         controllers: [{ notebookUri: NOTEBOOK_URI, controller }],
-        execute: () =>
+        send: () =>
           Deferred.succeed(requestStarted, undefined).pipe(
             Effect.andThen(Deferred.await(releaseRequest)),
             Effect.as({ tree: TREE }),
@@ -221,8 +220,8 @@ describe("NotebookDependencies", () => {
         });
         const ctx = yield* makeContext({
           controllers: [{ notebookUri: NOTEBOOK_URI, controller }],
-          execute: (request) =>
-            request.method === "get-dependency-tree"
+          send: (request) =>
+            request.kind === "get-dependency-tree"
               ? treeFailure
               : Effect.succeed({
                   packages: [{ name: "effect", version: "4.0.0" }],
@@ -249,9 +248,9 @@ describe("NotebookDependencies", () => {
             ],
           },
         });
-        expect(ctx.requests.map((request) => request.method)).toEqual([
+        expect(ctx.requests.map((request) => request.kind)).toEqual([
           "get-dependency-tree",
-          "get-package-list",
+          "list-packages",
         ]);
       }),
   );
@@ -265,7 +264,7 @@ describe("NotebookDependencies", () => {
         const controller = makeController({ id: "script" });
         const ctx = yield* makeContext({
           controllers: [{ notebookUri: NOTEBOOK_URI, controller }],
-          execute: () => failure,
+          send: () => failure,
         });
 
         const states = yield* collectUntilTerminal(NOTEBOOK_URI).pipe(
@@ -276,7 +275,7 @@ describe("NotebookDependencies", () => {
           _tag: "Failed",
           error: expectedError,
         });
-        expect(ctx.requests.map((request) => request.method)).toEqual([
+        expect(ctx.requests.map((request) => request.kind)).toEqual([
           "get-dependency-tree",
         ]);
       }),
@@ -285,8 +284,7 @@ describe("NotebookDependencies", () => {
   it.effect("reports a missing controller without calling the server", () =>
     Effect.gen(function* () {
       const ctx = yield* makeContext({
-        execute: (request) =>
-          Effect.die(`Unexpected method: ${request.method}`),
+        send: (request) => Effect.die(`Unexpected command: ${request.kind}`),
       });
 
       const states = yield* collectUntilTerminal(NOTEBOOK_URI).pipe(
@@ -309,9 +307,9 @@ describe("NotebookDependencies", () => {
       const controller = makeController({ id: "script" });
       const ctx = yield* makeContext({
         controllers: [{ notebookUri: NOTEBOOK_URI, controller }],
-        execute: (apiCall) => {
-          if (apiCall.method !== "get-dependency-tree") {
-            return Effect.die(`Unexpected method: ${apiCall.method}`);
+        send: (command) => {
+          if (command.kind !== "get-dependency-tree") {
+            return Effect.die(`Unexpected command: ${command.kind}`);
           }
           return Effect.succeed({
             tree: request++ === 0 ? firstTree : refreshedTree,
@@ -369,9 +367,9 @@ describe("NotebookDependencies", () => {
       const controller = makeController({ id: "script" });
       const ctx = yield* makeContext({
         controllers: [{ notebookUri: NOTEBOOK_URI, controller }],
-        execute: (apiCall) => {
-          if (apiCall.method !== "get-dependency-tree") {
-            return Effect.die(`Unexpected method: ${apiCall.method}`);
+        send: (command) => {
+          if (command.kind !== "get-dependency-tree") {
+            return Effect.die(`Unexpected command: ${command.kind}`);
           }
           return request++ === 0
             ? Deferred.succeed(firstRequestStarted, undefined).pipe(

--- a/extension/src/notebook/__tests__/NotebookSerializer.test.ts
+++ b/extension/src/notebook/__tests__/NotebookSerializer.test.ts
@@ -36,7 +36,7 @@ it.effect(
   Effect.fn(function* () {
     const layer = Layer.empty.pipe(
       Layer.provideMerge(NotebookSerializer.layer),
-      Layer.provideMerge(makeTestMarimoClient({ execute: () => Effect.never })),
+      Layer.provideMerge(makeTestMarimoClient({ send: () => Effect.never })),
       Layer.provideMerge(Constants.layer),
     );
 
@@ -64,7 +64,7 @@ it.effect(
     const vscode = yield* TestVsCode.make();
     const layer = Layer.empty.pipe(
       Layer.provideMerge(NotebookSerializer.layer),
-      Layer.provideMerge(makeTestMarimoClient({ execute: () => Effect.never })),
+      Layer.provideMerge(makeTestMarimoClient({ send: () => Effect.never })),
       Layer.provideMerge(Constants.layer),
       Layer.provideMerge(vscode.layer),
     );
@@ -106,7 +106,7 @@ it.effect(
       Layer.provideMerge(NotebookSerializer.layer),
       Layer.provideMerge(
         makeTestMarimoClient({
-          execute: () =>
+          send: () =>
             Effect.succeed({
               kind: "convertible",
             }),

--- a/extension/src/notebook/__tests__/NotebookSessionResources.test.ts
+++ b/extension/src/notebook/__tests__/NotebookSessionResources.test.ts
@@ -31,7 +31,7 @@ const withTestContext = Effect.fn(function* () {
   const document = createTestNotebookDocument(Uri.parse(NOTEBOOK_URI));
   const vscode = yield* TestVsCode.make({ initialDocuments: [document] });
   const runtime = makeTestNotebookRuntime({
-    execute: () => Effect.die("Unexpected marimo request"),
+    send: () => Effect.die("Unexpected marimo request"),
   });
   const sessions = NotebookDocumentSessions.layer.pipe(
     Layer.provide(vscode.layer),

--- a/extension/src/notebook/readNotebookOutputs.ts
+++ b/extension/src/notebook/readNotebookOutputs.ts
@@ -15,7 +15,7 @@ export const readNotebookOutputs = (
   const sessionCachePath = conventionalSessionCachePath(notebook);
   return marimo.readNotebookOutputs({
     notebookUri: notebook.id,
-    inner: { sessionCachePath },
+    sessionCachePath,
   });
 };
 

--- a/extension/src/panel/datasources/NotebookDatasources.ts
+++ b/extension/src/panel/datasources/NotebookDatasources.ts
@@ -662,13 +662,11 @@ export class NotebookDatasources extends Context.Service<NotebookDatasources>()(
             (requestId, kernelSessionId) =>
               marimo.listSqlSchemas({
                 notebookUri,
-                sessionId: kernelSessionId,
-                inner: {
-                  requestId,
-                  engine: connection,
-                  database,
-                  schemaPath: [...schemaPath],
-                },
+                kernelSessionId,
+                requestId,
+                engine: connection,
+                database,
+                schemaPath: [...schemaPath],
               }),
           );
         },
@@ -694,14 +692,12 @@ export class NotebookDatasources extends Context.Service<NotebookDatasources>()(
             (requestId, kernelSessionId) =>
               marimo.listSqlTables({
                 notebookUri,
-                sessionId: kernelSessionId,
-                inner: {
-                  requestId,
-                  engine: connection,
-                  database,
-                  schema,
-                  schemaPath: [...schemaPath],
-                },
+                kernelSessionId,
+                requestId,
+                engine: connection,
+                database,
+                schema,
+                schemaPath: [...schemaPath],
               }),
           );
         },

--- a/extension/src/panel/datasources/__tests__/NotebookDatasources.test.ts
+++ b/extension/src/panel/datasources/__tests__/NotebookDatasources.test.ts
@@ -15,7 +15,10 @@ import {
   createTestNotebookDocument,
   Uri,
 } from "../../../__mocks__/TestVsCode.ts";
-import { makeTestMarimoClient } from "../../../__tests__/__utils__/TestMarimoClient.ts";
+import {
+  makeTestMarimoClient,
+  type TestCommand,
+} from "../../../__tests__/__utils__/TestMarimoClient.ts";
 import { makeTestNotebookDocumentSession } from "../../../__tests__/__utils__/TestNotebookDocumentSession.ts";
 import { NOTEBOOK_TYPE } from "../../../constants.ts";
 import {
@@ -34,7 +37,6 @@ import type {
   SqlSchemaListPreviewNotification,
   SqlTableListPreviewNotification,
 } from "../../../types.ts";
-import type { MarimoApiCall } from "../../../types.ts";
 import { NotebookDatasources } from "../NotebookDatasources.ts";
 
 const NOTEBOOK_URI = notebookId("file:///test/notebook.py");
@@ -48,13 +50,13 @@ const SESSION = makeTestNotebookDocumentSession(
 );
 
 const makeLayer = (
-  execute: (request: MarimoApiCall) => Effect.Effect<unknown> = () =>
+  send: (request: TestCommand) => Effect.Effect<unknown> = () =>
     Effect.succeed(null),
   currentSession: () => NotebookDocumentSession = () => SESSION,
 ) =>
   Layer.effect(NotebookDatasources, NotebookDatasources.make).pipe(
     Layer.provide([
-      makeTestMarimoClient({ execute }),
+      makeTestMarimoClient({ send }),
       Layer.succeed(NotebookDocumentSessions, {
         current: (notebookUri) =>
           notebookUri === currentSession().notebookId
@@ -74,13 +76,13 @@ const makeLayer = (
 const makeRecordingLayer = (
   currentSession: () => NotebookDocumentSession = () => SESSION,
 ) => {
-  const calls: MarimoApiCall[] = [];
-  const waiters = new Map<number, Deferred.Deferred<MarimoApiCall>>();
-  const nextCall = (index: number): Effect.Effect<MarimoApiCall> =>
+  const calls: TestCommand[] = [];
+  const waiters = new Map<number, Deferred.Deferred<TestCommand>>();
+  const nextCall = (index: number): Effect.Effect<TestCommand> =>
     Effect.gen(function* () {
       const call = calls[index];
       if (call !== undefined) return call;
-      const waiter = yield* Deferred.make<MarimoApiCall>();
+      const waiter = yield* Deferred.make<TestCommand>();
       const current = calls[index];
       if (current !== undefined) return current;
       waiters.set(index, waiter);
@@ -311,11 +313,11 @@ it.effect("merges child schemas at their parent path", () => {
       service.loadSchemas(SESSION, "warehouse", "analytics", ["catalog"]),
     );
     const call = yield* nextCall(0);
-    assert(call.method === "list-sql-schemas");
+    assert(call.kind === "list-sql-schemas");
 
     const operation: SqlSchemaListPreviewNotification = {
       op: "sql-schema-list-preview",
-      request_id: requestId(call.params.inner.requestId),
+      request_id: requestId(call.requestId),
       metadata: {
         connection: "warehouse",
         database: "analytics",
@@ -355,11 +357,11 @@ it.effect("merges tables at a nested schema path", () => {
       ]),
     );
     const call = yield* nextCall(0);
-    assert(call.method === "list-sql-tables");
+    assert(call.kind === "list-sql-tables");
 
     const operation: SqlTableListPreviewNotification = {
       op: "sql-table-list-preview",
-      request_id: requestId(call.params.inner.requestId),
+      request_id: requestId(call.requestId),
       metadata: {
         type: "sql-metadata",
         connection: "warehouse",
@@ -398,11 +400,11 @@ it.effect("does not resolve deferred state after an error", () => {
       ),
     );
     const call = yield* nextCall(0);
-    assert(call.method === "list-sql-tables");
+    assert(call.kind === "list-sql-tables");
 
     yield* service.updateTableList(SESSION, KERNEL_SESSION_ID, {
       op: "sql-table-list-preview",
-      request_id: requestId(call.params.inner.requestId),
+      request_id: requestId(call.requestId),
       metadata: {
         type: "sql-metadata",
         connection: "warehouse",
@@ -473,10 +475,10 @@ it.effect("deduplicates concurrent schema expansion requests", () => {
       service.loadSchemas(SESSION, "warehouse", "analytics", []),
     );
     const call = yield* nextCall(0);
-    assert(call.method === "list-sql-schemas");
+    assert(call.kind === "list-sql-schemas");
     yield* service.updateSchemaList(SESSION, KERNEL_SESSION_ID, {
       op: "sql-schema-list-preview",
-      request_id: requestId(call.params.inner.requestId),
+      request_id: requestId(call.requestId),
       metadata: {
         connection: "warehouse",
         database: "analytics",
@@ -503,7 +505,7 @@ it.effect("interrupts an expansion send when its document session closes", () =>
     const sendStarted = yield* Deferred.make<void>();
     const releaseSend = yield* Deferred.make<void>();
     const sendFinalized = yield* Deferred.make<void>();
-    const calls: MarimoApiCall[] = [];
+    const calls: TestCommand[] = [];
     const layer = makeLayer(
       (request) =>
         Deferred.succeed(sendStarted, undefined).pipe(
@@ -570,11 +572,11 @@ it.effect("detaches completed expansions from the session scope", () => {
         .loadSchemas(session, "warehouse", "analytics", [])
         .pipe(Effect.forkChild);
       const request = yield* nextCall(index);
-      assert(request.method === "list-sql-schemas");
+      assert(request.kind === "list-sql-schemas");
 
       yield* service.updateSchemaList(session, KERNEL_SESSION_ID, {
         op: "sql-schema-list-preview",
-        request_id: requestId(request.params.inner.requestId),
+        request_id: requestId(request.requestId),
         metadata: {
           connection: "warehouse",
           database: "analytics",
@@ -619,8 +621,8 @@ it.effect("retries nested table expansion after an error", () => {
       ),
     );
     const call = yield* nextCall(0);
-    assert(call.method === "list-sql-tables");
-    expect(call.params.inner).toMatchObject({
+    assert(call.kind === "list-sql-tables");
+    expect(call).toMatchObject({
       engine: "warehouse",
       database: "analytics",
       schema: "events",
@@ -628,7 +630,7 @@ it.effect("retries nested table expansion after an error", () => {
     });
     yield* service.updateTableList(SESSION, KERNEL_SESSION_ID, {
       op: "sql-table-list-preview",
-      request_id: requestId(call.params.inner.requestId),
+      request_id: requestId(call.requestId),
       metadata: {
         type: "sql-metadata",
         connection: "warehouse",
@@ -648,7 +650,7 @@ it.effect("retries nested table expansion after an error", () => {
       ]),
     );
     const retryCall = yield* nextCall(1);
-    assert(retryCall.method === "list-sql-tables");
+    assert(retryCall.kind === "list-sql-tables");
     expect(calls).toHaveLength(2);
     yield* Fiber.interrupt(retry);
   }).pipe(Effect.provide(layer));
@@ -669,7 +671,7 @@ it.effect("shares one timeout deadline and retries after it expires", () => {
       Effect.result(service.loadSchemas(SESSION, "warehouse", "analytics", [])),
     );
     const firstCall = yield* nextCall(0);
-    assert(firstCall.method === "list-sql-schemas");
+    assert(firstCall.kind === "list-sql-schemas");
 
     yield* TestClock.adjust("20 seconds");
     const joined = yield* Effect.forkChild(
@@ -684,7 +686,7 @@ it.effect("shares one timeout deadline and retries after it expires", () => {
       service.loadSchemas(SESSION, "warehouse", "analytics", []),
     );
     const retryCall = yield* nextCall(1);
-    assert(retryCall.method === "list-sql-schemas");
+    assert(retryCall.kind === "list-sql-schemas");
     expect(calls).toHaveLength(2);
     yield* Fiber.interrupt(retry);
   }).pipe(Effect.provide(layer));

--- a/extension/src/panel/sessions/LiveSessions.ts
+++ b/extension/src/panel/sessions/LiveSessions.ts
@@ -95,10 +95,8 @@ export class LiveSessions extends Context.Service<LiveSessions>()(
         yield* marimo
           .restartSession({
             notebookUri,
-            inner: {
-              executable: current.value.executable,
-              workingDirectory: current.value.workingDirectory,
-            },
+            executable: current.value.executable,
+            workingDirectory: current.value.workingDirectory,
           })
           .pipe(
             Effect.tapError(() =>
@@ -129,7 +127,7 @@ export class LiveSessions extends Context.Service<LiveSessions>()(
       const shutdown = Effect.fn("LiveSessions.shutdown")(function* (
         notebookUri: NotebookId,
       ) {
-        yield* marimo.closeSession({ notebookUri, inner: {} });
+        yield* marimo.closeSession({ notebookUri });
         yield* refresh();
       });
 
@@ -139,7 +137,7 @@ export class LiveSessions extends Context.Service<LiveSessions>()(
       ) {
         yield* marimo.moveSession({
           notebookUri,
-          inner: { newNotebookUri },
+          newNotebookUri,
         });
         yield* refresh();
       });
@@ -158,11 +156,9 @@ export class LiveSessions extends Context.Service<LiveSessions>()(
         ) {
           yield* marimo.restartSession({
             notebookUri,
-            inner: {
-              executable,
-              workingDirectory,
-              createIfMissing: true,
-            },
+            executable,
+            workingDirectory,
+            createIfMissing: true,
           });
           yield* refresh();
         }),

--- a/extension/src/panel/sessions/__tests__/LiveSessions.test.ts
+++ b/extension/src/panel/sessions/__tests__/LiveSessions.test.ts
@@ -1,9 +1,11 @@
 import { expect, it } from "@effect/vitest";
 import { Effect, Layer, Result } from "effect";
 
-import { makeTestMarimoClient } from "../../../__tests__/__utils__/TestMarimoClient.ts";
+import {
+  makeTestMarimoClient,
+  type TestCommand,
+} from "../../../__tests__/__utils__/TestMarimoClient.ts";
 import { kernelSessionId, notebookId } from "../../../lib/__tests__/branded.ts";
-import type { MarimoApiCall } from "../../../types.ts";
 import { SessionNotFoundError, LiveSessions } from "../LiveSessions.ts";
 
 const NOTEBOOK_URI = notebookId("file:///workspace/notebook.py");
@@ -23,14 +25,14 @@ const SNAPSHOT = {
   ],
 } as const;
 
-function makeLayer(recorded: MarimoApiCall[], snapshot: unknown = SNAPSHOT) {
+function makeLayer(recorded: TestCommand[], snapshot: unknown = SNAPSHOT) {
   return LiveSessions.layer.pipe(
     Layer.provide(
       makeTestMarimoClient({
-        execute: (request) =>
+        send: (request) =>
           Effect.sync(() => {
             recorded.push(request);
-            return request.method === "list-sessions" ? snapshot : null;
+            return request.kind === "list-sessions" ? snapshot : null;
           }),
       }),
     ),
@@ -40,7 +42,7 @@ function makeLayer(recorded: MarimoApiCall[], snapshot: unknown = SNAPSHOT) {
 it.effect(
   "decodes the authoritative session snapshot",
   Effect.fn(function* () {
-    const recorded: MarimoApiCall[] = [];
+    const recorded: TestCommand[] = [];
 
     const live = yield* Effect.gen(function* () {
       const sessions = yield* LiveSessions;
@@ -48,14 +50,14 @@ it.effect(
     }).pipe(Effect.provide(makeLayer(recorded)));
 
     expect(live).toEqual(SNAPSHOT.sessions);
-    expect(recorded).toEqual([{ method: "list-sessions", params: {} }]);
+    expect(recorded).toEqual([{ kind: "list-sessions" }]);
   }),
 );
 
 it.effect(
   "shuts down every session and reconciles once",
   Effect.fn(function* () {
-    const recorded: MarimoApiCall[] = [];
+    const recorded: TestCommand[] = [];
     const secondNotebook = notebookId("file:///workspace/second.py");
     const snapshot = {
       sessions: [
@@ -75,9 +77,9 @@ it.effect(
     }).pipe(Effect.provide(makeLayer(recorded, snapshot)));
 
     expect(recorded).toEqual([
-      { method: "list-sessions", params: {} },
-      { method: "shutdown-all-sessions", params: {} },
-      { method: "list-sessions", params: {} },
+      { kind: "list-sessions" },
+      { kind: "shutdown-all-sessions" },
+      { kind: "list-sessions" },
     ]);
   }),
 );
@@ -85,7 +87,7 @@ it.effect(
 it.effect(
   "fails when a session disappears before restart",
   Effect.fn(function* () {
-    const recorded: MarimoApiCall[] = [];
+    const recorded: TestCommand[] = [];
     const result = yield* Effect.gen(function* () {
       const sessions = yield* LiveSessions;
       return yield* Effect.result(sessions.restart(NOTEBOOK_URI));
@@ -97,14 +99,14 @@ it.effect(
         new SessionNotFoundError({ notebookUri: NOTEBOOK_URI }),
       );
     }
-    expect(recorded).toEqual([{ method: "list-sessions", params: {} }]);
+    expect(recorded).toEqual([{ kind: "list-sessions" }]);
   }),
 );
 
 it.effect(
   "restarts a session and reconciles with the server snapshot",
   Effect.fn(function* () {
-    const recorded: MarimoApiCall[] = [];
+    const recorded: TestCommand[] = [];
 
     yield* Effect.gen(function* () {
       const sessions = yield* LiveSessions;
@@ -112,18 +114,14 @@ it.effect(
     }).pipe(Effect.provide(makeLayer(recorded)));
 
     expect(recorded).toEqual([
-      { method: "list-sessions", params: {} },
+      { kind: "list-sessions" },
       {
-        method: "restart-session",
-        params: {
-          notebookUri: NOTEBOOK_URI,
-          inner: {
-            executable: "/venv/bin/python",
-            workingDirectory: "/workspace",
-          },
-        },
+        kind: "restart-session",
+        notebookUri: NOTEBOOK_URI,
+        executable: "/venv/bin/python",
+        workingDirectory: "/workspace",
       },
-      { method: "list-sessions", params: {} },
+      { kind: "list-sessions" },
     ]);
   }),
 );

--- a/extension/src/renderer/utils.ts
+++ b/extension/src/renderer/utils.ts
@@ -35,7 +35,7 @@ export function createRequestClient(
     async sendFunctionRequest(request) {
       context.postMessage({
         command: "invoke-function",
-        params: { type: "invoke-function", ...request },
+        params: request,
       });
       return null;
     },

--- a/extension/src/schemas/Models.gen.ts
+++ b/extension/src/schemas/Models.gen.ts
@@ -1,7 +1,8 @@
 // AUTO-GENERATED FILE — DO NOT EDIT.
 //
-// Generated from `src/marimo_lsp/models.py` and the `marimo.api` registry
-// (`API_METHODS` in `src/marimo_lsp/api.py`) by `scripts.codegen`.
+// Generated from `src/marimo_lsp/protocol.py`, `src/marimo_lsp/models.py`,
+// and the `marimo.api` registry (`API_METHODS` in `src/marimo_lsp/api.py`)
+// by `scripts.codegen`.
 // Regenerate with `just codegen`.
 import type { components as MarimoApi } from "@marimo-team/openapi/src/api";
 import { Effect, Schema } from "effect";
@@ -39,6 +40,60 @@ export const NotebookIdFromString = Schema.String.pipe(
   Schema.brand("NotebookId"),
 );
 export type NotebookId = typeof NotebookIdFromString.Type;
+
+export const NotebookUriFromString = Schema.String.pipe(
+  Schema.brand("NotebookUri"),
+);
+export type NotebookUri = typeof NotebookUriFromString.Type;
+
+export const CellIdFromString = Schema.String.pipe(Schema.brand("CellId"));
+export type CellId = typeof CellIdFromString.Type;
+
+/**
+ * One cell and the exact source to execute for it.
+ */
+export const CellExecution = Schema.Struct({
+  cellId: CellIdFromString,
+  code: Schema.String,
+}).annotate({
+  identifier: "CellExecution",
+  parseOptions: { onExcessProperty: "error" },
+});
+export type CellExecution = typeof CellExecution.Type;
+
+/**
+ * Execute a batch of notebook cells, starting its kernel if necessary.
+ */
+export const Execute = Schema.Struct({
+  kind: Schema.Literal("execute"),
+  notebookUri: NotebookUriFromString,
+  executable: Schema.String,
+  workingDirectory: Schema.String,
+  cells: Schema.Array(CellExecution),
+}).annotate({
+  identifier: "Execute",
+  parseOptions: { onExcessProperty: "error" },
+});
+export type Execute = typeof Execute.Type;
+
+/**
+ * Remove one cell from the exact live kernel that owns it.
+ */
+export const DeleteCell = Schema.Struct({
+  kind: Schema.Literal("delete-cell"),
+  notebookUri: NotebookUriFromString,
+  kernelSessionId: KernelSessionIdFromString,
+  cellId: CellIdFromString,
+}).annotate({
+  identifier: "DeleteCell",
+  parseOptions: { onExcessProperty: "error" },
+});
+export type DeleteCell = typeof DeleteCell.Type;
+
+export const Command = Schema.Union([Execute, DeleteCell]).annotate({
+  identifier: "Command",
+});
+export type Command = typeof Command.Type;
 
 /**
  * The notebook's environment is a concrete venv with a known python executable.
@@ -1593,7 +1648,7 @@ export type MarimoApiCall =
       readonly params: typeof ExportAsMarkdownPayload.Encoded;
     };
 
-type Execute<E, R> = (call: MarimoApiCall) => Effect.Effect<unknown, E, R>;
+type ApiTransport<E, R> = (call: MarimoApiCall) => Effect.Effect<unknown, E, R>;
 
 /**
  * Validate the outgoing params against the payload schema (the wire/Encoded
@@ -1601,7 +1656,7 @@ type Execute<E, R> = (call: MarimoApiCall) => Effect.Effect<unknown, E, R>;
  * the response against the method's success schema.
  */
 const dispatch = <Payload extends Schema.Top, Success extends Schema.Top, E, R>(
-  execute: Execute<E, R>,
+  execute: ApiTransport<E, R>,
   call: MarimoApiCall & { readonly params: Payload["Encoded"] },
   payload: Payload,
   success: Success,
@@ -1622,7 +1677,7 @@ const dispatch = <Payload extends Schema.Top, Success extends Schema.Top, E, R>(
  * `execute`, and parses the response against the method's success schema —
  * both sides of the wire are earned, not asserted.
  */
-export const makeApiClient = <E, R>(execute: Execute<E, R>) => ({
+export const makeApiClient = <E, R>(execute: ApiTransport<E, R>) => ({
   executeCells: (params: typeof ExecuteCellsPayload.Encoded) =>
     dispatch(
       execute,

--- a/extension/src/schemas/Models.gen.ts
+++ b/extension/src/schemas/Models.gen.ts
@@ -1,7 +1,7 @@
 // AUTO-GENERATED FILE — DO NOT EDIT.
 //
 // Generated from `src/marimo_lsp/protocol.py`, `src/marimo_lsp/models.py`,
-// and the `marimo.api` registry (`API_METHODS` in `src/marimo_lsp/api.py`)
+// and the command registry (`COMMANDS` in `src/marimo_lsp/api.py`)
 // by `scripts.codegen`.
 // Regenerate with `just codegen`.
 import type { components as MarimoApi } from "@marimo-team/openapi/src/api";
@@ -77,6 +77,118 @@ export const Execute = Schema.Struct({
 export type Execute = typeof Execute.Type;
 
 /**
+ * Update one or more UI element values in an exact kernel.
+ */
+export const UpdateUiElement = Schema.Struct({
+  kind: Schema.Literal("update-ui-element"),
+  notebookUri: NotebookUriFromString,
+  kernelSessionId: KernelSessionIdFromString,
+  objectIds: Schema.Array(Schema.String),
+  values: Schema.Array(Schema.Unknown),
+  request: Schema.NullOr(Schema.Record(Schema.String, Schema.Unknown)).pipe(
+    Schema.withDecodingDefault(Effect.sync(() => null)),
+  ),
+  token: Schema.NullOr(Schema.String).pipe(
+    Schema.withDecodingDefault(Effect.sync(() => null)),
+  ),
+}).annotate({
+  identifier: "UpdateUiElement",
+  parseOptions: { onExcessProperty: "error" },
+});
+export type UpdateUiElement = typeof UpdateUiElement.Type;
+
+/**
+ * State update sent to one widget model.
+ */
+export const ModelUpdateMessage = Schema.Struct({
+  method: Schema.Literal("update"),
+  state: Schema.Record(Schema.String, Schema.Unknown),
+  bufferPaths: Schema.Array(
+    Schema.Array(Schema.Union([Schema.String, Schema.Int])),
+  ),
+}).annotate({
+  identifier: "ModelUpdateMessage",
+  parseOptions: { onExcessProperty: "error" },
+});
+export type ModelUpdateMessage = typeof ModelUpdateMessage.Type;
+
+/**
+ * Custom message sent to one widget model.
+ */
+export const ModelCustomMessage = Schema.Struct({
+  method: Schema.Literal("custom"),
+  content: Schema.Unknown,
+}).annotate({
+  identifier: "ModelCustomMessage",
+  parseOptions: { onExcessProperty: "error" },
+});
+export type ModelCustomMessage = typeof ModelCustomMessage.Type;
+
+/**
+ * Base64-encoded bytes on the msgspec JSON wire.
+ *
+ * Matches the compile-time `TypedString<"Base64String">` brand emitted
+ * by `@marimo-team/openapi`. Decode with `Schema.Uint8ArrayFromBase64`
+ * where actual bytes are needed.
+ */
+export const Base64String = Schema.String.pipe(Schema.brand("Base64String"));
+export type Base64String = typeof Base64String.Type;
+
+/**
+ * Update state for one widget model in an exact kernel.
+ */
+export const SetModelValue = Schema.Struct({
+  kind: Schema.Literal("set-model-value"),
+  notebookUri: NotebookUriFromString,
+  kernelSessionId: KernelSessionIdFromString,
+  modelId: Schema.String,
+  message: Schema.Union([ModelUpdateMessage, ModelCustomMessage]),
+  buffers: Schema.Array(Base64String),
+  token: Schema.NullOr(Schema.String).pipe(
+    Schema.withDecodingDefault(Effect.sync(() => null)),
+  ),
+}).annotate({
+  identifier: "SetModelValue",
+  parseOptions: { onExcessProperty: "error" },
+});
+export type SetModelValue = typeof SetModelValue.Type;
+
+/**
+ * Invoke a registered function in an exact kernel.
+ */
+export const InvokeFunction = Schema.Struct({
+  kind: Schema.Literal("invoke-function"),
+  notebookUri: NotebookUriFromString,
+  kernelSessionId: KernelSessionIdFromString,
+  functionCallId: Schema.String,
+  namespace: Schema.String,
+  functionName: Schema.String,
+  args: Schema.Record(Schema.String, Schema.Unknown),
+}).annotate({
+  identifier: "InvokeFunction",
+  parseOptions: { onExcessProperty: "error" },
+});
+export type InvokeFunction = typeof InvokeFunction.Type;
+
+/**
+ * Interrupt an exact kernel or cancel a pending scratch execution.
+ */
+export const Interrupt = Schema.Struct({
+  kind: Schema.Literal("interrupt"),
+  notebookUri: NotebookUriFromString,
+  kernelSessionId: Schema.NullOr(KernelSessionIdFromString).pipe(
+    Schema.withDecodingDefault(Effect.sync(() => null)),
+  ),
+  runId: Schema.NullOr(Schema.String).pipe(
+    Schema.withDecodingDefault(Effect.sync(() => null)),
+  ),
+}).annotate({
+  identifier: "Interrupt",
+  parseOptions: { onExcessProperty: "error" },
+});
+export type Interrupt = typeof Interrupt.Type;
+
+/**
  * Remove one cell from the exact live kernel that owns it.
  */
 export const DeleteCell = Schema.Struct({
@@ -90,35 +202,384 @@ export const DeleteCell = Schema.Struct({
 });
 export type DeleteCell = typeof DeleteCell.Type;
 
-export const Command = Schema.Union([Execute, DeleteCell]).annotate({
-  identifier: "Command",
+/**
+ * List immediate child schemas at a database path.
+ */
+export const ListSqlSchemas = Schema.Struct({
+  kind: Schema.Literal("list-sql-schemas"),
+  notebookUri: NotebookUriFromString,
+  kernelSessionId: KernelSessionIdFromString,
+  requestId: Schema.String,
+  engine: Schema.String,
+  database: Schema.String,
+  schemaPath: Schema.Array(Schema.String).pipe(
+    Schema.withDecodingDefault(Effect.sync(() => [])),
+  ),
+}).annotate({
+  identifier: "ListSqlSchemas",
+  parseOptions: { onExcessProperty: "error" },
 });
-export type Command = typeof Command.Type;
+export type ListSqlSchemas = typeof ListSqlSchemas.Type;
 
 /**
- * The notebook's environment is a concrete venv with a known python executable.
+ * List tables in one database schema.
+ */
+export const ListSqlTables = Schema.Struct({
+  kind: Schema.Literal("list-sql-tables"),
+  notebookUri: NotebookUriFromString,
+  kernelSessionId: KernelSessionIdFromString,
+  requestId: Schema.String,
+  engine: Schema.String,
+  database: Schema.String,
+  schema: Schema.String,
+  schemaPath: Schema.Array(Schema.String).pipe(
+    Schema.withDecodingDefault(Effect.sync(() => [])),
+  ),
+}).annotate({
+  identifier: "ListSqlTables",
+  parseOptions: { onExcessProperty: "error" },
+});
+export type ListSqlTables = typeof ListSqlTables.Type;
+
+/**
+ * Respond to a stdin prompt in an exact kernel.
+ */
+export const SendStdin = Schema.Struct({
+  kind: Schema.Literal("send-stdin"),
+  notebookUri: NotebookUriFromString,
+  kernelSessionId: KernelSessionIdFromString,
+  text: Schema.String,
+}).annotate({
+  identifier: "SendStdin",
+  parseOptions: { onExcessProperty: "error" },
+});
+export type SendStdin = typeof SendStdin.Type;
+
+/**
+ * Close the live session for one notebook.
+ */
+export const CloseSession = Schema.Struct({
+  kind: Schema.Literal("close-session"),
+  notebookUri: NotebookUriFromString,
+}).annotate({
+  identifier: "CloseSession",
+  parseOptions: { onExcessProperty: "error" },
+});
+export type CloseSession = typeof CloseSession.Type;
+
+/**
+ * Restart or restore the live session for one notebook.
+ */
+export const RestartSession = Schema.Struct({
+  kind: Schema.Literal("restart-session"),
+  notebookUri: NotebookUriFromString,
+  executable: Schema.String,
+  workingDirectory: Schema.String,
+  createIfMissing: Schema.Boolean.pipe(
+    Schema.withDecodingDefault(Effect.sync(() => false)),
+  ),
+}).annotate({
+  identifier: "RestartSession",
+  parseOptions: { onExcessProperty: "error" },
+});
+export type RestartSession = typeof RestartSession.Type;
+
+/**
+ * Move a live session after its notebook is renamed.
+ */
+export const MoveSession = Schema.Struct({
+  kind: Schema.Literal("move-session"),
+  notebookUri: NotebookUriFromString,
+  newNotebookUri: NotebookUriFromString,
+}).annotate({
+  identifier: "MoveSession",
+  parseOptions: { onExcessProperty: "error" },
+});
+export type MoveSession = typeof MoveSession.Type;
+
+/**
+ * List all live sessions owned by the language server.
+ */
+export const ListSessions = Schema.Struct({
+  kind: Schema.Literal("list-sessions"),
+}).annotate({
+  identifier: "ListSessions",
+  parseOptions: { onExcessProperty: "error" },
+});
+export type ListSessions = typeof ListSessions.Type;
+
+/**
+ * Close every live session owned by the language server.
+ */
+export const ShutdownAllSessions = Schema.Struct({
+  kind: Schema.Literal("shutdown-all-sessions"),
+}).annotate({
+  identifier: "ShutdownAllSessions",
+  parseOptions: { onExcessProperty: "error" },
+});
+export type ShutdownAllSessions = typeof ShutdownAllSessions.Type;
+
+/**
+ * Execute transient code against a notebook kernel.
+ */
+export const ExecuteScratchpad = Schema.Struct({
+  kind: Schema.Literal("execute-scratchpad"),
+  notebookUri: NotebookUriFromString,
+  executable: Schema.String,
+  workingDirectory: Schema.String,
+  code: Schema.String,
+  runId: Schema.NullOr(Schema.String).pipe(
+    Schema.withDecodingDefault(Effect.sync(() => null)),
+  ),
+}).annotate({
+  identifier: "ExecuteScratchpad",
+  parseOptions: { onExcessProperty: "error" },
+});
+export type ExecuteScratchpad = typeof ExecuteScratchpad.Type;
+
+/**
+ * A concrete environment identified by its Python executable.
  */
 export const VenvSource = Schema.Struct({
   kind: Schema.Literal("venv"),
   executable: Schema.String,
-}).annotate({ identifier: "VenvSource" });
+}).annotate({
+  identifier: "VenvSource",
+  parseOptions: { onExcessProperty: "error" },
+});
 export type VenvSource = typeof VenvSource.Type;
 
 /**
- * The notebook's environment is a PEP 723 sandbox script.
- *
- * The server resolves the script filename from the notebook URI; `uv`
- * derives the venv from the script's inline metadata.
+ * A PEP 723 environment resolved from the notebook script.
  */
 export const ScriptSource = Schema.Struct({
   kind: Schema.Literal("script"),
-}).annotate({ identifier: "ScriptSource" });
+}).annotate({
+  identifier: "ScriptSource",
+  parseOptions: { onExcessProperty: "error" },
+});
 export type ScriptSource = typeof ScriptSource.Type;
 
-export const PackageSource = Schema.Union([VenvSource, ScriptSource]).annotate({
-  identifier: "PackageSource",
+/**
+ * List packages installed in a notebook environment.
+ */
+export const ListPackages = Schema.Struct({
+  kind: Schema.Literal("list-packages"),
+  notebookUri: NotebookUriFromString,
+  source: Schema.Union([VenvSource, ScriptSource]),
+}).annotate({
+  identifier: "ListPackages",
+  parseOptions: { onExcessProperty: "error" },
 });
-export type PackageSource = typeof PackageSource.Type;
+export type ListPackages = typeof ListPackages.Type;
+
+/**
+ * Read the dependency tree for a notebook environment.
+ */
+export const GetDependencyTree = Schema.Struct({
+  kind: Schema.Literal("get-dependency-tree"),
+  notebookUri: NotebookUriFromString,
+  source: Schema.Union([VenvSource, ScriptSource]),
+}).annotate({
+  identifier: "GetDependencyTree",
+  parseOptions: { onExcessProperty: "error" },
+});
+export type GetDependencyTree = typeof GetDependencyTree.Type;
+
+/**
+ * Persisted marimo configuration for one notebook cell.
+ */
+export const SerializedNotebookCellConfig = Schema.Struct({
+  column: Schema.optional(Schema.NullOr(Schema.Int)),
+  disabled: Schema.optional(Schema.NullOr(Schema.Boolean)),
+  hide_code: Schema.optional(Schema.NullOr(Schema.Boolean)),
+}).annotate({ identifier: "SerializedNotebookCellConfig" });
+export type SerializedNotebookCellConfig =
+  typeof SerializedNotebookCellConfig.Type;
+
+/**
+ * One code cell in the serialized notebook format.
+ */
+export const SerializedNotebookCell = Schema.Struct({
+  code: Schema.NullOr(Schema.String),
+  code_hash: Schema.NullOr(Schema.String),
+  config: SerializedNotebookCellConfig,
+  id: Schema.NullOr(Schema.String),
+  name: Schema.NullOr(Schema.String),
+}).annotate({ identifier: "SerializedNotebookCell" });
+export type SerializedNotebookCell = typeof SerializedNotebookCell.Type;
+
+/**
+ * Metadata stored with the serialized notebook.
+ */
+export const SerializedNotebookMetadata = Schema.Struct({
+  marimo_version: Schema.optional(Schema.NullOr(Schema.String)),
+}).annotate({ identifier: "SerializedNotebookMetadata" });
+export type SerializedNotebookMetadata = typeof SerializedNotebookMetadata.Type;
+
+/**
+ * Owned projection of marimo's version-one notebook document.
+ */
+export const SerializedNotebookV1 = Schema.Struct({
+  cells: Schema.Array(SerializedNotebookCell),
+  metadata: SerializedNotebookMetadata,
+  version: Schema.Literal("1"),
+}).annotate({ identifier: "SerializedNotebookV1" });
+export type SerializedNotebookV1 = typeof SerializedNotebookV1.Type;
+
+/**
+ * Serialize notebook data to native marimo Python source.
+ */
+export const Serialize = Schema.Struct({
+  kind: Schema.Literal("serialize"),
+  notebook: SerializedNotebookV1,
+  appConfig: Schema.Record(Schema.String, Schema.Unknown).pipe(
+    Schema.withDecodingDefault(Effect.sync(() => ({}))),
+  ),
+  header: Schema.NullOr(Schema.String).pipe(
+    Schema.withDecodingDefault(Effect.sync(() => null)),
+  ),
+}).annotate({
+  identifier: "Serialize",
+  parseOptions: { onExcessProperty: "error" },
+});
+export type Serialize = typeof Serialize.Type;
+
+/**
+ * Deserialize source into notebook data.
+ */
+export const Deserialize = Schema.Struct({
+  kind: Schema.Literal("deserialize"),
+  source: Schema.String,
+}).annotate({
+  identifier: "Deserialize",
+  parseOptions: { onExcessProperty: "error" },
+});
+export type Deserialize = typeof Deserialize.Type;
+
+/**
+ * Read configuration for one notebook.
+ */
+export const GetConfiguration = Schema.Struct({
+  kind: Schema.Literal("get-configuration"),
+  notebookUri: NotebookUriFromString,
+}).annotate({
+  identifier: "GetConfiguration",
+  parseOptions: { onExcessProperty: "error" },
+});
+export type GetConfiguration = typeof GetConfiguration.Type;
+
+/**
+ * Merge a configuration patch for one notebook.
+ */
+export const UpdateConfiguration = Schema.Struct({
+  kind: Schema.Literal("update-configuration"),
+  notebookUri: NotebookUriFromString,
+  config: Schema.Record(Schema.String, Schema.Unknown),
+}).annotate({
+  identifier: "UpdateConfiguration",
+  parseOptions: { onExcessProperty: "error" },
+});
+export type UpdateConfiguration = typeof UpdateConfiguration.Type;
+
+/**
+ * Set the display theme for live sessions.
+ */
+export const SetDisplayTheme = Schema.Struct({
+  kind: Schema.Literal("set-display-theme"),
+  theme: Schema.Literals(["dark", "light"]),
+}).annotate({
+  identifier: "SetDisplayTheme",
+  parseOptions: { onExcessProperty: "error" },
+});
+export type SetDisplayTheme = typeof SetDisplayTheme.Type;
+
+/**
+ * Read outputs without starting a notebook kernel.
+ */
+export const ReadNotebookOutputs = Schema.Struct({
+  kind: Schema.Literal("read-notebook-outputs"),
+  notebookUri: NotebookUriFromString,
+  sessionCachePath: Schema.NullOr(Schema.String).pipe(
+    Schema.withDecodingDefault(Effect.sync(() => null)),
+  ),
+}).annotate({
+  identifier: "ReadNotebookOutputs",
+  parseOptions: { onExcessProperty: "error" },
+});
+export type ReadNotebookOutputs = typeof ReadNotebookOutputs.Type;
+
+/**
+ * Export one notebook as HTML.
+ */
+export const ExportHtml = Schema.Struct({
+  kind: Schema.Literal("export-html"),
+  notebookUri: NotebookUriFromString,
+  download: Schema.Boolean,
+  files: Schema.Array(Schema.String),
+  includeCode: Schema.Boolean,
+  assetUrl: Schema.NullOr(Schema.String).pipe(
+    Schema.withDecodingDefault(Effect.sync(() => null)),
+  ),
+}).annotate({
+  identifier: "ExportHtml",
+  parseOptions: { onExcessProperty: "error" },
+});
+export type ExportHtml = typeof ExportHtml.Type;
+
+/**
+ * Export one notebook as ipynb JSON.
+ */
+export const ExportIpynb = Schema.Struct({
+  kind: Schema.Literal("export-ipynb"),
+  notebookUri: NotebookUriFromString,
+}).annotate({
+  identifier: "ExportIpynb",
+  parseOptions: { onExcessProperty: "error" },
+});
+export type ExportIpynb = typeof ExportIpynb.Type;
+
+/**
+ * Export one notebook as Markdown.
+ */
+export const ExportMarkdown = Schema.Struct({
+  kind: Schema.Literal("export-markdown"),
+  notebookUri: NotebookUriFromString,
+}).annotate({
+  identifier: "ExportMarkdown",
+  parseOptions: { onExcessProperty: "error" },
+});
+export type ExportMarkdown = typeof ExportMarkdown.Type;
+
+export const Command = Schema.Union([
+  Execute,
+  UpdateUiElement,
+  SetModelValue,
+  InvokeFunction,
+  Interrupt,
+  DeleteCell,
+  ListSqlSchemas,
+  ListSqlTables,
+  SendStdin,
+  CloseSession,
+  RestartSession,
+  MoveSession,
+  ListSessions,
+  ShutdownAllSessions,
+  ExecuteScratchpad,
+  ListPackages,
+  GetDependencyTree,
+  Serialize,
+  Deserialize,
+  GetConfiguration,
+  UpdateConfiguration,
+  SetDisplayTheme,
+  ReadNotebookOutputs,
+  ExportHtml,
+  ExportIpynb,
+  ExportMarkdown,
+]).annotate({ identifier: "Command" });
+export type Command = typeof Command.Type;
 
 /**
  * App options understood by the extension, projected from ``AppConfig``.
@@ -347,16 +808,6 @@ export const NotebookDocument = Schema.Struct({
 export type NotebookDocument = typeof NotebookDocument.Type;
 
 /**
- * A request to deserialize Python source to notebook format.
- *
- * Contains the source code to be parsed.
- */
-export const DeserializeRequest = Schema.Struct({
-  source: Schema.String,
-}).annotate({ identifier: "DeserializeRequest" });
-export type DeserializeRequest = typeof DeserializeRequest.Type;
-
-/**
  * A successfully parsed native marimo notebook.
  */
 export const DeserializeSuccess = Schema.Struct({
@@ -403,96 +854,6 @@ export const ConvertRequest = Schema.Struct({
 export type ConvertRequest = typeof ConvertRequest.Type;
 
 /**
- * A request to interrupt the kernel execution.
- */
-export const InterruptRequest = Schema.Struct({
-  runId: Schema.NullOr(Schema.String).pipe(
-    Schema.withDecodingDefault(Effect.sync(() => null)),
-  ),
-  sessionId: Schema.NullOr(KernelSessionIdFromString).pipe(
-    Schema.withDecodingDefault(Effect.sync(() => null)),
-  ),
-}).annotate({ identifier: "InterruptRequest" });
-export type InterruptRequest = typeof InterruptRequest.Type;
-
-/**
- * A request to list installed packages in the kernel environment.
- */
-export const ListPackagesRequest = Schema.Struct({}).annotate({
-  identifier: "ListPackagesRequest",
-});
-export type ListPackagesRequest = typeof ListPackagesRequest.Type;
-
-/**
- * A request to get the dependency tree of installed packages.
- */
-export const DependencyTreeRequest = Schema.Struct({}).annotate({
-  identifier: "DependencyTreeRequest",
-});
-export type DependencyTreeRequest = typeof DependencyTreeRequest.Type;
-
-/**
- * A request to get the current configuration.
- */
-export const GetConfigurationRequest = Schema.Struct({}).annotate({
-  identifier: "GetConfigurationRequest",
-});
-export type GetConfigurationRequest = typeof GetConfigurationRequest.Type;
-
-/**
- * A request to close the current session.
- */
-export const CloseSessionRequest = Schema.Struct({}).annotate({
-  identifier: "CloseSessionRequest",
-});
-export type CloseSessionRequest = typeof CloseSessionRequest.Type;
-
-/**
- * A request to export the notebook as ipynb.
- */
-export const ExportAsIpynbRequest = Schema.Struct({}).annotate({
-  identifier: "ExportAsIpynbRequest",
-});
-export type ExportAsIpynbRequest = typeof ExportAsIpynbRequest.Type;
-
-/**
- * Execute arbitrary Python code outside the dependency graph.
- */
-export const ExecuteScratchRequest = Schema.Struct({
-  code: Schema.String,
-  runId: Schema.NullOr(Schema.String).pipe(
-    Schema.withDecodingDefault(Effect.sync(() => null)),
-  ),
-}).annotate({ identifier: "ExecuteScratchRequest" });
-export type ExecuteScratchRequest = typeof ExecuteScratchRequest.Type;
-
-/**
- * A request to update the user configuration.
- */
-export const UpdateConfigurationRequest = Schema.Struct({
-  config: Schema.Record(Schema.String, Schema.Unknown),
-}).annotate({ identifier: "UpdateConfigurationRequest" });
-export type UpdateConfigurationRequest = typeof UpdateConfigurationRequest.Type;
-
-/**
- * A request to set the display theme without persisting to disk.
- */
-export const SetDisplayThemeRequest = Schema.Struct({
-  theme: Schema.Literals(["dark", "light"]),
-}).annotate({ identifier: "SetDisplayThemeRequest" });
-export type SetDisplayThemeRequest = typeof SetDisplayThemeRequest.Type;
-
-/**
- * Resolve outputs for an opened notebook without starting a kernel.
- */
-export const ReadNotebookOutputsRequest = Schema.Struct({
-  sessionCachePath: Schema.NullOr(Schema.String).pipe(
-    Schema.withDecodingDefault(Effect.sync(() => null)),
-  ),
-}).annotate({ identifier: "ReadNotebookOutputsRequest" });
-export type ReadNotebookOutputsRequest = typeof ReadNotebookOutputsRequest.Type;
-
-/**
  * One cell projected from an authoritative live SessionView.
  */
 export const LiveCellReplay = Schema.Struct({
@@ -518,239 +879,6 @@ export const CellOutputReplay = Schema.Union([
 export type CellOutputReplay = typeof CellOutputReplay.Type;
 
 /**
- * Serializable HTTP request representation.
- *
- * Mimics Starlette/FastAPI Request but is pickle-able and contains only a safe
- * subset of data. Excludes session and auth to prevent exposing sensitive data.
- *
- * Attributes:
- *     url: Serialized URL with path, port, scheme, netloc, query, hostname.
- *     base_url: Serialized base URL.
- *     headers: Request headers (marimo-specific headers excluded).
- *     query_params: Query parameters mapped to lists of values.
- *     path_params: Path parameters from the URL route.
- *     cookies: Request cookies.
- *     meta: User-defined storage for custom data.
- *     user: User info from authentication middleware (e.g., is_authenticated, username).
- */
-export const HTTPRequest = Schema.Struct({
-  url: Schema.Record(Schema.String, Schema.Unknown),
-  base_url: Schema.Record(Schema.String, Schema.Unknown),
-  headers: Schema.Record(Schema.String, Schema.String),
-  query_params: Schema.Record(Schema.String, Schema.Array(Schema.String)),
-  path_params: Schema.Record(Schema.String, Schema.Unknown),
-  cookies: Schema.Record(Schema.String, Schema.String),
-  meta: Schema.Record(Schema.String, Schema.Unknown),
-  user: Schema.Unknown,
-}).annotate({ identifier: "HTTPRequest" });
-export type HTTPRequest = typeof HTTPRequest.Type;
-
-export const ExecuteCellsRequest = Schema.Struct({
-  cellIds: Schema.Array(Schema.String),
-  codes: Schema.Array(Schema.String),
-  request: Schema.NullOr(HTTPRequest).pipe(
-    Schema.withDecodingDefault(Effect.sync(() => null)),
-  ),
-}).annotate({ identifier: "ExecuteCellsRequest" });
-export type ExecuteCellsRequest = typeof ExecuteCellsRequest.Type;
-
-export const ExecuteCellsPayload = Schema.Struct({
-  notebookUri: NotebookIdFromString,
-  inner: ExecuteCellsRequest,
-  executable: Schema.String,
-  workingDirectory: Schema.String,
-});
-
-export const UpdateUIElementRequest = Schema.Struct({
-  objectIds: Schema.Array(Schema.String),
-  values: Schema.Array(Schema.Unknown),
-  request: Schema.NullOr(HTTPRequest).pipe(
-    Schema.withDecodingDefault(Effect.sync(() => null)),
-  ),
-  token: Schema.optional(Schema.String),
-}).annotate({ identifier: "UpdateUIElementRequest" });
-export type UpdateUIElementRequest = typeof UpdateUIElementRequest.Type;
-
-export const UpdateUiElementPayload = Schema.Struct({
-  notebookUri: NotebookIdFromString,
-  inner: UpdateUIElementRequest,
-  sessionId: KernelSessionIdFromString,
-});
-
-/**
- * Widget model state update message.
- *
- * Attributes:
- *     state: Model state updates.
- *     buffer_paths: Paths within state dict pointing to binary buffers.
- */
-export const ModelUpdateMessage = Schema.Struct({
-  method: Schema.Literal("update"),
-  state: Schema.Record(Schema.String, Schema.Unknown),
-  bufferPaths: Schema.Array(
-    Schema.Array(Schema.Union([Schema.String, Schema.Int])),
-  ),
-}).annotate({ identifier: "ModelUpdateMessage" });
-export type ModelUpdateMessage = typeof ModelUpdateMessage.Type;
-
-/**
- * Custom widget message.
- *
- * Attributes:
- *     content: Arbitrary content for the custom message.
- */
-export const ModelCustomMessage = Schema.Struct({
-  method: Schema.Literal("custom"),
-  content: Schema.Unknown,
-}).annotate({ identifier: "ModelCustomMessage" });
-export type ModelCustomMessage = typeof ModelCustomMessage.Type;
-
-/**
- * Base64-encoded bytes on the msgspec JSON wire.
- *
- * Matches the compile-time `TypedString<"Base64String">` brand emitted
- * by `@marimo-team/openapi`. Decode with `Schema.Uint8ArrayFromBase64`
- * where actual bytes are needed.
- */
-export const Base64String = Schema.String.pipe(Schema.brand("Base64String"));
-export type Base64String = typeof Base64String.Type;
-
-export const ModelRequest = Schema.Struct({
-  modelId: Schema.String,
-  message: Schema.Union([ModelUpdateMessage, ModelCustomMessage]),
-  buffers: Schema.Array(Base64String),
-  token: Schema.optional(Schema.String),
-}).annotate({ identifier: "ModelRequest" });
-export type ModelRequest = typeof ModelRequest.Type;
-
-export const SetModelValuePayload = Schema.Struct({
-  notebookUri: NotebookIdFromString,
-  inner: ModelRequest,
-  sessionId: KernelSessionIdFromString,
-});
-
-/**
- * Invoke a function from a UI element.
- *
- * Called when a UI element needs to invoke a Python function.
- *
- * Attributes:
- *     function_call_id: Unique identifier for this call.
- *     namespace: Namespace where the function is registered.
- *     function_name: Function to invoke.
- *     args: Keyword arguments for the function.
- */
-export const InvokeFunctionCommand = Schema.Struct({
-  type: Schema.Literal("invoke-function"),
-  functionCallId: Schema.String,
-  namespace: Schema.String,
-  functionName: Schema.String,
-  args: Schema.Record(Schema.String, Schema.Unknown),
-}).annotate({ identifier: "InvokeFunctionCommand" });
-export type InvokeFunctionCommand = typeof InvokeFunctionCommand.Type;
-
-export const InvokeFunctionPayload = Schema.Struct({
-  notebookUri: NotebookIdFromString,
-  inner: InvokeFunctionCommand,
-  sessionId: KernelSessionIdFromString,
-});
-
-export const InterruptPayload = Schema.Struct({
-  notebookUri: NotebookIdFromString,
-  inner: InterruptRequest,
-});
-
-export const DeleteCellRequest = Schema.Struct({
-  cellId: Schema.String,
-}).annotate({ identifier: "DeleteCellRequest" });
-export type DeleteCellRequest = typeof DeleteCellRequest.Type;
-
-export const DeleteCellPayload = Schema.Struct({
-  notebookUri: NotebookIdFromString,
-  inner: DeleteCellRequest,
-  sessionId: KernelSessionIdFromString,
-});
-
-export const ListSQLSchemasRequest = Schema.Struct({
-  requestId: Schema.String,
-  engine: Schema.String,
-  database: Schema.String,
-  schemaPath: Schema.Array(Schema.String).pipe(
-    Schema.withDecodingDefault(Effect.sync(() => [])),
-  ),
-}).annotate({ identifier: "ListSQLSchemasRequest" });
-export type ListSQLSchemasRequest = typeof ListSQLSchemasRequest.Type;
-
-export const ListSqlSchemasPayload = Schema.Struct({
-  notebookUri: NotebookIdFromString,
-  inner: ListSQLSchemasRequest,
-  sessionId: KernelSessionIdFromString,
-});
-
-export const ListSQLTablesRequest = Schema.Struct({
-  requestId: Schema.String,
-  engine: Schema.String,
-  database: Schema.String,
-  schema: Schema.String,
-  schemaPath: Schema.Array(Schema.String).pipe(
-    Schema.withDecodingDefault(Effect.sync(() => [])),
-  ),
-}).annotate({ identifier: "ListSQLTablesRequest" });
-export type ListSQLTablesRequest = typeof ListSQLTablesRequest.Type;
-
-export const ListSqlTablesPayload = Schema.Struct({
-  notebookUri: NotebookIdFromString,
-  inner: ListSQLTablesRequest,
-  sessionId: KernelSessionIdFromString,
-});
-
-export const StdinRequest = Schema.Struct({
-  text: Schema.String,
-}).annotate({ identifier: "StdinRequest" });
-export type StdinRequest = typeof StdinRequest.Type;
-
-export const SendStdinPayload = Schema.Struct({
-  notebookUri: NotebookIdFromString,
-  inner: StdinRequest,
-  sessionId: KernelSessionIdFromString,
-});
-
-export const CloseSessionPayload = Schema.Struct({
-  notebookUri: NotebookIdFromString,
-  inner: CloseSessionRequest,
-});
-
-/**
- * A request to restart a live session's kernel.
- */
-export const RestartSessionRequest = Schema.Struct({
-  executable: Schema.String,
-  workingDirectory: Schema.String,
-  createIfMissing: Schema.Boolean.pipe(
-    Schema.withDecodingDefault(Effect.sync(() => false)),
-  ),
-}).annotate({ identifier: "RestartSessionRequest" });
-export type RestartSessionRequest = typeof RestartSessionRequest.Type;
-
-export const RestartSessionPayload = Schema.Struct({
-  notebookUri: NotebookIdFromString,
-  inner: RestartSessionRequest,
-});
-
-/**
- * A request to move a live session to a renamed notebook URI.
- */
-export const MoveSessionRequest = Schema.Struct({
-  newNotebookUri: Schema.String,
-}).annotate({ identifier: "MoveSessionRequest" });
-export type MoveSessionRequest = typeof MoveSessionRequest.Type;
-
-export const MoveSessionPayload = Schema.Struct({
-  notebookUri: NotebookIdFromString,
-  inner: MoveSessionRequest,
-});
-
-/**
  * User-facing state for one live kernel session.
  */
 export const SessionInfo = Schema.Struct({
@@ -773,17 +901,6 @@ export const ListSessionsResponse = Schema.Struct({
 }).annotate({ identifier: "ListSessionsResponse" });
 export type ListSessionsResponse = typeof ListSessionsResponse.Type;
 
-export const ListSessionsPayload = Schema.Struct({});
-
-export const ShutdownAllSessionsPayload = Schema.Struct({});
-
-export const ExecuteScratchpadPayload = Schema.Struct({
-  notebookUri: NotebookIdFromString,
-  inner: ExecuteScratchRequest,
-  executable: Schema.String,
-  workingDirectory: Schema.String,
-});
-
 export const PackageDescription = Schema.Struct({
   name: Schema.String,
   version: Schema.String,
@@ -791,18 +908,12 @@ export const PackageDescription = Schema.Struct({
 export type PackageDescription = typeof PackageDescription.Type;
 
 /**
- * Response for ``get-package-list``.
+ * Response for ``list-packages``.
  */
 export const ListPackagesResponse = Schema.Struct({
   packages: Schema.Array(PackageDescription),
 }).annotate({ identifier: "ListPackagesResponse" });
 export type ListPackagesResponse = typeof ListPackagesResponse.Type;
-
-export const GetPackageListPayload = Schema.Struct({
-  notebookUri: NotebookIdFromString,
-  inner: ListPackagesRequest,
-  source: PackageSource,
-});
 
 export const DependencyTag = Schema.Struct({
   kind: Schema.String,
@@ -835,12 +946,6 @@ export const DependencyTreeResponse = Schema.Struct({
 }).annotate({ identifier: "DependencyTreeResponse" });
 export type DependencyTreeResponse = typeof DependencyTreeResponse.Type;
 
-export const GetDependencyTreePayload = Schema.Struct({
-  notebookUri: NotebookIdFromString,
-  inner: DependencyTreeRequest,
-  source: PackageSource,
-});
-
 /**
  * Response for ``serialize``.
  */
@@ -848,20 +953,6 @@ export const SerializeResponse = Schema.Struct({
   source: Schema.String,
 }).annotate({ identifier: "SerializeResponse" });
 export type SerializeResponse = typeof SerializeResponse.Type;
-
-export const SerializePayload = Schema.Struct({
-  notebook: NotebookV1,
-  appConfig: Schema.Record(Schema.String, Schema.Unknown).pipe(
-    Schema.withDecodingDefault(Effect.sync(() => ({}))),
-  ),
-  header: Schema.NullOr(Schema.String).pipe(
-    Schema.withDecodingDefault(Effect.sync(() => null)),
-  ),
-});
-
-export const DeserializePayload = Schema.Struct({
-  source: Schema.String,
-});
 
 /**
  * Configuration options for Anthropic.
@@ -1467,16 +1558,6 @@ export const GetConfigurationResponse = Schema.Struct({
 }).annotate({ identifier: "GetConfigurationResponse" });
 export type GetConfigurationResponse = typeof GetConfigurationResponse.Type;
 
-export const GetConfigurationPayload = Schema.Struct({
-  notebookUri: NotebookIdFromString,
-  inner: GetConfigurationRequest,
-});
-
-export const UpdateConfigurationPayload = Schema.Struct({
-  notebookUri: NotebookIdFromString,
-  inner: UpdateConfigurationRequest,
-});
-
 /**
  * Response for ``set-display-theme``.
  */
@@ -1484,10 +1565,6 @@ export const SetDisplayThemeResponse = Schema.Struct({
   success: Schema.Boolean,
 }).annotate({ identifier: "SetDisplayThemeResponse" });
 export type SetDisplayThemeResponse = typeof SetDisplayThemeResponse.Type;
-
-export const SetDisplayThemePayload = Schema.Struct({
-  theme: Schema.Literals(["dark", "light"]),
-});
 
 /**
  * Cell outputs replayed from live memory or a saved-session sidecar.
@@ -1498,366 +1575,223 @@ export const ReadNotebookOutputsResponse = Schema.Struct({
 export type ReadNotebookOutputsResponse =
   typeof ReadNotebookOutputsResponse.Type;
 
-export const ReadNotebookOutputsPayload = Schema.Struct({
-  notebookUri: NotebookIdFromString,
-  inner: ReadNotebookOutputsRequest,
-});
-
-export const ExportAsHTMLRequest = Schema.Struct({
-  download: Schema.Boolean,
-  files: Schema.Array(Schema.String),
-  includeCode: Schema.Boolean,
-  assetUrl: Schema.NullOr(Schema.String).pipe(
-    Schema.withDecodingDefault(Effect.sync(() => null)),
-  ),
-}).annotate({ identifier: "ExportAsHTMLRequest" });
-export type ExportAsHTMLRequest = typeof ExportAsHTMLRequest.Type;
-
-export const ExportAsHtmlPayload = Schema.Struct({
-  notebookUri: NotebookIdFromString,
-  inner: ExportAsHTMLRequest,
-});
-
-export const ExportAsIpynbPayload = Schema.Struct({
-  notebookUri: NotebookIdFromString,
-  inner: ExportAsIpynbRequest,
-});
+type CommandTransport<E, R> = (
+  command: typeof Command.Encoded,
+) => Effect.Effect<unknown, E, R>;
 
 /**
- * A request to export the notebook as Markdown.
+ * Validate the complete outgoing command, send it verbatim, and parse the
+ * response against the command's declared success schema.
  */
-export const ExportAsMarkdownRequest = Schema.Struct({}).annotate({
-  identifier: "ExportAsMarkdownRequest",
-});
-export type ExportAsMarkdownRequest = typeof ExportAsMarkdownRequest.Type;
-
-export const ExportAsMarkdownPayload = Schema.Struct({
-  notebookUri: NotebookIdFromString,
-  inner: ExportAsMarkdownRequest,
-});
-
-/**
- * Every command accepted by the `marimo.api` transport.
- *
- * Generated from the `API_METHODS` registry in `src/marimo_lsp/api.py`,
- * which is also what the server dispatches and validates against.
- */
-export type MarimoApiCall =
-  | {
-      readonly method: "execute-cells";
-      readonly params: typeof ExecuteCellsPayload.Encoded;
-    }
-  | {
-      readonly method: "update-ui-element";
-      readonly params: typeof UpdateUiElementPayload.Encoded;
-    }
-  | {
-      readonly method: "set-model-value";
-      readonly params: typeof SetModelValuePayload.Encoded;
-    }
-  | {
-      readonly method: "invoke-function";
-      readonly params: typeof InvokeFunctionPayload.Encoded;
-    }
-  | {
-      readonly method: "interrupt";
-      readonly params: typeof InterruptPayload.Encoded;
-    }
-  | {
-      readonly method: "delete-cell";
-      readonly params: typeof DeleteCellPayload.Encoded;
-    }
-  | {
-      readonly method: "list-sql-schemas";
-      readonly params: typeof ListSqlSchemasPayload.Encoded;
-    }
-  | {
-      readonly method: "list-sql-tables";
-      readonly params: typeof ListSqlTablesPayload.Encoded;
-    }
-  | {
-      readonly method: "send-stdin";
-      readonly params: typeof SendStdinPayload.Encoded;
-    }
-  | {
-      readonly method: "close-session";
-      readonly params: typeof CloseSessionPayload.Encoded;
-    }
-  | {
-      readonly method: "restart-session";
-      readonly params: typeof RestartSessionPayload.Encoded;
-    }
-  | {
-      readonly method: "move-session";
-      readonly params: typeof MoveSessionPayload.Encoded;
-    }
-  | {
-      readonly method: "list-sessions";
-      readonly params: typeof ListSessionsPayload.Encoded;
-    }
-  | {
-      readonly method: "shutdown-all-sessions";
-      readonly params: typeof ShutdownAllSessionsPayload.Encoded;
-    }
-  | {
-      readonly method: "execute-scratchpad";
-      readonly params: typeof ExecuteScratchpadPayload.Encoded;
-    }
-  | {
-      readonly method: "get-package-list";
-      readonly params: typeof GetPackageListPayload.Encoded;
-    }
-  | {
-      readonly method: "get-dependency-tree";
-      readonly params: typeof GetDependencyTreePayload.Encoded;
-    }
-  | {
-      readonly method: "serialize";
-      readonly params: typeof SerializePayload.Encoded;
-    }
-  | {
-      readonly method: "deserialize";
-      readonly params: typeof DeserializePayload.Encoded;
-    }
-  | {
-      readonly method: "get-configuration";
-      readonly params: typeof GetConfigurationPayload.Encoded;
-    }
-  | {
-      readonly method: "update-configuration";
-      readonly params: typeof UpdateConfigurationPayload.Encoded;
-    }
-  | {
-      readonly method: "set-display-theme";
-      readonly params: typeof SetDisplayThemePayload.Encoded;
-    }
-  | {
-      readonly method: "read-notebook-outputs";
-      readonly params: typeof ReadNotebookOutputsPayload.Encoded;
-    }
-  | {
-      readonly method: "export-as-html";
-      readonly params: typeof ExportAsHtmlPayload.Encoded;
-    }
-  | {
-      readonly method: "export-as-ipynb";
-      readonly params: typeof ExportAsIpynbPayload.Encoded;
-    }
-  | {
-      readonly method: "export-as-markdown";
-      readonly params: typeof ExportAsMarkdownPayload.Encoded;
-    };
-
-type ApiTransport<E, R> = (call: MarimoApiCall) => Effect.Effect<unknown, E, R>;
-
-/**
- * Validate the outgoing params against the payload schema (the wire/Encoded
- * side, so defaulted fields stay omittable), send them verbatim, and parse
- * the response against the method's success schema.
- */
-const dispatch = <Payload extends Schema.Top, Success extends Schema.Top, E, R>(
-  execute: ApiTransport<E, R>,
-  call: MarimoApiCall & { readonly params: Payload["Encoded"] },
-  payload: Payload,
+const dispatch = <Success extends Schema.Top, E, R>(
+  send: CommandTransport<E, R>,
+  command: typeof Command.Encoded,
   success: Success,
 ): Effect.Effect<
   Success["Type"],
   E | Schema.SchemaError,
-  R | Payload["DecodingServices"] | Success["DecodingServices"]
+  R | Success["DecodingServices"]
 > =>
-  Effect.andThen(
-    Schema.decodeEffect(payload)(call.params),
-    Effect.flatMap(execute(call), Schema.decodeUnknownEffect(success)),
+  Effect.flatMap(Schema.decodeEffect(Command)(command), () =>
+    Effect.flatMap(send(command), Schema.decodeUnknownEffect(success)),
   );
 
 /**
- * Typed `marimo.api` client surface: one method per registry entry.
+ * Named extension methods over the private owned command protocol.
  *
- * Each method encodes its payload, dispatches `{ method, params }` over
- * `execute`, and parses the response against the method's success schema —
- * both sides of the wire are earned, not asserted.
+ * Ordinary extension code never constructs or switches over the raw union.
  */
-export const makeApiClient = <E, R>(execute: ApiTransport<E, R>) => ({
-  executeCells: (params: typeof ExecuteCellsPayload.Encoded) =>
-    dispatch(
-      execute,
-      { method: "execute-cells", params },
-      ExecuteCellsPayload,
-      Schema.Null,
-    ),
-  updateUiElement: (params: typeof UpdateUiElementPayload.Encoded) =>
-    dispatch(
-      execute,
-      { method: "update-ui-element", params },
-      UpdateUiElementPayload,
-      Schema.Null,
-    ),
-  setModelValue: (params: typeof SetModelValuePayload.Encoded) =>
-    dispatch(
-      execute,
-      { method: "set-model-value", params },
-      SetModelValuePayload,
-      Schema.Null,
-    ),
-  invokeFunction: (params: typeof InvokeFunctionPayload.Encoded) =>
-    dispatch(
-      execute,
-      { method: "invoke-function", params },
-      InvokeFunctionPayload,
-      Schema.Null,
-    ),
-  interrupt: (params: typeof InterruptPayload.Encoded) =>
-    dispatch(
-      execute,
-      { method: "interrupt", params },
-      InterruptPayload,
-      Schema.Null,
-    ),
-  deleteCell: (params: typeof DeleteCellPayload.Encoded) =>
-    dispatch(
-      execute,
-      { method: "delete-cell", params },
-      DeleteCellPayload,
-      Schema.Null,
-    ),
-  listSqlSchemas: (params: typeof ListSqlSchemasPayload.Encoded) =>
-    dispatch(
-      execute,
-      { method: "list-sql-schemas", params },
-      ListSqlSchemasPayload,
-      Schema.Null,
-    ),
-  listSqlTables: (params: typeof ListSqlTablesPayload.Encoded) =>
-    dispatch(
-      execute,
-      { method: "list-sql-tables", params },
-      ListSqlTablesPayload,
-      Schema.Null,
-    ),
-  sendStdin: (params: typeof SendStdinPayload.Encoded) =>
-    dispatch(
-      execute,
-      { method: "send-stdin", params },
-      SendStdinPayload,
-      Schema.Null,
-    ),
-  closeSession: (params: typeof CloseSessionPayload.Encoded) =>
-    dispatch(
-      execute,
-      { method: "close-session", params },
-      CloseSessionPayload,
-      Schema.Null,
-    ),
-  restartSession: (params: typeof RestartSessionPayload.Encoded) =>
-    dispatch(
-      execute,
-      { method: "restart-session", params },
-      RestartSessionPayload,
-      Schema.Null,
-    ),
-  moveSession: (params: typeof MoveSessionPayload.Encoded) =>
-    dispatch(
-      execute,
-      { method: "move-session", params },
-      MoveSessionPayload,
-      Schema.Null,
-    ),
-  listSessions: (params: typeof ListSessionsPayload.Encoded) =>
-    dispatch(
-      execute,
-      { method: "list-sessions", params },
-      ListSessionsPayload,
-      ListSessionsResponse,
-    ),
-  shutdownAllSessions: (params: typeof ShutdownAllSessionsPayload.Encoded) =>
-    dispatch(
-      execute,
-      { method: "shutdown-all-sessions", params },
-      ShutdownAllSessionsPayload,
-      Schema.Null,
-    ),
-  executeScratchpad: (params: typeof ExecuteScratchpadPayload.Encoded) =>
-    dispatch(
-      execute,
-      { method: "execute-scratchpad", params },
-      ExecuteScratchpadPayload,
-      Schema.Null,
-    ),
-  getPackageList: (params: typeof GetPackageListPayload.Encoded) =>
-    dispatch(
-      execute,
-      { method: "get-package-list", params },
-      GetPackageListPayload,
-      ListPackagesResponse,
-    ),
-  getDependencyTree: (params: typeof GetDependencyTreePayload.Encoded) =>
-    dispatch(
-      execute,
-      { method: "get-dependency-tree", params },
-      GetDependencyTreePayload,
-      DependencyTreeResponse,
-    ),
-  serialize: (params: typeof SerializePayload.Encoded) =>
-    dispatch(
-      execute,
-      { method: "serialize", params },
-      SerializePayload,
-      SerializeResponse,
-    ),
-  deserialize: (params: typeof DeserializePayload.Encoded) =>
-    dispatch(
-      execute,
-      { method: "deserialize", params },
-      DeserializePayload,
-      DeserializeResult,
-    ),
-  getConfiguration: (params: typeof GetConfigurationPayload.Encoded) =>
-    dispatch(
-      execute,
-      { method: "get-configuration", params },
-      GetConfigurationPayload,
-      GetConfigurationResponse,
-    ),
-  updateConfiguration: (params: typeof UpdateConfigurationPayload.Encoded) =>
-    dispatch(
-      execute,
-      { method: "update-configuration", params },
-      UpdateConfigurationPayload,
-      MarimoConfig,
-    ),
-  setDisplayTheme: (params: typeof SetDisplayThemePayload.Encoded) =>
-    dispatch(
-      execute,
-      { method: "set-display-theme", params },
-      SetDisplayThemePayload,
-      SetDisplayThemeResponse,
-    ),
-  readNotebookOutputs: (params: typeof ReadNotebookOutputsPayload.Encoded) =>
-    dispatch(
-      execute,
-      { method: "read-notebook-outputs", params },
-      ReadNotebookOutputsPayload,
-      ReadNotebookOutputsResponse,
-    ),
-  exportAsHtml: (params: typeof ExportAsHtmlPayload.Encoded) =>
-    dispatch(
-      execute,
-      { method: "export-as-html", params },
-      ExportAsHtmlPayload,
-      Schema.String,
-    ),
-  exportAsIpynb: (params: typeof ExportAsIpynbPayload.Encoded) =>
-    dispatch(
-      execute,
-      { method: "export-as-ipynb", params },
-      ExportAsIpynbPayload,
-      Schema.String,
-    ),
-  exportAsMarkdown: (params: typeof ExportAsMarkdownPayload.Encoded) =>
-    dispatch(
-      execute,
-      { method: "export-as-markdown", params },
-      ExportAsMarkdownPayload,
-      Schema.String,
-    ),
+export const makeCommandClient = <E, R>(send: CommandTransport<E, R>) => ({
+  execute: (params: Omit<typeof Execute.Encoded, "kind">) => {
+    const command = {
+      kind: "execute",
+      ...params,
+    } satisfies typeof Execute.Encoded;
+    return dispatch(send, command, Schema.Null);
+  },
+  updateUiElement: (params: Omit<typeof UpdateUiElement.Encoded, "kind">) => {
+    const command = {
+      kind: "update-ui-element",
+      ...params,
+    } satisfies typeof UpdateUiElement.Encoded;
+    return dispatch(send, command, Schema.Null);
+  },
+  setModelValue: (params: Omit<typeof SetModelValue.Encoded, "kind">) => {
+    const command = {
+      kind: "set-model-value",
+      ...params,
+    } satisfies typeof SetModelValue.Encoded;
+    return dispatch(send, command, Schema.Null);
+  },
+  invokeFunction: (params: Omit<typeof InvokeFunction.Encoded, "kind">) => {
+    const command = {
+      kind: "invoke-function",
+      ...params,
+    } satisfies typeof InvokeFunction.Encoded;
+    return dispatch(send, command, Schema.Null);
+  },
+  interrupt: (params: Omit<typeof Interrupt.Encoded, "kind">) => {
+    const command = {
+      kind: "interrupt",
+      ...params,
+    } satisfies typeof Interrupt.Encoded;
+    return dispatch(send, command, Schema.Null);
+  },
+  deleteCell: (params: Omit<typeof DeleteCell.Encoded, "kind">) => {
+    const command = {
+      kind: "delete-cell",
+      ...params,
+    } satisfies typeof DeleteCell.Encoded;
+    return dispatch(send, command, Schema.Null);
+  },
+  listSqlSchemas: (params: Omit<typeof ListSqlSchemas.Encoded, "kind">) => {
+    const command = {
+      kind: "list-sql-schemas",
+      ...params,
+    } satisfies typeof ListSqlSchemas.Encoded;
+    return dispatch(send, command, Schema.Null);
+  },
+  listSqlTables: (params: Omit<typeof ListSqlTables.Encoded, "kind">) => {
+    const command = {
+      kind: "list-sql-tables",
+      ...params,
+    } satisfies typeof ListSqlTables.Encoded;
+    return dispatch(send, command, Schema.Null);
+  },
+  sendStdin: (params: Omit<typeof SendStdin.Encoded, "kind">) => {
+    const command = {
+      kind: "send-stdin",
+      ...params,
+    } satisfies typeof SendStdin.Encoded;
+    return dispatch(send, command, Schema.Null);
+  },
+  closeSession: (params: Omit<typeof CloseSession.Encoded, "kind">) => {
+    const command = {
+      kind: "close-session",
+      ...params,
+    } satisfies typeof CloseSession.Encoded;
+    return dispatch(send, command, Schema.Null);
+  },
+  restartSession: (params: Omit<typeof RestartSession.Encoded, "kind">) => {
+    const command = {
+      kind: "restart-session",
+      ...params,
+    } satisfies typeof RestartSession.Encoded;
+    return dispatch(send, command, Schema.Null);
+  },
+  moveSession: (params: Omit<typeof MoveSession.Encoded, "kind">) => {
+    const command = {
+      kind: "move-session",
+      ...params,
+    } satisfies typeof MoveSession.Encoded;
+    return dispatch(send, command, Schema.Null);
+  },
+  listSessions: (params: Omit<typeof ListSessions.Encoded, "kind">) => {
+    const command = {
+      kind: "list-sessions",
+      ...params,
+    } satisfies typeof ListSessions.Encoded;
+    return dispatch(send, command, ListSessionsResponse);
+  },
+  shutdownAllSessions: (
+    params: Omit<typeof ShutdownAllSessions.Encoded, "kind">,
+  ) => {
+    const command = {
+      kind: "shutdown-all-sessions",
+      ...params,
+    } satisfies typeof ShutdownAllSessions.Encoded;
+    return dispatch(send, command, Schema.Null);
+  },
+  executeScratchpad: (
+    params: Omit<typeof ExecuteScratchpad.Encoded, "kind">,
+  ) => {
+    const command = {
+      kind: "execute-scratchpad",
+      ...params,
+    } satisfies typeof ExecuteScratchpad.Encoded;
+    return dispatch(send, command, Schema.Null);
+  },
+  listPackages: (params: Omit<typeof ListPackages.Encoded, "kind">) => {
+    const command = {
+      kind: "list-packages",
+      ...params,
+    } satisfies typeof ListPackages.Encoded;
+    return dispatch(send, command, ListPackagesResponse);
+  },
+  getDependencyTree: (
+    params: Omit<typeof GetDependencyTree.Encoded, "kind">,
+  ) => {
+    const command = {
+      kind: "get-dependency-tree",
+      ...params,
+    } satisfies typeof GetDependencyTree.Encoded;
+    return dispatch(send, command, DependencyTreeResponse);
+  },
+  serialize: (params: Omit<typeof Serialize.Encoded, "kind">) => {
+    const command = {
+      kind: "serialize",
+      ...params,
+    } satisfies typeof Serialize.Encoded;
+    return dispatch(send, command, SerializeResponse);
+  },
+  deserialize: (params: Omit<typeof Deserialize.Encoded, "kind">) => {
+    const command = {
+      kind: "deserialize",
+      ...params,
+    } satisfies typeof Deserialize.Encoded;
+    return dispatch(send, command, DeserializeResult);
+  },
+  getConfiguration: (params: Omit<typeof GetConfiguration.Encoded, "kind">) => {
+    const command = {
+      kind: "get-configuration",
+      ...params,
+    } satisfies typeof GetConfiguration.Encoded;
+    return dispatch(send, command, GetConfigurationResponse);
+  },
+  updateConfiguration: (
+    params: Omit<typeof UpdateConfiguration.Encoded, "kind">,
+  ) => {
+    const command = {
+      kind: "update-configuration",
+      ...params,
+    } satisfies typeof UpdateConfiguration.Encoded;
+    return dispatch(send, command, MarimoConfig);
+  },
+  setDisplayTheme: (params: Omit<typeof SetDisplayTheme.Encoded, "kind">) => {
+    const command = {
+      kind: "set-display-theme",
+      ...params,
+    } satisfies typeof SetDisplayTheme.Encoded;
+    return dispatch(send, command, SetDisplayThemeResponse);
+  },
+  readNotebookOutputs: (
+    params: Omit<typeof ReadNotebookOutputs.Encoded, "kind">,
+  ) => {
+    const command = {
+      kind: "read-notebook-outputs",
+      ...params,
+    } satisfies typeof ReadNotebookOutputs.Encoded;
+    return dispatch(send, command, ReadNotebookOutputsResponse);
+  },
+  exportHtml: (params: Omit<typeof ExportHtml.Encoded, "kind">) => {
+    const command = {
+      kind: "export-html",
+      ...params,
+    } satisfies typeof ExportHtml.Encoded;
+    return dispatch(send, command, Schema.String);
+  },
+  exportIpynb: (params: Omit<typeof ExportIpynb.Encoded, "kind">) => {
+    const command = {
+      kind: "export-ipynb",
+      ...params,
+    } satisfies typeof ExportIpynb.Encoded;
+    return dispatch(send, command, Schema.String);
+  },
+  exportMarkdown: (params: Omit<typeof ExportMarkdown.Encoded, "kind">) => {
+    const command = {
+      kind: "export-markdown",
+      ...params,
+    } satisfies typeof ExportMarkdown.Encoded;
+    return dispatch(send, command, Schema.String);
+  },
 });

--- a/extension/src/schemas/__tests__/Models.gen.test.ts
+++ b/extension/src/schemas/__tests__/Models.gen.test.ts
@@ -4,13 +4,12 @@ import { Effect, Result, Schema } from "effect";
 import {
   CellMetadata,
   Command,
-  ExecuteCellsPayload,
-  ExecuteScratchRequest,
-  GetPackageListPayload,
-  makeApiClient,
+  Execute,
+  ExecuteScratchpad,
+  GetDependencyTree,
+  makeCommandClient,
   NotebookDocument,
   NotebookDocumentMetadata,
-  PackageSource,
   VenvSource,
 } from "../Models.gen.ts";
 
@@ -63,19 +62,31 @@ describe("Models.gen (msgspec → Effect Schema codegen)", () => {
   });
 
   it("decodes tagged unions by their msgspec tag field", () => {
-    const venv = Schema.decodeUnknownSync(PackageSource)({
-      kind: "venv",
-      executable: "/usr/bin/python3",
-    });
+    const venv = Schema.decodeUnknownSync(GetDependencyTree)({
+      kind: "get-dependency-tree",
+      notebookUri: "file:///nb.py",
+      source: {
+        kind: "venv",
+        executable: "/usr/bin/python3",
+      },
+    }).source;
     expect(venv).toEqual({ kind: "venv", executable: "/usr/bin/python3" });
 
-    const bad = Schema.decodeUnknownResult(PackageSource)({ kind: "conda" });
+    const bad = Schema.decodeUnknownResult(GetDependencyTree)({
+      kind: "get-dependency-tree",
+      notebookUri: "file:///nb.py",
+      source: { kind: "conda" },
+    });
     expect(Result.isFailure(bad)).toBe(true);
 
     // msgspec accepts an omitted tag when decoding a concrete struct, but
-    // requires it when decoding the tagged union used at this wire boundary.
-    const missing = Schema.decodeUnknownResult(PackageSource)({
-      executable: "/usr/bin/python3",
+    // requires it when decoding the tagged union used by the command.
+    const missing = Schema.decodeUnknownResult(GetDependencyTree)({
+      kind: "get-dependency-tree",
+      notebookUri: "file:///nb.py",
+      source: {
+        executable: "/usr/bin/python3",
+      },
     });
     expect(Result.isFailure(missing)).toBe(true);
   });
@@ -108,28 +119,30 @@ describe("Models.gen (msgspec → Effect Schema codegen)", () => {
   });
 
   it("rejects payloads msgspec would reject", () => {
-    const missingCode = Schema.decodeUnknownResult(ExecuteScratchRequest)({
+    const missingCode = Schema.decodeUnknownResult(ExecuteScratchpad)({
+      kind: "execute-scratchpad",
+      notebookUri: "file:///nb.py",
       runId: "abc",
     });
     expect(Result.isFailure(missingCode)).toBe(true);
   });
 
-  it("decodes a generated package command payload", () => {
-    const decoded = Schema.decodeUnknownSync(GetPackageListPayload)({
+  it("decodes a generated package command", () => {
+    const decoded = Schema.decodeUnknownSync(GetDependencyTree)({
+      kind: "get-dependency-tree",
       notebookUri: "file:///nb.py",
       source: { kind: "script" },
-      inner: {},
     });
-    expect(decoded.inner).toEqual({});
     expect(decoded.source).toEqual({ kind: "script" });
   });
 
-  it("requires workingDirectory for generated session command payloads", () => {
+  it("requires workingDirectory for execute commands", () => {
     expect(() =>
-      Schema.decodeUnknownSync(ExecuteCellsPayload)({
+      Schema.decodeUnknownSync(Execute)({
+        kind: "execute",
         notebookUri: "file:///nb.py",
         executable: "/usr/bin/python",
-        inner: { cellIds: ["cell-1"], codes: ["print(1)"] },
+        cells: [{ cellId: "cell-1", code: "print(1)" }],
       }),
     ).toThrow();
   });
@@ -193,9 +206,9 @@ describe("Models.gen (msgspec → Effect Schema codegen)", () => {
 
   it.effect("requires JSON null for fire-and-forget responses", () =>
     Effect.gen(function* () {
-      const api = makeApiClient(() => Effect.succeed(undefined));
+      const api = makeCommandClient(() => Effect.succeed(undefined));
       const result = yield* Effect.result(
-        api.interrupt({ notebookUri: "file:///nb.py", inner: {} }),
+        api.interrupt({ notebookUri: "file:///nb.py" }),
       );
       expect(Result.isFailure(result)).toBe(true);
     }),

--- a/extension/src/schemas/__tests__/Models.gen.test.ts
+++ b/extension/src/schemas/__tests__/Models.gen.test.ts
@@ -3,6 +3,7 @@ import { Effect, Result, Schema } from "effect";
 
 import {
   CellMetadata,
+  Command,
   ExecuteCellsPayload,
   ExecuteScratchRequest,
   GetPackageListPayload,
@@ -77,6 +78,33 @@ describe("Models.gen (msgspec → Effect Schema codegen)", () => {
       executable: "/usr/bin/python3",
     });
     expect(Result.isFailure(missing)).toBe(true);
+  });
+
+  it("decodes the flat owned command protocol", () => {
+    const decoded = Schema.decodeUnknownSync(Command)({
+      kind: "execute",
+      notebookUri: "file:///nb.py",
+      executable: "/usr/bin/python3",
+      workingDirectory: "/workspace",
+      cells: [{ cellId: "cell-1", code: "answer = 42" }],
+    });
+
+    expect(Schema.encodeSync(Command)(decoded)).toEqual({
+      kind: "execute",
+      notebookUri: "file:///nb.py",
+      executable: "/usr/bin/python3",
+      workingDirectory: "/workspace",
+      cells: [{ cellId: "cell-1", code: "answer = 42" }],
+    });
+
+    expect(
+      Result.isFailure(
+        Schema.decodeUnknownResult(Command)({
+          kind: "execute-cells",
+          notebookUri: "file:///nb.py",
+        }),
+      ),
+    ).toBe(true);
   });
 
   it("rejects payloads msgspec would reject", () => {

--- a/extension/src/schemas/__tests__/Models.gen.test.ts
+++ b/extension/src/schemas/__tests__/Models.gen.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "@effect/vitest";
 import { Effect, Result, Schema } from "effect";
 
+import commandProtocol from "../../../../tests/fixtures/command_protocol.json";
 import {
   CellMetadata,
   Command,
@@ -116,6 +117,19 @@ describe("Models.gen (msgspec → Effect Schema codegen)", () => {
         }),
       ),
     ).toBe(true);
+  });
+
+  it("matches the shared command compatibility corpus", () => {
+    for (const command of commandProtocol.valid) {
+      const decoded = Schema.decodeUnknownSync(Command)(command);
+      expect(Schema.encodeSync(Command)(decoded)).toEqual(command);
+    }
+
+    for (const command of commandProtocol.invalid) {
+      expect(
+        Result.isFailure(Schema.decodeUnknownResult(Command)(command)),
+      ).toBe(true);
+    }
   });
 
   it("rejects payloads msgspec would reject", () => {

--- a/extension/src/telemetry/__tests__/classifyNotebookDeserializeError.test.ts
+++ b/extension/src/telemetry/__tests__/classifyNotebookDeserializeError.test.ts
@@ -113,11 +113,8 @@ it("separates client lifecycle failures from internal RPC errors", () => {
 function commandError(cause: unknown) {
   return new MarimoCommandError({
     command: Redacted.make({
-      command: "marimo.api" as const,
-      params: {
-        method: "deserialize" as const,
-        params: { source: "DO_NOT_UPLOAD_COMMAND_SOURCE" },
-      },
+      kind: "deserialize" as const,
+      source: "DO_NOT_UPLOAD_COMMAND_SOURCE",
     }),
     cause,
     mode: "wasm",

--- a/extension/src/telemetry/__tests__/sentrySink.test.ts
+++ b/extension/src/telemetry/__tests__/sentrySink.test.ts
@@ -8,11 +8,8 @@ import { classifySentryError } from "../sentrySink.ts";
 function commandError(cause: Error): MarimoCommandError {
   return new MarimoCommandError({
     command: Redacted.make({
-      command: "marimo.api",
-      params: {
-        method: "deserialize",
-        params: { source: "" },
-      },
+      kind: "deserialize",
+      source: "",
     }),
     cause,
     mode: "wasm",

--- a/extension/src/telemetry/classifyNotebookDeserializeError.ts
+++ b/extension/src/telemetry/classifyNotebookDeserializeError.ts
@@ -86,8 +86,7 @@ export function classifyNotebookDeserializeError(
 }
 
 function commandMethod(error: MarimoCommandError): string | undefined {
-  const command = Redacted.value(error.command);
-  return command.params.method;
+  return Redacted.value(error.command).kind;
 }
 
 function rpcCode(error: unknown): number | undefined {

--- a/extension/src/types.ts
+++ b/extension/src/types.ts
@@ -42,18 +42,11 @@ export type MarimoConfig = Gen.MarimoConfig;
 export type SessionInfo = Gen.SessionInfo;
 export type SessionsSnapshot = Gen.ListSessionsResponse;
 
-/**
- * Wire shape of one `marimo.api` call. The generated client
- * (`schemas/Models.gen.ts`, from the `API_METHODS` registry in
- * `src/marimo_lsp/api.py`) owns the per-method payload/response schemas;
- * this is what they erase to at the transport.
- */
-export type MarimoApiCall = Gen.MarimoApiCall;
-
-/** The kernel-bound `inner` payload of a generated `marimo.api` method. */
-type InnerOf<Payload> = Payload extends { readonly inner: infer Inner }
-  ? Inner
-  : never;
+type EncodedCommand = typeof Gen.Command.Encoded;
+type CommandFields<K extends EncodedCommand["kind"]> = Omit<
+  Extract<EncodedCommand, { readonly kind: K }>,
+  "kind" | "notebookUri" | "kernelSessionId"
+>;
 
 /**
  * Subset of API methods allowed to be dispatched by the renderer.
@@ -73,10 +66,10 @@ type InnerOf<Payload> = Payload extends { readonly inner: infer Inner }
  * extension (which has access to the VSCode API and notebook editor).
  */
 type RendererCommandMap = {
-  // Forward to extension marimo.api
-  "update-ui-element": InnerOf<typeof Gen.UpdateUiElementPayload.Encoded>;
-  "set-model-value": InnerOf<typeof Gen.SetModelValuePayload.Encoded>;
-  "invoke-function": InnerOf<typeof Gen.InvokeFunctionPayload.Encoded>;
+  // Forward to the extension's private command protocol.
+  "update-ui-element": CommandFields<"update-ui-element">;
+  "set-model-value": CommandFields<"set-model-value">;
+  "invoke-function": CommandFields<"invoke-function">;
   // Custom
   "navigate-to-cell": { cellId: NotebookCellId };
   // Image toolbar: the sandboxed renderer can't read cross-origin image bytes,

--- a/scripts/codegen/effect_schemas.py
+++ b/scripts/codegen/effect_schemas.py
@@ -1,13 +1,13 @@
 # Copyright 2026 Marimo. All rights reserved.
 
-"""Generate Effect `Schema` definitions from `marimo_lsp.models` msgspec Structs.
+"""Generate Effect `Schema` definitions from owned msgspec protocol types.
 
 Walks msgspec's introspection IR (`msgspec.inspect`) directly — no JSON Schema
 round-trip — and emits `extension/src/schemas/Models.gen.ts` so the TypeScript
 side *parses* our own wire types instead of assuming them.
 
-Only types owned by marimo-lsp are emitted. Types re-exported from marimo core
-(`ExecuteCellsRequest`, ...) stay on the `@marimo-team/openapi` path.
+The generated named client validates the owned tagged command union before it
+crosses the private LSP request and validates each declared response.
 
 Run through the repository codegen entry point: ``just codegen``.
 """
@@ -21,7 +21,7 @@ import msgspec
 import msgspec.inspect as mi
 
 from marimo_lsp import models, protocol
-from marimo_lsp.api import API_METHODS, ApiMethod
+from marimo_lsp.api import COMMANDS, CommandSpec
 from scripts.codegen.output import EXTENSION
 
 OUTPUT = EXTENSION / "src" / "schemas" / "Models.gen.ts"
@@ -31,7 +31,7 @@ HEADER = """\
 // AUTO-GENERATED FILE — DO NOT EDIT.
 //
 // Generated from `src/marimo_lsp/protocol.py`, `src/marimo_lsp/models.py`,
-// and the `marimo.api` registry (`API_METHODS` in `src/marimo_lsp/api.py`)
+// and the command registry (`COMMANDS` in `src/marimo_lsp/api.py`)
 // by `scripts.codegen`.
 // Regenerate with `just codegen`.
 import type { components as MarimoApi } from "@marimo-team/openapi/src/api";
@@ -82,26 +82,14 @@ _StructLike = mi.StructType | mi.DataclassType | mi.TypedDictType
 # (exported name, type) pairs. The emitter topologically orders dependencies.
 CONCRETE: list[tuple[str, type | object]] = [
     ("Command", protocol.Command),
-    ("PackageSource", models.PackageSource),
     ("OwnedAppConfig", models.OwnedAppConfig),
     ("KernelNotification", models.KernelNotification),
     ("DocumentAnalysis", models.DocumentAnalysis),
     ("CellMetadata", models.CellMetadata),
     ("NotebookDocumentMetadata", models.NotebookDocumentMetadata),
     ("NotebookDocument", models.NotebookDocument),
-    ("DeserializeRequest", models.DeserializeRequest),
     ("DeserializeResult", models.DeserializeResult),
     ("ConvertRequest", models.ConvertRequest),
-    ("InterruptRequest", models.InterruptRequest),
-    ("ListPackagesRequest", models.ListPackagesRequest),
-    ("DependencyTreeRequest", models.DependencyTreeRequest),
-    ("GetConfigurationRequest", models.GetConfigurationRequest),
-    ("CloseSessionRequest", models.CloseSessionRequest),
-    ("ExportAsIpynbRequest", models.ExportAsIpynbRequest),
-    ("ExecuteScratchRequest", models.ExecuteScratchRequest),
-    ("UpdateConfigurationRequest", models.UpdateConfigurationRequest),
-    ("SetDisplayThemeRequest", models.SetDisplayThemeRequest),
-    ("ReadNotebookOutputsRequest", models.ReadNotebookOutputsRequest),
     ("CellOutputReplay", models.CellOutputReplay),
 ]
 
@@ -502,54 +490,44 @@ class Emitter:
             f"export type {name} = typeof {name}.Type;\n"
         )
 
-    def emit_api_method(self, method: ApiMethod) -> tuple[str, str]:
-        """Emit the payload schema for one registry entry.
-
-        Returns the method's PascalCase name and success schema expression (the
-        client factory references the success schema statically per method).
-        """
-        class_name = _pascal(method.name)
-        info = mi.type_info(method.request)
-        if not isinstance(info, _StructLike):
-            msg = f"api method {method.name!r} request must be struct-like"
+    def emit_command(self, spec: CommandSpec) -> tuple[str, str, str, str]:
+        """Return a command's schema, method, tag, and success schema."""
+        info = mi.type_info(spec.request)
+        if not isinstance(info, mi.StructType) or info.tag is None:
+            msg = f"command {spec.request!r} must be a tagged struct"
             raise TypeError(msg)
-        payload = self.fields_src(info, indent="  ")
-        success = self.type_expr(mi.type_info(method.response))
-        self.definitions.append(
-            f"export const {class_name}Payload = Schema.Struct({{\n{payload}}});\n"
+        return (
+            info.cls.__name__,
+            _camel(str(info.tag)),
+            str(info.tag),
+            self.type_expr(mi.type_info(spec.response)),
         )
-        return class_name, success
 
 
 _DISPATCH_HELPER = """\
-type ApiTransport<E, R> = (call: MarimoApiCall) => Effect.Effect<unknown, E, R>;
+type CommandTransport<E, R> = (
+  command: typeof Command.Encoded,
+) => Effect.Effect<unknown, E, R>;
 
 /**
- * Validate the outgoing params against the payload schema (the wire/Encoded
- * side, so defaulted fields stay omittable), send them verbatim, and parse
- * the response against the method's success schema.
+ * Validate the complete outgoing command, send it verbatim, and parse the
+ * response against the command's declared success schema.
  */
 const dispatch = <
-  Payload extends Schema.Top,
   Success extends Schema.Top,
   E,
   R,
 >(
-  execute: ApiTransport<E, R>,
-  call: MarimoApiCall & { readonly params: Payload["Encoded"] },
-  payload: Payload,
+  send: CommandTransport<E, R>,
+  command: typeof Command.Encoded,
   success: Success,
 ): Effect.Effect<
   Success["Type"],
   E | Schema.SchemaError,
-  R | Payload["DecodingServices"] | Success["DecodingServices"]
+  R | Success["DecodingServices"]
 > =>
-  Effect.andThen(
-    Schema.decodeEffect(payload)(call.params),
-    Effect.flatMap(
-      execute(call),
-      Schema.decodeUnknownEffect(success),
-    ),
+  Effect.flatMap(Schema.decodeEffect(Command)(command), () =>
+    Effect.flatMap(send(command), Schema.decodeUnknownEffect(success)),
   );
 """
 
@@ -558,43 +536,23 @@ def generate() -> str:
     emitter = Emitter()
     for name, t in CONCRETE:
         emitter.emit_named(name, t)
-    api = [emitter.emit_api_method(method) for method in API_METHODS]
-    members = "\n".join(
-        f"  | {{ readonly method: {_ts_string(method.name)}; "
-        f"readonly params: typeof {class_name}Payload.Encoded }}"
-        for (class_name, _), method in zip(api, API_METHODS, strict=True)
-    )
-    emitter.definitions.append(
-        "/**\n"
-        " * Every command accepted by the `marimo.api` transport.\n"
-        " *\n"
-        " * Generated from the `API_METHODS` registry in `src/marimo_lsp/api.py`,\n"
-        " * which is also what the server dispatches and validates against.\n"
-        " */\n"
-        f"export type MarimoApiCall =\n{members};\n"
-    )
+    commands = [emitter.emit_command(spec) for spec in COMMANDS]
     emitter.definitions.append(_DISPATCH_HELPER)
     methods = "\n".join(
-        f"  {_camel(method.name)}: (\n"
-        f"    params: typeof {class_name}Payload.Encoded,\n"
-        f"  ) =>\n"
-        f"    dispatch(\n"
-        f"      execute,\n"
-        f"      {{ method: {_ts_string(method.name)}, params }},\n"
-        f"      {class_name}Payload,\n"
-        f"      {success},\n"
-        f"    ),"
-        for (class_name, success), method in zip(api, API_METHODS, strict=True)
+        f'  {method}: (params: Omit<typeof {class_name}.Encoded, "kind">) => {{\n'
+        f"    const command = {{ kind: {_ts_string(tag)}, ...params }} "
+        f"satisfies typeof {class_name}.Encoded;\n"
+        f"    return dispatch(send, command, {success});\n"
+        "  },"
+        for class_name, method, tag, success in commands
     )
     emitter.definitions.append(
         "/**\n"
-        " * Typed `marimo.api` client surface: one method per registry entry.\n"
+        " * Named extension methods over the private owned command protocol.\n"
         " *\n"
-        " * Each method encodes its payload, dispatches `{ method, params }` over\n"
-        " * `execute`, and parses the response against the method's success schema —\n"
-        " * both sides of the wire are earned, not asserted.\n"
+        " * Ordinary extension code never constructs or switches over the raw union.\n"
         " */\n"
-        "export const makeApiClient = <E, R>(execute: ApiTransport<E, R>) => ({\n"
+        "export const makeCommandClient = <E, R>(send: CommandTransport<E, R>) => ({\n"
         f"{methods}\n"
         "});\n"
     )

--- a/scripts/codegen/effect_schemas.py
+++ b/scripts/codegen/effect_schemas.py
@@ -20,7 +20,7 @@ import json
 import msgspec
 import msgspec.inspect as mi
 
-from marimo_lsp import models
+from marimo_lsp import models, protocol
 from marimo_lsp.api import API_METHODS, ApiMethod
 from scripts.codegen.output import EXTENSION
 
@@ -30,8 +30,9 @@ LABEL = "Effect schemas"
 HEADER = """\
 // AUTO-GENERATED FILE — DO NOT EDIT.
 //
-// Generated from `src/marimo_lsp/models.py` and the `marimo.api` registry
-// (`API_METHODS` in `src/marimo_lsp/api.py`) by `scripts.codegen`.
+// Generated from `src/marimo_lsp/protocol.py`, `src/marimo_lsp/models.py`,
+// and the `marimo.api` registry (`API_METHODS` in `src/marimo_lsp/api.py`)
+// by `scripts.codegen`.
 // Regenerate with `just codegen`.
 import type { components as MarimoApi } from "@marimo-team/openapi/src/api";
 import { Effect, Schema } from "effect";
@@ -80,6 +81,7 @@ _StructLike = mi.StructType | mi.DataclassType | mi.TypedDictType
 
 # (exported name, type) pairs. The emitter topologically orders dependencies.
 CONCRETE: list[tuple[str, type | object]] = [
+    ("Command", protocol.Command),
     ("PackageSource", models.PackageSource),
     ("OwnedAppConfig", models.OwnedAppConfig),
     ("KernelNotification", models.KernelNotification),
@@ -183,6 +185,19 @@ class Emitter:
         self.alias_by_expr: dict[str, str] = {}
         self.in_flight: set[type] = set()
         self.recursive: set[type] = set()
+        # These two brands predate first-class protocol metadata and remain in
+        # the static header while legacy models migrate to the owned protocol.
+        self.brand_schemas: dict[str, str] = {
+            "KernelSessionId": "KernelSessionIdFromString",
+            "NotebookId": "NotebookIdFromString",
+        }
+
+    @staticmethod
+    def metadata_brand(t: mi.Type) -> object | None:
+        """Return the owned brand attached to a msgspec metadata node."""
+        if not isinstance(t, mi.Metadata) or t.extra_json_schema is None:
+            return None
+        return t.extra_json_schema.get(protocol.BRAND_METADATA_KEY)
 
     # Exhaustive dispatch over msgspec's IR node types is a flat switch by
     # design; splitting it up would hide the one-to-one mapping this encodes.
@@ -221,8 +236,11 @@ class Emitter:
                 args = ", ".join(self.type_expr(i) for i in items)
                 return f"Schema.Tuple([{args}])"
             case mi.Metadata(type=inner):
-                # `typing.Annotated[..., msgspec.Meta(...)]`; constraints are
-                # already folded into the inner node.
+                brand = self.metadata_brand(t)
+                if brand is not None:
+                    return self.brand_ref(brand, inner)
+                # Other `msgspec.Meta` constraints are already folded into the
+                # inner node.
                 return self.type_expr(inner)
             case mi.UnionType(types=types):
                 return self.union_expr(list(types))
@@ -260,6 +278,27 @@ class Emitter:
                 f"export type {name} = typeof {name}.Type;\n"
             )
         return name
+
+    def brand_ref(self, brand: object, inner: mi.Type) -> str:
+        """Emit or reference an owned nominal string schema."""
+        if not isinstance(brand, str) or not brand.isidentifier():
+            msg = f"invalid owned brand name: {brand!r}"
+            raise ValueError(msg)
+        if not isinstance(inner, mi.StrType):
+            msg = f"owned brand {brand!r} must annotate a string"
+            raise TypeError(msg)
+
+        schema_name = self.brand_schemas.get(brand)
+        if schema_name is not None:
+            return schema_name
+
+        schema_name = f"{brand}FromString"
+        self.brand_schemas[brand] = schema_name
+        self.definitions.append(
+            f'export const {schema_name} = Schema.String.pipe(Schema.brand("{brand}"));\n'
+            f"export type {brand} = typeof {schema_name}.Type;\n"
+        )
+        return schema_name
 
     def struct_ref(self, t: _StructLike) -> str:
         """Emit a struct/dataclass/TypedDict definition (once); return its name."""
@@ -352,6 +391,12 @@ class Emitter:
             case mi.TupleType(item_types=items):
                 return f"readonly [{', '.join(self.ts_type(i) for i in items)}]"
             case mi.Metadata(type=inner):
+                brand = self.metadata_brand(t)
+                if brand is not None:
+                    self.brand_ref(brand, inner)
+                    if not isinstance(brand, str):  # guarded by brand_ref
+                        raise AssertionError
+                    return brand
                 return self.ts_type(inner)
             case mi.UnionType(types=types):
                 return " | ".join(self.ts_type(x) for x in types)
@@ -363,6 +408,33 @@ class Emitter:
                 msg = f"no TS type mapping for {type(t).__name__}"
                 raise NotImplementedError(msg)
 
+    def field_type_expr(self, t: _StructLike, field: mi.Field) -> str:
+        """Resolve one field, including temporary legacy type projections."""
+        if self.metadata_brand(field.type) is not None:
+            expr = self.type_expr(field.type)
+        elif t.cls in {models.LiveCellReplay, models.SavedCellReplay} and (
+            field.name == "notification"
+        ):
+            expr = "CellOperationNotification"
+        elif t.cls is models.KernelNotification and field.name == "notification":
+            expr = "MarimoNotification"
+        elif t.cls is models.DocumentAnalysis and field.name == "analysis":
+            expr = "VariablesNotification"
+        elif field.name == "notebook_uri":
+            expr = "NotebookIdFromString"
+        elif field.name == "session_id":
+            nullable = isinstance(field.type, mi.UnionType) and any(
+                isinstance(member, mi.NoneType) for member in field.type.types
+            )
+            expr = (
+                "Schema.NullOr(KernelSessionIdFromString)"
+                if nullable
+                else "KernelSessionIdFromString"
+            )
+        else:
+            expr = self.type_expr(field.type)
+        return expr
+
     def fields_src(self, t: _StructLike, indent: str) -> str:
         lines: list[str] = []
         if isinstance(t, mi.StructType) and t.tag_field is not None:
@@ -372,27 +444,7 @@ class Emitter:
             tag = _ts_string(str(t.tag))
             lines.append(f"{indent}{_prop(t.tag_field)}: Schema.Literal({tag}),")
         for field in t.fields:
-            if t.cls in {models.LiveCellReplay, models.SavedCellReplay} and (
-                field.name == "notification"
-            ):
-                expr = "CellOperationNotification"
-            elif t.cls is models.KernelNotification and field.name == "notification":
-                expr = "MarimoNotification"
-            elif t.cls is models.DocumentAnalysis and field.name == "analysis":
-                expr = "VariablesNotification"
-            elif field.name == "notebook_uri":
-                expr = "NotebookIdFromString"
-            elif field.name == "session_id":
-                nullable = isinstance(field.type, mi.UnionType) and any(
-                    isinstance(member, mi.NoneType) for member in field.type.types
-                )
-                expr = (
-                    "Schema.NullOr(KernelSessionIdFromString)"
-                    if nullable
-                    else "KernelSessionIdFromString"
-                )
-            else:
-                expr = self.type_expr(field.type)
+            expr = self.field_type_expr(t, field)
             prop = _prop(field.encode_name)
             if field.required:
                 rendered = expr if prop == expr else f"{prop}: {expr}"
@@ -470,7 +522,7 @@ class Emitter:
 
 
 _DISPATCH_HELPER = """\
-type Execute<E, R> = (call: MarimoApiCall) => Effect.Effect<unknown, E, R>;
+type ApiTransport<E, R> = (call: MarimoApiCall) => Effect.Effect<unknown, E, R>;
 
 /**
  * Validate the outgoing params against the payload schema (the wire/Encoded
@@ -483,7 +535,7 @@ const dispatch = <
   E,
   R,
 >(
-  execute: Execute<E, R>,
+  execute: ApiTransport<E, R>,
   call: MarimoApiCall & { readonly params: Payload["Encoded"] },
   payload: Payload,
   success: Success,
@@ -542,7 +594,7 @@ def generate() -> str:
         " * `execute`, and parses the response against the method's success schema —\n"
         " * both sides of the wire are earned, not asserted.\n"
         " */\n"
-        "export const makeApiClient = <E, R>(execute: Execute<E, R>) => ({\n"
+        "export const makeApiClient = <E, R>(execute: ApiTransport<E, R>) => ({\n"
         f"{methods}\n"
         "});\n"
     )

--- a/src/marimo_lsp/api.py
+++ b/src/marimo_lsp/api.py
@@ -1,6 +1,6 @@
 # Copyright 2026 Marimo. All rights reserved.
 
-"""Handlers for marimo.api commands."""
+"""Handlers for the owned private command protocol."""
 
 from __future__ import annotations
 
@@ -29,65 +29,54 @@ from marimo._export.serialization import serialize_notebook_snapshot
 from marimo._messaging.msgspec_encoder import encode_json_bytes
 from marimo._runtime.commands import (
     ExecuteScratchpadCommand,
+    HTTPRequest,
     InvokeFunctionCommand,
+    ModelCustomMessage,
+    ModelUpdateMessage,
 )
 from marimo._runtime.packages.package_manager import PackageDescription
 from marimo._runtime.packages.package_managers import create_package_manager
 from marimo._schemas.export import ExportAsHTMLRequest, to_html_export_options
 from marimo._schemas.export_options import IPYNBExportOptions, MarkdownExportOptions
+from marimo._schemas.notebook import NotebookV1
 from marimo._schemas.serialization import (
     AppInstantiation,
     Header,
 )
 from marimo._session.requests import InstantiateNotebookRequest
 from marimo._session.state.serialize import serialize_session_view
+from marimo._types.ids import (
+    CellId_t,
+    RequestId,
+    SessionId,
+    UIElementId,
+    WidgetModelId,
+)
 from pygls.uris import to_fs_path
 from typing_extensions import TypeForm
 
+from marimo_lsp import protocol
 from marimo_lsp.app_file_manager import find_notebook_document, snapshot_for_scratchpad
 from marimo_lsp.loggers import get_logger
 from marimo_lsp.models import (
-    CloseSessionRequest,
     DeleteCellRequest,
-    DependencyTreeRequest,
     DependencyTreeResponse,
     DeserializeConvertible,
     DeserializeInvalidSyntax,
-    DeserializeRequest,
     DeserializeResult,
     DeserializeSuccess,
     ExecuteCellsRequest,
-    ExecuteScratchRequest,
-    ExportAsIpynbRequest,
-    ExportAsMarkdownRequest,
-    GetConfigurationRequest,
     GetConfigurationResponse,
-    InterruptRequest,
-    KernelCommand,
-    ListPackagesRequest,
     ListPackagesResponse,
-    ListSessionsRequest,
     ListSessionsResponse,
     ListSQLSchemasRequest,
     ListSQLTablesRequest,
     ModelRequest,
-    MoveSessionRequest,
-    NotebookCommand,
     NotebookDocument,
-    PackageCommand,
-    ReadNotebookOutputsRequest,
     ReadNotebookOutputsResponse,
-    RestartSessionRequest,
-    ScriptSource,
     SerializeResponse,
-    SessionCommand,
-    SetDisplayThemeRequest,
     SetDisplayThemeResponse,
-    ShutdownAllSessionsRequest,
-    StdinRequest,
-    UpdateConfigurationRequest,
     UpdateUIElementRequest,
-    VenvSource,
 )
 from marimo_lsp.package_manager import LspPackageManager
 
@@ -97,7 +86,6 @@ if TYPE_CHECKING:
         PartialMarimoConfig,
         SharingConfig,
     )
-    from marimo._types.ids import SessionId
     from pygls.lsp.server import LanguageServer
 
     from marimo_lsp.sessions import Session, Sessions
@@ -108,7 +96,7 @@ _APP_CONFIG_FIELD_NAMES = frozenset(
 )
 
 
-__all__ = ["API_METHODS", "ApiBuilder", "ApiMethod", "handle_api_command"]
+__all__ = ["COMMANDS", "CommandBuilder", "CommandSpec", "handle_command"]
 
 logger = get_logger()
 _API_HANDLER_PARAMETER_COUNT = 2
@@ -133,41 +121,42 @@ class ApiContext:
     sessions: Sessions
 
 
-type ApiHandler[Req, Res] = typing.Callable[
+type CommandHandler[Req, Res] = typing.Callable[
     [ApiContext, Req],
     typing.Awaitable[Res],
 ]
 
 
 @dataclasses.dataclass(frozen=True)
-class ApiMethod[Req, Res]:
-    """One ``marimo.api`` method consumed by dispatch and schema generation."""
+class CommandSpec[Req, Res]:
+    """One owned command consumed by dispatch and schema generation."""
 
-    name: str
     request: TypeForm[Req]
     response: TypeForm[Res]
-    handler: ApiHandler[Req, Res]
+    handler: CommandHandler[Req, Res]
 
 
-class ApiBuilder:
-    """Build a method table from typed async handler declarations."""
+class CommandBuilder:
+    """Build a command table from typed async handler declarations."""
 
     def __init__(self) -> None:
-        self._methods: list[ApiMethod[typing.Any, typing.Any]] = []
+        self._commands: list[CommandSpec[typing.Any, typing.Any]] = []
         self._built = False
 
     def __call__[Req, Res](
         self,
-        name: str,
-    ) -> typing.Callable[[ApiHandler[Req, Res]], ApiHandler[Req, Res]]:
-        """Register an async handler under its wire method name."""
+        command_type: TypeForm[Req],
+    ) -> typing.Callable[[CommandHandler[Req, Res]], CommandHandler[Req, Res]]:
+        """Register an async handler for one tagged command variant."""
 
-        def register(handler: ApiHandler[Req, Res]) -> ApiHandler[Req, Res]:
+        def register(
+            handler: CommandHandler[Req, Res],
+        ) -> CommandHandler[Req, Res]:
             if self._built:
-                msg = "cannot register API methods after build()"
+                msg = "cannot register commands after build()"
                 raise RuntimeError(msg)
             if not inspect.iscoroutinefunction(handler):
-                msg = f"API handler {name!r} must be async"
+                msg = f"command handler {command_type!r} must be async"
                 raise TypeError(msg)
 
             parameters = list(inspect.signature(handler).parameters.values())
@@ -178,50 +167,56 @@ class ApiBuilder:
             if len(parameters) != _API_HANDLER_PARAMETER_COUNT or any(
                 parameter.kind not in positional for parameter in parameters
             ):
-                msg = f"API handler {name!r} must accept (ApiContext, request)"
+                msg = f"command handler {command_type!r} must accept (ApiContext, request)"
                 raise TypeError(msg)
 
             hints = typing.get_type_hints(handler)
             context_parameter, request_parameter = parameters
             if hints.get(context_parameter.name) is not ApiContext:
-                msg = f"API handler {name!r} first parameter must be ApiContext"
+                msg = f"command handler {command_type!r} first parameter must be ApiContext"
                 raise TypeError(msg)
             if request_parameter.name not in hints:
-                msg = f"API handler {name!r} request parameter must be annotated"
+                msg = f"command handler {command_type!r} request must be annotated"
                 raise TypeError(msg)
             if "return" not in hints:
-                msg = f"API handler {name!r} return type must be annotated"
+                msg = f"command handler {command_type!r} return must be annotated"
                 raise TypeError(msg)
 
             request = cast("TypeForm[Req]", hints[request_parameter.name])
+            if request is not command_type:
+                msg = (
+                    f"command handler annotation {request!r} does not match "
+                    f"registered type {command_type!r}"
+                )
+                raise TypeError(msg)
             response_hint = hints["return"]
             response = cast(
                 "TypeForm[Res]",
                 type(None) if response_hint is None else response_hint,
             )
-            self._methods.append(ApiMethod(name, request, response, handler))
+            self._commands.append(CommandSpec(request, response, handler))
             return handler
 
         return register
 
-    def build(self) -> tuple[ApiMethod[typing.Any, typing.Any], ...]:
-        """Validate and return the immutable method table."""
+    def build(self) -> tuple[CommandSpec[typing.Any, typing.Any], ...]:
+        """Validate and return the immutable command table."""
         if self._built:
-            msg = "API method table has already been built"
+            msg = "command table has already been built"
             raise RuntimeError(msg)
 
-        names: set[str] = set()
-        for method in self._methods:
-            if method.name in names:
-                msg = f"duplicate API method: {method.name!r}"
+        command_types: set[object] = set()
+        for command in self._commands:
+            if command.request in command_types:
+                msg = f"duplicate command type: {command.request!r}"
                 raise ValueError(msg)
-            names.add(method.name)
+            command_types.add(command.request)
 
         self._built = True
-        return tuple(self._methods)
+        return tuple(self._commands)
 
 
-marimo_api = ApiBuilder()
+command = CommandBuilder()
 
 
 class SessionNotFoundError(ValueError):
@@ -266,11 +261,8 @@ def _get_display_config(config: MarimoConfig) -> DisplayConfig:
     return cast("DisplayConfig", config.get("display", {}))
 
 
-@marimo_api("execute-cells")
-async def run(
-    ctx: ApiContext,
-    args: SessionCommand[ExecuteCellsRequest],
-) -> None:
+@command(protocol.Execute)
+async def run(ctx: ApiContext, args: protocol.Execute) -> None:
     logger.info(f"run for {args.notebook_uri}")
     session = await ctx.sessions.start(
         args.notebook_uri, args.executable, args.working_directory
@@ -285,160 +277,218 @@ async def run(
         InstantiateNotebookRequest(auto_run=False, object_ids=[], values=[]),
         http_request=None,
     )
-    session.put_control_request(args.inner.as_command(), from_consumer_id=None)
+    request = ExecuteCellsRequest(
+        cell_ids=[CellId_t(str(cell.cell_id)) for cell in args.cells],
+        codes=[cell.code for cell in args.cells],
+    )
+    session.put_control_request(request.as_command(), from_consumer_id=None)
     logger.info(f"Execution request sent for {args.notebook_uri}")
 
 
-@marimo_api("update-ui-element")
+@command(protocol.UpdateUiElement)
 async def set_ui_element_value(
     ctx: ApiContext,
-    args: KernelCommand[UpdateUIElementRequest],
+    args: protocol.UpdateUiElement,
 ) -> None:
     logger.info(f"set_ui_element_value for {args.notebook_uri}")
-    session = _require_kernel_session(ctx, args.notebook_uri, args.session_id)
-    session.put_control_request(args.inner.as_command(), from_consumer_id=None)
+    session = _require_kernel_session(
+        ctx, args.notebook_uri, SessionId(str(args.kernel_session_id))
+    )
+    http_request = (
+        msgspec.convert(args.request, type=HTTPRequest)
+        if args.request is not None
+        else None
+    )
+    kwargs: dict[str, object] = {
+        "object_ids": [UIElementId(value) for value in args.object_ids],
+        "values": args.values,
+        "request": http_request,
+    }
+    if args.token is not None:
+        kwargs["token"] = args.token
+    request = UpdateUIElementRequest(**kwargs)  # ty: ignore[invalid-argument-type]
+    session.put_control_request(request.as_command(), from_consumer_id=None)
 
 
-@marimo_api("set-model-value")
+@command(protocol.SetModelValue)
 async def set_model_value(
     ctx: ApiContext,
-    args: KernelCommand[ModelRequest],
+    args: protocol.SetModelValue,
 ) -> None:
     logger.info(f"set_model_value for {args.notebook_uri}")
-    session = _require_kernel_session(ctx, args.notebook_uri, args.session_id)
-    session.put_control_request(args.inner.as_command(), from_consumer_id=None)
+    session = _require_kernel_session(
+        ctx, args.notebook_uri, SessionId(str(args.kernel_session_id))
+    )
+    match args.message:
+        case protocol.ModelUpdateMessage():
+            message = ModelUpdateMessage(
+                state=cast("typing.Any", args.message.state),
+                buffer_paths=args.message.buffer_paths,
+            )
+        case protocol.ModelCustomMessage():
+            message = ModelCustomMessage(
+                content=cast("typing.Any", args.message.content)
+            )
+    kwargs = {
+        "model_id": WidgetModelId(args.model_id),
+        "message": message,
+        "buffers": args.buffers,
+    }
+    if args.token is not None:
+        kwargs["token"] = args.token
+    request = ModelRequest(**kwargs)  # ty: ignore[invalid-argument-type]
+    session.put_control_request(request.as_command(), from_consumer_id=None)
 
 
-@marimo_api("invoke-function")
+@command(protocol.InvokeFunction)
 async def function_call_request(
     ctx: ApiContext,
-    args: KernelCommand[InvokeFunctionCommand],
+    args: protocol.InvokeFunction,
 ) -> None:
     logger.info(f"function_call_request for {args.notebook_uri}")
-    session = _require_kernel_session(ctx, args.notebook_uri, args.session_id)
-    session.put_control_request(args.inner, from_consumer_id=None)
+    session = _require_kernel_session(
+        ctx, args.notebook_uri, SessionId(str(args.kernel_session_id))
+    )
+    session.put_control_request(
+        InvokeFunctionCommand(
+            function_call_id=RequestId(args.function_call_id),
+            namespace=args.namespace,
+            function_name=args.function_name,
+            args=args.args,
+        ),
+        from_consumer_id=None,
+    )
 
 
-@marimo_api("interrupt")
-async def interrupt(
-    ctx: ApiContext,
-    args: NotebookCommand[InterruptRequest],
-) -> None:
+@command(protocol.Interrupt)
+async def interrupt(ctx: ApiContext, args: protocol.Interrupt) -> None:
     logger.info(f"interrupt for {args.notebook_uri}")
-    if args.inner.run_id is not None:
-        ctx.sessions.cancel_scratchpad(args.notebook_uri, args.inner.run_id)
+    if args.run_id is not None:
+        ctx.sessions.cancel_scratchpad(args.notebook_uri, args.run_id)
         logger.info(
-            f"Scratchpad cancellation recorded for {args.notebook_uri} "
-            f"({args.inner.run_id})"
+            f"Scratchpad cancellation recorded for {args.notebook_uri} ({args.run_id})"
         )
         return
 
-    session_id = args.inner.session_id
+    session_id = args.kernel_session_id
     if session_id is None:
         raise KernelSessionRequiredError(args.notebook_uri)
-    session = _require_kernel_session(ctx, args.notebook_uri, session_id)
+    session = _require_kernel_session(
+        ctx, args.notebook_uri, SessionId(str(session_id))
+    )
     session.try_interrupt()
     logger.info(f"Interrupt request sent for {args.notebook_uri}")
 
 
-@marimo_api("delete-cell")
+@command(protocol.DeleteCell)
 async def delete_cell(
     ctx: ApiContext,
-    args: KernelCommand[DeleteCellRequest],
+    args: protocol.DeleteCell,
 ) -> None:
     logger.info(f"delete_cell for {args.notebook_uri}")
-    session = _require_kernel_session(ctx, args.notebook_uri, args.session_id)
-    session.put_control_request(args.inner.as_command(), from_consumer_id=None)
+    session = _require_kernel_session(
+        ctx, args.notebook_uri, SessionId(str(args.kernel_session_id))
+    )
+    request = DeleteCellRequest(cell_id=CellId_t(str(args.cell_id)))
+    session.put_control_request(request.as_command(), from_consumer_id=None)
     logger.info(f"Delete cell request sent for {args.notebook_uri}")
 
 
-@marimo_api("list-sql-schemas")
+@command(protocol.ListSqlSchemas)
 async def list_sql_schemas(
     ctx: ApiContext,
-    args: KernelCommand[ListSQLSchemasRequest],
+    args: protocol.ListSqlSchemas,
 ) -> None:
     """Request the immediate child schemas at a database path."""
-    session = _require_kernel_session(ctx, args.notebook_uri, args.session_id)
-    session.put_control_request(args.inner.as_command(), from_consumer_id=None)
+    session = _require_kernel_session(
+        ctx, args.notebook_uri, SessionId(str(args.kernel_session_id))
+    )
+    request = ListSQLSchemasRequest(
+        request_id=RequestId(args.request_id),
+        engine=args.engine,
+        database=args.database,
+        schema_path=args.schema_path,
+    )
+    session.put_control_request(request.as_command(), from_consumer_id=None)
 
 
-@marimo_api("list-sql-tables")
+@command(protocol.ListSqlTables)
 async def list_sql_tables(
     ctx: ApiContext,
-    args: KernelCommand[ListSQLTablesRequest],
+    args: protocol.ListSqlTables,
 ) -> None:
     """Request the tables belonging to a schema path."""
-    session = _require_kernel_session(ctx, args.notebook_uri, args.session_id)
-    session.put_control_request(args.inner.as_command(), from_consumer_id=None)
+    session = _require_kernel_session(
+        ctx, args.notebook_uri, SessionId(str(args.kernel_session_id))
+    )
+    request = ListSQLTablesRequest(
+        request_id=RequestId(args.request_id),
+        engine=args.engine,
+        database=args.database,
+        schema=args.schema,
+        schema_path=args.schema_path,
+    )
+    session.put_control_request(request.as_command(), from_consumer_id=None)
 
 
-@marimo_api("send-stdin")
-async def send_stdin(
-    ctx: ApiContext,
-    args: KernelCommand[StdinRequest],
-) -> None:
+@command(protocol.SendStdin)
+async def send_stdin(ctx: ApiContext, args: protocol.SendStdin) -> None:
     logger.info(f"send_stdin for {args.notebook_uri}")
-    session = _require_kernel_session(ctx, args.notebook_uri, args.session_id)
-    session.put_input(args.inner.text)
+    session = _require_kernel_session(
+        ctx, args.notebook_uri, SessionId(str(args.kernel_session_id))
+    )
+    session.put_input(args.text)
 
 
-@marimo_api("close-session")
-async def close_session(
-    ctx: ApiContext,
-    args: NotebookCommand[CloseSessionRequest],
-) -> None:
+@command(protocol.CloseSession)
+async def close_session(ctx: ApiContext, args: protocol.CloseSession) -> None:
     logger.info(f"close_session for {args.notebook_uri}")
     ctx.sessions.close(args.notebook_uri)
 
 
-@marimo_api("restart-session")
+@command(protocol.RestartSession)
 async def restart_session(
     ctx: ApiContext,
-    args: NotebookCommand[RestartSessionRequest],
+    args: protocol.RestartSession,
 ) -> None:
     logger.info(f"restart_session for {args.notebook_uri}")
     restarted = await ctx.sessions.restart(
         args.notebook_uri,
-        executable=args.inner.executable,
-        working_directory=args.inner.working_directory,
-        create_if_missing=args.inner.create_if_missing,
+        executable=args.executable,
+        working_directory=args.working_directory,
+        create_if_missing=args.create_if_missing,
     )
     if restarted is None:
         raise SessionNotFoundError(args.notebook_uri)
 
 
-@marimo_api("move-session")
-async def move_session(
-    ctx: ApiContext,
-    args: NotebookCommand[MoveSessionRequest],
-) -> None:
-    logger.info(
-        f"move_session from {args.notebook_uri} to {args.inner.new_notebook_uri}"
-    )
-    ctx.sessions.move(args.notebook_uri, args.inner.new_notebook_uri)
+@command(protocol.MoveSession)
+async def move_session(ctx: ApiContext, args: protocol.MoveSession) -> None:
+    logger.info(f"move_session from {args.notebook_uri} to {args.new_notebook_uri}")
+    ctx.sessions.move(args.notebook_uri, args.new_notebook_uri)
 
 
-@marimo_api("list-sessions")
+@command(protocol.ListSessions)
 async def list_sessions(
     ctx: ApiContext,
-    _args: ListSessionsRequest,
+    _args: protocol.ListSessions,
 ) -> ListSessionsResponse:
     return ListSessionsResponse(sessions=ctx.sessions.describe())
 
 
-@marimo_api("shutdown-all-sessions")
+@command(protocol.ShutdownAllSessions)
 async def shutdown_all_sessions(
     ctx: ApiContext,
-    _args: ShutdownAllSessionsRequest,
+    _args: protocol.ShutdownAllSessions,
 ) -> None:
     """Close every live kernel session with one collection mutation."""
     ctx.sessions.close_all()
 
 
-@marimo_api("execute-scratchpad")
+@command(protocol.ExecuteScratchpad)
 async def execute_scratch(
     ctx: ApiContext,
-    args: SessionCommand[ExecuteScratchRequest],
+    args: protocol.ExecuteScratchpad,
 ) -> None:
     """Execute code in the scratchpad (isolated from dependency graph).
 
@@ -450,7 +500,7 @@ async def execute_scratch(
     Creates the session on demand when none exists, like :func:`run`.
     """
     logger.info(f"execute_scratch for {args.notebook_uri}")
-    run_id = args.inner.run_id
+    run_id = args.run_id
     if run_id is not None and ctx.sessions.take_scratchpad_cancellation(
         args.notebook_uri, run_id
     ):
@@ -495,8 +545,8 @@ async def execute_scratch(
 
         session.put_control_request(
             ExecuteScratchpadCommand(
-                code=args.inner.code,
-                run_id=args.inner.run_id,
+                code=args.code,
+                run_id=args.run_id,
                 notebook_cells=notebook_cells,
                 cell_outputs=cell_outputs,
             ),
@@ -508,10 +558,10 @@ async def execute_scratch(
     logger.info(f"Scratchpad execution request sent for {args.notebook_uri}")
 
 
-@marimo_api("get-package-list")
+@command(protocol.ListPackages)
 async def get_package_list(
     _ctx: ApiContext,
-    args: PackageCommand[ListPackagesRequest],
+    args: protocol.ListPackages,
 ) -> ListPackagesResponse:
     logger.info(f"get_package_list for {args.notebook_uri}")
     package_manager = _package_manager_for(args.source)
@@ -519,7 +569,7 @@ async def get_package_list(
         logger.warning(f"Package manager not installed for {args.notebook_uri}")
         return ListPackagesResponse(packages=[])
 
-    if isinstance(args.source, ScriptSource):
+    if isinstance(args.source, protocol.ScriptSource):
         # No bound venv to `uv pip list` against; flatten `uv tree --script`
         # instead. Falling through to the venv path here would list packages
         # from whatever Python uv defaulted to (the LSP's own env), not the
@@ -533,15 +583,15 @@ async def get_package_list(
     return ListPackagesResponse(packages=package_manager.list_packages())
 
 
-@marimo_api("get-dependency-tree")
+@command(protocol.GetDependencyTree)
 async def get_dependency_tree(
     _ctx: ApiContext,
-    args: PackageCommand[DependencyTreeRequest],
+    args: protocol.GetDependencyTree,
 ) -> DependencyTreeResponse:
     logger.info(f"get_dependency_tree for {args.notebook_uri}")
     package_manager = _package_manager_for(args.source)
 
-    if isinstance(args.source, ScriptSource):
+    if isinstance(args.source, protocol.ScriptSource):
         # PEP 723 sandbox script: derive the filename from the notebook URI
         # and let `uv tree --script <file>` resolve the env.
         filename = _script_filename(args.notebook_uri)
@@ -575,7 +625,7 @@ def _flatten_tree(tree: object) -> list[PackageDescription]:
     """Walk a `uv tree` result and return a deduplicated list of packages.
 
     Mirrors marimo's own `UvPackageManager.list_packages` flattening so that
-    the script-mode `get-package-list` response shape matches the venv-mode
+    the script-mode `list-packages` response shape matches the venv-mode
     `uv pip list` response.
     """
     if tree is None:
@@ -595,7 +645,7 @@ def _flatten_tree(tree: object) -> list[PackageDescription]:
     return sorted(packages, key=lambda p: p.name)
 
 
-def _package_manager_for(source: VenvSource | ScriptSource) -> LspPackageManager:
+def _package_manager_for(source: protocol.PackageSource) -> LspPackageManager:
     """Build a package manager for the given environment source.
 
     We pin the underlying tool to `uv` for both variants today: `uv pip list`
@@ -603,16 +653,19 @@ def _package_manager_for(source: VenvSource | ScriptSource) -> LspPackageManager
     introspect a PEP 723 script's deps. A future server-side change can pick
     the user's preferred manager for venv mode without a wire-protocol change.
     """
-    venv_location = source.executable if isinstance(source, VenvSource) else None
+    venv_location = (
+        source.executable if isinstance(source, protocol.VenvSource) else None
+    )
     return LspPackageManager(
         delegate=create_package_manager("uv"),
         venv_location=venv_location,
     )
 
 
-@marimo_api("serialize")
-async def serialize(_ctx: ApiContext, args: NotebookDocument) -> SerializeResponse:
-    ir = MarimoConvert.from_notebook_v1(args.notebook).to_ir()
+@command(protocol.Serialize)
+async def serialize(_ctx: ApiContext, args: protocol.Serialize) -> SerializeResponse:
+    notebook = msgspec.convert(args.notebook, type=NotebookV1)
+    ir = MarimoConvert.from_notebook_v1(notebook).to_ir()
     known_options = {
         name: value
         for name, value in args.app_config.items()
@@ -692,10 +745,10 @@ def _restore_unknown_app_options(source: str, options: dict[str, object]) -> str
     return f"{source[: end - 1]}{insertion}{source[end - 1 :]}"
 
 
-@marimo_api("deserialize")
+@command(protocol.Deserialize)
 async def deserialize(
     _ctx: ApiContext,
-    args: DeserializeRequest,
+    args: protocol.Deserialize,
 ) -> DeserializeResult:
     try:
         converter = MarimoConvert.from_py(args.source)
@@ -768,10 +821,10 @@ def _classify_convertible(
     return DeserializeConvertible()
 
 
-@marimo_api("get-configuration")
+@command(protocol.GetConfiguration)
 async def get_configuration(
     ctx: ApiContext,
-    args: NotebookCommand[GetConfigurationRequest],
+    args: protocol.GetConfiguration,
 ) -> GetConfigurationResponse:
     """Get the current marimo configuration."""
     session = ctx.sessions.get(args.notebook_uri)
@@ -782,13 +835,13 @@ async def get_configuration(
     return GetConfigurationResponse(config=session.get_config())
 
 
-@marimo_api("update-configuration")
+@command(protocol.UpdateConfiguration)
 async def update_configuration(
     ctx: ApiContext,
-    args: NotebookCommand[UpdateConfigurationRequest],
+    args: protocol.UpdateConfiguration,
 ) -> MarimoConfig:
     """Update the marimo user configuration."""
-    config = _as_partial_marimo_config(args.inner.config)
+    config = _as_partial_marimo_config(args.config)
     session = ctx.sessions.get(args.notebook_uri)
     if not session:
         manager = get_default_config_manager(current_path=to_fs_path(args.notebook_uri))
@@ -798,10 +851,10 @@ async def update_configuration(
     return session.save_config(config)
 
 
-@marimo_api("set-display-theme")
+@command(protocol.SetDisplayTheme)
 async def set_display_theme(
     ctx: ApiContext,
-    args: SetDisplayThemeRequest,
+    args: protocol.SetDisplayTheme,
 ) -> SetDisplayThemeResponse:
     """Set the display theme in all kernels without persisting to disk."""
     for session in ctx.sessions:
@@ -814,15 +867,15 @@ async def set_display_theme(
     return SetDisplayThemeResponse(success=True)
 
 
-@marimo_api("read-notebook-outputs")
+@command(protocol.ReadNotebookOutputs)
 async def read_notebook_outputs(
     ctx: ApiContext,
-    args: NotebookCommand[ReadNotebookOutputsRequest],
+    args: protocol.ReadNotebookOutputs,
 ) -> ReadNotebookOutputsResponse:
     """Replay the live SessionView, falling back to a compatible sidecar."""
     replay = await ctx.sessions.read_notebook_outputs(
         args.notebook_uri,
-        session_cache_path=args.inner.session_cache_path,
+        session_cache_path=args.session_cache_path,
     )
     # Match marimo's websocket JSON normalization before pygls serializes the
     # response (for example, non-finite output numbers become JSON null).
@@ -832,10 +885,10 @@ async def read_notebook_outputs(
     )
 
 
-@marimo_api("export-as-html")
+@command(protocol.ExportHtml)
 async def export_as_html(
     ctx: ApiContext,
-    args: NotebookCommand[ExportAsHTMLRequest],
+    args: protocol.ExportHtml,
 ) -> str:
     """Export the notebook as HTML with current outputs."""
     logger.info(f"export_as_html for {args.notebook_uri}")
@@ -857,7 +910,14 @@ async def export_as_html(
                 include_model_notifications=True,
             ),
             display_config=_get_display_config(config),
-            options=to_html_export_options(args.inner),
+            options=to_html_export_options(
+                ExportAsHTMLRequest(
+                    download=args.download,
+                    files=args.files,
+                    include_code=args.include_code,
+                    asset_url=args.asset_url,
+                )
+            ),
             sharing_config=cast("SharingConfig | None", config.get("sharing")),
         )
     )
@@ -865,10 +925,10 @@ async def export_as_html(
     return html
 
 
-@marimo_api("export-as-ipynb")
+@command(protocol.ExportIpynb)
 async def export_as_ipynb(
     ctx: ApiContext,
-    args: NotebookCommand[ExportAsIpynbRequest],
+    args: protocol.ExportIpynb,
 ) -> str:
     """Export the notebook as ipynb with current outputs."""
     logger.info(f"export_as_ipynb for {args.notebook_uri}")
@@ -895,10 +955,10 @@ async def export_as_ipynb(
     return json.dumps(ipynb)
 
 
-@marimo_api("export-as-markdown")
+@command(protocol.ExportMarkdown)
 async def export_as_markdown(
     ctx: ApiContext,
-    args: NotebookCommand[ExportAsMarkdownRequest],
+    args: protocol.ExportMarkdown,
 ) -> str:
     """Export the notebook as Markdown."""
     logger.info(f"export_as_markdown for {args.notebook_uri}")
@@ -917,29 +977,26 @@ async def export_as_markdown(
     return result.text
 
 
-API_METHODS = marimo_api.build()
+COMMANDS = command.build()
 
-_API_BY_NAME = {method.name: method for method in API_METHODS}
+_COMMAND_BY_TYPE = {spec.request: spec for spec in COMMANDS}
 
 
-async def handle_api_command(
+async def handle_command(
     ls: LanguageServer,
     sessions: Sessions,
-    method: str,
-    params: dict[str, object],
+    request: protocol.Command,
 ) -> object:
-    """Unified API endpoint for all marimo internal methods.
+    """Dispatch a validated owned command and validate its response.
 
-    Converts ``params`` into the method's request type, runs the handler, and
-    validates the result against the declared response annotation so the wire
-    always matches the generated client schemas.
+    The command's concrete type selects its handler; there is no second string
+    method or untyped params envelope to keep in sync with the tagged union.
     """
-    spec = _API_BY_NAME.get(method)
+    spec = _COMMAND_BY_TYPE.get(type(request))
     if spec is None:
-        logger.warning(f"Unknown API method: {method}")
-        raise ValueError(method)
+        msg = f"Unknown command type: {type(request)!r}"
+        raise TypeError(msg)
 
-    request = msgspec.convert(params, type=spec.request)
     result = await spec.handler(ApiContext(ls=ls, sessions=sessions), request)
 
     validated = msgspec.convert(result, type=spec.response)

--- a/src/marimo_lsp/models.py
+++ b/src/marimo_lsp/models.py
@@ -28,11 +28,6 @@ from marimo._schemas.notebook import (
 from marimo._server.models.packages import DependencyTreeNode  # noqa: TC002
 from marimo._types.ids import SessionId  # noqa: TC002
 
-# NOTE: the generic structs below use the legacy TypeVar spelling (noqa: UP046)
-# because msgspec's annotation resolver cannot see PEP 695 type parameters —
-# `NotebookCommand[X]` raises `NameError: name 'T' is not defined` at decode.
-T = typing.TypeVar("T", bound=msgspec.Struct)
-
 # Sentinel the frontend `@marimo-team/smart-cells` SQL parser writes into
 # `sourceProjections.sql.engine` for the implicit default engine. We must not
 # emit `engine=__marimo_duckdb` when round-tripping these cells.
@@ -60,27 +55,6 @@ class OwnedAppConfig(msgspec.Struct):
     auto_download: list[str] = msgspec.field(default_factory=list)
 
 
-class NotebookCommand(msgspec.Struct, typing.Generic[T], rename="camel"):  # noqa: UP046
-    """Wraps a marimo command with its target notebook context.
-
-    Associates any marimo command/request with the specific notebook
-    it should operate on, enabling proper routing in multi-notebook
-    environments.
-    """
-
-    notebook_uri: str
-    """The URI of the notebook."""
-
-    inner: T
-    """The wrapped marimo command to execute."""
-
-
-class KernelCommand(NotebookCommand[T]):
-    """A command addressed to one exact live kernel."""
-
-    session_id: SessionId
-
-
 class KernelNotification(msgspec.Struct, rename="camel"):
     """A notification emitted by one exact live kernel."""
 
@@ -94,47 +68,6 @@ class DocumentAnalysis(msgspec.Struct, rename="camel"):
 
     notebook_uri: str
     analysis: VariablesNotification
-
-
-class SessionCommand(NotebookCommand[T]):
-    """A notebook command that is further routed to a specific runtime/session."""
-
-    executable: str
-    """The target environment Python executable."""
-
-    working_directory: str
-    """Absolute working directory for the launched kernel."""
-
-
-class VenvSource(msgspec.Struct, tag="venv", tag_field="kind", rename="camel"):
-    """The notebook's environment is a concrete venv with a known python executable."""
-
-    executable: str
-    """Path to the python binary inside the venv."""
-
-
-class ScriptSource(msgspec.Struct, tag="script", tag_field="kind", rename="camel"):
-    """The notebook's environment is a PEP 723 sandbox script.
-
-    The server resolves the script filename from the notebook URI; `uv`
-    derives the venv from the script's inline metadata.
-    """
-
-
-PackageSource = VenvSource | ScriptSource
-"""Discriminated union of environment sources for package endpoints."""
-
-
-class PackageCommand(NotebookCommand[T]):
-    """A notebook command that describes its python environment via a `PackageSource`.
-
-    Distinct from `SessionCommand`: package endpoints don't talk to a live
-    marimo kernel — they shell out to `uv` — and sandbox notebooks have no
-    pre-resolved python executable for the client to send.
-    """
-
-    source: PackageSource
-    """How to resolve the notebook's python environment."""
 
 
 type SmartCellQuotePrefix = typing.Literal["", "f", "r", "fr", "rf"]
@@ -257,17 +190,6 @@ class NotebookDocument(msgspec.Struct, rename="camel"):
     header: str | None = None
 
 
-class DeserializeRequest(msgspec.Struct, rename="camel"):
-    """
-    A request to deserialize Python source to notebook format.
-
-    Contains the source code to be parsed.
-    """
-
-    source: str
-    """The Python source code to deserialize."""
-
-
 class DeserializeSuccess(
     msgspec.Struct, tag="success", tag_field="kind", rename="camel"
 ):
@@ -303,64 +225,6 @@ class ConvertRequest(msgspec.Struct, rename="camel"):
     """The identifier for the text document to convert"""
 
 
-class InterruptRequest(msgspec.Struct, rename="camel"):
-    """A request to interrupt the kernel execution."""
-
-    run_id: str | None = None
-    """Optional scratchpad run to cancel.
-
-    Correlating cancellation lets the language server remember an interrupt
-    that arrives while the run's kernel session is still starting.
-    """
-
-    session_id: SessionId | None = None
-    """The exact live kernel to interrupt for an ordinary cancellation."""
-
-
-class ListPackagesRequest(msgspec.Struct, rename="camel"):
-    """A request to list installed packages in the kernel environment."""
-
-
-class DependencyTreeRequest(msgspec.Struct, rename="camel"):
-    """A request to get the dependency tree of installed packages."""
-
-
-class GetConfigurationRequest(msgspec.Struct, rename="camel"):
-    """A request to get the current configuration."""
-
-
-class CloseSessionRequest(msgspec.Struct, rename="camel"):
-    """A request to close the current session."""
-
-
-class RestartSessionRequest(msgspec.Struct, rename="camel"):
-    """A request to restart a live session's kernel."""
-
-    executable: str
-    """Executable used to restart or restore the session."""
-
-    working_directory: str
-    """Working directory used to restart or restore the session."""
-
-    create_if_missing: bool = False
-    """Create a replacement only for an explicit restore operation."""
-
-
-class MoveSessionRequest(msgspec.Struct, rename="camel"):
-    """A request to move a live session to a renamed notebook URI."""
-
-    new_notebook_uri: str
-    """The notebook URI after the rename."""
-
-
-class ListSessionsRequest(msgspec.Struct, rename="camel"):
-    """A request for all live sessions owned by this language server."""
-
-
-class ShutdownAllSessionsRequest(msgspec.Struct, rename="camel"):
-    """A request to close every live session owned by this language server."""
-
-
 class SessionInfo(msgspec.Struct, rename="camel", frozen=True):
     """User-facing state for one live kernel session."""
 
@@ -380,62 +244,8 @@ class ListSessionsResponse(msgspec.Struct, rename="camel"):
     sessions: list[SessionInfo]
 
 
-class ExportAsIpynbRequest(msgspec.Struct, rename="camel"):
-    """A request to export the notebook as ipynb."""
-
-
-class ExportAsMarkdownRequest(msgspec.Struct, rename="camel"):
-    """A request to export the notebook as Markdown."""
-
-
-class ExecuteScratchRequest(msgspec.Struct, rename="camel"):
-    """Execute arbitrary Python code outside the dependency graph."""
-
-    code: str
-    """The Python code to execute."""
-
-    run_id: str | None = None
-    """Optional correlation id, echoed back on the kernel's ``completed-run``
-    ``marimo/operation`` notification (consumed client-side in KernelManager).
-
-    Lets a caller wait for *its* completion (including any code-mode cascade)
-    rather than the scratch cell's idle.
-    """
-
-
-class UpdateConfigurationRequest(msgspec.Struct, rename="camel"):
-    """A request to update the user configuration."""
-
-    config: dict[str, object]
-    """The partial configuration to merge with the current config."""
-
-
-class SetDisplayThemeRequest(msgspec.Struct, rename="camel"):
-    """A request to set the display theme without persisting to disk."""
-
-    theme: typing.Literal["light", "dark"]
-    """The theme to set ('light' or 'dark')."""
-
-
-class ReadNotebookOutputsRequest(msgspec.Struct, rename="camel"):
-    """Resolve outputs for an opened notebook without starting a kernel."""
-
-    session_cache_path: str | None = None
-    """Conventional cold-cache path, or ``None`` for live-session replay only."""
-
-
-class ApiRequest(msgspec.Struct, rename="camel"):
-    """A unified API request for all marimo internal methods."""
-
-    method: str
-    """The API method to call (e.g., 'run', 'interrupt', 'serialize')."""
-
-    params: dict[str, object]
-    """The parameters for the method."""
-
-
 class ListPackagesResponse(msgspec.Struct, rename="camel"):
-    """Response for ``get-package-list``."""
+    """Response for ``list-packages``."""
 
     packages: list[PackageDescription]
     """Installed packages in the notebook's environment."""

--- a/src/marimo_lsp/protocol.py
+++ b/src/marimo_lsp/protocol.py
@@ -30,12 +30,112 @@ KernelSessionId = typing.NewType("KernelSessionId", str)
 CellId = typing.NewType("CellId", str)
 """Opaque identifier for one notebook cell."""
 
+type JsonObject = dict[str, object]
+type AppConfig = dict[str, object]
+
+
+class SerializedNotebookCellConfig(typing.TypedDict, total=False):
+    """Persisted marimo configuration for one notebook cell."""
+
+    column: int | None
+    disabled: bool | None
+    hide_code: bool | None
+
+
+class SerializedNotebookCell(typing.TypedDict):
+    """One code cell in the serialized notebook format."""
+
+    id: str | None
+    code: str | None
+    code_hash: str | None
+    name: str | None
+    config: SerializedNotebookCellConfig
+
+
+class SerializedNotebookMetadata(typing.TypedDict, total=False):
+    """Metadata stored with the serialized notebook."""
+
+    marimo_version: str | None
+
+
+class SerializedNotebookV1(typing.TypedDict):
+    """Owned projection of marimo's version-one notebook document."""
+
+    version: typing.Literal["1"]
+    metadata: SerializedNotebookMetadata
+    cells: list[SerializedNotebookCell]
+
+
+class NotebookDocument(
+    msgspec.Struct,
+    rename="camel",
+    forbid_unknown_fields=True,
+):
+    """Strict notebook data plus source-level application metadata."""
+
+    notebook: SerializedNotebookV1
+    app_config: AppConfig = msgspec.field(default_factory=dict)
+    header: str | None = None
+
 
 class CellExecution(msgspec.Struct, rename="camel", forbid_unknown_fields=True):
     """One cell and the exact source to execute for it."""
 
     cell_id: typing.Annotated[CellId, _brand("CellId")]
     code: str
+
+
+class ModelUpdateMessage(
+    msgspec.Struct,
+    tag="update",
+    tag_field="method",
+    rename="camel",
+    forbid_unknown_fields=True,
+):
+    """State update sent to one widget model."""
+
+    state: JsonObject
+    buffer_paths: list[list[str | int]]
+
+
+class ModelCustomMessage(
+    msgspec.Struct,
+    tag="custom",
+    tag_field="method",
+    rename="camel",
+    forbid_unknown_fields=True,
+):
+    """Custom message sent to one widget model."""
+
+    content: object
+
+
+type ModelMessage = ModelUpdateMessage | ModelCustomMessage
+
+
+class VenvSource(
+    msgspec.Struct,
+    tag="venv",
+    tag_field="kind",
+    rename="camel",
+    forbid_unknown_fields=True,
+):
+    """A concrete environment identified by its Python executable."""
+
+    executable: str
+
+
+class ScriptSource(
+    msgspec.Struct,
+    tag="script",
+    tag_field="kind",
+    rename="camel",
+    forbid_unknown_fields=True,
+):
+    """A PEP 723 environment resolved from the notebook script."""
+
+
+type PackageSource = VenvSource | ScriptSource
 
 
 class Execute(
@@ -67,5 +167,366 @@ class DeleteCell(
     cell_id: typing.Annotated[CellId, _brand("CellId")]
 
 
-type Command = Execute | DeleteCell
+class UpdateUiElement(
+    msgspec.Struct,
+    tag="update-ui-element",
+    tag_field="kind",
+    rename="camel",
+    forbid_unknown_fields=True,
+):
+    """Update one or more UI element values in an exact kernel."""
+
+    notebook_uri: typing.Annotated[NotebookUri, _brand("NotebookUri")]
+    kernel_session_id: typing.Annotated[KernelSessionId, _brand("KernelSessionId")]
+    object_ids: list[str]
+    values: list[object]
+    request: JsonObject | None = None
+    token: str | None = None
+
+
+class SetModelValue(
+    msgspec.Struct,
+    tag="set-model-value",
+    tag_field="kind",
+    rename="camel",
+    forbid_unknown_fields=True,
+):
+    """Update state for one widget model in an exact kernel."""
+
+    notebook_uri: typing.Annotated[NotebookUri, _brand("NotebookUri")]
+    kernel_session_id: typing.Annotated[KernelSessionId, _brand("KernelSessionId")]
+    model_id: str
+    message: ModelMessage
+    buffers: list[bytes]
+    token: str | None = None
+
+
+class InvokeFunction(
+    msgspec.Struct,
+    tag="invoke-function",
+    tag_field="kind",
+    rename="camel",
+    forbid_unknown_fields=True,
+):
+    """Invoke a registered function in an exact kernel."""
+
+    notebook_uri: typing.Annotated[NotebookUri, _brand("NotebookUri")]
+    kernel_session_id: typing.Annotated[KernelSessionId, _brand("KernelSessionId")]
+    function_call_id: str
+    namespace: str
+    function_name: str
+    args: JsonObject
+
+
+class Interrupt(
+    msgspec.Struct,
+    tag="interrupt",
+    tag_field="kind",
+    rename="camel",
+    forbid_unknown_fields=True,
+):
+    """Interrupt an exact kernel or cancel a pending scratch execution."""
+
+    notebook_uri: typing.Annotated[NotebookUri, _brand("NotebookUri")]
+    kernel_session_id: (
+        typing.Annotated[KernelSessionId, _brand("KernelSessionId")] | None
+    ) = None
+    run_id: str | None = None
+
+
+class ListSqlSchemas(
+    msgspec.Struct,
+    tag="list-sql-schemas",
+    tag_field="kind",
+    rename="camel",
+    forbid_unknown_fields=True,
+):
+    """List immediate child schemas at a database path."""
+
+    notebook_uri: typing.Annotated[NotebookUri, _brand("NotebookUri")]
+    kernel_session_id: typing.Annotated[KernelSessionId, _brand("KernelSessionId")]
+    request_id: str
+    engine: str
+    database: str
+    schema_path: list[str] = msgspec.field(default_factory=list)
+
+
+class ListSqlTables(
+    msgspec.Struct,
+    tag="list-sql-tables",
+    tag_field="kind",
+    rename="camel",
+    forbid_unknown_fields=True,
+):
+    """List tables in one database schema."""
+
+    notebook_uri: typing.Annotated[NotebookUri, _brand("NotebookUri")]
+    kernel_session_id: typing.Annotated[KernelSessionId, _brand("KernelSessionId")]
+    request_id: str
+    engine: str
+    database: str
+    schema: str
+    schema_path: list[str] = msgspec.field(default_factory=list)
+
+
+class SendStdin(
+    msgspec.Struct,
+    tag="send-stdin",
+    tag_field="kind",
+    rename="camel",
+    forbid_unknown_fields=True,
+):
+    """Respond to a stdin prompt in an exact kernel."""
+
+    notebook_uri: typing.Annotated[NotebookUri, _brand("NotebookUri")]
+    kernel_session_id: typing.Annotated[KernelSessionId, _brand("KernelSessionId")]
+    text: str
+
+
+class CloseSession(
+    msgspec.Struct,
+    tag="close-session",
+    tag_field="kind",
+    rename="camel",
+    forbid_unknown_fields=True,
+):
+    """Close the live session for one notebook."""
+
+    notebook_uri: typing.Annotated[NotebookUri, _brand("NotebookUri")]
+
+
+class RestartSession(
+    msgspec.Struct,
+    tag="restart-session",
+    tag_field="kind",
+    rename="camel",
+    forbid_unknown_fields=True,
+):
+    """Restart or restore the live session for one notebook."""
+
+    notebook_uri: typing.Annotated[NotebookUri, _brand("NotebookUri")]
+    executable: str
+    working_directory: str
+    create_if_missing: bool = False
+
+
+class MoveSession(
+    msgspec.Struct,
+    tag="move-session",
+    tag_field="kind",
+    rename="camel",
+    forbid_unknown_fields=True,
+):
+    """Move a live session after its notebook is renamed."""
+
+    notebook_uri: typing.Annotated[NotebookUri, _brand("NotebookUri")]
+    new_notebook_uri: typing.Annotated[NotebookUri, _brand("NotebookUri")]
+
+
+class ListSessions(
+    msgspec.Struct,
+    tag="list-sessions",
+    tag_field="kind",
+    rename="camel",
+    forbid_unknown_fields=True,
+):
+    """List all live sessions owned by the language server."""
+
+
+class ShutdownAllSessions(
+    msgspec.Struct,
+    tag="shutdown-all-sessions",
+    tag_field="kind",
+    rename="camel",
+    forbid_unknown_fields=True,
+):
+    """Close every live session owned by the language server."""
+
+
+class ExecuteScratchpad(
+    msgspec.Struct,
+    tag="execute-scratchpad",
+    tag_field="kind",
+    rename="camel",
+    forbid_unknown_fields=True,
+):
+    """Execute transient code against a notebook kernel."""
+
+    notebook_uri: typing.Annotated[NotebookUri, _brand("NotebookUri")]
+    executable: str
+    working_directory: str
+    code: str
+    run_id: str | None = None
+
+
+class ListPackages(
+    msgspec.Struct,
+    tag="list-packages",
+    tag_field="kind",
+    rename="camel",
+    forbid_unknown_fields=True,
+):
+    """List packages installed in a notebook environment."""
+
+    notebook_uri: typing.Annotated[NotebookUri, _brand("NotebookUri")]
+    source: PackageSource
+
+
+class GetDependencyTree(
+    msgspec.Struct,
+    tag="get-dependency-tree",
+    tag_field="kind",
+    rename="camel",
+    forbid_unknown_fields=True,
+):
+    """Read the dependency tree for a notebook environment."""
+
+    notebook_uri: typing.Annotated[NotebookUri, _brand("NotebookUri")]
+    source: PackageSource
+
+
+class Serialize(
+    msgspec.Struct,
+    tag="serialize",
+    tag_field="kind",
+    rename="camel",
+    forbid_unknown_fields=True,
+):
+    """Serialize notebook data to native marimo Python source."""
+
+    notebook: SerializedNotebookV1
+    app_config: AppConfig = msgspec.field(default_factory=dict)
+    header: str | None = None
+
+
+class Deserialize(
+    msgspec.Struct,
+    tag="deserialize",
+    tag_field="kind",
+    rename="camel",
+    forbid_unknown_fields=True,
+):
+    """Deserialize source into notebook data."""
+
+    source: str
+
+
+class GetConfiguration(
+    msgspec.Struct,
+    tag="get-configuration",
+    tag_field="kind",
+    rename="camel",
+    forbid_unknown_fields=True,
+):
+    """Read configuration for one notebook."""
+
+    notebook_uri: typing.Annotated[NotebookUri, _brand("NotebookUri")]
+
+
+class UpdateConfiguration(
+    msgspec.Struct,
+    tag="update-configuration",
+    tag_field="kind",
+    rename="camel",
+    forbid_unknown_fields=True,
+):
+    """Merge a configuration patch for one notebook."""
+
+    notebook_uri: typing.Annotated[NotebookUri, _brand("NotebookUri")]
+    config: JsonObject
+
+
+class SetDisplayTheme(
+    msgspec.Struct,
+    tag="set-display-theme",
+    tag_field="kind",
+    rename="camel",
+    forbid_unknown_fields=True,
+):
+    """Set the display theme for live sessions."""
+
+    theme: typing.Literal["light", "dark"]
+
+
+class ReadNotebookOutputs(
+    msgspec.Struct,
+    tag="read-notebook-outputs",
+    tag_field="kind",
+    rename="camel",
+    forbid_unknown_fields=True,
+):
+    """Read outputs without starting a notebook kernel."""
+
+    notebook_uri: typing.Annotated[NotebookUri, _brand("NotebookUri")]
+    session_cache_path: str | None = None
+
+
+class ExportHtml(
+    msgspec.Struct,
+    tag="export-html",
+    tag_field="kind",
+    rename="camel",
+    forbid_unknown_fields=True,
+):
+    """Export one notebook as HTML."""
+
+    notebook_uri: typing.Annotated[NotebookUri, _brand("NotebookUri")]
+    download: bool
+    files: list[str]
+    include_code: bool
+    asset_url: str | None = None
+
+
+class ExportIpynb(
+    msgspec.Struct,
+    tag="export-ipynb",
+    tag_field="kind",
+    rename="camel",
+    forbid_unknown_fields=True,
+):
+    """Export one notebook as ipynb JSON."""
+
+    notebook_uri: typing.Annotated[NotebookUri, _brand("NotebookUri")]
+
+
+class ExportMarkdown(
+    msgspec.Struct,
+    tag="export-markdown",
+    tag_field="kind",
+    rename="camel",
+    forbid_unknown_fields=True,
+):
+    """Export one notebook as Markdown."""
+
+    notebook_uri: typing.Annotated[NotebookUri, _brand("NotebookUri")]
+
+
+type Command = (
+    Execute
+    | UpdateUiElement
+    | SetModelValue
+    | InvokeFunction
+    | Interrupt
+    | DeleteCell
+    | ListSqlSchemas
+    | ListSqlTables
+    | SendStdin
+    | CloseSession
+    | RestartSession
+    | MoveSession
+    | ListSessions
+    | ShutdownAllSessions
+    | ExecuteScratchpad
+    | ListPackages
+    | GetDependencyTree
+    | Serialize
+    | Deserialize
+    | GetConfiguration
+    | UpdateConfiguration
+    | SetDisplayTheme
+    | ReadNotebookOutputs
+    | ExportHtml
+    | ExportIpynb
+    | ExportMarkdown
+)
 """Commands accepted by the private ``marimo/command`` request."""

--- a/src/marimo_lsp/protocol.py
+++ b/src/marimo_lsp/protocol.py
@@ -1,0 +1,71 @@
+# Copyright 2026 Marimo. All rights reserved.
+
+"""Owned messages exchanged privately between marimo-lsp and the extension.
+
+This module is the source for cross-language type generation. It deliberately
+does not import marimo: conversion to and from marimo's runtime types belongs in
+an Adapter at the marimo seam.
+"""
+
+from __future__ import annotations
+
+import typing
+
+import msgspec
+
+BRAND_METADATA_KEY = "x-marimo-lsp-brand"
+"""Metadata key consumed by cross-language protocol generators."""
+
+
+def _brand(name: str) -> msgspec.Meta:
+    return msgspec.Meta(extra_json_schema={BRAND_METADATA_KEY: name})
+
+
+NotebookUri = typing.NewType("NotebookUri", str)
+"""URI identifying one notebook document."""
+
+KernelSessionId = typing.NewType("KernelSessionId", str)
+"""Opaque identifier for one exact live kernel session."""
+
+CellId = typing.NewType("CellId", str)
+"""Opaque identifier for one notebook cell."""
+
+
+class CellExecution(msgspec.Struct, rename="camel", forbid_unknown_fields=True):
+    """One cell and the exact source to execute for it."""
+
+    cell_id: typing.Annotated[CellId, _brand("CellId")]
+    code: str
+
+
+class Execute(
+    msgspec.Struct,
+    tag="execute",
+    tag_field="kind",
+    rename="camel",
+    forbid_unknown_fields=True,
+):
+    """Execute a batch of notebook cells, starting its kernel if necessary."""
+
+    notebook_uri: typing.Annotated[NotebookUri, _brand("NotebookUri")]
+    executable: str
+    working_directory: str
+    cells: list[CellExecution]
+
+
+class DeleteCell(
+    msgspec.Struct,
+    tag="delete-cell",
+    tag_field="kind",
+    rename="camel",
+    forbid_unknown_fields=True,
+):
+    """Remove one cell from the exact live kernel that owns it."""
+
+    notebook_uri: typing.Annotated[NotebookUri, _brand("NotebookUri")]
+    kernel_session_id: typing.Annotated[KernelSessionId, _brand("KernelSessionId")]
+    cell_id: typing.Annotated[CellId, _brand("CellId")]
+
+
+type Command = Execute | DeleteCell
+"""Commands accepted by the private ``marimo/command`` request."""

--- a/src/marimo_lsp/server.py
+++ b/src/marimo_lsp/server.py
@@ -14,11 +14,12 @@ from marimo._convert.converters import MarimoConvert
 from pygls.lsp.server import LanguageServer
 from pygls.uris import to_fs_path, uri_scheme
 
-from marimo_lsp.api import handle_api_command
+from marimo_lsp.api import handle_command
 from marimo_lsp.completions import get_completions
 from marimo_lsp.diagnostics import GraphUpdaterRegistry
 from marimo_lsp.loggers import get_logger
-from marimo_lsp.models import ApiRequest, ConvertRequest
+from marimo_lsp.models import ConvertRequest
+from marimo_lsp.protocol import Command
 from marimo_lsp.sessions import Sessions
 
 logger = get_logger()
@@ -26,6 +27,18 @@ logger = get_logger()
 if typing.TYPE_CHECKING:
     from marimo_lsp.kernels import Kernels
     from marimo_lsp.saved_session_store import SavedSessionFiles
+
+
+def _json_rpc_value(value: object) -> object:
+    """Project pygls' tuple-like ``Object`` carrier back to JSON built-ins."""
+    as_dict = getattr(value, "_asdict", None)
+    if callable(as_dict):
+        value = as_dict()
+    if isinstance(value, dict):
+        return {str(key): _json_rpc_value(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_json_rpc_value(item) for item in value]
+    return value
 
 
 def create_server(  # noqa: C901, PLR0915
@@ -187,12 +200,12 @@ def create_server(  # noqa: C901, PLR0915
 
         return get_completions(ls, params)
 
-    @server.command("marimo.api")
-    async def api(ls: LanguageServer, params: typing.Any):  # noqa: ANN401
-        """Unified API endpoint for all marimo internal methods."""
-        logger.info("marimo.api")
-        args = msgspec.convert(params, type=ApiRequest)
-        return await handle_api_command(ls, sessions, args.method, args.params)
+    @server.feature("marimo/command")
+    async def command(ls: LanguageServer, params: object):
+        """Private command protocol shared with the bundled extension."""
+        logger.info("marimo/command")
+        request = msgspec.convert(_json_rpc_value(params), type=Command)
+        return await handle_command(ls, sessions, request)
 
     @server.command("marimo.convert")
     async def convert(ls: LanguageServer, params: typing.Any):  # noqa: ANN401

--- a/tests/fixtures/command_protocol.json
+++ b/tests/fixtures/command_protocol.json
@@ -1,0 +1,186 @@
+{
+  "valid": [
+    {
+      "kind": "execute",
+      "notebookUri": "file:///notebook.py",
+      "executable": "/venv/bin/python",
+      "workingDirectory": "/workspace",
+      "cells": [{ "cellId": "cell-1", "code": "answer = 42" }]
+    },
+    {
+      "kind": "update-ui-element",
+      "notebookUri": "file:///notebook.py",
+      "kernelSessionId": "kernel-1",
+      "objectIds": ["slider"],
+      "values": [42],
+      "request": null,
+      "token": null
+    },
+    {
+      "kind": "set-model-value",
+      "notebookUri": "file:///notebook.py",
+      "kernelSessionId": "kernel-1",
+      "modelId": "model-1",
+      "message": {
+        "method": "update",
+        "state": { "value": 42 },
+        "bufferPaths": []
+      },
+      "buffers": [],
+      "token": null
+    },
+    {
+      "kind": "invoke-function",
+      "notebookUri": "file:///notebook.py",
+      "kernelSessionId": "kernel-1",
+      "functionCallId": "call-1",
+      "namespace": "widget",
+      "functionName": "refresh",
+      "args": { "force": true }
+    },
+    {
+      "kind": "interrupt",
+      "notebookUri": "file:///notebook.py",
+      "kernelSessionId": "kernel-1",
+      "runId": null
+    },
+    {
+      "kind": "delete-cell",
+      "notebookUri": "file:///notebook.py",
+      "kernelSessionId": "kernel-1",
+      "cellId": "cell-1"
+    },
+    {
+      "kind": "list-sql-schemas",
+      "notebookUri": "file:///notebook.py",
+      "kernelSessionId": "kernel-1",
+      "requestId": "request-1",
+      "engine": "duckdb",
+      "database": "memory",
+      "schemaPath": []
+    },
+    {
+      "kind": "list-sql-tables",
+      "notebookUri": "file:///notebook.py",
+      "kernelSessionId": "kernel-1",
+      "requestId": "request-1",
+      "engine": "duckdb",
+      "database": "memory",
+      "schema": "main",
+      "schemaPath": ["catalog"]
+    },
+    {
+      "kind": "send-stdin",
+      "notebookUri": "file:///notebook.py",
+      "kernelSessionId": "kernel-1",
+      "text": "yes\n"
+    },
+    {
+      "kind": "close-session",
+      "notebookUri": "file:///notebook.py"
+    },
+    {
+      "kind": "restart-session",
+      "notebookUri": "file:///notebook.py",
+      "executable": "/venv/bin/python",
+      "workingDirectory": "/workspace",
+      "createIfMissing": false
+    },
+    {
+      "kind": "move-session",
+      "notebookUri": "file:///old.py",
+      "newNotebookUri": "file:///new.py"
+    },
+    { "kind": "list-sessions" },
+    { "kind": "shutdown-all-sessions" },
+    {
+      "kind": "execute-scratchpad",
+      "notebookUri": "file:///notebook.py",
+      "executable": "/venv/bin/python",
+      "workingDirectory": "/workspace",
+      "code": "answer + 1",
+      "runId": null
+    },
+    {
+      "kind": "list-packages",
+      "notebookUri": "file:///notebook.py",
+      "source": { "kind": "venv", "executable": "/venv/bin/python" }
+    },
+    {
+      "kind": "get-dependency-tree",
+      "notebookUri": "file:///notebook.py",
+      "source": { "kind": "script" }
+    },
+    {
+      "kind": "serialize",
+      "notebook": {
+        "version": "1",
+        "metadata": { "marimo_version": "0.24.0" },
+        "cells": [
+          {
+            "id": "cell-1",
+            "code": "answer = 42",
+            "code_hash": null,
+            "name": "answer",
+            "config": {
+              "column": null,
+              "disabled": false,
+              "hide_code": false
+            }
+          }
+        ]
+      },
+      "appConfig": { "width": "full" },
+      "header": null
+    },
+    { "kind": "deserialize", "source": "import marimo\n" },
+    {
+      "kind": "get-configuration",
+      "notebookUri": "file:///notebook.py"
+    },
+    {
+      "kind": "update-configuration",
+      "notebookUri": "file:///notebook.py",
+      "config": { "display": { "theme": "dark" } }
+    },
+    { "kind": "set-display-theme", "theme": "dark" },
+    {
+      "kind": "read-notebook-outputs",
+      "notebookUri": "file:///notebook.py",
+      "sessionCachePath": null
+    },
+    {
+      "kind": "export-html",
+      "notebookUri": "file:///notebook.py",
+      "download": false,
+      "files": [],
+      "includeCode": true,
+      "assetUrl": null
+    },
+    {
+      "kind": "export-ipynb",
+      "notebookUri": "file:///notebook.py"
+    },
+    {
+      "kind": "export-markdown",
+      "notebookUri": "file:///notebook.py"
+    }
+  ],
+  "invalid": [
+    {
+      "method": "execute",
+      "params": { "notebookUri": "file:///notebook.py" }
+    },
+    {
+      "kind": "execute-cells",
+      "notebookUri": "file:///notebook.py"
+    },
+    {
+      "kind": "delete-cell",
+      "notebookUri": "file:///notebook.py",
+      "kernelSessionId": "kernel-1",
+      "inner": { "cellId": "cell-1" }
+    },
+    { "kind": "list-sessions", "unexpected": true }
+  ]
+}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -10,12 +10,12 @@ import msgspec
 import pytest
 from marimo._config.config import DEFAULT_CONFIG
 from marimo._convert.converters import MarimoConvert
-from marimo._runtime.commands import InvokeFunctionCommand, ModelUpdateMessage
-from marimo._types.ids import CellId_t, RequestId, SessionId, WidgetModelId
+from marimo._types.ids import RequestId, SessionId
 
+from marimo_lsp import protocol
 from marimo_lsp.api import (
-    ApiBuilder,
     ApiContext,
+    CommandBuilder,
     KernelSessionMismatchError,
     KernelSessionRequiredError,
     _restore_unknown_app_options,
@@ -25,7 +25,7 @@ from marimo_lsp.api import (
     export_as_markdown,
     function_call_request,
     get_configuration,
-    handle_api_command,
+    handle_command,
     interrupt,
     list_sql_schemas,
     list_sql_tables,
@@ -35,25 +35,11 @@ from marimo_lsp.api import (
     update_configuration,
 )
 from marimo_lsp.models import (
-    DeleteCellRequest,
     DeserializeConvertible,
     DeserializeInvalidSyntax,
-    DeserializeRequest,
     DeserializeSuccess,
-    ExecuteScratchRequest,
-    ExportAsMarkdownRequest,
-    GetConfigurationRequest,
-    InterruptRequest,
-    KernelCommand,
     ListSQLSchemasRequest,
     ListSQLTablesRequest,
-    ModelRequest,
-    NotebookCommand,
-    SessionCommand,
-    SetDisplayThemeRequest,
-    StdinRequest,
-    UpdateConfigurationRequest,
-    UpdateUIElementRequest,
 )
 
 if TYPE_CHECKING:
@@ -70,11 +56,12 @@ async def test_execute_scratch_skips_a_run_cancelled_before_startup() -> None:
 
     await execute_scratch(
         _context(sessions),
-        SessionCommand(
-            notebook_uri=NOTEBOOK_URI,
+        protocol.ExecuteScratchpad(
+            notebook_uri=protocol.NotebookUri(NOTEBOOK_URI),
             executable="/usr/bin/python",
             working_directory="/workspace",
-            inner=ExecuteScratchRequest(code="print('late')", run_id="run-1"),
+            code="print('late')",
+            run_id="run-1",
         ),
     )
 
@@ -92,11 +79,12 @@ async def test_execute_scratch_skips_a_run_cancelled_during_startup() -> None:
     with patch("marimo_lsp.api.find_notebook_document", return_value=MagicMock()):
         await execute_scratch(
             _context(sessions),
-            SessionCommand(
-                notebook_uri=NOTEBOOK_URI,
+            protocol.ExecuteScratchpad(
+                notebook_uri=protocol.NotebookUri(NOTEBOOK_URI),
                 executable="/usr/bin/python",
                 working_directory="/workspace",
-                inner=ExecuteScratchRequest(code="print('late')", run_id="run-1"),
+                code="print('late')",
+                run_id="run-1",
             ),
         )
 
@@ -120,11 +108,12 @@ async def test_execute_scratch_claims_idle_session_before_dispatch() -> None:
     ):
         await execute_scratch(
             _context(sessions),
-            SessionCommand(
-                notebook_uri=NOTEBOOK_URI,
+            protocol.ExecuteScratchpad(
+                notebook_uri=protocol.NotebookUri(NOTEBOOK_URI),
                 executable="/usr/bin/python",
                 working_directory="/workspace",
-                inner=ExecuteScratchRequest(code="print('later')", run_id="run-1"),
+                code="print('later')",
+                run_id="run-1",
             ),
         )
 
@@ -139,9 +128,9 @@ async def test_run_correlated_interrupt_records_scratchpad_cancellation() -> Non
 
     await interrupt(
         _context(sessions),
-        NotebookCommand(
-            notebook_uri=NOTEBOOK_URI,
-            inner=InterruptRequest(run_id="run-1"),
+        protocol.Interrupt(
+            notebook_uri=protocol.NotebookUri(NOTEBOOK_URI),
+            run_id="run-1",
         ),
     )
 
@@ -158,10 +147,10 @@ async def test_send_stdin_targets_one_exact_kernel_session() -> None:
 
     await send_stdin(
         _context(sessions),
-        KernelCommand(
-            notebook_uri=NOTEBOOK_URI,
-            session_id=session_id,
-            inner=StdinRequest(text="answer"),
+        protocol.SendStdin(
+            notebook_uri=protocol.NotebookUri(NOTEBOOK_URI),
+            kernel_session_id=protocol.KernelSessionId(str(session_id)),
+            text="answer",
         ),
     )
 
@@ -177,10 +166,12 @@ async def test_send_stdin_rejects_a_replaced_kernel_session() -> None:
     with pytest.raises(KernelSessionMismatchError):
         await send_stdin(
             _context(sessions),
-            KernelCommand(
-                notebook_uri=NOTEBOOK_URI,
-                session_id=SessionId("00000000-0000-4000-8000-000000000001"),
-                inner=StdinRequest(text="stale"),
+            protocol.SendStdin(
+                notebook_uri=protocol.NotebookUri(NOTEBOOK_URI),
+                kernel_session_id=protocol.KernelSessionId(
+                    "00000000-0000-4000-8000-000000000001"
+                ),
+                text="stale",
             ),
         )
 
@@ -193,37 +184,62 @@ LIVE_SESSION_ID = SessionId("00000000-0000-4000-8000-000000000002")
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("handler", "inner"),
+    ("handler", "command"),
     [
-        (set_ui_element_value, UpdateUIElementRequest(object_ids=[], values=[])),
+        (
+            set_ui_element_value,
+            protocol.UpdateUiElement(
+                notebook_uri=protocol.NotebookUri(NOTEBOOK_URI),
+                kernel_session_id=protocol.KernelSessionId(str(STALE_SESSION_ID)),
+                object_ids=[],
+                values=[],
+            ),
+        ),
         (
             set_model_value,
-            ModelRequest(
-                model_id=WidgetModelId("model-1"),
-                message=ModelUpdateMessage(state={}, buffer_paths=[]),
+            protocol.SetModelValue(
+                notebook_uri=protocol.NotebookUri(NOTEBOOK_URI),
+                kernel_session_id=protocol.KernelSessionId(str(STALE_SESSION_ID)),
+                model_id="model-1",
+                message=protocol.ModelUpdateMessage(state={}, buffer_paths=[]),
                 buffers=[],
             ),
         ),
         (
             function_call_request,
-            InvokeFunctionCommand(
-                function_call_id=RequestId("request-1"),
+            protocol.InvokeFunction(
+                notebook_uri=protocol.NotebookUri(NOTEBOOK_URI),
+                kernel_session_id=protocol.KernelSessionId(str(STALE_SESSION_ID)),
+                function_call_id="request-1",
                 namespace="ns",
                 function_name="fn",
                 args={},
             ),
         ),
-        (delete_cell, DeleteCellRequest(cell_id=CellId_t("cell-1"))),
+        (
+            delete_cell,
+            protocol.DeleteCell(
+                notebook_uri=protocol.NotebookUri(NOTEBOOK_URI),
+                kernel_session_id=protocol.KernelSessionId(str(STALE_SESSION_ID)),
+                cell_id=protocol.CellId("cell-1"),
+            ),
+        ),
         (
             list_sql_schemas,
-            ListSQLSchemasRequest(
-                request_id=RequestId("request-1"), engine="duckdb", database="db"
+            protocol.ListSqlSchemas(
+                notebook_uri=protocol.NotebookUri(NOTEBOOK_URI),
+                kernel_session_id=protocol.KernelSessionId(str(STALE_SESSION_ID)),
+                request_id="request-1",
+                engine="duckdb",
+                database="db",
             ),
         ),
         (
             list_sql_tables,
-            ListSQLTablesRequest(
-                request_id=RequestId("request-1"),
+            protocol.ListSqlTables(
+                notebook_uri=protocol.NotebookUri(NOTEBOOK_URI),
+                kernel_session_id=protocol.KernelSessionId(str(STALE_SESSION_ID)),
+                request_id="request-1",
                 engine="duckdb",
                 database="db",
                 schema="main",
@@ -232,8 +248,8 @@ LIVE_SESSION_ID = SessionId("00000000-0000-4000-8000-000000000002")
     ],
 )
 async def test_kernel_commands_reject_a_replaced_kernel_session(
-    handler: Callable[[ApiContext, KernelCommand[msgspec.Struct]], Awaitable[None]],
-    inner: msgspec.Struct,
+    handler: Callable[..., Awaitable[None]],
+    command: protocol.Command,
 ) -> None:
     session = MagicMock(session_id=LIVE_SESSION_ID)
     sessions = MagicMock()
@@ -242,11 +258,7 @@ async def test_kernel_commands_reject_a_replaced_kernel_session(
     with pytest.raises(KernelSessionMismatchError):
         await handler(
             _context(sessions),
-            KernelCommand(
-                notebook_uri=NOTEBOOK_URI,
-                session_id=STALE_SESSION_ID,
-                inner=inner,
-            ),
+            command,
         )
 
     session.put_control_request.assert_not_called()
@@ -261,9 +273,9 @@ async def test_interrupt_rejects_a_replaced_kernel_session() -> None:
     with pytest.raises(KernelSessionMismatchError):
         await interrupt(
             _context(sessions),
-            NotebookCommand(
-                notebook_uri=NOTEBOOK_URI,
-                inner=InterruptRequest(session_id=STALE_SESSION_ID),
+            protocol.Interrupt(
+                notebook_uri=protocol.NotebookUri(NOTEBOOK_URI),
+                kernel_session_id=protocol.KernelSessionId(str(STALE_SESSION_ID)),
             ),
         )
 
@@ -277,7 +289,7 @@ async def test_interrupt_requires_a_kernel_session_id() -> None:
     with pytest.raises(KernelSessionRequiredError):
         await interrupt(
             _context(sessions),
-            NotebookCommand(notebook_uri=NOTEBOOK_URI, inner=InterruptRequest()),
+            protocol.Interrupt(notebook_uri=protocol.NotebookUri(NOTEBOOK_URI)),
         )
 
     sessions.get.assert_not_called()
@@ -295,13 +307,15 @@ if __name__ == "__main__":
     app.run()
 """
 
-    result = await deserialize(_context(MagicMock()), DeserializeRequest(source=source))
+    result = await deserialize(
+        _context(MagicMock()), protocol.Deserialize(source=source)
+    )
 
     assert isinstance(result, DeserializeSuccess)
 
 
 @pytest.mark.asyncio
-async def test_legacy_and_unknown_app_config_round_trip_over_api_wire() -> None:
+async def test_legacy_and_unknown_app_config_round_trip_over_command_wire() -> None:
     source = """\
 import marimo
 
@@ -318,11 +332,10 @@ if __name__ == "__main__":
 
     deserialized = cast(
         "dict[str, object]",
-        await handle_api_command(
+        await handle_command(
             MagicMock(),
             MagicMock(),
-            "deserialize",
-            {"source": source},
+            protocol.Deserialize(source=source),
         ),
     )
     deserialized_notebook = cast("dict[str, object]", deserialized["notebook"])
@@ -334,11 +347,13 @@ if __name__ == "__main__":
 
     serialized = cast(
         "dict[str, object]",
-        await handle_api_command(
+        await handle_command(
             MagicMock(),
             MagicMock(),
-            "serialize",
-            deserialized_notebook,
+            msgspec.convert(
+                {"kind": "serialize", **deserialized_notebook},
+                type=protocol.Command,
+            ),
         ),
     )
     serialized_source = serialized["source"]
@@ -384,10 +399,7 @@ if __name__ == "__main__":
 
     markdown = await export_as_markdown(
         _context(sessions),
-        NotebookCommand(
-            notebook_uri=NOTEBOOK_URI,
-            inner=ExportAsMarkdownRequest(),
-        ),
+        protocol.ExportMarkdown(notebook_uri=protocol.NotebookUri(NOTEBOOK_URI)),
     )
 
     assert "title: Report" in markdown
@@ -407,7 +419,9 @@ def _():
     return
 """
 
-    result = await deserialize(_context(MagicMock()), DeserializeRequest(source=source))
+    result = await deserialize(
+        _context(MagicMock()), protocol.Deserialize(source=source)
+    )
 
     assert isinstance(result, DeserializeSuccess)
     assert [cell["code"] for cell in result.notebook.notebook["cells"]] == ["value = ("]
@@ -427,7 +441,7 @@ def _():
 """
     result = await deserialize(
         _context(MagicMock()),
-        DeserializeRequest(source=source),
+        protocol.Deserialize(source=source),
     )
 
     assert isinstance(result, DeserializeSuccess)
@@ -439,7 +453,7 @@ def _():
 @pytest.mark.asyncio
 async def test_deserialize_classifies_plain_python() -> None:
     result = await deserialize(
-        _context(MagicMock()), DeserializeRequest(source="print('hello')\n")
+        _context(MagicMock()), protocol.Deserialize(source="print('hello')\n")
     )
 
     assert isinstance(result, DeserializeConvertible)
@@ -449,7 +463,7 @@ async def test_deserialize_classifies_plain_python() -> None:
 async def test_deserialize_classifies_jupytext_percent_as_convertible() -> None:
     result = await deserialize(
         _context(MagicMock()),
-        DeserializeRequest(source="# %%\nprint('hello')\n"),
+        protocol.Deserialize(source="# %%\nprint('hello')\n"),
     )
 
     assert isinstance(result, DeserializeConvertible)
@@ -466,7 +480,9 @@ async def test_deserialize_classifies_jupytext_percent_as_convertible() -> None:
     ],
 )
 async def test_deserialize_accepts_convertible_notebook_syntax(source: str) -> None:
-    result = await deserialize(_context(MagicMock()), DeserializeRequest(source=source))
+    result = await deserialize(
+        _context(MagicMock()), protocol.Deserialize(source=source)
+    )
 
     assert isinstance(result, DeserializeConvertible)
 
@@ -474,7 +490,7 @@ async def test_deserialize_accepts_convertible_notebook_syntax(source: str) -> N
 @pytest.mark.asyncio
 async def test_deserialize_rejects_malformed_jupytext_cell() -> None:
     result = await deserialize(
-        _context(MagicMock()), DeserializeRequest(source="# %%\nprint(\n")
+        _context(MagicMock()), protocol.Deserialize(source="# %%\nprint(\n")
     )
 
     assert isinstance(result, DeserializeInvalidSyntax)
@@ -493,7 +509,9 @@ async def test_deserialize_rejects_malformed_jupytext_cell() -> None:
 async def test_deserialize_reports_syntax_errors_in_non_marimo_python(
     source: str,
 ) -> None:
-    result = await deserialize(_context(MagicMock()), DeserializeRequest(source=source))
+    result = await deserialize(
+        _context(MagicMock()), protocol.Deserialize(source=source)
+    )
 
     assert isinstance(result, DeserializeInvalidSyntax)
     assert result.line is not None
@@ -502,7 +520,7 @@ async def test_deserialize_reports_syntax_errors_in_non_marimo_python(
 @pytest.mark.asyncio
 async def test_percent_marker_inside_string_is_just_convertible_python() -> None:
     result = await deserialize(
-        _context(MagicMock()), DeserializeRequest(source='x = "# %%"\n')
+        _context(MagicMock()), protocol.Deserialize(source='x = "# %%"\n')
     )
 
     assert isinstance(result, DeserializeConvertible)
@@ -518,7 +536,7 @@ async def test_deserialize_propagates_unexpected_converter_error() -> None:
         pytest.raises(RuntimeError, match="converter broke"),
     ):
         await deserialize(
-            _context(MagicMock()), DeserializeRequest(source="print('hello')")
+            _context(MagicMock()), protocol.Deserialize(source="print('hello')")
         )
 
 
@@ -526,36 +544,35 @@ def _context(sessions: MagicMock) -> ApiContext:
     return ApiContext(ls=MagicMock(), sessions=sessions)
 
 
-def test_api_builder_infers_contract_from_handler() -> None:
-    builder = ApiBuilder()
+def test_command_builder_infers_contract_from_handler() -> None:
+    builder = CommandBuilder()
 
-    @builder("example")
+    @builder(protocol.UpdateConfiguration)
     async def handler(
         _ctx: ApiContext,
-        request: UpdateConfigurationRequest,
+        request: protocol.UpdateConfiguration,
     ) -> str:
         return str(request.config)
 
-    (method,) = builder.build()
+    (command,) = builder.build()
 
-    assert method.name == "example"
-    assert method.request is UpdateConfigurationRequest
-    assert method.response is str
-    assert method.handler is handler
+    assert command.request is protocol.UpdateConfiguration
+    assert command.response is str
+    assert command.handler is handler
 
 
-def test_api_builder_rejects_duplicate_methods() -> None:
-    builder = ApiBuilder()
+def test_command_builder_rejects_duplicate_commands() -> None:
+    builder = CommandBuilder()
 
-    @builder("duplicate")
-    async def first(_ctx: ApiContext, _request: UpdateConfigurationRequest) -> None:
+    @builder(protocol.UpdateConfiguration)
+    async def first(_ctx: ApiContext, _request: protocol.UpdateConfiguration) -> None:
         pass
 
-    @builder("duplicate")
-    async def second(_ctx: ApiContext, _request: UpdateConfigurationRequest) -> None:
+    @builder(protocol.UpdateConfiguration)
+    async def second(_ctx: ApiContext, _request: protocol.UpdateConfiguration) -> None:
         pass
 
-    with pytest.raises(ValueError, match="duplicate API method"):
+    with pytest.raises(ValueError, match="duplicate command type"):
         builder.build()
 
 
@@ -568,9 +585,9 @@ async def test_update_configuration_returns_saved_config() -> None:
 
     result = await update_configuration(
         _context(sessions),
-        NotebookCommand(
-            notebook_uri="file:///notebook.py",
-            inner=UpdateConfigurationRequest(config={}),
+        protocol.UpdateConfiguration(
+            notebook_uri=protocol.NotebookUri("file:///notebook.py"),
+            config={},
         ),
     )
 
@@ -594,9 +611,9 @@ async def test_update_configuration_returns_effective_config_without_session(
     ) as get_manager:
         result = await update_configuration(
             _context(sessions),
-            NotebookCommand(
-                notebook_uri=notebook_path.as_uri(),
-                inner=UpdateConfigurationRequest(config=partial_config),
+            protocol.UpdateConfiguration(
+                notebook_uri=protocol.NotebookUri(notebook_path.as_uri()),
+                config=partial_config,
             ),
         )
 
@@ -620,9 +637,8 @@ async def test_get_configuration_loads_without_session(tmp_path: Path) -> None:
     ) as get_manager:
         result = await get_configuration(
             _context(sessions),
-            NotebookCommand(
-                notebook_uri=notebook_path.as_uri(),
-                inner=GetConfigurationRequest(),
+            protocol.GetConfiguration(
+                notebook_uri=protocol.NotebookUri(notebook_path.as_uri()),
             ),
         )
 
@@ -642,16 +658,19 @@ async def test_update_configuration_propagates_save_errors() -> None:
     with pytest.raises(OSError, match="config is read-only"):
         await update_configuration(
             _context(sessions),
-            NotebookCommand(
-                notebook_uri="file:///notebook.py",
-                inner=UpdateConfigurationRequest(config={}),
+            protocol.UpdateConfiguration(
+                notebook_uri=protocol.NotebookUri("file:///notebook.py"),
+                config={},
             ),
         )
 
 
 def test_display_theme_rejects_unresolved_theme() -> None:
     with pytest.raises(msgspec.ValidationError):
-        msgspec.convert({"theme": "system"}, type=SetDisplayThemeRequest)
+        msgspec.convert(
+            {"kind": "set-display-theme", "theme": "system"},
+            type=protocol.Command,
+        )
 
 
 @pytest.mark.asyncio
@@ -669,10 +688,13 @@ async def test_list_sql_schemas_is_forwarded_to_the_kernel() -> None:
 
     await list_sql_schemas(
         _context(sessions),
-        KernelCommand(
-            notebook_uri="file:///notebook.py",
-            session_id=session_id,
-            inner=request,
+        protocol.ListSqlSchemas(
+            notebook_uri=protocol.NotebookUri("file:///notebook.py"),
+            kernel_session_id=protocol.KernelSessionId(str(session_id)),
+            request_id="schemas",
+            engine="warehouse",
+            database="analytics",
+            schema_path=["catalog"],
         ),
     )
 
@@ -697,10 +719,14 @@ async def test_list_sql_tables_is_forwarded_to_the_kernel() -> None:
 
     await list_sql_tables(
         _context(sessions),
-        KernelCommand(
-            notebook_uri="file:///notebook.py",
-            session_id=session_id,
-            inner=request,
+        protocol.ListSqlTables(
+            notebook_uri=protocol.NotebookUri("file:///notebook.py"),
+            kernel_session_id=protocol.KernelSessionId(str(session_id)),
+            request_id="tables",
+            engine="warehouse",
+            database="analytics",
+            schema="events",
+            schema_path=["catalog", "events"],
         ),
     )
 
@@ -710,20 +736,28 @@ async def test_list_sql_tables_is_forwarded_to_the_kernel() -> None:
 
 
 @pytest.mark.parametrize(
-    ("handler", "sql_request"),
+    ("handler", "command"),
     [
         (
             list_sql_schemas,
-            ListSQLSchemasRequest(
-                request_id=RequestId("schemas"),
+            protocol.ListSqlSchemas(
+                notebook_uri=protocol.NotebookUri(NOTEBOOK_URI),
+                kernel_session_id=protocol.KernelSessionId(
+                    "00000000-0000-4000-8000-000000000001"
+                ),
+                request_id="schemas",
                 engine="warehouse",
                 database="analytics",
             ),
         ),
         (
             list_sql_tables,
-            ListSQLTablesRequest(
-                request_id=RequestId("tables"),
+            protocol.ListSqlTables(
+                notebook_uri=protocol.NotebookUri(NOTEBOOK_URI),
+                kernel_session_id=protocol.KernelSessionId(
+                    "00000000-0000-4000-8000-000000000001"
+                ),
+                request_id="tables",
                 engine="warehouse",
                 database="analytics",
                 schema="events",
@@ -734,7 +768,7 @@ async def test_list_sql_tables_is_forwarded_to_the_kernel() -> None:
 @pytest.mark.asyncio
 async def test_list_sql_metadata_rejects_a_missing_session(
     handler: Callable[..., Awaitable[None]],
-    sql_request: ListSQLSchemasRequest | ListSQLTablesRequest,
+    command: protocol.ListSqlSchemas | protocol.ListSqlTables,
 ) -> None:
     sessions = MagicMock()
     sessions.get.return_value = None
@@ -742,9 +776,5 @@ async def test_list_sql_metadata_rejects_a_missing_session(
     with pytest.raises(ValueError, match=f"No session found for {NOTEBOOK_URI}"):
         await handler(
             _context(sessions),
-            KernelCommand(
-                notebook_uri=NOTEBOOK_URI,
-                session_id=SessionId("00000000-0000-4000-8000-000000000001"),
-                inner=sql_request,
-            ),
+            command,
         )

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -1,0 +1,57 @@
+# Copyright 2026 Marimo. All rights reserved.
+
+import ast
+import inspect
+import json
+
+import msgspec
+import pytest
+
+from marimo_lsp import protocol
+
+
+def test_protocol_module_does_not_import_marimo() -> None:
+    tree = ast.parse(inspect.getsource(protocol))
+    imported = {
+        alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Import)
+        for alias in node.names
+    } | {
+        node.module
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom) and node.module is not None
+    }
+
+    assert not {
+        name for name in imported if name == "marimo" or name.startswith("marimo.")
+    }
+
+
+def test_command_is_a_flat_discriminated_union() -> None:
+    command = protocol.Execute(
+        notebook_uri=protocol.NotebookUri("file:///notebook.py"),
+        executable="/venv/bin/python",
+        working_directory="/workspace",
+        cells=[
+            protocol.CellExecution(
+                cell_id=protocol.CellId("cell-1"),
+                code="answer = 42",
+            )
+        ],
+    )
+
+    encoded = msgspec.json.encode(command)
+    assert json.loads(encoded) == {
+        "kind": "execute",
+        "notebookUri": "file:///notebook.py",
+        "executable": "/venv/bin/python",
+        "workingDirectory": "/workspace",
+        "cells": [{"cellId": "cell-1", "code": "answer = 42"}],
+    }
+    assert msgspec.json.decode(encoded, type=protocol.Command) == command
+
+
+def test_command_rejects_unknown_variants() -> None:
+    with pytest.raises(msgspec.ValidationError, match="Invalid value"):
+        msgspec.json.decode(b'{"kind":"unknown"}', type=protocol.Command)

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -3,11 +3,15 @@
 import ast
 import inspect
 import json
+from pathlib import Path
 
 import msgspec
+import msgspec.inspect as msgspec_inspect
 import pytest
 
 from marimo_lsp import protocol
+
+COMMAND_PROTOCOL = Path(__file__).parent / "fixtures" / "command_protocol.json"
 
 
 def test_protocol_module_does_not_import_marimo() -> None:
@@ -55,3 +59,23 @@ def test_command_is_a_flat_discriminated_union() -> None:
 def test_command_rejects_unknown_variants() -> None:
     with pytest.raises(msgspec.ValidationError, match="Invalid value"):
         msgspec.json.decode(b'{"kind":"unknown"}', type=protocol.Command)
+
+
+def test_command_protocol_compatibility_corpus() -> None:
+    corpus = json.loads(COMMAND_PROTOCOL.read_text())
+    commands = [
+        msgspec.convert(value, type=protocol.Command) for value in corpus["valid"]
+    ]
+    command_type = msgspec_inspect.type_info(protocol.Command)
+
+    assert isinstance(command_type, msgspec_inspect.UnionType)
+    assert {type(command) for command in commands} == {
+        variant.cls
+        for variant in command_type.types
+        if isinstance(variant, msgspec_inspect.StructType)
+    }
+    assert [msgspec.to_builtins(command) for command in commands] == corpus["valid"]
+
+    for value in corpus["invalid"]:
+        with pytest.raises(msgspec.ValidationError):
+            msgspec.convert(value, type=protocol.Command)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -54,6 +54,12 @@ def asdict(obj: Any) -> dict[str, Any]:  # noqa: ANN401
     return obj
 
 
+async def send_command(client: LanguageClient, command: dict[str, object]) -> Any:  # noqa: ANN401 - pytest-lsp exposes dynamic JSON-RPC results
+    """Send one value from the private owned command union."""
+    result = await client.protocol.send_request_async("marimo/command", command)
+    return asdict(result)
+
+
 def assert_one_kernel_session(messages: list[dict[str, Any]]) -> None:
     session_ids = {
         message["sessionId"] for message in messages if "sessionId" in message
@@ -136,12 +142,7 @@ async def client(lsp_process: LanguageClient):  # noqa: ANN201
             )
         )
 
-    await lsp_process.workspace_execute_command_async(
-        lsp.ExecuteCommandParams(
-            command="marimo.api",
-            arguments=[{"method": "shutdown-all-sessions", "params": {}}],
-        )
-    )
+    await send_command(lsp_process, {"kind": "shutdown-all-sessions"})
 
     # Tests register per-test notification handlers on the shared client.
     lsp_process.protocol.fm.features.clear()
@@ -298,21 +299,15 @@ async def test_enabling_disabled_cell_runs_registered_source(
         )
     )
 
-    await client.workspace_execute_command_async(
-        lsp.ExecuteCommandParams(
-            command="marimo.api",
-            arguments=[
-                {
-                    "method": "execute-cells",
-                    "params": {
-                        "notebookUri": uri,
-                        "executable": sys.executable,
-                        "workingDirectory": str(Path.cwd()),
-                        "inner": {"cellIds": ["cell1"], "codes": [source]},
-                    },
-                }
-            ],
-        )
+    await send_command(
+        client,
+        {
+            "kind": "execute",
+            "notebookUri": uri,
+            "executable": sys.executable,
+            "workingDirectory": str(Path.cwd()),
+            "cells": [{"cellId": "cell1", "code": source}],
+        },
     )
     await asyncio.wait_for(initial_run_completed.wait(), timeout=5)
     assert not stdout.done()
@@ -426,16 +421,9 @@ async def test_marimo_serialize_command(client: LanguageClient) -> None:
         ],
     }
 
-    result = await client.workspace_execute_command_async(
-        lsp.ExecuteCommandParams(
-            command="marimo.api",
-            arguments=[
-                {
-                    "method": "serialize",
-                    "params": {"notebook": notebook, "header": "marimo app"},
-                }
-            ],
-        )
+    result = await send_command(
+        client,
+        {"kind": "serialize", "notebook": notebook, "header": "marimo app"},
     )
 
     assert result is not None
@@ -477,12 +465,8 @@ if __name__ == "__main__":
     app.run()
 """
 
-    result = await client.workspace_execute_command_async(
-        lsp.ExecuteCommandParams(
-            command="marimo.api",
-            arguments=[{"method": "deserialize", "params": {"source": source}}],
-        )
-    )
+    result = await send_command(client, {"kind": "deserialize", "source": source})
+    result["notebook"]["notebook"]["metadata"]["marimo_version"] = "<marimo-version>"
 
     assert result == snapshot(
         {
@@ -503,7 +487,7 @@ if __name__ == "__main__":
                             },
                         }
                     ],
-                    "metadata": {"marimo_version": "0.24.0"},
+                    "metadata": {"marimo_version": "<marimo-version>"},
                 },
                 "appConfig": {
                     "width": "compact",
@@ -524,20 +508,13 @@ async def test_marimo_get_package_list_venv_no_session(
     client: LanguageClient,
 ) -> None:
     """Package list with a venv source works without a live session."""
-    result = await client.workspace_execute_command_async(
-        lsp.ExecuteCommandParams(
-            command="marimo.api",
-            arguments=[
-                {
-                    "method": "get-package-list",
-                    "params": {
-                        "notebookUri": "file:///nonexistent.py",
-                        "source": {"kind": "venv", "executable": sys.executable},
-                        "inner": {},
-                    },
-                }
-            ],
-        )
+    result = await send_command(
+        client,
+        {
+            "kind": "list-packages",
+            "notebookUri": "file:///nonexistent.py",
+            "source": {"kind": "venv", "executable": sys.executable},
+        },
     )
 
     # Endpoint is session-free; uv lists packages from the executable directly.
@@ -576,44 +553,28 @@ async def test_marimo_get_package_list_with_session(client: LanguageClient) -> N
     )
 
     # Run a cell to ensure session is created
-    await client.workspace_execute_command_async(
-        lsp.ExecuteCommandParams(
-            command="marimo.api",
-            arguments=[
-                {
-                    "method": "execute-cells",
-                    "params": {
-                        "notebookUri": "file:///package_test.py",
-                        "executable": sys.executable,
-                        "workingDirectory": str(Path.cwd()),
-                        "inner": {
-                            "cellIds": ["cell1"],
-                            "codes": ["x = 1"],
-                        },
-                    },
-                }
-            ],
-        )
+    await send_command(
+        client,
+        {
+            "kind": "execute",
+            "notebookUri": "file:///package_test.py",
+            "executable": sys.executable,
+            "workingDirectory": str(Path.cwd()),
+            "cells": [{"cellId": "cell1", "code": "x = 1"}],
+        },
     )
 
     # Give the session a moment to start
     await asyncio.sleep(0.1)
 
     # Now get the package list
-    result = await client.workspace_execute_command_async(
-        lsp.ExecuteCommandParams(
-            command="marimo.api",
-            arguments=[
-                {
-                    "method": "get-package-list",
-                    "params": {
-                        "notebookUri": "file:///package_test.py",
-                        "source": {"kind": "venv", "executable": sys.executable},
-                        "inner": {},
-                    },
-                }
-            ],
-        )
+    result = await send_command(
+        client,
+        {
+            "kind": "list-packages",
+            "notebookUri": "file:///package_test.py",
+            "source": {"kind": "venv", "executable": sys.executable},
+        },
     )
 
     # Should return a list of packages (at least some common ones should be present)
@@ -679,45 +640,31 @@ async def test_execute_scratchpad_binds_code_mode_and_emits_transaction(
     )
 
     # Create + instantiate the session so we have a live kernel.
-    await client.workspace_execute_command_async(
-        lsp.ExecuteCommandParams(
-            command="marimo.api",
-            arguments=[
-                {
-                    "method": "execute-cells",
-                    "params": {
-                        "notebookUri": uri,
-                        "executable": sys.executable,
-                        "workingDirectory": str(Path.cwd()),
-                        "inner": {"cellIds": ["cell1"], "codes": ["x = 1"]},
-                    },
-                }
-            ],
-        )
+    await send_command(
+        client,
+        {
+            "kind": "execute",
+            "notebookUri": uri,
+            "executable": sys.executable,
+            "workingDirectory": str(Path.cwd()),
+            "cells": [{"cellId": "cell1", "code": "x = 1"}],
+        },
     )
 
     # Use code mode from inside the scratchpad to commit a new cell.
-    await client.workspace_execute_command_async(
-        lsp.ExecuteCommandParams(
-            command="marimo.api",
-            arguments=[
-                {
-                    "method": "execute-scratchpad",
-                    "params": {
-                        "notebookUri": uri,
-                        "executable": sys.executable,
-                        "workingDirectory": str(Path.cwd()),
-                        "inner": {
-                            "code": (
-                                "import marimo._code_mode as cm\n"
-                                "async with cm.get_context() as ctx:\n"
-                                "    ctx.create_cell('z = 1')\n"
-                            )
-                        },
-                    },
-                }
-            ],
-        )
+    await send_command(
+        client,
+        {
+            "kind": "execute-scratchpad",
+            "notebookUri": uri,
+            "executable": sys.executable,
+            "workingDirectory": str(Path.cwd()),
+            "code": (
+                "import marimo._code_mode as cm\n"
+                "async with cm.get_context() as ctx:\n"
+                "    ctx.create_cell('z = 1')\n"
+            ),
+        },
     )
 
     # The code-mode commit arrives asynchronously as a notebook-document
@@ -790,46 +737,32 @@ async def test_code_mode_edit_cell_config_on_existing_cell(
     )
 
     # Create + instantiate the session so we have a live kernel.
-    await client.workspace_execute_command_async(
-        lsp.ExecuteCommandParams(
-            command="marimo.api",
-            arguments=[
-                {
-                    "method": "execute-cells",
-                    "params": {
-                        "notebookUri": uri,
-                        "executable": sys.executable,
-                        "workingDirectory": str(Path.cwd()),
-                        "inner": {"cellIds": ["cell1"], "codes": ["x = 1"]},
-                    },
-                }
-            ],
-        )
+    await send_command(
+        client,
+        {
+            "kind": "execute",
+            "notebookUri": uri,
+            "executable": sys.executable,
+            "workingDirectory": str(Path.cwd()),
+            "cells": [{"cellId": "cell1", "code": "x = 1"}],
+        },
     )
 
     # Edit only the config of the existing cell — this reads its current
     # CellConfig (`existing.column`), which used to be a dict and crash.
-    await client.workspace_execute_command_async(
-        lsp.ExecuteCommandParams(
-            command="marimo.api",
-            arguments=[
-                {
-                    "method": "execute-scratchpad",
-                    "params": {
-                        "notebookUri": uri,
-                        "executable": sys.executable,
-                        "workingDirectory": str(Path.cwd()),
-                        "inner": {
-                            "code": (
-                                "import marimo._code_mode as cm\n"
-                                "async with cm.get_context() as ctx:\n"
-                                "    ctx.edit_cell(ctx.cells[0].id, hide_code=True)\n"
-                            )
-                        },
-                    },
-                }
-            ],
-        )
+    await send_command(
+        client,
+        {
+            "kind": "execute-scratchpad",
+            "notebookUri": uri,
+            "executable": sys.executable,
+            "workingDirectory": str(Path.cwd()),
+            "code": (
+                "import marimo._code_mode as cm\n"
+                "async with cm.get_context() as ctx:\n"
+                "    ctx.edit_cell(ctx.cells[0].id, hide_code=True)\n"
+            ),
+        },
     )
 
     change = await asyncio.wait_for(set_config, timeout=30)
@@ -852,20 +785,13 @@ async def test_marimo_get_dependency_tree_venv_no_session(
     `uv tree` requires a uv-managed project; against an arbitrary venv it returns
     None. The endpoint should answer regardless of session state.
     """
-    result = await client.workspace_execute_command_async(
-        lsp.ExecuteCommandParams(
-            command="marimo.api",
-            arguments=[
-                {
-                    "method": "get-dependency-tree",
-                    "params": {
-                        "notebookUri": "file:///nonexistent.py",
-                        "source": {"kind": "venv", "executable": sys.executable},
-                        "inner": {},
-                    },
-                }
-            ],
-        )
+    result = await send_command(
+        client,
+        {
+            "kind": "get-dependency-tree",
+            "notebookUri": "file:///nonexistent.py",
+            "source": {"kind": "venv", "executable": sys.executable},
+        },
     )
 
     assert result is not None
@@ -900,44 +826,28 @@ async def test_marimo_get_dependency_tree_with_session(client: LanguageClient) -
     )
 
     # Run a cell to ensure session is created
-    await client.workspace_execute_command_async(
-        lsp.ExecuteCommandParams(
-            command="marimo.api",
-            arguments=[
-                {
-                    "method": "execute-cells",
-                    "params": {
-                        "notebookUri": "file:///dep_tree_test.py",
-                        "executable": sys.executable,
-                        "workingDirectory": str(Path.cwd()),
-                        "inner": {
-                            "cellIds": ["cell1"],
-                            "codes": ["x = 1"],
-                        },
-                    },
-                }
-            ],
-        )
+    await send_command(
+        client,
+        {
+            "kind": "execute",
+            "notebookUri": "file:///dep_tree_test.py",
+            "executable": sys.executable,
+            "workingDirectory": str(Path.cwd()),
+            "cells": [{"cellId": "cell1", "code": "x = 1"}],
+        },
     )
 
     # Give the session a moment to start
     await asyncio.sleep(0.1)
 
     # Now get the dependency tree
-    result = await client.workspace_execute_command_async(
-        lsp.ExecuteCommandParams(
-            command="marimo.api",
-            arguments=[
-                {
-                    "method": "get-dependency-tree",
-                    "params": {
-                        "notebookUri": "file:///dep_tree_test.py",
-                        "source": {"kind": "venv", "executable": sys.executable},
-                        "inner": {},
-                    },
-                }
-            ],
-        )
+    result = await send_command(
+        client,
+        {
+            "kind": "get-dependency-tree",
+            "notebookUri": "file:///dep_tree_test.py",
+            "source": {"kind": "venv", "executable": sys.executable},
+        },
     )
 
     # Should return a tree or None
@@ -997,20 +907,13 @@ async def test_marimo_get_dependency_tree_script_source(
     without requiring a kernel session.
     """
     script = _build_local_script_fixture(tmp_path)
-    result = await client.workspace_execute_command_async(
-        lsp.ExecuteCommandParams(
-            command="marimo.api",
-            arguments=[
-                {
-                    "method": "get-dependency-tree",
-                    "params": {
-                        "notebookUri": script.as_uri(),
-                        "source": {"kind": "script"},
-                        "inner": {},
-                    },
-                }
-            ],
-        )
+    result = await send_command(
+        client,
+        {
+            "kind": "get-dependency-tree",
+            "notebookUri": script.as_uri(),
+            "source": {"kind": "script"},
+        },
     )
 
     assert result is not None
@@ -1034,20 +937,13 @@ async def test_marimo_get_dependency_tree_script_no_pep723(
     script = tmp_path / "plain_script.py"
     script.write_text("print('no metadata')\n")
 
-    result = await client.workspace_execute_command_async(
-        lsp.ExecuteCommandParams(
-            command="marimo.api",
-            arguments=[
-                {
-                    "method": "get-dependency-tree",
-                    "params": {
-                        "notebookUri": script.as_uri(),
-                        "source": {"kind": "script"},
-                        "inner": {},
-                    },
-                }
-            ],
-        )
+    result = await send_command(
+        client,
+        {
+            "kind": "get-dependency-tree",
+            "notebookUri": script.as_uri(),
+            "source": {"kind": "script"},
+        },
     )
 
     assert result == {"tree": None}
@@ -1062,20 +958,13 @@ async def test_marimo_get_package_list_script_source(
     the LSP's own Python — listing the wrong env entirely.
     """
     script = _build_local_script_fixture(tmp_path)
-    result = await client.workspace_execute_command_async(
-        lsp.ExecuteCommandParams(
-            command="marimo.api",
-            arguments=[
-                {
-                    "method": "get-package-list",
-                    "params": {
-                        "notebookUri": script.as_uri(),
-                        "source": {"kind": "script"},
-                        "inner": {},
-                    },
-                }
-            ],
-        )
+    result = await send_command(
+        client,
+        {
+            "kind": "list-packages",
+            "notebookUri": script.as_uri(),
+            "source": {"kind": "script"},
+        },
     )
 
     assert result is not None
@@ -1133,24 +1022,15 @@ x\
             await asyncio.sleep(0.1)
             completion_event.set()
 
-    await client.workspace_execute_command_async(
-        lsp.ExecuteCommandParams(
-            command="marimo.api",
-            arguments=[
-                {
-                    "method": "execute-cells",
-                    "params": {
-                        "notebookUri": "file:///exec_test.py",
-                        "executable": sys.executable,
-                        "workingDirectory": str(Path.cwd()),
-                        "inner": {
-                            "cellIds": ["cell1"],
-                            "codes": [code],
-                        },
-                    },
-                }
-            ],
-        )
+    await send_command(
+        client,
+        {
+            "kind": "execute",
+            "notebookUri": "file:///exec_test.py",
+            "executable": sys.executable,
+            "workingDirectory": str(Path.cwd()),
+            "cells": [{"cellId": "cell1", "code": code}],
+        },
     )
 
     await asyncio.wait_for(completion_event.wait(), timeout=5.0)
@@ -1393,25 +1273,16 @@ async def test_marimo_run_with_ancestor_cell(client: LanguageClient) -> None:
             await asyncio.sleep(0.1)
             completion_event.set()
 
-    await client.workspace_execute_command_async(
-        lsp.ExecuteCommandParams(
-            command="marimo.api",
-            arguments=[
-                {
-                    "method": "execute-cells",
-                    "params": {
-                        "notebookUri": "file:///exec_test.py",
-                        "executable": sys.executable,
-                        "workingDirectory": str(Path.cwd()),
-                        # Just run cell_y, and cell_x should be run automatically
-                        "inner": {
-                            "cellIds": ["cell2"],
-                            "codes": [code_y],
-                        },
-                    },
-                }
-            ],
-        )
+    await send_command(
+        client,
+        {
+            "kind": "execute",
+            "notebookUri": "file:///exec_test.py",
+            "executable": sys.executable,
+            "workingDirectory": str(Path.cwd()),
+            # Just run cell_y, and cell_x should be run automatically
+            "cells": [{"cellId": "cell2", "code": code_y}],
+        },
     )
 
     await asyncio.wait_for(completion_event.wait(), timeout=5.0)
@@ -1945,24 +1816,15 @@ async def test_scratchpad_execution(client: LanguageClient) -> None:
                 scratch_completion_event.set()
 
     # Execute a cell to start the kernel session
-    await client.workspace_execute_command_async(
-        lsp.ExecuteCommandParams(
-            command="marimo.api",
-            arguments=[
-                {
-                    "method": "execute-cells",
-                    "params": {
-                        "notebookUri": "file:///scratch_test.py",
-                        "executable": sys.executable,
-                        "workingDirectory": str(Path.cwd()),
-                        "inner": {
-                            "cellIds": ["cell1"],
-                            "codes": [notebook_code],
-                        },
-                    },
-                }
-            ],
-        )
+    await send_command(
+        client,
+        {
+            "kind": "execute",
+            "notebookUri": "file:///scratch_test.py",
+            "executable": sys.executable,
+            "workingDirectory": str(Path.cwd()),
+            "cells": [{"cellId": "cell1", "code": notebook_code}],
+        },
     )
 
     # Wait for the cell execution to complete (kernel is now running)
@@ -1977,23 +1839,15 @@ y = 42
 print("scratchpad output")
 y\
 """
-    await client.workspace_execute_command_async(
-        lsp.ExecuteCommandParams(
-            command="marimo.api",
-            arguments=[
-                {
-                    "method": "execute-scratchpad",
-                    "params": {
-                        "notebookUri": "file:///scratch_test.py",
-                        "executable": sys.executable,
-                        "workingDirectory": str(Path.cwd()),
-                        "inner": {
-                            "code": scratchpad_code,
-                        },
-                    },
-                }
-            ],
-        )
+    await send_command(
+        client,
+        {
+            "kind": "execute-scratchpad",
+            "notebookUri": "file:///scratch_test.py",
+            "executable": sys.executable,
+            "workingDirectory": str(Path.cwd()),
+            "code": scratchpad_code,
+        },
     )
 
     await asyncio.wait_for(scratch_completion_event.wait(), timeout=5.0)
@@ -2134,21 +1988,15 @@ async def test_scratchpad_creates_session_when_missing(
                 scratch_done.set()
 
     # No cell was ever executed, so there is no session for this notebook yet.
-    await client.workspace_execute_command_async(
-        lsp.ExecuteCommandParams(
-            command="marimo.api",
-            arguments=[
-                {
-                    "method": "execute-scratchpad",
-                    "params": {
-                        "notebookUri": uri,
-                        "executable": sys.executable,
-                        "workingDirectory": str(Path.cwd()),
-                        "inner": {"code": "print('from new session')"},
-                    },
-                }
-            ],
-        )
+    await send_command(
+        client,
+        {
+            "kind": "execute-scratchpad",
+            "notebookUri": uri,
+            "executable": sys.executable,
+            "workingDirectory": str(Path.cwd()),
+            "code": "print('from new session')",
+        },
     )
 
     # Must not hang: the session is created and the code runs.

--- a/tests/test_wasm.py
+++ b/tests/test_wasm.py
@@ -55,9 +55,7 @@ async def test_wasm_server_handles_initialize_message() -> None:
                             "codeActionKinds": ["refactor.rewrite"],
                             "resolveProvider": False,
                         },
-                        "executeCommandProvider": {
-                            "commands": ["marimo.api", "marimo.convert"]
-                        },
+                        "executeCommandProvider": {"commands": ["marimo.convert"]},
                         "diagnosticProvider": {
                             "interFileDependencies": False,
                             "workspaceDiagnostics": False,
@@ -79,7 +77,7 @@ async def test_wasm_server_handles_initialize_message() -> None:
 
 
 @pytest.mark.asyncio
-async def test_wasm_server_drives_async_api_handler() -> None:
+async def test_wasm_server_drives_async_command_handler() -> None:
     messages: list[object] = []
     server = create_bridge(
         lambda message: messages.append(msgspec.json.decode(message)),
@@ -90,12 +88,9 @@ async def test_wasm_server_drives_async_api_handler() -> None:
         msgspec.json.encode(
             {
                 "id": 1,
-                "method": "workspace/executeCommand",
+                "method": "marimo/command",
                 "jsonrpc": "2.0",
-                "params": {
-                    "command": "marimo.api",
-                    "arguments": [{"method": "list-sessions", "params": {}}],
-                },
+                "params": {"kind": "list-sessions"},
             }
         ).decode()
     )


### PR DESCRIPTION
The extension currently calls `marimo.api` with a string method and a separate params object. Python recovers the request type after method lookup, while codegen reconstructs the same association for TypeScript.

The private boundary is now one tagged union owned by marimo-lsp:

```python
class Execute(msgspec.Struct, tag="execute", tag_field="kind"):
    notebook_uri: NotebookUri
    cells: list[CellExecution]

type Command = Execute | Interrupt | DeleteCell | ...
```

The same command table drives Python dispatch, response validation, Effect schema generation, and the generated client. The extension sends each variant directly over `marimo/command`, without a second method discriminator.
