### PR TITLE
Own notebook documents at the LSP boundary

### DIFF
--- a/extension/src/commands/__tests__/configureAutoExport.test.ts
+++ b/extension/src/commands/__tests__/configureAutoExport.test.ts
@@ -15,6 +15,11 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+const appOptions = (
+  autoDownload: ReadonlyArray<string>,
+  passthrough: Readonly<Record<string, unknown>> = {},
+) => ({ managed: { autoDownload: [...autoDownload] }, passthrough });
+
 const notebookFor = (
   editor: ReturnType<typeof TestVsCode.makeNotebookEditor>,
 ) => MarimoNotebookDocument.tryFrom(editor.notebook);
@@ -48,7 +53,7 @@ it.effect(
     const editor = TestVsCode.makeNotebookEditor("/test/report.py", {
       data: {
         metadata: MarimoNotebookDocument.createMetadata({
-          appConfig: { auto_download: ["html"] },
+          appOptions: appOptions(["html"]),
         }),
         cells: [
           {
@@ -99,7 +104,7 @@ it.effect(
       data: {
         cells: [],
         metadata: MarimoNotebookDocument.createMetadata({
-          appConfig: { auto_download: ["markdown", "html"] },
+          appOptions: appOptions(["markdown", "html"]),
         }),
       },
     });
@@ -137,7 +142,7 @@ it.effect(
       data: {
         cells: [],
         metadata: MarimoNotebookDocument.createMetadata({
-          appConfig: { auto_download: ["html", "ipynb", "markdown"] },
+          appOptions: appOptions(["html", "ipynb", "markdown"]),
         }),
       },
     });
@@ -176,7 +181,7 @@ it.effect(
       data: {
         cells: [],
         metadata: MarimoNotebookDocument.createMetadata({
-          appConfig: { auto_download: ["html"] },
+          appOptions: appOptions(["html"]),
         }),
       },
     });
@@ -189,13 +194,13 @@ it.effect(
             if (!isRecord(marimo)) {
               throw new Error("Expected marimo notebook metadata");
             }
-            const appConfig = marimo.appConfig;
-            if (!isRecord(appConfig)) {
-              throw new Error("Expected marimo app config");
+            const currentAppOptions = marimo.appOptions;
+            if (!isRecord(currentAppOptions)) {
+              throw new Error("Expected marimo app options");
             }
-            marimo.appConfig = {
-              ...appConfig,
-              width: "full",
+            marimo.appOptions = {
+              ...currentAppOptions,
+              passthrough: { width: "full" },
             };
             return Option.some(items.filter((item) => item.label === "IPYNB"));
           }),
@@ -223,8 +228,18 @@ it.effect(
     const parsed = yield* MarimoNotebookDocument.from(
       updated.notebook,
     ).parseMetadata();
-    expect(parsed.appConfig).toMatchObject({ width: "full" });
-    expect(parsed.appConfig.auto_download).toEqual(["ipynb"]);
+    expect(parsed.appOptions).toMatchInlineSnapshot(`
+      {
+        "managed": {
+          "autoDownload": [
+            "ipynb",
+          ],
+        },
+        "passthrough": {
+          "width": "full",
+        },
+      }
+    `);
   }),
 );
 
@@ -237,7 +252,7 @@ it.effect(
       data: {
         cells: [],
         metadata: MarimoNotebookDocument.createMetadata({
-          appConfig: { auto_download: ["html"] },
+          appOptions: appOptions(["html"]),
         }),
       },
     });
@@ -286,7 +301,7 @@ it.effect(
       data: {
         cells: [],
         metadata: MarimoNotebookDocument.createMetadata({
-          appConfig: { auto_download: ["html"] },
+          appOptions: appOptions(["html"]),
         }),
       },
     });

--- a/extension/src/commands/__tests__/showNotebookMenu.test.ts
+++ b/extension/src/commands/__tests__/showNotebookMenu.test.ts
@@ -181,7 +181,7 @@ describe("showNotebookMenu", () => {
       const editor = TestVsCode.makeNotebookEditor("/test/report.py", {
         data: {
           metadata: MarimoNotebookDocument.createMetadata({
-            appConfig: { auto_download: [] },
+            appOptions: { managed: { autoDownload: [] }, passthrough: {} },
           }),
           cells: [
             {

--- a/extension/src/commands/configureAutoExport.ts
+++ b/extension/src/commands/configureAutoExport.ts
@@ -3,7 +3,7 @@ import { Effect, Option } from "effect";
 import type { AutoExportFormat } from "../features/AutoExport.ts";
 import { VsCode } from "../platform/VsCode.ts";
 import type { MarimoNotebookDocument } from "../schemas/MarimoNotebookDocument.ts";
-import type { OwnedAppConfig } from "../schemas/Models.gen.ts";
+import type { ManagedAppOptions } from "../schemas/Models.gen.ts";
 
 const FORMATS = ["html", "ipynb", "markdown"] as const;
 
@@ -11,9 +11,9 @@ const isManagedFormat = (format: string): format is AutoExportFormat =>
   format === "html" || format === "ipynb" || format === "markdown";
 
 export function mergeAutoDownloadFormats(
-  current: OwnedAppConfig["auto_download"],
+  current: ManagedAppOptions["autoDownload"],
   selected: ReadonlyArray<AutoExportFormat>,
-): OwnedAppConfig["auto_download"] {
+): ManagedAppOptions["autoDownload"] {
   const retained = current.filter(
     (format) => !isManagedFormat(format) || selected.includes(format),
   );
@@ -36,7 +36,7 @@ export const configureAutoExport = Effect.fn("command.configureAutoExport")(
     }
 
     const metadata = yield* notebook.value.parseMetadata();
-    const current = metadata.appConfig.auto_download;
+    const current = metadata.appOptions.managed.autoDownload;
     const selected = yield* code.window.showQuickPickItemsMany(
       [
         {
@@ -68,7 +68,7 @@ export const configureAutoExport = Effect.fn("command.configureAutoExport")(
     // The picker can stay open while another command updates notebook metadata.
     // Merge into the latest app config so those concurrent changes survive.
     const latestMetadata = yield* notebook.value.parseMetadata();
-    const latest = latestMetadata.appConfig.auto_download;
+    const latest = latestMetadata.appOptions.managed.autoDownload;
     const next = mergeAutoDownloadFormats(
       latest,
       selected.value.map((item) => item.value),
@@ -81,7 +81,13 @@ export const configureAutoExport = Effect.fn("command.configureAutoExport")(
     }
 
     const nextMetadata = notebook.value.buildMetadataUpdate({
-      appConfig: { ...latestMetadata.appConfig, auto_download: next },
+      appOptions: {
+        ...latestMetadata.appOptions,
+        managed: {
+          ...latestMetadata.appOptions.managed,
+          autoDownload: next,
+        },
+      },
     });
     const edit = new code.WorkspaceEdit();
     edit.set(notebook.value.uri, [

--- a/extension/src/features/AutoExport.ts
+++ b/extension/src/features/AutoExport.ts
@@ -179,7 +179,7 @@ export const AutoExportLive = Layer.effectDiscard(
         if (notebook.isUntitled) return;
 
         const metadata = yield* notebook.parseMetadata();
-        const enabled = metadata.appConfig.auto_download;
+        const enabled = metadata.appOptions.managed.autoDownload;
         const formats = (["html", "ipynb", "markdown"] as const).filter(
           (format) => enabled.includes(format),
         );

--- a/extension/src/features/__tests__/AutoExport.test.ts
+++ b/extension/src/features/__tests__/AutoExport.test.ts
@@ -63,8 +63,11 @@ const withTestCtx = Effect.fn(function* (
   const editor = TestVsCode.makeNotebookEditor("/test/report.py", {
     data: {
       metadata: MarimoNotebookDocument.createMetadata({
-        appConfig: {
-          auto_download: [...(options.autoDownload ?? ["html", "ipynb"])],
+        appOptions: {
+          managed: {
+            autoDownload: [...(options.autoDownload ?? ["html", "ipynb"])],
+          },
+          passthrough: {},
         },
       }),
       cells: [
@@ -316,7 +319,10 @@ describe("AutoExport", () => {
         const reopened = TestVsCode.makeNotebookEditor("/test/report.py", {
           data: {
             metadata: MarimoNotebookDocument.createMetadata({
-              appConfig: { auto_download: ["html", "ipynb"] },
+              appOptions: {
+                managed: { autoDownload: ["html", "ipynb"] },
+                passthrough: {},
+              },
             }),
             cells: [
               {

--- a/extension/src/notebook/NotebookSerializer.ts
+++ b/extension/src/notebook/NotebookSerializer.ts
@@ -80,9 +80,12 @@ export class NotebookSerializer extends Context.Service<NotebookSerializer>()(
         function* (notebook: vscode.NotebookData) {
           yield* Effect.annotateCurrentSpan("cellCount", notebook.cells.length);
 
-          const result = yield* marimo.serialize(
-            yield* notebookDataToNotebookDocument(notebook, constants),
-          );
+          const result = yield* marimo.printNotebook({
+            document: yield* notebookDataToNotebookDocument(
+              notebook,
+              constants,
+            ),
+          });
           return new TextEncoder().encode(result.source);
         },
       );
@@ -91,21 +94,19 @@ export class NotebookSerializer extends Context.Service<NotebookSerializer>()(
         function* (bytes: Uint8Array) {
           yield* Effect.annotateCurrentSpan("bytes", bytes.length);
           const result = yield* marimo
-            .deserialize({
+            .parseNotebook({
               source: new TextDecoder().decode(bytes),
             })
             .pipe(Effect.timeout(DESERIALIZE_TIMEOUT));
           if (result.kind !== "success") {
             return yield* new NotebookSourceError({ failure: result });
           }
-          const {
-            notebook: { notebook: document, appOptions, header },
-          } = result;
+          const { document } = result;
 
           const notebook = {
             metadata: MarimoNotebookDocument.createMetadata({
-              appOptions,
-              header,
+              appOptions: document.appOptions,
+              header: document.header,
               notebookMetadata: document.metadata,
             }),
             cells: document.cells.map((cell) => {
@@ -302,10 +303,7 @@ function notebookDataToNotebookDocument(
   }: {
     LanguageId: Constants["Service"]["LanguageId"];
   },
-): Effect.Effect<
-  Omit<typeof Api.Serialize.Encoded, "kind">,
-  Schema.SchemaError
-> {
+): Effect.Effect<typeof Api.NotebookDocument.Encoded, Schema.SchemaError> {
   const { cells, metadata = {} } = notebook;
   const sqlParser = new SQLParser();
   const markdownParser = new MarkdownParser();
@@ -329,71 +327,69 @@ function notebookDataToNotebookDocument(
     });
 
     return {
-      notebook: {
-        version: "1",
-        metadata: documentMetadata.notebookMetadata ?? {},
-        cells: decodedCells.map(({ cell, cellMetadata, hasOptions }) => {
-          const name = cellMetadata.marimo.name;
-          const config = (fallback: typeof Api.NotebookCellConfig.Type) =>
-            hasOptions ? cellMetadata.marimo.options : fallback;
-          const markdownConfig = {
-            ...cellMetadata.marimo.options,
-            hide_code: cellMetadata.marimo.options.hide_code ?? true,
-          };
+      version: "1",
+      metadata: documentMetadata.notebookMetadata ?? {},
+      cells: decodedCells.map(({ cell, cellMetadata, hasOptions }) => {
+        const name = cellMetadata.marimo.name;
+        const config = (fallback: typeof Api.NotebookCellConfig.Type) =>
+          hasOptions ? cellMetadata.marimo.options : fallback;
+        const markdownConfig = {
+          ...cellMetadata.marimo.options,
+          hide_code: cellMetadata.marimo.options.hide_code ?? true,
+        };
 
-          // oxlint-disable-next-line typescript/no-unsafe-enum-comparison
-          if (cell.kind === NotebookCellKind.Markup) {
-            // Check if this is a markdown cell with metadata
-            if (cell.languageId === LanguageId.Markdown) {
-              const result = markdownParser.transformOut(
-                cell.value,
-                cellMetadata.marimo.sourceProjections.markdown ??
-                  markdownParser.defaultMetadata,
-              );
-              return {
-                id: null,
-                code: result.code,
-                code_hash: null,
-                name,
-                config: markdownConfig,
-              };
-            }
-            // Otherwise use the default wrapInMarkdown
-            return {
-              id: null,
-              code: wrapInMarkdown(cell.value),
-              code_hash: null,
-              name,
-              config: markdownConfig,
-            };
-          }
-
-          // Handle SQL cells - transform back to Python mo.sql() wrapper
-          if (cell.languageId === LanguageId.Sql) {
-            const result = sqlParser.transformOut(
+        // oxlint-disable-next-line typescript/no-unsafe-enum-comparison
+        if (cell.kind === NotebookCellKind.Markup) {
+          // Check if this is a markdown cell with metadata
+          if (cell.languageId === LanguageId.Markdown) {
+            const result = markdownParser.transformOut(
               cell.value,
-              cellMetadata.marimo.sourceProjections.sql ??
-                sqlParser.defaultMetadata,
+              cellMetadata.marimo.sourceProjections.markdown ??
+                markdownParser.defaultMetadata,
             );
             return {
               id: null,
               code: result.code,
               code_hash: null,
               name,
-              config: config({}),
+              config: markdownConfig,
             };
           }
-
-          // Default Python cells
+          // Otherwise use the default wrapInMarkdown
           return {
             id: null,
-            code: cell.value,
+            code: wrapInMarkdown(cell.value),
+            code_hash: null,
+            name,
+            config: markdownConfig,
+          };
+        }
+
+        // Handle SQL cells - transform back to Python mo.sql() wrapper
+        if (cell.languageId === LanguageId.Sql) {
+          const result = sqlParser.transformOut(
+            cell.value,
+            cellMetadata.marimo.sourceProjections.sql ??
+              sqlParser.defaultMetadata,
+          );
+          return {
+            id: null,
+            code: result.code,
             code_hash: null,
             name,
             config: config({}),
           };
-        }),
-      },
+        }
+
+        // Default Python cells
+        return {
+          id: null,
+          code: cell.value,
+          code_hash: null,
+          name,
+          config: config({}),
+        };
+      }),
       appOptions: documentMetadata.appOptions,
       header: documentMetadata.header ?? null,
     };

--- a/extension/src/notebook/NotebookSerializer.ts
+++ b/extension/src/notebook/NotebookSerializer.ts
@@ -99,12 +99,12 @@ export class NotebookSerializer extends Context.Service<NotebookSerializer>()(
             return yield* new NotebookSourceError({ failure: result });
           }
           const {
-            notebook: { notebook: document, appConfig, header },
+            notebook: { notebook: document, appOptions, header },
           } = result;
 
           const notebook = {
             metadata: MarimoNotebookDocument.createMetadata({
-              appConfig,
+              appOptions,
               header,
               notebookMetadata: document.metadata,
             }),
@@ -394,7 +394,7 @@ function notebookDataToNotebookDocument(
           };
         }),
       },
-      appConfig: documentMetadata.appConfig,
+      appOptions: documentMetadata.appOptions,
       header: documentMetadata.header ?? null,
     };
   });

--- a/extension/src/notebook/NotebookSourceError.ts
+++ b/extension/src/notebook/NotebookSourceError.ts
@@ -3,7 +3,7 @@ import { Data } from "effect";
 import type * as Api from "../schemas/Models.gen.ts";
 
 export type NotebookSourceFailure = Exclude<
-  Api.DeserializeResult,
+  Api.ParseNotebookResult,
   { readonly kind: "success" }
 >;
 

--- a/extension/src/schemas/MarimoNotebookDocument.ts
+++ b/extension/src/schemas/MarimoNotebookDocument.ts
@@ -45,7 +45,6 @@ const notebookMetadataEquivalence = Schema.toEquivalence(
   Api.MarimoNotebookMetadata,
 );
 
-const parseOwnedAppConfig = Schema.decodeUnknownEffect(Api.OwnedAppConfig);
 const MARKUP_CELL_KIND: vscode.NotebookCellKind = 1;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -394,12 +393,6 @@ export class MarimoNotebookDocument {
     const raw = asRecord(this.#raw.metadata);
     return parseNotebookMetadata(
       Object.hasOwn(raw, "marimo") ? raw.marimo : {},
-    ).pipe(
-      Effect.flatMap((metadata) =>
-        parseOwnedAppConfig(metadata.appConfig).pipe(
-          Effect.map((appConfig) => ({ ...metadata, appConfig })),
-        ),
-      ),
     );
   }
 

--- a/extension/src/schemas/Models.gen.ts
+++ b/extension/src/schemas/Models.gen.ts
@@ -428,12 +428,41 @@ export const SerializedNotebookV1 = Schema.Struct({
 export type SerializedNotebookV1 = typeof SerializedNotebookV1.Type;
 
 /**
+ * Source-level app options managed by the extension.
+ */
+export const ManagedAppOptions = Schema.Struct({
+  autoDownload: Schema.Array(Schema.String).pipe(
+    Schema.withDecodingDefault(Effect.sync(() => [])),
+  ),
+}).annotate({
+  identifier: "ManagedAppOptions",
+  parseOptions: { onExcessProperty: "error" },
+});
+export type ManagedAppOptions = typeof ManagedAppOptions.Type;
+
+/**
+ * Managed app options plus an opaque lossless passthrough bag.
+ */
+export const AppOptions = Schema.Struct({
+  managed: ManagedAppOptions.pipe(
+    Schema.withDecodingDefault(Effect.sync(() => ({}))),
+  ),
+  passthrough: Schema.Record(Schema.String, Schema.Unknown).pipe(
+    Schema.withDecodingDefault(Effect.sync(() => ({}))),
+  ),
+}).annotate({
+  identifier: "AppOptions",
+  parseOptions: { onExcessProperty: "error" },
+});
+export type AppOptions = typeof AppOptions.Type;
+
+/**
  * Serialize notebook data to native marimo Python source.
  */
 export const Serialize = Schema.Struct({
   kind: Schema.Literal("serialize"),
   notebook: SerializedNotebookV1,
-  appConfig: Schema.Record(Schema.String, Schema.Unknown).pipe(
+  appOptions: AppOptions.pipe(
     Schema.withDecodingDefault(Effect.sync(() => ({}))),
   ),
   header: Schema.NullOr(Schema.String).pipe(
@@ -580,22 +609,6 @@ export const Command = Schema.Union([
   ExportMarkdown,
 ]).annotate({ identifier: "Command" });
 export type Command = typeof Command.Type;
-
-/**
- * App options understood by the extension, projected from ``AppConfig``.
- *
- * Codegen preserves excess properties in TypeScript so parsing this owned
- * subset never discards options belonging to marimo or a future extension.
- */
-export const OwnedAppConfig = Schema.Struct({
-  auto_download: Schema.Array(Schema.String).pipe(
-    Schema.withDecodingDefault(Effect.sync(() => [])),
-  ),
-}).annotate({
-  identifier: "OwnedAppConfig",
-  parseOptions: { onExcessProperty: "preserve" },
-});
-export type OwnedAppConfig = typeof OwnedAppConfig.Type;
 
 /**
  * A notification emitted by one exact live kernel.
@@ -745,7 +758,7 @@ export type NotebookMetadata = typeof NotebookMetadata.Type;
  * Persisted marimo-owned metadata on an LSP notebook document.
  */
 export const MarimoNotebookMetadata = Schema.Struct({
-  appConfig: Schema.Record(Schema.String, Schema.Unknown).pipe(
+  appOptions: AppOptions.pipe(
     Schema.withDecodingDefault(Effect.sync(() => ({}))),
   ),
   header: Schema.NullOr(Schema.String).pipe(
@@ -798,7 +811,7 @@ export type NotebookV1 = typeof NotebookV1.Type;
  */
 export const NotebookDocument = Schema.Struct({
   notebook: NotebookV1,
-  appConfig: Schema.Record(Schema.String, Schema.Unknown).pipe(
+  appOptions: AppOptions.pipe(
     Schema.withDecodingDefault(Effect.sync(() => ({}))),
   ),
   header: Schema.NullOr(Schema.String).pipe(

--- a/extension/src/schemas/Models.gen.ts
+++ b/extension/src/schemas/Models.gen.ts
@@ -387,45 +387,34 @@ export const GetDependencyTree = Schema.Struct({
 export type GetDependencyTree = typeof GetDependencyTree.Type;
 
 /**
+ * Opaque-compatible metadata stored with a notebook document.
+ */
+export const NotebookMetadata = Schema.Struct({
+  marimo_version: Schema.optional(Schema.NullOr(Schema.String)),
+}).annotate({ identifier: "NotebookMetadata" });
+export type NotebookMetadata = typeof NotebookMetadata.Type;
+
+/**
  * Persisted marimo configuration for one notebook cell.
  */
-export const SerializedNotebookCellConfig = Schema.Struct({
+export const NotebookCellConfig = Schema.Struct({
   column: Schema.optional(Schema.NullOr(Schema.Int)),
   disabled: Schema.optional(Schema.NullOr(Schema.Boolean)),
   hide_code: Schema.optional(Schema.NullOr(Schema.Boolean)),
-}).annotate({ identifier: "SerializedNotebookCellConfig" });
-export type SerializedNotebookCellConfig =
-  typeof SerializedNotebookCellConfig.Type;
+}).annotate({ identifier: "NotebookCellConfig" });
+export type NotebookCellConfig = typeof NotebookCellConfig.Type;
 
 /**
- * One code cell in the serialized notebook format.
+ * One code cell in an owned notebook document.
  */
-export const SerializedNotebookCell = Schema.Struct({
+export const NotebookCell = Schema.Struct({
   code: Schema.NullOr(Schema.String),
   code_hash: Schema.NullOr(Schema.String),
-  config: SerializedNotebookCellConfig,
+  config: NotebookCellConfig,
   id: Schema.NullOr(Schema.String),
   name: Schema.NullOr(Schema.String),
-}).annotate({ identifier: "SerializedNotebookCell" });
-export type SerializedNotebookCell = typeof SerializedNotebookCell.Type;
-
-/**
- * Metadata stored with the serialized notebook.
- */
-export const SerializedNotebookMetadata = Schema.Struct({
-  marimo_version: Schema.optional(Schema.NullOr(Schema.String)),
-}).annotate({ identifier: "SerializedNotebookMetadata" });
-export type SerializedNotebookMetadata = typeof SerializedNotebookMetadata.Type;
-
-/**
- * Owned projection of marimo's version-one notebook document.
- */
-export const SerializedNotebookV1 = Schema.Struct({
-  cells: Schema.Array(SerializedNotebookCell),
-  metadata: SerializedNotebookMetadata,
-  version: Schema.Literal("1"),
-}).annotate({ identifier: "SerializedNotebookV1" });
-export type SerializedNotebookV1 = typeof SerializedNotebookV1.Type;
+}).annotate({ identifier: "NotebookCell" });
+export type NotebookCell = typeof NotebookCell.Type;
 
 /**
  * Source-level app options managed by the extension.
@@ -457,11 +446,12 @@ export const AppOptions = Schema.Struct({
 export type AppOptions = typeof AppOptions.Type;
 
 /**
- * Serialize notebook data to native marimo Python source.
+ * Owned notebook data plus source-level application metadata.
  */
-export const Serialize = Schema.Struct({
-  kind: Schema.Literal("serialize"),
-  notebook: SerializedNotebookV1,
+export const NotebookDocument = Schema.Struct({
+  version: Schema.Literal("1"),
+  metadata: NotebookMetadata,
+  cells: Schema.Array(NotebookCell),
   appOptions: AppOptions.pipe(
     Schema.withDecodingDefault(Effect.sync(() => ({}))),
   ),
@@ -469,22 +459,34 @@ export const Serialize = Schema.Struct({
     Schema.withDecodingDefault(Effect.sync(() => null)),
   ),
 }).annotate({
-  identifier: "Serialize",
+  identifier: "NotebookDocument",
   parseOptions: { onExcessProperty: "error" },
 });
-export type Serialize = typeof Serialize.Type;
+export type NotebookDocument = typeof NotebookDocument.Type;
 
 /**
- * Deserialize source into notebook data.
+ * Print an owned notebook document as native marimo Python source.
  */
-export const Deserialize = Schema.Struct({
-  kind: Schema.Literal("deserialize"),
-  source: Schema.String,
+export const PrintNotebook = Schema.Struct({
+  kind: Schema.Literal("print-notebook"),
+  document: NotebookDocument,
 }).annotate({
-  identifier: "Deserialize",
+  identifier: "PrintNotebook",
   parseOptions: { onExcessProperty: "error" },
 });
-export type Deserialize = typeof Deserialize.Type;
+export type PrintNotebook = typeof PrintNotebook.Type;
+
+/**
+ * Parse native marimo Python source into an owned notebook document.
+ */
+export const ParseNotebook = Schema.Struct({
+  kind: Schema.Literal("parse-notebook"),
+  source: Schema.String,
+}).annotate({
+  identifier: "ParseNotebook",
+  parseOptions: { onExcessProperty: "error" },
+});
+export type ParseNotebook = typeof ParseNotebook.Type;
 
 /**
  * Read configuration for one notebook.
@@ -598,8 +600,8 @@ export const Command = Schema.Union([
   ExecuteScratchpad,
   ListPackages,
   GetDependencyTree,
-  Serialize,
-  Deserialize,
+  PrintNotebook,
+  ParseNotebook,
   GetConfiguration,
   UpdateConfiguration,
   SetDisplayTheme,
@@ -628,16 +630,6 @@ export const DocumentAnalysis = Schema.Struct({
   analysis: VariablesNotification,
 }).annotate({ identifier: "DocumentAnalysis" });
 export type DocumentAnalysis = typeof DocumentAnalysis.Type;
-
-/**
- * Configuration for a notebook cell
- */
-export const NotebookCellConfig = Schema.Struct({
-  column: Schema.optional(Schema.NullOr(Schema.Int)),
-  disabled: Schema.optional(Schema.NullOr(Schema.Boolean)),
-  hide_code: Schema.optional(Schema.NullOr(Schema.Boolean)),
-}).annotate({ identifier: "NotebookCellConfig" });
-export type NotebookCellConfig = typeof NotebookCellConfig.Type;
 
 /**
  * Projection state for displaying a Python markdown cell.
@@ -747,14 +739,6 @@ export const CellMetadata = Schema.Struct({
 export type CellMetadata = typeof CellMetadata.Type;
 
 /**
- * Metadata about the notebook
- */
-export const NotebookMetadata = Schema.Struct({
-  marimo_version: Schema.optional(Schema.NullOr(Schema.String)),
-}).annotate({ identifier: "NotebookMetadata" });
-export type NotebookMetadata = typeof NotebookMetadata.Type;
-
-/**
  * Persisted marimo-owned metadata on an LSP notebook document.
  */
 export const MarimoNotebookMetadata = Schema.Struct({
@@ -785,54 +769,21 @@ export const NotebookDocumentMetadata = Schema.Struct({
 export type NotebookDocumentMetadata = typeof NotebookDocumentMetadata.Type;
 
 /**
- * Code cell specific structure
- */
-export const NotebookCell = Schema.Struct({
-  code: Schema.NullOr(Schema.String),
-  code_hash: Schema.NullOr(Schema.String),
-  config: NotebookCellConfig,
-  id: Schema.NullOr(Schema.String),
-  name: Schema.NullOr(Schema.String),
-}).annotate({ identifier: "NotebookCell" });
-export type NotebookCell = typeof NotebookCell.Type;
-
-/**
- * Main notebook structure
- */
-export const NotebookV1 = Schema.Struct({
-  cells: Schema.Array(NotebookCell),
-  metadata: NotebookMetadata,
-  version: Schema.Literal("1"),
-}).annotate({ identifier: "NotebookV1" });
-export type NotebookV1 = typeof NotebookV1.Type;
-
-/**
- * Strict JSON notebook data plus source-level application metadata.
- */
-export const NotebookDocument = Schema.Struct({
-  notebook: NotebookV1,
-  appOptions: AppOptions.pipe(
-    Schema.withDecodingDefault(Effect.sync(() => ({}))),
-  ),
-  header: Schema.NullOr(Schema.String).pipe(
-    Schema.withDecodingDefault(Effect.sync(() => null)),
-  ),
-}).annotate({ identifier: "NotebookDocument" });
-export type NotebookDocument = typeof NotebookDocument.Type;
-
-/**
  * A successfully parsed native marimo notebook.
  */
-export const DeserializeSuccess = Schema.Struct({
+export const ParseNotebookSuccess = Schema.Struct({
   kind: Schema.Literal("success"),
-  notebook: NotebookDocument,
-}).annotate({ identifier: "DeserializeSuccess" });
-export type DeserializeSuccess = typeof DeserializeSuccess.Type;
+  document: NotebookDocument,
+}).annotate({
+  identifier: "ParseNotebookSuccess",
+  parseOptions: { onExcessProperty: "error" },
+});
+export type ParseNotebookSuccess = typeof ParseNotebookSuccess.Type;
 
 /**
  * Python syntax prevented the source from being inspected.
  */
-export const DeserializeInvalidSyntax = Schema.Struct({
+export const ParseNotebookInvalidSyntax = Schema.Struct({
   kind: Schema.Literal("invalid-syntax"),
   line: Schema.NullOr(Schema.Int).pipe(
     Schema.withDecodingDefault(Effect.sync(() => null)),
@@ -840,23 +791,29 @@ export const DeserializeInvalidSyntax = Schema.Struct({
   column: Schema.NullOr(Schema.Int).pipe(
     Schema.withDecodingDefault(Effect.sync(() => null)),
   ),
-}).annotate({ identifier: "DeserializeInvalidSyntax" });
-export type DeserializeInvalidSyntax = typeof DeserializeInvalidSyntax.Type;
+}).annotate({
+  identifier: "ParseNotebookInvalidSyntax",
+  parseOptions: { onExcessProperty: "error" },
+});
+export type ParseNotebookInvalidSyntax = typeof ParseNotebookInvalidSyntax.Type;
 
 /**
  * Valid Python source that can be converted to a marimo notebook.
  */
-export const DeserializeConvertible = Schema.Struct({
+export const ParseNotebookConvertible = Schema.Struct({
   kind: Schema.Literal("convertible"),
-}).annotate({ identifier: "DeserializeConvertible" });
-export type DeserializeConvertible = typeof DeserializeConvertible.Type;
+}).annotate({
+  identifier: "ParseNotebookConvertible",
+  parseOptions: { onExcessProperty: "error" },
+});
+export type ParseNotebookConvertible = typeof ParseNotebookConvertible.Type;
 
-export const DeserializeResult = Schema.Union([
-  DeserializeSuccess,
-  DeserializeInvalidSyntax,
-  DeserializeConvertible,
-]).annotate({ identifier: "DeserializeResult" });
-export type DeserializeResult = typeof DeserializeResult.Type;
+export const ParseNotebookResult = Schema.Union([
+  ParseNotebookSuccess,
+  ParseNotebookInvalidSyntax,
+  ParseNotebookConvertible,
+]).annotate({ identifier: "ParseNotebookResult" });
+export type ParseNotebookResult = typeof ParseNotebookResult.Type;
 
 /**
  * A request to convert a file source a marimo notebook.
@@ -960,12 +917,15 @@ export const DependencyTreeResponse = Schema.Struct({
 export type DependencyTreeResponse = typeof DependencyTreeResponse.Type;
 
 /**
- * Response for ``serialize``.
+ * Native marimo Python source printed from an owned notebook document.
  */
-export const SerializeResponse = Schema.Struct({
+export const PrintNotebookResult = Schema.Struct({
   source: Schema.String,
-}).annotate({ identifier: "SerializeResponse" });
-export type SerializeResponse = typeof SerializeResponse.Type;
+}).annotate({
+  identifier: "PrintNotebookResult",
+  parseOptions: { onExcessProperty: "error" },
+});
+export type PrintNotebookResult = typeof PrintNotebookResult.Type;
 
 /**
  * Configuration options for Anthropic.
@@ -1740,19 +1700,19 @@ export const makeCommandClient = <E, R>(send: CommandTransport<E, R>) => ({
     } satisfies typeof GetDependencyTree.Encoded;
     return dispatch(send, command, DependencyTreeResponse);
   },
-  serialize: (params: Omit<typeof Serialize.Encoded, "kind">) => {
+  printNotebook: (params: Omit<typeof PrintNotebook.Encoded, "kind">) => {
     const command = {
-      kind: "serialize",
+      kind: "print-notebook",
       ...params,
-    } satisfies typeof Serialize.Encoded;
-    return dispatch(send, command, SerializeResponse);
+    } satisfies typeof PrintNotebook.Encoded;
+    return dispatch(send, command, PrintNotebookResult);
   },
-  deserialize: (params: Omit<typeof Deserialize.Encoded, "kind">) => {
+  parseNotebook: (params: Omit<typeof ParseNotebook.Encoded, "kind">) => {
     const command = {
-      kind: "deserialize",
+      kind: "parse-notebook",
       ...params,
-    } satisfies typeof Deserialize.Encoded;
-    return dispatch(send, command, DeserializeResult);
+    } satisfies typeof ParseNotebook.Encoded;
+    return dispatch(send, command, ParseNotebookResult);
   },
   getConfiguration: (params: Omit<typeof GetConfiguration.Encoded, "kind">) => {
     const command = {

--- a/extension/src/schemas/__tests__/MarimoNotebookDocument.test.ts
+++ b/extension/src/schemas/__tests__/MarimoNotebookDocument.test.ts
@@ -108,17 +108,19 @@ describe("MarimoNotebookCell metadata updates", () => {
   );
 });
 
-describe("MarimoNotebookDocument app config", () => {
-  it("validates owned options and preserves options it does not understand", () => {
+describe("MarimoNotebookDocument app options", () => {
+  it("validates managed options and preserves passthrough options", () => {
     const raw = createTestNotebookDocument("file:///test/notebook_mo.py", {
       data: {
         cells: [],
         metadata: {
           marimo: {
-            appConfig: {
-              auto_download: ["html", "future-format"],
-              width: "wide",
-              future_setting: { answer: 42 },
+            appOptions: {
+              managed: { autoDownload: ["html", "future-format"] },
+              passthrough: {
+                width: "wide",
+                future_setting: { answer: 42 },
+              },
             },
           },
         },
@@ -128,11 +130,22 @@ describe("MarimoNotebookDocument app config", () => {
     const parsed = Effect.runSync(
       MarimoNotebookDocument.from(raw).parseMetadata(),
     );
-    expect(parsed.appConfig.auto_download).toEqual(["html", "future-format"]);
-    expect(parsed.appConfig).toMatchObject({
-      width: "wide",
-      future_setting: { answer: 42 },
-    });
+    expect(parsed.appOptions).toMatchInlineSnapshot(`
+      {
+        "managed": {
+          "autoDownload": [
+            "html",
+            "future-format",
+          ],
+        },
+        "passthrough": {
+          "future_setting": {
+            "answer": 42,
+          },
+          "width": "wide",
+        },
+      }
+    `);
   });
 
   it("rejects invalid values for the option owned by the extension", () => {
@@ -140,7 +153,9 @@ describe("MarimoNotebookDocument app config", () => {
       data: {
         cells: [],
         metadata: {
-          marimo: { appConfig: { auto_download: [42] } },
+          marimo: {
+            appOptions: { managed: { autoDownload: [42] }, passthrough: {} },
+          },
         },
       },
     });

--- a/extension/src/schemas/__tests__/Models.gen.test.ts
+++ b/extension/src/schemas/__tests__/Models.gen.test.ts
@@ -191,7 +191,7 @@ describe("Models.gen (msgspec → Effect Schema codegen)", () => {
     });
   });
 
-  it("preserves app constructor options as an open record", () => {
+  it("separates managed app options from the passthrough record", () => {
     const decoded = Schema.decodeUnknownSync(NotebookDocument)({
       notebook: {
         version: "1",
@@ -206,16 +206,30 @@ describe("Models.gen (msgspec → Effect Schema codegen)", () => {
           },
         ],
       },
-      appConfig: { width: "full", future_setting: { answer: 42 } },
+      appOptions: {
+        managed: { autoDownload: ["html", "future-format"] },
+        passthrough: { width: "full", future_setting: { answer: 42 } },
+      },
       header: null,
     });
 
-    expect(decoded.notebook.cells[0]?.config.hide_code).toBe(true);
-    expect(decoded.appConfig?.width).toBe("full");
-    expect(decoded.appConfig?.future_setting).toEqual({ answer: 42 });
-    expect(
-      Schema.encodeSync(NotebookDocument)(decoded).appConfig?.future_setting,
-    ).toEqual({ answer: 42 });
+    expect(Schema.encodeSync(NotebookDocument)(decoded).appOptions)
+      .toMatchInlineSnapshot(`
+        {
+          "managed": {
+            "autoDownload": [
+              "html",
+              "future-format",
+            ],
+          },
+          "passthrough": {
+            "future_setting": {
+              "answer": 42,
+            },
+            "width": "full",
+          },
+        }
+      `);
   });
 
   it.effect("requires JSON null for fire-and-forget responses", () =>

--- a/extension/src/schemas/__tests__/Models.gen.test.ts
+++ b/extension/src/schemas/__tests__/Models.gen.test.ts
@@ -193,19 +193,17 @@ describe("Models.gen (msgspec → Effect Schema codegen)", () => {
 
   it("separates managed app options from the passthrough record", () => {
     const decoded = Schema.decodeUnknownSync(NotebookDocument)({
-      notebook: {
-        version: "1",
-        metadata: { marimo_version: "0.23.15" },
-        cells: [
-          {
-            id: "cell-id",
-            code: "x = 1",
-            code_hash: null,
-            name: "cell",
-            config: { hide_code: true },
-          },
-        ],
-      },
+      version: "1",
+      metadata: { marimo_version: "0.23.15" },
+      cells: [
+        {
+          id: "cell-id",
+          code: "x = 1",
+          code_hash: null,
+          name: "cell",
+          config: { hide_code: true },
+        },
+      ],
       appOptions: {
         managed: { autoDownload: ["html", "future-format"] },
         passthrough: { width: "full", future_setting: { answer: 42 } },

--- a/extension/src/telemetry/__tests__/classifyNotebookDeserializeError.test.ts
+++ b/extension/src/telemetry/__tests__/classifyNotebookDeserializeError.test.ts
@@ -85,7 +85,7 @@ it("groups internal RPC failures by method, code, and exception class", () => {
     domain: "notebook.deserialize",
     kind: "rpc.internal",
     safeContext: {
-      "rpc.method": "deserialize",
+      "rpc.method": "parse-notebook",
       "rpc.code": -32603,
       "error.exception_class": "ResponseError",
       "lsp.mode": "wasm",
@@ -104,7 +104,7 @@ it("separates client lifecycle failures from internal RPC errors", () => {
 
   expect(result.kind).toBe("transport.client-not-running");
   expect(result.safeContext).toEqual({
-    "rpc.method": "deserialize",
+    "rpc.method": "parse-notebook",
     "error.exception_class": "Error",
     "lsp.mode": "wasm",
   });
@@ -113,7 +113,7 @@ it("separates client lifecycle failures from internal RPC errors", () => {
 function commandError(cause: unknown) {
   return new MarimoCommandError({
     command: Redacted.make({
-      kind: "deserialize" as const,
+      kind: "parse-notebook" as const,
       source: "DO_NOT_UPLOAD_COMMAND_SOURCE",
     }),
     cause,

--- a/extension/src/telemetry/__tests__/sentrySink.test.ts
+++ b/extension/src/telemetry/__tests__/sentrySink.test.ts
@@ -8,7 +8,7 @@ import { classifySentryError } from "../sentrySink.ts";
 function commandError(cause: Error): MarimoCommandError {
   return new MarimoCommandError({
     command: Redacted.make({
-      kind: "deserialize",
+      kind: "parse-notebook",
       source: "",
     }),
     cause,
@@ -66,7 +66,7 @@ it("fingerprints command errors by their nested Python failure", () => {
       "error.domain": "notebook.deserialize",
       "error.exception_class": "KernelOpenError",
       "error.kind": "marimo-command.kernel-bridge-exit",
-      "rpc.method": "deserialize",
+      "rpc.method": "parse-notebook",
       "rpc.code": "-32603",
       "lsp.mode": "wasm",
     },
@@ -91,7 +91,7 @@ it("preserves specific transport classifications for command failures", () => {
       "error.domain": "notebook.deserialize",
       "error.exception_class": "Error",
       "error.kind": "transport.client-not-running",
-      "rpc.method": "deserialize",
+      "rpc.method": "parse-notebook",
       "lsp.mode": "wasm",
     },
     fingerprint: [

--- a/scripts/codegen/effect_schemas.py
+++ b/scripts/codegen/effect_schemas.py
@@ -87,8 +87,8 @@ CONCRETE: list[tuple[str, type | object]] = [
     ("DocumentAnalysis", models.DocumentAnalysis),
     ("CellMetadata", models.CellMetadata),
     ("NotebookDocumentMetadata", models.NotebookDocumentMetadata),
-    ("NotebookDocument", models.NotebookDocument),
-    ("DeserializeResult", models.DeserializeResult),
+    ("NotebookDocument", protocol.NotebookDocument),
+    ("ParseNotebookResult", protocol.ParseNotebookResult),
     ("ConvertRequest", models.ConvertRequest),
     ("CellOutputReplay", models.CellOutputReplay),
 ]

--- a/scripts/codegen/effect_schemas.py
+++ b/scripts/codegen/effect_schemas.py
@@ -82,7 +82,7 @@ _StructLike = mi.StructType | mi.DataclassType | mi.TypedDictType
 # (exported name, type) pairs. The emitter topologically orders dependencies.
 CONCRETE: list[tuple[str, type | object]] = [
     ("Command", protocol.Command),
-    ("OwnedAppConfig", models.OwnedAppConfig),
+    ("AppOptions", protocol.AppOptions),
     ("KernelNotification", models.KernelNotification),
     ("DocumentAnalysis", models.DocumentAnalysis),
     ("CellMetadata", models.CellMetadata),

--- a/src/marimo_lsp/api.py
+++ b/src/marimo_lsp/api.py
@@ -4,20 +4,15 @@
 
 from __future__ import annotations
 
-import ast
 import dataclasses
 import inspect
 import json
-import keyword
 import typing
 from typing import TYPE_CHECKING, cast
 
 import msgspec
-from marimo._ast.compiler import module_compile
-from marimo._ast.parse import MarimoFileError
 from marimo._config.config import MarimoConfig  # noqa: TC002 - API introspection
 from marimo._config.manager import get_default_config_manager
-from marimo._convert.converters import MarimoConvert
 from marimo._export.exporter import Exporter, export_markdown
 from marimo._export.requests import (
     HTMLExportRequest,
@@ -37,11 +32,6 @@ from marimo._runtime.packages.package_manager import PackageDescription
 from marimo._runtime.packages.package_managers import create_package_manager
 from marimo._schemas.export import ExportAsHTMLRequest, to_html_export_options
 from marimo._schemas.export_options import IPYNBExportOptions, MarkdownExportOptions
-from marimo._schemas.notebook import NotebookV1
-from marimo._schemas.serialization import (
-    AppInstantiation,
-    Header,
-)
 from marimo._session.requests import InstantiateNotebookRequest
 from marimo._session.state.serialize import serialize_session_view
 from marimo._types.ids import (
@@ -54,22 +44,12 @@ from marimo._types.ids import (
 from pygls.uris import to_fs_path
 from typing_extensions import TypeForm
 
-from marimo_lsp import protocol
+from marimo_lsp import notebook_source, protocol
 from marimo_lsp.app_file_manager import find_notebook_document, snapshot_for_scratchpad
-from marimo_lsp.app_options import (
-    MARIMO_APP_OPTION_NAMES,
-    app_options_from_source,
-    known_marimo_app_options,
-    merge_app_options,
-)
 from marimo_lsp.loggers import get_logger
 from marimo_lsp.models import (
     DeleteCellRequest,
     DependencyTreeResponse,
-    DeserializeConvertible,
-    DeserializeInvalidSyntax,
-    DeserializeResult,
-    DeserializeSuccess,
     ExecuteCellsRequest,
     GetConfigurationResponse,
     ListPackagesResponse,
@@ -77,9 +57,7 @@ from marimo_lsp.models import (
     ListSQLSchemasRequest,
     ListSQLTablesRequest,
     ModelRequest,
-    NotebookDocument,
     ReadNotebookOutputsResponse,
-    SerializeResponse,
     SetDisplayThemeResponse,
     UpdateUIElementRequest,
 )
@@ -662,162 +640,20 @@ def _package_manager_for(source: protocol.PackageSource) -> LspPackageManager:
     )
 
 
-@command(protocol.Serialize)
-async def serialize(_ctx: ApiContext, args: protocol.Serialize) -> SerializeResponse:
-    notebook = msgspec.convert(args.notebook, type=NotebookV1)
-    ir = MarimoConvert.from_notebook_v1(notebook).to_ir()
-    known_options = known_marimo_app_options(args.app_options)
-    ir = dataclasses.replace(
-        ir,
-        app=AppInstantiation(options=known_options),
-        header=Header(value=args.header) if args.header is not None else None,
-    )
-    source = MarimoConvert.from_ir(ir).to_py()
-    return SerializeResponse(
-        source=_restore_unknown_app_options(
-            source,
-            merge_app_options(args.app_options),
-        )
-    )
-
-
-def _restore_unknown_app_options(source: str, options: dict[str, object]) -> str:
-    """Restore opaque options dropped by marimo's current code generator.
-
-    Marimo parses unknown literal kwargs, but ``generate_filecontents_from_ir``
-    projects them through its installed ``_AppConfig`` and loses them. Replace
-    only the generated ``marimo.App(...)`` expression so future options survive
-    a save without reformatting the rest of the notebook.
-    """
-    known_options = MARIMO_APP_OPTION_NAMES
-    unknown_options = [
-        (name, value) for name, value in options.items() if name not in known_options
-    ]
-    if not unknown_options:
-        return source
-
-    rendered_options: list[str] = []
-    for name, value in unknown_options:
-        if not name.isidentifier() or keyword.iskeyword(name):
-            msg = f"App config key cannot be represented as a keyword: {name!r}"
-            raise ValueError(msg)
-        rendered = repr(value)
-        try:
-            ast.literal_eval(rendered)
-        except (ValueError, SyntaxError) as error:
-            msg = f"App config value is not a Python literal: {name!r}={rendered}"
-            raise ValueError(msg) from error
-        rendered_options.append(f"{name}={rendered}")
-
-    tree = ast.parse(source)
-    call = next(
-        (
-            node.value
-            for node in tree.body
-            if isinstance(node, ast.Assign)
-            and any(
-                isinstance(target, ast.Name) and target.id == "app"
-                for target in node.targets
-            )
-            and isinstance(node.value, ast.Call)
-            and isinstance(node.value.func, ast.Attribute)
-            and isinstance(node.value.func.value, ast.Name)
-            and node.value.func.value.id == "marimo"
-            and node.value.func.attr == "App"
-        ),
-        None,
-    )
-    if call is None or call.end_lineno is None or call.end_col_offset is None:
-        msg = "Generated notebook did not contain marimo.App(...)"
-        raise ValueError(msg)
-
-    lines = source.splitlines(keepends=True)
-
-    def offset(line_number: int, byte_column: int) -> int:
-        line = lines[line_number - 1]
-        char_column = len(line.encode()[:byte_column].decode())
-        return sum(map(len, lines[: line_number - 1])) + char_column
-
-    end = offset(call.end_lineno, call.end_col_offset)
-    separator = ", " if call.args or call.keywords else ""
-    insertion = f"{separator}{', '.join(rendered_options)}"
-    return f"{source[: end - 1]}{insertion}{source[end - 1 :]}"
-
-
-@command(protocol.Deserialize)
-async def deserialize(
+@command(protocol.PrintNotebook)
+async def print_notebook(
     _ctx: ApiContext,
-    args: protocol.Deserialize,
-) -> DeserializeResult:
-    try:
-        converter = MarimoConvert.from_py(args.source)
-        ir = converter.to_ir()
-    except SyntaxError as error:
-        return _classify_convertible(args.source, syntax_error=error)
-    except MarimoFileError as error:
-        if str(error) != "`marimo.App` definition expected.":
-            raise
-        return _classify_convertible(args.source)
-
-    if not ir.valid:
-        return _classify_convertible(args.source)
-
-    return DeserializeSuccess(
-        notebook=NotebookDocument(
-            notebook=converter.to_notebook_v1(),
-            app_options=app_options_from_source(args.source, ir.app.options),
-            header=ir.header.value if ir.header is not None else None,
-        )
-    )
+    args: protocol.PrintNotebook,
+) -> protocol.PrintNotebookResult:
+    return notebook_source.print_notebook(args.document)
 
 
-def _syntax_error_position(
-    source: str, error: SyntaxError
-) -> tuple[int | None, int | None]:
-    if error.filename == "notebook.py":
-        return error.lineno, error.offset
-
-    # Some failures in marimo's cell fallback are relative to the extracted
-    # cell body. Only translate them when the offending line is unambiguous.
-    if error.text is None:
-        return None, None
-    error_line = error.text.rstrip("\r\n")
-    matches = [
-        line_number
-        for line_number, source_line in enumerate(source.splitlines(), start=1)
-        if source_line == error_line
-    ]
-    if len(matches) != 1:
-        return None, None
-    return matches[0], error.offset
-
-
-def _classify_convertible(
-    source: str,
-    syntax_error: SyntaxError | None = None,
-) -> DeserializeConvertible | DeserializeInvalidSyntax:
-    try:
-        # Use the same compiler as marimo cells so valid notebook constructs,
-        # notably top-level await, are not rejected as ordinary scripts.
-        module_compile(source)
-    except SyntaxError as error:
-        if "# %%" in source:
-            try:
-                # Jupytext magics are not Python syntax until the percent
-                # converter rewrites them. Validate the conversion we actually
-                # offer instead of guessing from the original source.
-                converted = MarimoConvert.from_non_marimo_python_script(source).to_ir()
-                for cell in converted.cells:
-                    module_compile(cell.code)
-            except SyntaxError:
-                pass
-            else:
-                return DeserializeConvertible()
-
-        failure = syntax_error or error
-        line, column = _syntax_error_position(source, failure)
-        return DeserializeInvalidSyntax(line=line, column=column)
-    return DeserializeConvertible()
+@command(protocol.ParseNotebook)
+async def parse_notebook(
+    _ctx: ApiContext,
+    args: protocol.ParseNotebook,
+) -> protocol.ParseNotebookResult:
+    return notebook_source.parse_notebook(args.source)
 
 
 @command(protocol.GetConfiguration)

--- a/src/marimo_lsp/api.py
+++ b/src/marimo_lsp/api.py
@@ -13,7 +13,6 @@ import typing
 from typing import TYPE_CHECKING, cast
 
 import msgspec
-from marimo._ast.app_config import _AppConfig
 from marimo._ast.compiler import module_compile
 from marimo._ast.parse import MarimoFileError
 from marimo._config.config import MarimoConfig  # noqa: TC002 - API introspection
@@ -57,6 +56,12 @@ from typing_extensions import TypeForm
 
 from marimo_lsp import protocol
 from marimo_lsp.app_file_manager import find_notebook_document, snapshot_for_scratchpad
+from marimo_lsp.app_options import (
+    MARIMO_APP_OPTION_NAMES,
+    app_options_from_source,
+    known_marimo_app_options,
+    merge_app_options,
+)
 from marimo_lsp.loggers import get_logger
 from marimo_lsp.models import (
     DeleteCellRequest,
@@ -89,11 +94,6 @@ if TYPE_CHECKING:
     from pygls.lsp.server import LanguageServer
 
     from marimo_lsp.sessions import Session, Sessions
-
-
-_APP_CONFIG_FIELD_NAMES = frozenset(
-    field.name for field in dataclasses.fields(_AppConfig)
-)
 
 
 __all__ = ["COMMANDS", "CommandBuilder", "CommandSpec", "handle_command"]
@@ -666,11 +666,7 @@ def _package_manager_for(source: protocol.PackageSource) -> LspPackageManager:
 async def serialize(_ctx: ApiContext, args: protocol.Serialize) -> SerializeResponse:
     notebook = msgspec.convert(args.notebook, type=NotebookV1)
     ir = MarimoConvert.from_notebook_v1(notebook).to_ir()
-    known_options = {
-        name: value
-        for name, value in args.app_config.items()
-        if name in _APP_CONFIG_FIELD_NAMES
-    }
+    known_options = known_marimo_app_options(args.app_options)
     ir = dataclasses.replace(
         ir,
         app=AppInstantiation(options=known_options),
@@ -678,7 +674,10 @@ async def serialize(_ctx: ApiContext, args: protocol.Serialize) -> SerializeResp
     )
     source = MarimoConvert.from_ir(ir).to_py()
     return SerializeResponse(
-        source=_restore_unknown_app_options(source, args.app_config)
+        source=_restore_unknown_app_options(
+            source,
+            merge_app_options(args.app_options),
+        )
     )
 
 
@@ -690,7 +689,7 @@ def _restore_unknown_app_options(source: str, options: dict[str, object]) -> str
     only the generated ``marimo.App(...)`` expression so future options survive
     a save without reformatting the rest of the notebook.
     """
-    known_options = _APP_CONFIG_FIELD_NAMES
+    known_options = MARIMO_APP_OPTION_NAMES
     unknown_options = [
         (name, value) for name, value in options.items() if name not in known_options
     ]
@@ -766,7 +765,7 @@ async def deserialize(
     return DeserializeSuccess(
         notebook=NotebookDocument(
             notebook=converter.to_notebook_v1(),
-            app_config={**_AppConfig().asdict(), **ir.app.options},
+            app_options=app_options_from_source(args.source, ir.app.options),
             header=ir.header.value if ir.header is not None else None,
         )
     )

--- a/src/marimo_lsp/app_file_manager.py
+++ b/src/marimo_lsp/app_file_manager.py
@@ -16,6 +16,7 @@ from marimo._messaging.notebook.outputs import CellOutputs
 from marimo._types.ids import CellId_t
 from pygls.uris import to_fs_path
 
+from marimo_lsp.app_options import merge_app_options
 from marimo_lsp.utils import (
     decode_cell_metadata,
     decode_notebook_document_metadata,
@@ -132,7 +133,7 @@ def sync_app_with_workspace(
     notebook = find_notebook_document(workspace, notebook_uri)
 
     metadata = decode_notebook_document_metadata(notebook)
-    app_options = metadata.app_config
+    app_options = merge_app_options(metadata.app_options)
     if app is None:
         app = InternalApp(App(**app_options))
 

--- a/src/marimo_lsp/app_options.py
+++ b/src/marimo_lsp/app_options.py
@@ -6,16 +6,20 @@ from __future__ import annotations
 
 import ast
 import dataclasses
+import math
 from typing import TYPE_CHECKING
 
 from marimo._ast.app_config import _AppConfig
+from marimo._ast.parse import Parser
 
 from marimo_lsp import protocol
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
-MARIMO_APP_OPTION_NAMES = frozenset(
+# Do not use _AppConfig.from_untrusted_dict to discover these: it treats
+# method names such as `asdict` as writable config attributes.
+MARIMO_APP_CONFIG_FIELDS = frozenset(
     field.name for field in dataclasses.fields(_AppConfig)
 )
 
@@ -57,32 +61,21 @@ def app_options_from_source(
     constants. The private protocol can preserve any JSON-shaped literal, so
     overlay those source values on the options marimo successfully parsed.
     """
-    options = dict(parsed_options)
+    options = {
+        name: value
+        for name, value in parsed_options.items()
+        if _is_json_value(value)
+    }
     options.update(_literal_app_options(source))
     return split_app_options(options)
 
 
-def known_marimo_app_options(options: protocol.AppOptions) -> dict[str, object]:
-    """Project the owned representation into this runtime's known options."""
-    return {
-        name: value
-        for name, value in merge_app_options(options).items()
-        if name in MARIMO_APP_OPTION_NAMES
-    }
-
-
 def _literal_app_options(source: str) -> dict[str, object]:
-    try:
-        tree = ast.parse(source)
-    except SyntaxError:
-        # Marimo can recover an otherwise valid notebook whose cell body has a
-        # syntax error. Its parsed app options remain the best available view.
-        return {}
-    call = next(
-        (
-            node.value
-            for node in tree.body
-            if isinstance(node, ast.Assign)
+    body = Parser(source, filepath="notebook.py").node_stack()
+    call: ast.Call | None = None
+    while (node := next(body)) is not None:
+        if (
+            isinstance(node, ast.Assign)
             and len(node.targets) == 1
             and isinstance(node.targets[0], ast.Name)
             and node.targets[0].id == "app"
@@ -90,9 +83,9 @@ def _literal_app_options(source: str) -> dict[str, object]:
             and isinstance(node.value.func, ast.Attribute)
             and isinstance(node.value.func.value, ast.Name)
             and node.value.func.attr == "App"
-        ),
-        None,
-    )
+        ):
+            call = node.value
+            break
     if call is None:
         return {}
 
@@ -110,8 +103,10 @@ def _literal_app_options(source: str) -> dict[str, object]:
 
 
 def _is_json_value(value: object) -> bool:
-    if value is None or isinstance(value, bool | int | float | str):
+    if value is None or isinstance(value, bool | int | str):
         return True
+    if isinstance(value, float):
+        return math.isfinite(value)
     if isinstance(value, list):
         return all(_is_json_value(item) for item in value)
     if isinstance(value, dict):

--- a/src/marimo_lsp/app_options.py
+++ b/src/marimo_lsp/app_options.py
@@ -1,0 +1,121 @@
+# Copyright 2026 Marimo. All rights reserved.
+
+"""Adapt owned app options at the marimo runtime boundary."""
+
+from __future__ import annotations
+
+import ast
+import dataclasses
+from typing import TYPE_CHECKING
+
+from marimo._ast.app_config import _AppConfig
+
+from marimo_lsp import protocol
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+MARIMO_APP_OPTION_NAMES = frozenset(
+    field.name for field in dataclasses.fields(_AppConfig)
+)
+
+
+def split_app_options(options: Mapping[str, object]) -> protocol.AppOptions:
+    """Split marimo's flat kwargs into managed and passthrough options."""
+    passthrough = dict(options)
+    raw_auto_download = passthrough.pop("auto_download", [])
+    if not isinstance(raw_auto_download, list):
+        msg = "marimo.App auto_download must be a list of strings"
+        raise TypeError(msg)
+    auto_download: list[str] = []
+    for item in raw_auto_download:
+        if not isinstance(item, str):
+            msg = "marimo.App auto_download must be a list of strings"
+            raise TypeError(msg)
+        auto_download.append(item)
+    return protocol.AppOptions(
+        managed=protocol.ManagedAppOptions(auto_download=auto_download),
+        passthrough=passthrough,
+    )
+
+
+def merge_app_options(options: protocol.AppOptions) -> dict[str, object]:
+    """Rebuild flat marimo kwargs, with managed values winning collisions."""
+    return {
+        **options.passthrough,
+        "auto_download": options.managed.auto_download,
+    }
+
+
+def app_options_from_source(
+    source: str,
+    parsed_options: Mapping[str, object],
+) -> protocol.AppOptions:
+    """Recover literal app kwargs before marimo normalizes their values.
+
+    Marimo's parser intentionally understands only constants and flat lists of
+    constants. The private protocol can preserve any JSON-shaped literal, so
+    overlay those source values on the options marimo successfully parsed.
+    """
+    options = dict(parsed_options)
+    options.update(_literal_app_options(source))
+    return split_app_options(options)
+
+
+def known_marimo_app_options(options: protocol.AppOptions) -> dict[str, object]:
+    """Project the owned representation into this runtime's known options."""
+    return {
+        name: value
+        for name, value in merge_app_options(options).items()
+        if name in MARIMO_APP_OPTION_NAMES
+    }
+
+
+def _literal_app_options(source: str) -> dict[str, object]:
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        # Marimo can recover an otherwise valid notebook whose cell body has a
+        # syntax error. Its parsed app options remain the best available view.
+        return {}
+    call = next(
+        (
+            node.value
+            for node in tree.body
+            if isinstance(node, ast.Assign)
+            and len(node.targets) == 1
+            and isinstance(node.targets[0], ast.Name)
+            and node.targets[0].id == "app"
+            and isinstance(node.value, ast.Call)
+            and isinstance(node.value.func, ast.Attribute)
+            and isinstance(node.value.func.value, ast.Name)
+            and node.value.func.attr == "App"
+        ),
+        None,
+    )
+    if call is None:
+        return {}
+
+    options: dict[str, object] = {}
+    for keyword in call.keywords:
+        if keyword.arg is None:
+            continue
+        try:
+            value = ast.literal_eval(keyword.value)
+        except (ValueError, SyntaxError):
+            continue
+        if _is_json_value(value):
+            options[keyword.arg] = value
+    return options
+
+
+def _is_json_value(value: object) -> bool:
+    if value is None or isinstance(value, bool | int | float | str):
+        return True
+    if isinstance(value, list):
+        return all(_is_json_value(item) for item in value)
+    if isinstance(value, dict):
+        return all(
+            isinstance(key, str) and _is_json_value(item) for key, item in value.items()
+        )
+    return False

--- a/src/marimo_lsp/app_options.py
+++ b/src/marimo_lsp/app_options.py
@@ -62,9 +62,7 @@ def app_options_from_source(
     overlay those source values on the options marimo successfully parsed.
     """
     options = {
-        name: value
-        for name, value in parsed_options.items()
-        if _is_json_value(value)
+        name: value for name, value in parsed_options.items() if _is_json_value(value)
     }
     options.update(_literal_app_options(source))
     return split_app_options(options)

--- a/src/marimo_lsp/models.py
+++ b/src/marimo_lsp/models.py
@@ -28,31 +28,12 @@ from marimo._schemas.notebook import (
 from marimo._server.models.packages import DependencyTreeNode  # noqa: TC002
 from marimo._types.ids import SessionId  # noqa: TC002
 
+from marimo_lsp.protocol import AppOptions
+
 # Sentinel the frontend `@marimo-team/smart-cells` SQL parser writes into
 # `sourceProjections.sql.engine` for the implicit default engine. We must not
 # emit `engine=__marimo_duckdb` when round-tripping these cells.
 DEFAULT_SQL_ENGINE = "__marimo_duckdb"
-
-
-# Opaque ``marimo.App`` constructor options preserved across the wire.
-#
-# Marimo deliberately accepts ``**kwargs`` for forward/backward compatibility:
-# unknown keys are ignored by the installed runtime, while known keys accept
-# legacy values. The extension should therefore type and validate only options
-# it owns instead of duplicating marimo's evolving private ``_AppConfig``.
-type AppConfig = dict[str, object]
-
-
-class OwnedAppConfig(msgspec.Struct):
-    """App options understood by the extension, projected from ``AppConfig``.
-
-    Codegen preserves excess properties in TypeScript so parsing this owned
-    subset never discards options belonging to marimo or a future extension.
-    """
-
-    __preserve_unknown_fields__: typing.ClassVar[bool] = True
-
-    auto_download: list[str] = msgspec.field(default_factory=list)
 
 
 class KernelNotification(msgspec.Struct, rename="camel"):
@@ -167,7 +148,7 @@ class MarimoNotebookMetadata(
 ):
     """Persisted marimo-owned metadata on an LSP notebook document."""
 
-    app_config: AppConfig = msgspec.field(default_factory=dict)
+    app_options: AppOptions = msgspec.field(default_factory=AppOptions)
     header: str | None = None
     notebook_metadata: NotebookMetadata = msgspec.field(default_factory=dict)
 
@@ -186,7 +167,7 @@ class NotebookDocument(msgspec.Struct, rename="camel"):
     """Strict JSON notebook data plus source-level application metadata."""
 
     notebook: NotebookV1
-    app_config: AppConfig = msgspec.field(default_factory=dict)
+    app_options: AppOptions = msgspec.field(default_factory=AppOptions)
     header: str | None = None
 
 

--- a/src/marimo_lsp/models.py
+++ b/src/marimo_lsp/models.py
@@ -20,15 +20,10 @@ from marimo._messaging.notification import (  # noqa: TC002
     VariablesNotification,
 )
 from marimo._runtime.packages.package_manager import PackageDescription  # noqa: TC002
-from marimo._schemas.notebook import (
-    NotebookCellConfig,
-    NotebookMetadata,
-    NotebookV1,
-)
 from marimo._server.models.packages import DependencyTreeNode  # noqa: TC002
 from marimo._types.ids import SessionId  # noqa: TC002
 
-from marimo_lsp.protocol import AppOptions
+from marimo_lsp.protocol import AppOptions, NotebookCellConfig, NotebookMetadata
 
 # Sentinel the frontend `@marimo-team/smart-cells` SQL parser writes into
 # `sourceProjections.sql.engine` for the implicit default engine. We must not
@@ -101,10 +96,10 @@ class MarimoCellMetadata(msgspec.Struct, rename="camel", forbid_unknown_fields=T
     """The marimo cell name."""
 
     config: NotebookCellConfig = msgspec.field(
-        default_factory=NotebookCellConfig,
+        default_factory=dict,
         name="options",
     )
-    """The marimo `NotebookCellConfig`.
+    """The owned notebook cell configuration.
 
     Synced on the wire as ``options`` (VS Code's notebook cell config key); we
     expose it as ``config`` to match marimo's downstream vocabulary
@@ -163,42 +158,6 @@ class NotebookDocumentMetadata(
     marimo: MarimoNotebookMetadata
 
 
-class NotebookDocument(msgspec.Struct, rename="camel"):
-    """Strict JSON notebook data plus source-level application metadata."""
-
-    notebook: NotebookV1
-    app_options: AppOptions = msgspec.field(default_factory=AppOptions)
-    header: str | None = None
-
-
-class DeserializeSuccess(
-    msgspec.Struct, tag="success", tag_field="kind", rename="camel"
-):
-    """A successfully parsed native marimo notebook."""
-
-    notebook: NotebookDocument
-
-
-class DeserializeInvalidSyntax(
-    msgspec.Struct, tag="invalid-syntax", tag_field="kind", rename="camel"
-):
-    """Python syntax prevented the source from being inspected."""
-
-    line: int | None = None
-    column: int | None = None
-
-
-class DeserializeConvertible(
-    msgspec.Struct, tag="convertible", tag_field="kind", rename="camel"
-):
-    """Valid Python source that can be converted to a marimo notebook."""
-
-
-type DeserializeResult = (
-    DeserializeSuccess | DeserializeInvalidSyntax | DeserializeConvertible
-)
-
-
 class ConvertRequest(msgspec.Struct, rename="camel"):
     """A request to convert a file source a marimo notebook."""
 
@@ -237,13 +196,6 @@ class DependencyTreeResponse(msgspec.Struct, rename="camel"):
 
     tree: DependencyTreeNode | None = None
     """The environment's dependency tree, or ``None`` when unresolvable."""
-
-
-class SerializeResponse(msgspec.Struct, rename="camel"):
-    """Response for ``serialize``."""
-
-    source: str
-    """The notebook rendered as Python source."""
 
 
 class GetConfigurationResponse(msgspec.Struct, rename="camel"):

--- a/src/marimo_lsp/notebook_source.py
+++ b/src/marimo_lsp/notebook_source.py
@@ -1,0 +1,219 @@
+# Copyright 2026 Marimo. All rights reserved.
+
+"""Adapt owned notebook documents to and from native marimo Python source."""
+
+from __future__ import annotations
+
+import ast
+import keyword
+from dataclasses import replace
+
+import msgspec
+from marimo._ast.codegen import generate_filecontents_from_ir
+from marimo._ast.compiler import module_compile
+from marimo._ast.parse import MarimoFileError
+from marimo._ast.parse import parse_notebook as parse_marimo_notebook
+from marimo._convert.non_marimo_python_script import (
+    convert_non_marimo_python_script_to_notebook_ir,
+)
+from marimo._convert.notebook import convert_from_ir_to_notebook_v1
+from marimo._schemas.serialization import (
+    EMPTY_NOTEBOOK_SERIALIZATION,
+    AppInstantiation,
+    CellDef,
+    Header,
+    NotebookSerializationV1,
+)
+
+from marimo_lsp import protocol
+from marimo_lsp.app_options import (
+    MARIMO_APP_CONFIG_FIELDS,
+    app_options_from_source,
+    merge_app_options,
+)
+
+
+def print_notebook(document: protocol.NotebookDocument) -> protocol.PrintNotebookResult:
+    """Print an owned notebook document through marimo's source generator."""
+    ir = _document_to_ir(document)
+    return protocol.PrintNotebookResult(source=_print_ir(ir))
+
+
+def parse_notebook(source: str) -> protocol.ParseNotebookResult:
+    """Parse native marimo source into an owned notebook document."""
+    try:
+        ir = parse_marimo_notebook(source, filepath="notebook.py") or replace(
+            EMPTY_NOTEBOOK_SERIALIZATION,
+            filename="notebook.py",
+        )
+    except SyntaxError as error:
+        return _classify_convertible(source, syntax_error=error)
+    except MarimoFileError as error:
+        if str(error) != "`marimo.App` definition expected.":
+            raise
+        return _classify_convertible(source)
+
+    if not ir.valid:
+        return _classify_convertible(source)
+
+    notebook = msgspec.to_builtins(convert_from_ir_to_notebook_v1(ir))
+    if not isinstance(notebook, dict):
+        msg = "marimo notebook conversion did not produce an object"
+        raise TypeError(msg)
+    document = msgspec.convert(
+        {
+            **notebook,
+            "appOptions": app_options_from_source(source, ir.app.options),
+            "header": ir.header.value if ir.header is not None else None,
+        },
+        type=protocol.NotebookDocument,
+    )
+    return protocol.ParseNotebookSuccess(document=document)
+
+
+def _document_to_ir(
+    document: protocol.NotebookDocument,
+) -> NotebookSerializationV1:
+    """Adapt an owned notebook document to marimo's source-level IR."""
+    return NotebookSerializationV1(
+        app=AppInstantiation(options=merge_app_options(document.app_options)),
+        header=Header(value=document.header) if document.header is not None else None,
+        version=None,
+        cells=[
+            CellDef(
+                code=cell.get("code", "") or "",
+                name=cell.get("name", "") or "",
+                options={
+                    "column": cell.get("config", {}).get("column"),
+                    "disabled": cell.get("config", {}).get("disabled", False),
+                    "hide_code": cell.get("config", {}).get("hide_code", False),
+                },
+            )
+            for cell in document.cells
+        ],
+        violations=[],
+        valid=True,
+    )
+
+
+def _print_ir(ir: NotebookSerializationV1) -> str:
+    """Print marimo IR while preserving options its generator does not know."""
+    unknown_options = {
+        name: value
+        for name, value in ir.app.options.items()
+        if name not in MARIMO_APP_CONFIG_FIELDS
+    }
+    printable_ir = replace(
+        ir,
+        app=AppInstantiation(
+            options={
+                name: value
+                for name, value in ir.app.options.items()
+                if name in MARIMO_APP_CONFIG_FIELDS
+            }
+        ),
+    )
+    source = generate_filecontents_from_ir(printable_ir)
+    return _restore_unknown_app_options(source, unknown_options)
+
+
+def _restore_unknown_app_options(source: str, options: dict[str, object]) -> str:
+    """Restore opaque options dropped by marimo's current source generator."""
+    if not options:
+        return source
+
+    rendered_options: list[str] = []
+    for name, value in options.items():
+        if not name.isidentifier() or keyword.iskeyword(name):
+            msg = f"App config key cannot be represented as a keyword: {name!r}"
+            raise ValueError(msg)
+        rendered = repr(value)
+        try:
+            ast.literal_eval(rendered)
+        except (ValueError, SyntaxError) as error:
+            msg = f"App config value is not a Python literal: {name!r}={rendered}"
+            raise ValueError(msg) from error
+        rendered_options.append(f"{name}={rendered}")
+
+    tree = ast.parse(source)
+    call = next(
+        (
+            node.value
+            for node in tree.body
+            if isinstance(node, ast.Assign)
+            and any(
+                isinstance(target, ast.Name) and target.id == "app"
+                for target in node.targets
+            )
+            and isinstance(node.value, ast.Call)
+            and isinstance(node.value.func, ast.Attribute)
+            and isinstance(node.value.func.value, ast.Name)
+            and node.value.func.value.id == "marimo"
+            and node.value.func.attr == "App"
+        ),
+        None,
+    )
+    if call is None or call.end_lineno is None or call.end_col_offset is None:
+        msg = "Generated notebook did not contain marimo.App(...)"
+        raise ValueError(msg)
+
+    lines = source.splitlines(keepends=True)
+
+    def offset(line_number: int, byte_column: int) -> int:
+        line = lines[line_number - 1]
+        char_column = len(line.encode()[:byte_column].decode())
+        return sum(map(len, lines[: line_number - 1])) + char_column
+
+    end = offset(call.end_lineno, call.end_col_offset)
+    separator = ", " if call.args or call.keywords else ""
+    insertion = f"{separator}{', '.join(rendered_options)}"
+    return f"{source[: end - 1]}{insertion}{source[end - 1 :]}"
+
+
+def _syntax_error_position(
+    source: str, error: SyntaxError
+) -> tuple[int | None, int | None]:
+    if error.filename == "notebook.py":
+        return error.lineno, error.offset
+
+    # Some failures in marimo's cell fallback are relative to the extracted
+    # cell body. Only translate them when the offending line is unambiguous.
+    if error.text is None:
+        return None, None
+    error_line = error.text.rstrip("\r\n")
+    matches = [
+        line_number
+        for line_number, source_line in enumerate(source.splitlines(), start=1)
+        if source_line == error_line
+    ]
+    if len(matches) != 1:
+        return None, None
+    return matches[0], error.offset
+
+
+def _classify_convertible(
+    source: str,
+    syntax_error: SyntaxError | None = None,
+) -> protocol.ParseNotebookConvertible | protocol.ParseNotebookInvalidSyntax:
+    try:
+        # Use the same compiler as marimo cells so valid notebook constructs,
+        # notably top-level await, are not rejected as ordinary scripts.
+        module_compile(source)
+    except SyntaxError as error:
+        if "# %%" in source:
+            try:
+                # Jupytext magics are not Python syntax until the percent
+                # converter rewrites them. Validate the conversion we actually
+                # offer instead of guessing from the original source.
+                converted = convert_non_marimo_python_script_to_notebook_ir(source)
+                for cell in converted.cells:
+                    module_compile(cell.code)
+            except SyntaxError:
+                pass
+            else:
+                return protocol.ParseNotebookConvertible()
+
+        failure = syntax_error or error
+        line, column = _syntax_error_position(source, failure)
+        return protocol.ParseNotebookInvalidSyntax(line=line, column=column)
+    return protocol.ParseNotebookConvertible()

--- a/src/marimo_lsp/protocol.py
+++ b/src/marimo_lsp/protocol.py
@@ -54,7 +54,7 @@ class AppOptions(
     passthrough: dict[str, object] = msgspec.field(default_factory=dict)
 
 
-class SerializedNotebookCellConfig(typing.TypedDict, total=False):
+class NotebookCellConfig(typing.TypedDict, total=False):
     """Persisted marimo configuration for one notebook cell."""
 
     column: int | None
@@ -62,28 +62,20 @@ class SerializedNotebookCellConfig(typing.TypedDict, total=False):
     hide_code: bool | None
 
 
-class SerializedNotebookCell(typing.TypedDict):
-    """One code cell in the serialized notebook format."""
+class NotebookCell(typing.TypedDict):
+    """One code cell in an owned notebook document."""
 
     id: str | None
     code: str | None
     code_hash: str | None
     name: str | None
-    config: SerializedNotebookCellConfig
+    config: NotebookCellConfig
 
 
-class SerializedNotebookMetadata(typing.TypedDict, total=False):
-    """Metadata stored with the serialized notebook."""
+class NotebookMetadata(typing.TypedDict, total=False):
+    """Opaque-compatible metadata stored with a notebook document."""
 
     marimo_version: str | None
-
-
-class SerializedNotebookV1(typing.TypedDict):
-    """Owned projection of marimo's version-one notebook document."""
-
-    version: typing.Literal["1"]
-    metadata: SerializedNotebookMetadata
-    cells: list[SerializedNotebookCell]
 
 
 class NotebookDocument(
@@ -91,11 +83,63 @@ class NotebookDocument(
     rename="camel",
     forbid_unknown_fields=True,
 ):
-    """Strict notebook data plus source-level application metadata."""
+    """Owned notebook data plus source-level application metadata."""
 
-    notebook: SerializedNotebookV1
+    version: typing.Literal["1"]
+    metadata: NotebookMetadata
+    cells: list[NotebookCell]
     app_options: AppOptions = msgspec.field(default_factory=AppOptions)
     header: str | None = None
+
+
+class PrintNotebookResult(
+    msgspec.Struct,
+    rename="camel",
+    forbid_unknown_fields=True,
+):
+    """Native marimo Python source printed from an owned notebook document."""
+
+    source: str
+
+
+class ParseNotebookSuccess(
+    msgspec.Struct,
+    tag="success",
+    tag_field="kind",
+    rename="camel",
+    forbid_unknown_fields=True,
+):
+    """A successfully parsed native marimo notebook."""
+
+    document: NotebookDocument
+
+
+class ParseNotebookInvalidSyntax(
+    msgspec.Struct,
+    tag="invalid-syntax",
+    tag_field="kind",
+    rename="camel",
+    forbid_unknown_fields=True,
+):
+    """Python syntax prevented the source from being inspected."""
+
+    line: int | None = None
+    column: int | None = None
+
+
+class ParseNotebookConvertible(
+    msgspec.Struct,
+    tag="convertible",
+    tag_field="kind",
+    rename="camel",
+    forbid_unknown_fields=True,
+):
+    """Valid Python source that can be converted to a marimo notebook."""
+
+
+type ParseNotebookResult = (
+    ParseNotebookSuccess | ParseNotebookInvalidSyntax | ParseNotebookConvertible
+)
 
 
 class CellExecution(msgspec.Struct, rename="camel", forbid_unknown_fields=True):
@@ -405,28 +449,26 @@ class GetDependencyTree(
     source: PackageSource
 
 
-class Serialize(
+class PrintNotebook(
     msgspec.Struct,
-    tag="serialize",
+    tag="print-notebook",
     tag_field="kind",
     rename="camel",
     forbid_unknown_fields=True,
 ):
-    """Serialize notebook data to native marimo Python source."""
+    """Print an owned notebook document as native marimo Python source."""
 
-    notebook: SerializedNotebookV1
-    app_options: AppOptions = msgspec.field(default_factory=AppOptions)
-    header: str | None = None
+    document: NotebookDocument
 
 
-class Deserialize(
+class ParseNotebook(
     msgspec.Struct,
-    tag="deserialize",
+    tag="parse-notebook",
     tag_field="kind",
     rename="camel",
     forbid_unknown_fields=True,
 ):
-    """Deserialize source into notebook data."""
+    """Parse native marimo Python source into an owned notebook document."""
 
     source: str
 
@@ -539,8 +581,8 @@ type Command = (
     | ExecuteScratchpad
     | ListPackages
     | GetDependencyTree
-    | Serialize
-    | Deserialize
+    | PrintNotebook
+    | ParseNotebook
     | GetConfiguration
     | UpdateConfiguration
     | SetDisplayTheme

--- a/src/marimo_lsp/protocol.py
+++ b/src/marimo_lsp/protocol.py
@@ -31,7 +31,27 @@ CellId = typing.NewType("CellId", str)
 """Opaque identifier for one notebook cell."""
 
 type JsonObject = dict[str, object]
-type AppConfig = dict[str, object]
+
+
+class ManagedAppOptions(
+    msgspec.Struct,
+    rename="camel",
+    forbid_unknown_fields=True,
+):
+    """Source-level app options managed by the extension."""
+
+    auto_download: list[str] = msgspec.field(default_factory=list)
+
+
+class AppOptions(
+    msgspec.Struct,
+    rename="camel",
+    forbid_unknown_fields=True,
+):
+    """Managed app options plus an opaque lossless passthrough bag."""
+
+    managed: ManagedAppOptions = msgspec.field(default_factory=ManagedAppOptions)
+    passthrough: dict[str, object] = msgspec.field(default_factory=dict)
 
 
 class SerializedNotebookCellConfig(typing.TypedDict, total=False):
@@ -74,7 +94,7 @@ class NotebookDocument(
     """Strict notebook data plus source-level application metadata."""
 
     notebook: SerializedNotebookV1
-    app_config: AppConfig = msgspec.field(default_factory=dict)
+    app_options: AppOptions = msgspec.field(default_factory=AppOptions)
     header: str | None = None
 
 
@@ -395,7 +415,7 @@ class Serialize(
     """Serialize notebook data to native marimo Python source."""
 
     notebook: SerializedNotebookV1
-    app_config: AppConfig = msgspec.field(default_factory=dict)
+    app_options: AppOptions = msgspec.field(default_factory=AppOptions)
     header: str | None = None
 
 

--- a/tests/fixtures/command_protocol.json
+++ b/tests/fixtures/command_protocol.json
@@ -112,8 +112,8 @@
       "source": { "kind": "script" }
     },
     {
-      "kind": "serialize",
-      "notebook": {
+      "kind": "print-notebook",
+      "document": {
         "version": "1",
         "metadata": { "marimo_version": "0.24.0" },
         "cells": [
@@ -128,15 +128,15 @@
               "hide_code": false
             }
           }
-        ]
-      },
-      "appOptions": {
-        "managed": { "autoDownload": ["html"] },
-        "passthrough": { "width": "full" }
-      },
-      "header": null
+        ],
+        "appOptions": {
+          "managed": { "autoDownload": ["html"] },
+          "passthrough": { "width": "full" }
+        },
+        "header": null
+      }
     },
-    { "kind": "deserialize", "source": "import marimo\n" },
+    { "kind": "parse-notebook", "source": "import marimo\n" },
     {
       "kind": "get-configuration",
       "notebookUri": "file:///notebook.py"

--- a/tests/fixtures/command_protocol.json
+++ b/tests/fixtures/command_protocol.json
@@ -130,7 +130,10 @@
           }
         ]
       },
-      "appConfig": { "width": "full" },
+      "appOptions": {
+        "managed": { "autoDownload": ["html"] },
+        "passthrough": { "width": "full" }
+      },
       "header": null
     },
     { "kind": "deserialize", "source": "import marimo\n" },

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import msgspec
 import pytest
+from inline_snapshot import snapshot
 from marimo._config.config import DEFAULT_CONFIG
 from marimo._convert.converters import MarimoConvert
 from marimo._types.ids import RequestId, SessionId
@@ -30,10 +31,12 @@ from marimo_lsp.api import (
     list_sql_schemas,
     list_sql_tables,
     send_stdin,
+    serialize,
     set_model_value,
     set_ui_element_value,
     update_configuration,
 )
+from marimo_lsp.app_options import app_options_from_source, merge_app_options
 from marimo_lsp.models import (
     DeserializeConvertible,
     DeserializeInvalidSyntax,
@@ -315,7 +318,7 @@ if __name__ == "__main__":
 
 
 @pytest.mark.asyncio
-async def test_legacy_and_unknown_app_config_round_trip_over_command_wire() -> None:
+async def test_managed_and_passthrough_app_options_round_trip() -> None:
     source = """\
 import marimo
 
@@ -323,6 +326,7 @@ app = marimo.App(
     width="wide",
     auto_download=["html"],
     future_setting="keep",
+    future_object={"answer": 42},
     asdict="method-name collision",
 )
 
@@ -339,11 +343,18 @@ if __name__ == "__main__":
         ),
     )
     deserialized_notebook = cast("dict[str, object]", deserialized["notebook"])
-    app_config = cast("dict[str, object]", deserialized_notebook["appConfig"])
-    assert app_config["width"] == "wide"
-    assert app_config["auto_download"] == ["html"]
-    assert app_config["future_setting"] == "keep"
-    assert app_config["asdict"] == "method-name collision"
+    app_options = cast("dict[str, object]", deserialized_notebook["appOptions"])
+    assert app_options == snapshot(
+        {
+            "managed": {"autoDownload": ["html"]},
+            "passthrough": {
+                "width": "wide",
+                "future_setting": "keep",
+                "future_object": {"answer": 42},
+                "asdict": "method-name collision",
+            },
+        }
+    )
 
     serialized = cast(
         "dict[str, object]",
@@ -358,11 +369,46 @@ if __name__ == "__main__":
     )
     serialized_source = serialized["source"]
     assert isinstance(serialized_source, str)
-    reparsed_options = MarimoConvert.from_py(serialized_source).to_ir().app.options
-    assert reparsed_options["width"] == "wide"
-    assert reparsed_options["auto_download"] == ["html"]
-    assert reparsed_options["future_setting"] == "keep"
-    assert reparsed_options["asdict"] == "method-name collision"
+    parsed_options = MarimoConvert.from_py(serialized_source).to_ir().app.options
+    reparsed = app_options_from_source(serialized_source, parsed_options)
+    assert msgspec.to_builtins(reparsed) == snapshot(
+        {
+            "managed": {"autoDownload": ["html"]},
+            "passthrough": {
+                "width": "wide",
+                "future_setting": "keep",
+                "future_object": {"answer": 42},
+                "asdict": "method-name collision",
+            },
+        }
+    )
+
+
+def test_managed_app_options_win_passthrough_collisions() -> None:
+    options = protocol.AppOptions(
+        managed=protocol.ManagedAppOptions(auto_download=["html"]),
+        passthrough={
+            "auto_download": ["ipynb"],
+            "width": "full",
+        },
+    )
+
+    assert merge_app_options(options) == snapshot(
+        {"auto_download": ["html"], "width": "full"}
+    )
+
+
+@pytest.mark.asyncio
+async def test_empty_auto_download_is_omitted_from_notebook_source() -> None:
+    result = await serialize(
+        _context(MagicMock()),
+        protocol.Serialize(
+            notebook={"version": "1", "metadata": {}, "cells": []},
+        ),
+    )
+
+    assert "auto_download" not in result.source
+    assert "app = marimo.App()" in result.source
 
 
 def test_restore_unknown_app_options_reports_non_literal_value() -> None:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -19,9 +19,7 @@ from marimo_lsp.api import (
     CommandBuilder,
     KernelSessionMismatchError,
     KernelSessionRequiredError,
-    _restore_unknown_app_options,
     delete_cell,
-    deserialize,
     execute_scratch,
     export_as_markdown,
     function_call_request,
@@ -30,20 +28,19 @@ from marimo_lsp.api import (
     interrupt,
     list_sql_schemas,
     list_sql_tables,
+    parse_notebook,
+    print_notebook,
     send_stdin,
-    serialize,
     set_model_value,
     set_ui_element_value,
     update_configuration,
 )
 from marimo_lsp.app_options import app_options_from_source, merge_app_options
 from marimo_lsp.models import (
-    DeserializeConvertible,
-    DeserializeInvalidSyntax,
-    DeserializeSuccess,
     ListSQLSchemasRequest,
     ListSQLTablesRequest,
 )
+from marimo_lsp.notebook_source import _restore_unknown_app_options
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
@@ -300,7 +297,7 @@ async def test_interrupt_requires_a_kernel_session_id() -> None:
 
 
 @pytest.mark.asyncio
-async def test_deserialize_native_marimo_notebook() -> None:
+async def test_parse_native_marimo_notebook() -> None:
     source = """\
 import marimo
 
@@ -310,11 +307,11 @@ if __name__ == "__main__":
     app.run()
 """
 
-    result = await deserialize(
-        _context(MagicMock()), protocol.Deserialize(source=source)
+    result = await parse_notebook(
+        _context(MagicMock()), protocol.ParseNotebook(source=source)
     )
 
-    assert isinstance(result, DeserializeSuccess)
+    assert isinstance(result, protocol.ParseNotebookSuccess)
 
 
 @pytest.mark.asyncio
@@ -327,23 +324,22 @@ app = marimo.App(
     auto_download=["html"],
     future_setting="keep",
     future_object={"answer": 42},
-    asdict="method-name collision",
 )
 
 if __name__ == "__main__":
     app.run()
 """
 
-    deserialized = cast(
+    parsed = cast(
         "dict[str, object]",
         await handle_command(
             MagicMock(),
             MagicMock(),
-            protocol.Deserialize(source=source),
+            protocol.ParseNotebook(source=source),
         ),
     )
-    deserialized_notebook = cast("dict[str, object]", deserialized["notebook"])
-    app_options = cast("dict[str, object]", deserialized_notebook["appOptions"])
+    document = cast("dict[str, object]", parsed["document"])
+    app_options = cast("dict[str, object]", document["appOptions"])
     assert app_options == snapshot(
         {
             "managed": {"autoDownload": ["html"]},
@@ -351,7 +347,6 @@ if __name__ == "__main__":
                 "width": "wide",
                 "future_setting": "keep",
                 "future_object": {"answer": 42},
-                "asdict": "method-name collision",
             },
         }
     )
@@ -362,7 +357,7 @@ if __name__ == "__main__":
             MagicMock(),
             MagicMock(),
             msgspec.convert(
-                {"kind": "serialize", **deserialized_notebook},
+                {"kind": "print-notebook", "document": document},
                 type=protocol.Command,
             ),
         ),
@@ -378,10 +373,28 @@ if __name__ == "__main__":
                 "width": "wide",
                 "future_setting": "keep",
                 "future_object": {"answer": 42},
-                "asdict": "method-name collision",
             },
         }
     )
+
+
+@pytest.mark.asyncio
+async def test_passthrough_option_cannot_overwrite_marimo_config_method() -> None:
+    result = await print_notebook(
+        _context(MagicMock()),
+        protocol.PrintNotebook(
+            document=protocol.NotebookDocument(
+                version="1",
+                metadata={},
+                cells=[],
+                app_options=protocol.AppOptions(
+                    passthrough={"asdict": "method-name collision"}
+                ),
+            ),
+        ),
+    )
+
+    assert "asdict='method-name collision'" in result.source
 
 
 def test_managed_app_options_win_passthrough_collisions() -> None:
@@ -400,10 +413,14 @@ def test_managed_app_options_win_passthrough_collisions() -> None:
 
 @pytest.mark.asyncio
 async def test_empty_auto_download_is_omitted_from_notebook_source() -> None:
-    result = await serialize(
+    result = await print_notebook(
         _context(MagicMock()),
-        protocol.Serialize(
-            notebook={"version": "1", "metadata": {}, "cells": []},
+        protocol.PrintNotebook(
+            document=protocol.NotebookDocument(
+                version="1",
+                metadata={},
+                cells=[],
+            ),
         ),
     )
 
@@ -453,11 +470,11 @@ if __name__ == "__main__":
 
 
 @pytest.mark.asyncio
-async def test_deserialize_recovers_syntax_error_inside_cell() -> None:
+async def test_parse_recovers_syntax_error_inside_cell() -> None:
     source = """\
 import marimo
 
-app = marimo.App()
+app = marimo.App(future_object={"answer": 42})
 
 @app.cell
 def _():
@@ -465,16 +482,51 @@ def _():
     return
 """
 
-    result = await deserialize(
-        _context(MagicMock()), protocol.Deserialize(source=source)
+    result = await parse_notebook(
+        _context(MagicMock()), protocol.ParseNotebook(source=source)
     )
 
-    assert isinstance(result, DeserializeSuccess)
-    assert [cell["code"] for cell in result.notebook.notebook["cells"]] == ["value = ("]
+    assert isinstance(result, protocol.ParseNotebookSuccess)
+    assert [cell["code"] for cell in result.document.cells] == ["value = ("]
+    assert result.document.app_options.passthrough == snapshot(
+        {"future_object": {"answer": 42}}
+    )
+
+    printed = await print_notebook(
+        _context(MagicMock()),
+        protocol.PrintNotebook(document=result.document),
+    )
+    assert "future_object={'answer': 42}" in printed.source
 
 
 @pytest.mark.asyncio
-async def test_deserialize_recovers_indentation_error_inside_cell() -> None:
+async def test_parse_drops_non_json_app_options() -> None:
+    source = """\
+import marimo
+
+app = marimo.App(
+    future_setting=1e999,
+    future_object={"values": [1e999]},
+)
+"""
+
+    result = await parse_notebook(
+        _context(MagicMock()), protocol.ParseNotebook(source=source)
+    )
+
+    assert isinstance(result, protocol.ParseNotebookSuccess)
+    assert result.document.app_options.passthrough == {}
+
+    printed = await print_notebook(
+        _context(MagicMock()),
+        protocol.PrintNotebook(document=result.document),
+    )
+    assert "future_setting" not in printed.source
+    assert "future_object" not in printed.source
+
+
+@pytest.mark.asyncio
+async def test_parse_recovers_indentation_error_inside_cell() -> None:
     source = """\
 import marimo
 app = marimo.App()
@@ -485,34 +537,34 @@ def _():
       y = 2
     return
 """
-    result = await deserialize(
+    result = await parse_notebook(
         _context(MagicMock()),
-        protocol.Deserialize(source=source),
+        protocol.ParseNotebook(source=source),
     )
 
-    assert isinstance(result, DeserializeSuccess)
-    assert [cell["code"] for cell in result.notebook.notebook["cells"]] == [
+    assert isinstance(result, protocol.ParseNotebookSuccess)
+    assert [cell["code"] for cell in result.document.cells] == [
         "if True:\n    x = 1\n  y = 2"
     ]
 
 
 @pytest.mark.asyncio
-async def test_deserialize_classifies_plain_python() -> None:
-    result = await deserialize(
-        _context(MagicMock()), protocol.Deserialize(source="print('hello')\n")
+async def test_parse_classifies_plain_python() -> None:
+    result = await parse_notebook(
+        _context(MagicMock()), protocol.ParseNotebook(source="print('hello')\n")
     )
 
-    assert isinstance(result, DeserializeConvertible)
+    assert isinstance(result, protocol.ParseNotebookConvertible)
 
 
 @pytest.mark.asyncio
-async def test_deserialize_classifies_jupytext_percent_as_convertible() -> None:
-    result = await deserialize(
+async def test_parse_classifies_jupytext_percent_as_convertible() -> None:
+    result = await parse_notebook(
         _context(MagicMock()),
-        protocol.Deserialize(source="# %%\nprint('hello')\n"),
+        protocol.ParseNotebook(source="# %%\nprint('hello')\n"),
     )
 
-    assert isinstance(result, DeserializeConvertible)
+    assert isinstance(result, protocol.ParseNotebookConvertible)
 
 
 @pytest.mark.asyncio
@@ -525,21 +577,21 @@ async def test_deserialize_classifies_jupytext_percent_as_convertible() -> None:
         "# %%\n%%bash\necho hello\n",
     ],
 )
-async def test_deserialize_accepts_convertible_notebook_syntax(source: str) -> None:
-    result = await deserialize(
-        _context(MagicMock()), protocol.Deserialize(source=source)
+async def test_parse_accepts_convertible_notebook_syntax(source: str) -> None:
+    result = await parse_notebook(
+        _context(MagicMock()), protocol.ParseNotebook(source=source)
     )
 
-    assert isinstance(result, DeserializeConvertible)
+    assert isinstance(result, protocol.ParseNotebookConvertible)
 
 
 @pytest.mark.asyncio
-async def test_deserialize_rejects_malformed_jupytext_cell() -> None:
-    result = await deserialize(
-        _context(MagicMock()), protocol.Deserialize(source="# %%\nprint(\n")
+async def test_parse_rejects_malformed_jupytext_cell() -> None:
+    result = await parse_notebook(
+        _context(MagicMock()), protocol.ParseNotebook(source="# %%\nprint(\n")
     )
 
-    assert isinstance(result, DeserializeInvalidSyntax)
+    assert isinstance(result, protocol.ParseNotebookInvalidSyntax)
     assert result.line == 2
 
 
@@ -552,37 +604,37 @@ async def test_deserialize_rejects_malformed_jupytext_cell() -> None:
         "import marimo\napp = marimo.App(\n",
     ],
 )
-async def test_deserialize_reports_syntax_errors_in_non_marimo_python(
+async def test_parse_reports_syntax_errors_in_non_marimo_python(
     source: str,
 ) -> None:
-    result = await deserialize(
-        _context(MagicMock()), protocol.Deserialize(source=source)
+    result = await parse_notebook(
+        _context(MagicMock()), protocol.ParseNotebook(source=source)
     )
 
-    assert isinstance(result, DeserializeInvalidSyntax)
+    assert isinstance(result, protocol.ParseNotebookInvalidSyntax)
     assert result.line is not None
 
 
 @pytest.mark.asyncio
 async def test_percent_marker_inside_string_is_just_convertible_python() -> None:
-    result = await deserialize(
-        _context(MagicMock()), protocol.Deserialize(source='x = "# %%"\n')
+    result = await parse_notebook(
+        _context(MagicMock()), protocol.ParseNotebook(source='x = "# %%"\n')
     )
 
-    assert isinstance(result, DeserializeConvertible)
+    assert isinstance(result, protocol.ParseNotebookConvertible)
 
 
 @pytest.mark.asyncio
-async def test_deserialize_propagates_unexpected_converter_error() -> None:
+async def test_parse_propagates_unexpected_converter_error() -> None:
     with (
         patch(
-            "marimo_lsp.api.MarimoConvert.from_py",
+            "marimo_lsp.notebook_source.parse_marimo_notebook",
             side_effect=RuntimeError("converter broke"),
         ),
         pytest.raises(RuntimeError, match="converter broke"),
     ):
-        await deserialize(
-            _context(MagicMock()), protocol.Deserialize(source="print('hello')")
+        await parse_notebook(
+            _context(MagicMock()), protocol.ParseNotebook(source="print('hello')")
         )
 
 

--- a/tests/test_app_file_manager.py
+++ b/tests/test_app_file_manager.py
@@ -97,7 +97,13 @@ class TestSyncAppWithWorkspace:
             uri,
             metadata={
                 "marimo": {
-                    "appConfig": {"width": "medium", "sql_output": "polars"},
+                    "appOptions": {
+                        "managed": {"autoDownload": []},
+                        "passthrough": {
+                            "width": "medium",
+                            "sql_output": "polars",
+                        },
+                    },
                     "header": "",
                     "notebookMetadata": {"marimo_version": "0.23.16"},
                 }
@@ -113,7 +119,12 @@ class TestSyncAppWithWorkspace:
             uri,
             metadata={
                 "marimo": {
-                    "appConfig": {"width": "wide", "future_setting": True},
+                    "appOptions": {
+                        "passthrough": {
+                            "width": "wide",
+                            "future_setting": True,
+                        }
+                    },
                 }
             },
         )
@@ -128,7 +139,7 @@ class TestSyncAppWithWorkspace:
             uri,
             metadata={
                 "foreign": {"anything": True},
-                "marimo": {"appConfig": {"width": "full"}},
+                "marimo": {"appOptions": {"passthrough": {"width": "full"}}},
             },
         )
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -405,8 +405,7 @@ async def test_file_notebook_did_close_detaches_session() -> None:
     sessions.close.assert_not_called()
 
 
-async def test_marimo_serialize_command(client: LanguageClient) -> None:
-    """Test the marimo.serialize command."""
+async def test_print_notebook_command(client: LanguageClient) -> None:
     notebook = {
         "version": "1",
         "metadata": {},
@@ -423,7 +422,14 @@ async def test_marimo_serialize_command(client: LanguageClient) -> None:
 
     result = await send_command(
         client,
-        {"kind": "serialize", "notebook": notebook, "header": "marimo app"},
+        {
+            "kind": "print-notebook",
+            "document": {
+                **notebook,
+                "appOptions": {},
+                "header": "marimo app",
+            },
+        },
     )
 
     assert result is not None
@@ -448,8 +454,7 @@ if __name__ == "__main__":
 """)
 
 
-async def test_marimo_deserialize_command(client: LanguageClient) -> None:
-    """Test the marimo.deserialize command."""
+async def test_parse_notebook_command(client: LanguageClient) -> None:
     source = """
 import marimo
 
@@ -465,30 +470,28 @@ if __name__ == "__main__":
     app.run()
 """
 
-    result = await send_command(client, {"kind": "deserialize", "source": source})
-    result["notebook"]["notebook"]["metadata"]["marimo_version"] = "<marimo-version>"
+    result = await send_command(client, {"kind": "parse-notebook", "source": source})
+    result["document"]["metadata"]["marimo_version"] = "<marimo-version>"
 
     assert result == snapshot(
         {
             "kind": "success",
-            "notebook": {
-                "notebook": {
-                    "version": "1",
-                    "cells": [
-                        {
-                            "id": "Hbol",
-                            "code": "import marimo as mo",
-                            "code_hash": "1d0db38904205bec4d6f6f6a1f6cec3e",
-                            "name": "__",
-                            "config": {
-                                "column": None,
-                                "disabled": False,
-                                "hide_code": False,
-                            },
-                        }
-                    ],
-                    "metadata": {"marimo_version": "<marimo-version>"},
-                },
+            "document": {
+                "version": "1",
+                "cells": [
+                    {
+                        "id": "Hbol",
+                        "code": "import marimo as mo",
+                        "code_hash": "1d0db38904205bec4d6f6f6a1f6cec3e",
+                        "name": "__",
+                        "config": {
+                            "column": None,
+                            "disabled": False,
+                            "hide_code": False,
+                        },
+                    }
+                ],
+                "metadata": {"marimo_version": "<marimo-version>"},
                 "appOptions": {
                     "managed": {"autoDownload": []},
                     "passthrough": {},

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -489,14 +489,9 @@ if __name__ == "__main__":
                     ],
                     "metadata": {"marimo_version": "<marimo-version>"},
                 },
-                "appConfig": {
-                    "width": "compact",
-                    "app_title": None,
-                    "layout_file": None,
-                    "css_file": None,
-                    "html_head_file": None,
-                    "auto_download": [],
-                    "sql_output": "auto",
+                "appOptions": {
+                    "managed": {"autoDownload": []},
+                    "passthrough": {},
                 },
                 "header": "",
             },


### PR DESCRIPTION
Notebook serialization currently exposes a marimo-shaped V1 document with app options and header data wrapped around it. The private protocol now uses one flat owned document:

```ts
interface NotebookDocument {
  readonly version: "1";
  readonly metadata: NotebookMetadata;
  readonly cells: ReadonlyArray<NotebookCell>;
  readonly appOptions: AppOptions;
  readonly header: string | null;
}
```

The generated client exposes `printNotebook({ document })` and `parseNotebook({ source })`. Python maps the owned document to marimo's source-level IR, keeping marimo transport types out of the extension contract.

Only `autoDownload` is managed by the extension. Other literal `marimo.App` options pass through unchanged, including options unknown to the installed marimo version.
