### PR TITLE
Reset stale notebook controller affinity

### DIFF
--- a/extension/src/config/__tests__/NotebookConfiguration.test.ts
+++ b/extension/src/config/__tests__/NotebookConfiguration.test.ts
@@ -1,6 +1,5 @@
 import { assert, describe, expect, it } from "@effect/vitest";
 import { Deferred, Effect, Fiber, Layer, Option, Scope, Stream } from "effect";
-import { TestClock } from "effect/testing";
 
 import {
   createTestNotebookDocument,
@@ -74,7 +73,11 @@ const invalidateConfig = (notebookUri: NotebookId) =>
     ),
   );
 
-const configurationChanges = (notebookUri: NotebookId, take: number) =>
+const configurationChanges = (
+  notebookUri: NotebookId,
+  take: number,
+  ready: Deferred.Deferred<void>,
+) =>
   Effect.gen(function* () {
     const sessions = yield* NotebookDocumentSessions;
     const resources = yield* NotebookSessionResources;
@@ -85,7 +88,15 @@ const configurationChanges = (notebookUri: NotebookId, take: number) =>
         session.value,
         NotebookConfiguration.pipe(
           Effect.flatMap((configuration) =>
-            configuration.changes.pipe(Stream.take(take), Stream.runCollect),
+            configuration.changes.pipe(
+              Stream.tap((value) =>
+                Option.isSome(value)
+                  ? Deferred.succeed(ready, undefined)
+                  : Effect.void,
+              ),
+              Stream.take(take),
+              Stream.runCollect,
+            ),
           ),
         ),
       )
@@ -212,10 +223,11 @@ describe("NotebookConfiguration", () => {
       });
 
       yield* Effect.gen(function* () {
+        const ready = yield* Deferred.make<void>();
         const collected = yield* Effect.forkChild(
-          configurationChanges(NOTEBOOK_URI, 4),
+          configurationChanges(NOTEBOOK_URI, 4, ready),
         );
-        yield* TestClock.adjust("1 millis");
+        yield* Deferred.await(ready);
 
         yield* updateConfig(NOTEBOOK_URI, {
           runtime: { on_cell_change: "lazy" },
@@ -362,7 +374,7 @@ describe("NotebookConfiguration", () => {
         yield* ctx.setConfig(NOTEBOOK_URI, LAZY_CONFIG);
         const replacement = createTestNotebookDocument(Uri.parse(NOTEBOOK_URI));
         yield* ctx.vscode.openNotebook(replacement);
-        yield* TestClock.adjust("1 millis");
+        yield* Effect.yieldNow;
 
         expect(yield* getConfig(NOTEBOOK_URI)).toEqual(LAZY_CONFIG);
       }).pipe(Effect.provide(ctx.layer));
@@ -383,12 +395,12 @@ describe("NotebookConfiguration", () => {
         yield* ctx.setConfig(NOTEBOOK_URI, LAZY_CONFIG);
         const replacement = createTestNotebookDocument(Uri.parse(NOTEBOOK_URI));
         yield* ctx.vscode.openNotebook(replacement);
-        yield* TestClock.adjust("1 millis");
+        yield* Effect.yieldNow;
         expect(yield* getConfig(NOTEBOOK_URI)).toEqual(LAZY_CONFIG);
 
         yield* ctx.setConfig(NOTEBOOK_URI, AUTORUN_CONFIG);
         yield* ctx.vscode.closeNotebook(first);
-        yield* TestClock.adjust("1 millis");
+        yield* Effect.yieldNow;
         expect(yield* getConfig(NOTEBOOK_URI)).toEqual(LAZY_CONFIG);
       }).pipe(Effect.provide(ctx.layer));
     }),

--- a/extension/src/features/__tests__/CellInputVisibilitySync.test.ts
+++ b/extension/src/features/__tests__/CellInputVisibilitySync.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "@effect/vitest";
 import { Effect, Layer, Option, Ref } from "effect";
-import { TestClock } from "effect/testing";
 
 import {
   createNotebookCell,
@@ -148,7 +147,7 @@ describe("CellInputVisibilitySync", () => {
 
       yield* Effect.gen(function* () {
         yield* vscode.setActiveNotebookEditor(Option.some(editor));
-        yield* TestClock.adjust("1 millis");
+        yield* Effect.yieldNow;
 
         expect(
           yield* commandRanges(vscode, "notebook.cell.collapseCellInput"),
@@ -179,7 +178,7 @@ describe("CellInputVisibilitySync", () => {
       yield* vscode.setActiveNotebookEditor(Option.some(editor));
 
       yield* Effect.gen(function* () {
-        yield* TestClock.adjust("1 millis");
+        yield* Effect.yieldNow;
 
         expect(
           yield* commandRanges(vscode, "notebook.cell.collapseCellInput"),
@@ -207,11 +206,11 @@ describe("CellInputVisibilitySync", () => {
       yield* vscode.setActiveNotebookEditor(Option.some(editor));
 
       yield* Effect.gen(function* () {
-        yield* TestClock.adjust("1 millis");
+        yield* Effect.yieldNow;
         yield* vscode.setActiveNotebookEditor(Option.none());
-        yield* TestClock.adjust("1 millis");
+        yield* Effect.yieldNow;
         yield* vscode.setActiveNotebookEditor(Option.some(editor));
-        yield* TestClock.adjust("1 millis");
+        yield* Effect.yieldNow;
 
         expect(
           yield* commandRanges(vscode, "notebook.cell.expandCellInput"),
@@ -227,11 +226,11 @@ describe("CellInputVisibilitySync", () => {
 
       yield* Effect.gen(function* () {
         yield* vscode.setActiveNotebookEditor(Option.some(editor));
-        yield* TestClock.adjust("1 millis");
+        yield* Effect.yieldNow;
         yield* vscode.setActiveNotebookEditor(Option.none());
-        yield* TestClock.adjust("1 millis");
+        yield* Effect.yieldNow;
         yield* vscode.setActiveNotebookEditor(Option.some(editor));
-        yield* TestClock.adjust("1 millis");
+        yield* Effect.yieldNow;
 
         expect(
           yield* commandRanges(vscode, "notebook.cell.collapseCellInput"),
@@ -248,12 +247,12 @@ describe("CellInputVisibilitySync", () => {
 
       yield* Effect.gen(function* () {
         yield* vscode.setActiveNotebookEditor(Option.some(editor));
-        yield* TestClock.adjust("1 millis");
+        yield* Effect.yieldNow;
         yield* vscode.setActiveNotebookEditor(Option.none());
         yield* vscode.closeNotebook(editor.notebook);
-        yield* TestClock.adjust("1 millis");
+        yield* Effect.yieldNow;
         yield* vscode.setActiveNotebookEditor(Option.some(reopened));
-        yield* TestClock.adjust("1 millis");
+        yield* Effect.yieldNow;
 
         expect(
           yield* commandRanges(vscode, "notebook.cell.collapseCellInput"),
@@ -269,9 +268,9 @@ describe("CellInputVisibilitySync", () => {
 
       yield* Effect.gen(function* () {
         yield* vscode.setActiveNotebookEditor(Option.some(editor));
-        yield* TestClock.adjust("1 millis");
+        yield* Effect.yieldNow;
         yield* changeNotebook(vscode, states([false]), states([true]));
-        yield* TestClock.adjust("1 millis");
+        yield* Effect.yieldNow;
 
         expect(
           yield* commandRanges(vscode, "notebook.cell.collapseCellInput"),
@@ -287,9 +286,9 @@ describe("CellInputVisibilitySync", () => {
 
       yield* Effect.gen(function* () {
         yield* vscode.setActiveNotebookEditor(Option.some(editor));
-        yield* TestClock.adjust("1 millis");
+        yield* Effect.yieldNow;
         yield* changeNotebook(vscode, states([true]), states([false]));
-        yield* TestClock.adjust("1 millis");
+        yield* Effect.yieldNow;
 
         expect(
           yield* commandRanges(vscode, "notebook.cell.expandCellInput"),
@@ -305,12 +304,12 @@ describe("CellInputVisibilitySync", () => {
 
       yield* Effect.gen(function* () {
         yield* vscode.setActiveNotebookEditor(Option.some(editor));
-        yield* TestClock.adjust("1 millis");
+        yield* Effect.yieldNow;
         yield* changeNotebook(vscode, states([false, true]), [
           { stableId: "cell-1", hideCode: true },
           { stableId: "cell-0", hideCode: false },
         ]);
-        yield* TestClock.adjust("1 millis");
+        yield* Effect.yieldNow;
 
         expect(
           yield* commandRanges(vscode, "notebook.cell.collapseCellInput"),
@@ -337,9 +336,9 @@ describe("CellInputVisibilitySync", () => {
 
       yield* Effect.gen(function* () {
         yield* vscode.setActiveNotebookEditor(Option.some(editor));
-        yield* TestClock.adjust("1 millis");
+        yield* Effect.yieldNow;
         yield* changeNotebook(vscode, before, after);
-        yield* TestClock.adjust("1 millis");
+        yield* Effect.yieldNow;
 
         expect(
           yield* commandRanges(vscode, "notebook.cell.expandCellInput"),
@@ -372,11 +371,11 @@ describe("CellInputVisibilitySync", () => {
 
       yield* Effect.gen(function* () {
         yield* vscode.setActiveNotebookEditor(Option.some(editor));
-        yield* TestClock.adjust("1 millis");
+        yield* Effect.yieldNow;
         yield* changeNotebook(vscode, states([false]), states([true]));
-        yield* TestClock.adjust("1 millis");
+        yield* Effect.yieldNow;
         yield* changeNotebook(vscode, states([true]), states([true]));
-        yield* TestClock.adjust("1 millis");
+        yield* Effect.yieldNow;
 
         expect(yield* Ref.get(attempts)).toBe(2);
       }).pipe(Effect.provide(layer));

--- a/extension/src/features/__tests__/MarimoFileDetector.test.ts
+++ b/extension/src/features/__tests__/MarimoFileDetector.test.ts
@@ -1,6 +1,5 @@
 import { expect, it } from "@effect/vitest";
 import { Effect, Layer, Option, Ref } from "effect";
-import { TestClock } from "effect/testing";
 
 import {
   createTestTextDocument,
@@ -141,8 +140,8 @@ if __name__ == "__main__":
 
       // Set the active text editor
       yield* ctx.vscode.setActiveTextEditor(Option.some(editor));
-      // Give the detector time to process the change
-      yield* TestClock.adjust("100 millis");
+      // Give the detector a scheduler turn to process the change
+      yield* Effect.yieldNow;
     }).pipe(Effect.provide(ctx.layer));
 
     expect(yield* Ref.get(ctx.vscode.executions)).toEqual([
@@ -241,7 +240,7 @@ my_app = marimo.App()
 
       // set new notebook
       yield* ctx.vscode.setActiveTextEditor(Option.some(editor));
-      yield* TestClock.adjust("100 millis");
+      yield* Effect.yieldNow;
     }).pipe(Effect.provide(ctx.layer));
 
     expect(yield* Ref.get(ctx.vscode.executions)).toEqual([

--- a/extension/src/features/__tests__/ThemeSync.test.ts
+++ b/extension/src/features/__tests__/ThemeSync.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "@effect/vitest";
-import { Effect, Layer, Option, Ref, SubscriptionRef } from "effect";
+import { Effect, Layer, Option, Ref, Schedule, SubscriptionRef } from "effect";
 
 import { TestTelemetryLive } from "../../__mocks__/TestTelemetry.ts";
 import { TestVsCode } from "../../__mocks__/TestVsCode.ts";
@@ -65,6 +65,19 @@ const withTestCtx = Effect.fn(function* (
   };
 });
 
+const waitForExecutions = (
+  executions: Ref.Ref<ReadonlyArray<TestCommand>>,
+  predicate: (executions: ReadonlyArray<TestCommand>) => boolean,
+) =>
+  Effect.yieldNow.pipe(
+    Effect.andThen(Ref.get(executions)),
+    Effect.filterOrFail(
+      predicate,
+      () => "ThemeSync executions have not settled" as const,
+    ),
+    Effect.retry(Schedule.recurs(100)),
+  );
+
 describe("ThemeSync", () => {
   it.effect(
     "sends set-display-theme on theme change",
@@ -73,10 +86,19 @@ describe("ThemeSync", () => {
 
       yield* Effect.gen(function* () {
         yield* ctx.vscode.setActiveNotebookEditor(Option.some(ctx.editor));
-        yield* Effect.yieldNow;
+        yield* waitForExecutions(
+          ctx.executions,
+          (executions) => executions.length >= 2,
+        );
 
         yield* SubscriptionRef.set(ctx.themeRef, "dark");
-        yield* Effect.yieldNow;
+        yield* waitForExecutions(ctx.executions, (executions) =>
+          executions.some(
+            (execution) =>
+              execution.kind === "set-display-theme" &&
+              execution.theme === "dark",
+          ),
+        );
 
         expect(yield* Ref.get(ctx.executions)).toMatchInlineSnapshot(`
           [
@@ -106,10 +128,19 @@ describe("ThemeSync", () => {
       yield* Effect.gen(function* () {
         // The focus is on a text editor. The registry has no notebook.
         yield* ctx.vscode.setActiveNotebookEditor(Option.none());
-        yield* Effect.yieldNow;
+        yield* waitForExecutions(
+          ctx.executions,
+          (executions) => executions.length >= 1,
+        );
 
         yield* SubscriptionRef.set(ctx.themeRef, "dark");
-        yield* Effect.yieldNow;
+        yield* waitForExecutions(ctx.executions, (executions) =>
+          executions.some(
+            (execution) =>
+              execution.kind === "set-display-theme" &&
+              execution.theme === "dark",
+          ),
+        );
 
         // set-display-theme updates all running sessions. The kernels must
         // get the change when no notebook is focused.
@@ -128,7 +159,10 @@ describe("ThemeSync", () => {
 
       yield* Effect.gen(function* () {
         yield* ctx.vscode.setActiveNotebookEditor(Option.some(ctx.editor));
-        yield* Effect.yieldNow;
+        yield* waitForExecutions(
+          ctx.executions,
+          (executions) => executions.length >= 2,
+        );
 
         expect(yield* Ref.get(ctx.executions)).toMatchInlineSnapshot(`
           [

--- a/extension/src/features/__tests__/ThemeSync.test.ts
+++ b/extension/src/features/__tests__/ThemeSync.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "@effect/vitest";
 import { Effect, Layer, Option, Ref, SubscriptionRef } from "effect";
-import { TestClock } from "effect/testing";
 
 import { TestTelemetryLive } from "../../__mocks__/TestTelemetry.ts";
 import { TestVsCode } from "../../__mocks__/TestVsCode.ts";
@@ -74,10 +73,10 @@ describe("ThemeSync", () => {
 
       yield* Effect.gen(function* () {
         yield* ctx.vscode.setActiveNotebookEditor(Option.some(ctx.editor));
-        yield* TestClock.adjust("1 millis");
+        yield* Effect.yieldNow;
 
         yield* SubscriptionRef.set(ctx.themeRef, "dark");
-        yield* TestClock.adjust("1 millis");
+        yield* Effect.yieldNow;
 
         expect(yield* Ref.get(ctx.executions)).toMatchInlineSnapshot(`
           [
@@ -107,10 +106,10 @@ describe("ThemeSync", () => {
       yield* Effect.gen(function* () {
         // The focus is on a text editor. The registry has no notebook.
         yield* ctx.vscode.setActiveNotebookEditor(Option.none());
-        yield* TestClock.adjust("1 millis");
+        yield* Effect.yieldNow;
 
         yield* SubscriptionRef.set(ctx.themeRef, "dark");
-        yield* TestClock.adjust("1 millis");
+        yield* Effect.yieldNow;
 
         // set-display-theme updates all running sessions. The kernels must
         // get the change when no notebook is focused.
@@ -129,7 +128,7 @@ describe("ThemeSync", () => {
 
       yield* Effect.gen(function* () {
         yield* ctx.vscode.setActiveNotebookEditor(Option.some(ctx.editor));
-        yield* TestClock.adjust("1 millis");
+        yield* Effect.yieldNow;
 
         expect(yield* Ref.get(ctx.executions)).toMatchInlineSnapshot(`
           [

--- a/extension/src/kernel/NotebookControllers.ts
+++ b/extension/src/kernel/NotebookControllers.ts
@@ -179,6 +179,7 @@ const updateNotebookAffinityEffect = Effect.fn("updateNotebookAffinity")(
   }) {
     const { notebook, sandboxController, handlesRef, code } = options;
     const handles = yield* SynchronizedRef.get(handlesRef);
+    const preferredControllerIds = new Set<string>();
 
     // Check if header includes "/// script"
     if (notebook.header.includes("/// script")) {
@@ -186,52 +187,55 @@ const updateNotebookAffinityEffect = Effect.fn("updateNotebookAffinity")(
         "Setting affinity to sandbox controller (script header detected)",
       ).pipe(Effect.annotateLogs({ notebookUri: notebook.uri.toString() }));
 
-      // Prefer sandbox controller
-      yield* sandboxController.updateNotebookAffinity(
-        notebook.rawNotebookDocument,
-        code.NotebookControllerAffinity.Preferred,
-      );
+      preferredControllerIds.add(sandboxController.id);
+    } else {
+      // Check for venv next to notebook
+      const notebookDir = NodePath.dirname(notebook.uri.fsPath);
+      const venvPath = findVenvPath(NodePath.join(notebookDir, ".venv"));
 
-      return;
-    }
-
-    // Check for venv next to notebook
-    const notebookDir = NodePath.dirname(notebook.uri.fsPath);
-    const venvPath = findVenvPath(NodePath.join(notebookDir, ".venv"));
-
-    if (Option.isSome(venvPath)) {
-      yield* Effect.logDebug(
-        "Setting affinity to venv controller (venv detected)",
-      ).pipe(
-        Effect.annotateLogs({
-          notebookUri: notebook.id,
-          venvPath: venvPath.value,
-        }),
-      );
-
-      // Find controller with matching venv path
-      // The venv path should contain the Python executable
-      const venvControllers = HashMap.filter(handles, (handle) => {
-        const controllerVenv = findVenvPath(handle.controller.executable);
-        return (
-          Option.isSome(controllerVenv) &&
-          controllerVenv.value === venvPath.value
+      if (Option.isSome(venvPath)) {
+        yield* Effect.logDebug(
+          "Setting affinity to venv controller (venv detected)",
+        ).pipe(
+          Effect.annotateLogs({
+            notebookUri: notebook.id,
+            venvPath: venvPath.value,
+          }),
         );
-      });
 
-      for (const handle of HashMap.values(venvControllers)) {
-        yield* handle.controller.updateNotebookAffinity(
-          notebook.rawNotebookDocument,
-          code.NotebookControllerAffinity.Preferred,
-        );
+        // Find controllers with matching venv paths. The venv path should
+        // contain the Python executable.
+        for (const handle of HashMap.values(handles)) {
+          const controllerVenv = findVenvPath(handle.controller.executable);
+          if (
+            Option.isSome(controllerVenv) &&
+            controllerVenv.value === venvPath.value
+          ) {
+            preferredControllerIds.add(handle.controller.id);
+          }
+        }
+      } else {
+        yield* Effect.logDebug(
+          "No affinity preference set (no script header or venv)",
+        ).pipe(Effect.annotateLogs({ notebookUri: notebook.id }));
       }
-      return;
     }
 
-    // Otherwise, don't set any affinity (let VSCode use defaults)
-    yield* Effect.logDebug(
-      "No affinity preference set (no script header or venv)",
-    ).pipe(Effect.annotateLogs({ notebookUri: notebook.id }));
+    const controllers = [
+      sandboxController,
+      ...Array.from(HashMap.values(handles), (handle) => handle.controller),
+    ];
+    yield* Effect.forEach(
+      controllers,
+      (controller) =>
+        controller.updateNotebookAffinity(
+          notebook.rawNotebookDocument,
+          preferredControllerIds.has(controller.id)
+            ? code.NotebookControllerAffinity.Preferred
+            : code.NotebookControllerAffinity.Default,
+        ),
+      { discard: true },
+    );
   },
 );
 

--- a/extension/src/kernel/__tests__/NotebookControllers.test.ts
+++ b/extension/src/kernel/__tests__/NotebookControllers.test.ts
@@ -1,7 +1,10 @@
+import * as NodeFs from "node:fs";
+import * as NodeOs from "node:os";
+import * as NodePath from "node:path";
+
 import { assert, expect, it } from "@effect/vitest";
 import type * as py from "@vscode/python-extension";
 import { Effect, Fiber, Layer, Option, Stream } from "effect";
-import { TestClock } from "effect/testing";
 import type * as vscode from "vscode";
 
 import { TestPythonExtension } from "../../__mocks__/TestPythonExtension.ts";
@@ -15,7 +18,26 @@ import {
 import { NotebookRuntime } from "../../kernel/NotebookRuntime.ts";
 import { notebookId } from "../../lib/__tests__/branded.ts";
 import { Constants } from "../../platform/Constants.ts";
+import { VsCode } from "../../platform/VsCode.ts";
 import { makeControllerSelectionChanges } from "../ControllerSelectionChanges.ts";
+
+const affinityMap = (
+  updates: ReadonlyArray<{
+    controllerId: string;
+    affinity: vscode.NotebookControllerAffinity;
+  }>,
+) =>
+  Object.fromEntries(
+    updates.map(({ controllerId, affinity }) => [controllerId, affinity]),
+  );
+
+const scriptNotebookEditor = (uri: string) =>
+  TestVsCode.makeNotebookEditor(uri, {
+    data: {
+      cells: [],
+      metadata: { marimo: { header: "/// script" } },
+    },
+  });
 
 const withTestCtx = Effect.fn(function* (
   options: {
@@ -100,7 +122,7 @@ it.effect(
         editor.notebook,
         true,
       );
-      yield* TestClock.adjust("10 millis");
+      yield* Effect.yieldNow;
 
       const selectedNotebook = yield* notebooks.forNotebook(
         notebookId(editor.notebook.uri.toString()),
@@ -164,10 +186,10 @@ it.effect(
       // the mock PubSub before we publish; the PubSub has no replay, so an
       // event published before the fork first runs would be silently lost.
       // Production wraps a vscode event listener registered at activation.
-      yield* TestClock.adjust("1 millis");
+      yield* Effect.yieldNow;
 
       yield* ctx.python.addEnvironment(second);
-      yield* TestClock.adjust("10 millis");
+      yield* Effect.yieldNow;
       expect((yield* ctx.vscode.snapshot()).controllers).toEqual([
         "marimo-/home/user/.venv/bin/python",
         "marimo-/usr/local/bin/python3.11",
@@ -175,7 +197,7 @@ it.effect(
       ]);
 
       yield* ctx.python.removeEnvironment(first);
-      yield* TestClock.adjust("10 millis");
+      yield* Effect.yieldNow;
       expect((yield* ctx.vscode.snapshot()).controllers).toEqual([
         "marimo-/usr/local/bin/python3.11",
         "marimo-sandbox",
@@ -198,16 +220,16 @@ it.effect(
       // Drain so the selection listener and the environmentChanges consumer
       // (both forked during layer construction) are attached before the mock
       // events below fire; see the comments in the two tests above.
-      yield* TestClock.adjust("1 millis");
+      yield* Effect.yieldNow;
       yield* ctx.vscode.selectNotebookController(
         `marimo-${executable}`,
         editor.notebook,
         true,
       );
-      yield* TestClock.adjust("10 millis");
+      yield* Effect.yieldNow;
 
       yield* ctx.python.removeEnvironment(environment);
-      yield* TestClock.adjust("10 millis");
+      yield* Effect.yieldNow;
 
       expect((yield* ctx.vscode.snapshot()).controllers).toContain(
         `marimo-${executable}`,
@@ -217,20 +239,151 @@ it.effect(
 );
 
 it.effect(
-  "does not set affinity without a script header or adjacent venv",
+  "sets all controllers to default without a script header or adjacent venv",
   Effect.fn(function* () {
+    const executable = "/usr/local/bin/python3.11";
     const ctx = yield* withTestCtx({
-      initialEnvs: [TestPythonExtension.makeVenv("/usr/local/bin/python3.11")],
+      initialEnvs: [TestPythonExtension.makeVenv(executable)],
     });
 
     yield* Effect.gen(function* () {
       yield* NotebookRuntime;
+      const code = yield* VsCode;
       const editor = TestVsCode.makeNotebookEditor("/test/notebook_mo.py");
 
       yield* ctx.vscode.setActiveNotebookEditor(Option.some(editor));
-      yield* TestClock.adjust("100 millis");
+      yield* Effect.yieldNow;
 
-      expect(yield* ctx.vscode.getAffinityUpdates()).toEqual([]);
+      const updates = yield* ctx.vscode.getAffinityUpdates();
+      expect(updates).toHaveLength(2);
+      expect(affinityMap(updates)).toEqual({
+        "marimo-sandbox": code.NotebookControllerAffinity.Default,
+        [`marimo-${executable}`]: code.NotebookControllerAffinity.Default,
+      });
+    }).pipe(Effect.provide(ctx.layer));
+  }),
+);
+
+it.effect(
+  "resets sandbox affinity after the script header is removed",
+  Effect.fn(function* () {
+    const executable = "/usr/local/bin/python3.11";
+    const ctx = yield* withTestCtx({
+      initialEnvs: [TestPythonExtension.makeVenv(executable)],
+    });
+
+    yield* Effect.gen(function* () {
+      yield* NotebookRuntime;
+      const code = yield* VsCode;
+      const uri = "/test/notebook_mo.py";
+
+      yield* ctx.vscode.setActiveNotebookEditor(
+        Option.some(scriptNotebookEditor(uri)),
+      );
+      yield* Effect.yieldNow;
+      yield* ctx.vscode.setActiveNotebookEditor(
+        Option.some(TestVsCode.makeNotebookEditor(uri)),
+      );
+      yield* Effect.yieldNow;
+
+      const updates = yield* ctx.vscode.getAffinityUpdates();
+      expect(updates).toHaveLength(4);
+      expect(affinityMap(updates.slice(0, 2))).toEqual({
+        "marimo-sandbox": code.NotebookControllerAffinity.Preferred,
+        [`marimo-${executable}`]: code.NotebookControllerAffinity.Default,
+      });
+      expect(affinityMap(updates.slice(2))).toEqual({
+        "marimo-sandbox": code.NotebookControllerAffinity.Default,
+        [`marimo-${executable}`]: code.NotebookControllerAffinity.Default,
+      });
+    }).pipe(Effect.provide(ctx.layer));
+  }),
+);
+
+it.effect(
+  "resets venv affinity after the adjacent venv is removed",
+  Effect.fn(function* () {
+    using project = NodeFs.mkdtempDisposableSync(
+      NodePath.join(NodeOs.tmpdir(), "marimo-controller-affinity-"),
+    );
+    const venv = NodePath.join(project.path, ".venv");
+    const executable = NodePath.join(venv, "bin", "python");
+    const pyvenvConfig = NodePath.join(venv, "pyvenv.cfg");
+    NodeFs.mkdirSync(NodePath.dirname(executable), { recursive: true });
+    NodeFs.writeFileSync(pyvenvConfig, "");
+
+    const ctx = yield* withTestCtx({
+      initialEnvs: [TestPythonExtension.makeVenv(executable)],
+    });
+
+    yield* Effect.gen(function* () {
+      yield* NotebookRuntime;
+      const code = yield* VsCode;
+      const uri = NodePath.join(project.path, "notebook_mo.py");
+
+      yield* ctx.vscode.setActiveNotebookEditor(
+        Option.some(TestVsCode.makeNotebookEditor(uri)),
+      );
+      yield* Effect.yieldNow;
+      NodeFs.unlinkSync(pyvenvConfig);
+      yield* ctx.vscode.setActiveNotebookEditor(
+        Option.some(TestVsCode.makeNotebookEditor(uri)),
+      );
+      yield* Effect.yieldNow;
+
+      const updates = yield* ctx.vscode.getAffinityUpdates();
+      expect(updates).toHaveLength(4);
+      expect(affinityMap(updates.slice(0, 2))).toEqual({
+        "marimo-sandbox": code.NotebookControllerAffinity.Default,
+        [`marimo-${executable}`]: code.NotebookControllerAffinity.Preferred,
+      });
+      expect(affinityMap(updates.slice(2))).toEqual({
+        "marimo-sandbox": code.NotebookControllerAffinity.Default,
+        [`marimo-${executable}`]: code.NotebookControllerAffinity.Default,
+      });
+    }).pipe(Effect.provide(ctx.layer));
+  }),
+);
+
+it.effect(
+  "demotes sandbox affinity when an adjacent venv replaces the script header",
+  Effect.fn(function* () {
+    using project = NodeFs.mkdtempDisposableSync(
+      NodePath.join(NodeOs.tmpdir(), "marimo-controller-affinity-"),
+    );
+    const venv = NodePath.join(project.path, ".venv");
+    const executable = NodePath.join(venv, "bin", "python");
+    NodeFs.mkdirSync(NodePath.dirname(executable), { recursive: true });
+    NodeFs.writeFileSync(NodePath.join(venv, "pyvenv.cfg"), "");
+
+    const ctx = yield* withTestCtx({
+      initialEnvs: [TestPythonExtension.makeVenv(executable)],
+    });
+
+    yield* Effect.gen(function* () {
+      yield* NotebookRuntime;
+      const code = yield* VsCode;
+      const uri = NodePath.join(project.path, "notebook_mo.py");
+
+      yield* ctx.vscode.setActiveNotebookEditor(
+        Option.some(scriptNotebookEditor(uri)),
+      );
+      yield* Effect.yieldNow;
+      yield* ctx.vscode.setActiveNotebookEditor(
+        Option.some(TestVsCode.makeNotebookEditor(uri)),
+      );
+      yield* Effect.yieldNow;
+
+      const updates = yield* ctx.vscode.getAffinityUpdates();
+      expect(updates).toHaveLength(4);
+      expect(affinityMap(updates.slice(0, 2))).toEqual({
+        "marimo-sandbox": code.NotebookControllerAffinity.Preferred,
+        [`marimo-${executable}`]: code.NotebookControllerAffinity.Default,
+      });
+      expect(affinityMap(updates.slice(2))).toEqual({
+        "marimo-sandbox": code.NotebookControllerAffinity.Default,
+        [`marimo-${executable}`]: code.NotebookControllerAffinity.Preferred,
+      });
     }).pipe(Effect.provide(ctx.layer));
   }),
 );

--- a/extension/src/kernel/__tests__/NotebookRuntimeOperations.test.ts
+++ b/extension/src/kernel/__tests__/NotebookRuntimeOperations.test.ts
@@ -60,6 +60,20 @@ const REPLACEMENT_SESSION_ID = kernelSessionId(
   "00000000-0000-4000-8000-000000000002",
 );
 
+const settle = <A, E, R>(
+  get: Effect.Effect<A, E, R>,
+  predicate: (value: A) => boolean,
+  failure: string,
+) =>
+  Effect.gen(function* () {
+    for (let attempt = 0; attempt <= 100; attempt++) {
+      const value = yield* get;
+      if (predicate(value)) return value;
+      if (attempt < 100) yield* Effect.yieldNow;
+    }
+    return yield* Effect.fail(failure);
+  });
+
 const withTestCtx = Effect.fn(function* (
   activeSessionId: KernelSessionId = ACTIVE_SESSION_ID,
   workspace: {
@@ -495,12 +509,57 @@ describe("NotebookRuntime cell identity", () => {
             },
           ],
         });
-        yield* Effect.yieldNow;
 
-        const commands = yield* SubscriptionRef.get(ctx.executions);
-        expect(commands.some((command) => command.kind === "delete-cell")).toBe(
-          false,
+        // The assertion below is negative, so the unchanged command list
+        // cannot tell us when the move has been processed. Follow it with an
+        // observable deletion on the same sequential change stream. Once the
+        // marker deletion is recorded, the preceding move event has completed.
+        const markerCell = createTestNotebookDocument(
+          NodePath.join(process.cwd(), "cell-move-marker_mo.py"),
+          {
+            data: {
+              cells: [
+                {
+                  kind: 1,
+                  value: "",
+                  languageId: "python",
+                  metadata: MarimoNotebookCell.createMetadata({
+                    marimoRuntime: { stableId: "cell-move-marker" },
+                  }),
+                },
+              ],
+            },
+          },
+        ).cellAt(0);
+        yield* ctx.vscode.notebookChange({
+          notebook: ctx.editor.notebook,
+          metadata: undefined,
+          cellChanges: [],
+          contentChanges: [
+            {
+              range: new NotebookRange(1, 1),
+              removedCells: [markerCell],
+              addedCells: [],
+            },
+          ],
+        });
+        const commands = yield* settle(
+          SubscriptionRef.get(ctx.executions),
+          (calls) =>
+            calls.some(
+              (command) =>
+                command.kind === "delete-cell" &&
+                command.cellId === "cell-move-marker",
+            ),
+          "cell change pipeline did not settle",
         );
+
+        expect(
+          commands.some(
+            (command) =>
+              command.kind === "delete-cell" && command.cellId === "cell-1",
+          ),
+        ).toBe(false);
       }).pipe(Effect.provide(ctx.layer));
     }),
   );
@@ -1096,7 +1155,7 @@ describe("NotebookRuntime state eviction", () => {
       const ctx = yield* withTestCtx();
 
       yield* Effect.gen(function* () {
-        yield* NotebookRuntime;
+        const runtime = yield* NotebookRuntime;
         const variables = yield* NotebookVariables;
         const datasources = yield* NotebookDatasources;
 
@@ -1204,7 +1263,18 @@ describe("NotebookRuntime state eviction", () => {
         // A delayed close from the old document must not clear replacement
         // session state.
         yield* ctx.vscode.closeNotebook(ctx.editor.notebook);
-        yield* Effect.yieldNow;
+        // Opening a marker document on the same sequential lifecycle stream
+        // gives the stale close an observable ordering barrier. Once the
+        // marker has a session, the preceding close has been handled.
+        const lifecycleMarker = createTestNotebookDocument(
+          NodePath.join(process.cwd(), "lifecycle-marker_mo.py"),
+        );
+        yield* ctx.vscode.openNotebook(lifecycleMarker);
+        yield* settle(
+          runtime.forDocument(lifecycleMarker).pipe(Effect.option),
+          Option.isSome,
+          "notebook lifecycle pipeline did not settle",
+        );
         expect(
           Option.isSome(yield* variables.getVariables(ctx.notebookUri)),
         ).toBe(true);

--- a/extension/src/kernel/__tests__/NotebookRuntimeOperations.test.ts
+++ b/extension/src/kernel/__tests__/NotebookRuntimeOperations.test.ts
@@ -14,7 +14,6 @@ import {
   Stream,
   SubscriptionRef,
 } from "effect";
-import { TestClock } from "effect/testing";
 
 import { TestPythonExtension } from "../../__mocks__/TestPythonExtension.ts";
 import { TestTelemetryLive } from "../../__mocks__/TestTelemetry.ts";
@@ -387,7 +386,7 @@ describe("NotebookRuntime operation processing", () => {
       yield* Effect.gen(function* () {
         yield* NotebookRuntime;
         yield* ctx.vscode.setActiveNotebookEditor(Option.some(ctx.editor));
-        yield* TestClock.adjust("1 millis");
+        yield* Effect.yieldNow;
 
         yield* PubSub.publish(ctx.operationsPubSub, {
           notebookUri: ctx.notebookUri,
@@ -410,7 +409,7 @@ describe("NotebookRuntime operation processing", () => {
         yield* Deferred.await(editStarted);
 
         yield* ctx.vscode.closeNotebook(ctx.editor.notebook);
-        yield* TestClock.adjust("1 millis");
+        yield* Effect.yieldNow;
 
         expect(yield* Ref.get(ctx.errorMessages)).toEqual([]);
       }).pipe(Effect.provide(ctx.layer));
@@ -432,7 +431,7 @@ describe("NotebookRuntime cell identity", () => {
         // vscode event listener registered during activation, so the event
         // cannot fire before the listener exists; the mock's PubSub has no
         // replay, so a publish before the fork first runs is silently lost.
-        yield* TestClock.adjust("1 millis");
+        yield* Effect.yieldNow;
 
         const cell = ctx.editor.notebook.cellAt(0);
         yield* ctx.vscode.notebookChange({
@@ -447,9 +446,15 @@ describe("NotebookRuntime cell identity", () => {
             },
           ],
         });
-        yield* TestClock.adjust("10 millis");
+        const executions = yield* SubscriptionRef.changes(ctx.executions).pipe(
+          Stream.filter((commands) =>
+            commands.some((command) => command.kind === "delete-cell"),
+          ),
+          Stream.runHead,
+          Effect.map(Option.getOrThrow),
+        );
 
-        expect(yield* SubscriptionRef.get(ctx.executions)).toContainEqual({
+        expect(executions).toContainEqual({
           kind: "delete-cell",
           notebookUri: ctx.notebookUri,
           kernelSessionId: ACTIVE_SESSION_ID,
@@ -470,7 +475,7 @@ describe("NotebookRuntime cell identity", () => {
         // deleted-cell test above); without it this test would pass vacuously
         // because the mock PubSub drops events published before the forked
         // consumer subscribes.
-        yield* TestClock.adjust("1 millis");
+        yield* Effect.yieldNow;
 
         const cell = ctx.editor.notebook.cellAt(0);
         yield* ctx.vscode.notebookChange({
@@ -490,7 +495,7 @@ describe("NotebookRuntime cell identity", () => {
             },
           ],
         });
-        yield* TestClock.adjust("10 millis");
+        yield* Effect.yieldNow;
 
         const commands = yield* SubscriptionRef.get(ctx.executions);
         expect(commands.some((command) => command.kind === "delete-cell")).toBe(
@@ -513,7 +518,7 @@ describe("NotebookRuntime stdin", () => {
 
         // Set active editor so NotebookEditorRegistry can find it
         yield* ctx.vscode.setActiveNotebookEditor(Option.some(ctx.editor));
-        yield* TestClock.adjust("1 millis");
+        yield* Effect.yieldNow;
 
         // Push a cell-op with stdin console output
         yield* PubSub.publish(
@@ -530,7 +535,7 @@ describe("NotebookRuntime stdin", () => {
             ],
           }),
         );
-        yield* TestClock.adjust("1 millis");
+        yield* Effect.yieldNow;
 
         // Provide the input (unblocks showInputBox)
         yield* Queue.offer(ctx.inputQueue, Option.some("foo"));
@@ -564,7 +569,7 @@ describe("NotebookRuntime stdin", () => {
         const cellId = Option.getOrThrow(cell.id);
 
         yield* ctx.vscode.setActiveNotebookEditor(Option.some(ctx.editor));
-        yield* TestClock.adjust("10 millis");
+        yield* Effect.yieldNow;
 
         yield* PubSub.publish(
           ctx.operationsPubSub,
@@ -580,7 +585,7 @@ describe("NotebookRuntime stdin", () => {
             ],
           }),
         );
-        yield* TestClock.adjust("1 millis");
+        yield* Effect.yieldNow;
 
         // User cancels the input box
         yield* Queue.offer(ctx.inputQueue, Option.none());
@@ -615,7 +620,7 @@ describe("NotebookRuntime stdin", () => {
       yield* Effect.gen(function* () {
         const cellId = Option.getOrThrow(ctx.notebook.cellAt(0).id);
         yield* ctx.vscode.setActiveNotebookEditor(Option.some(ctx.editor));
-        yield* TestClock.adjust("1 millis");
+        yield* Effect.yieldNow;
 
         yield* PubSub.publish(
           ctx.operationsPubSub,
@@ -634,9 +639,9 @@ describe("NotebookRuntime stdin", () => {
         yield* ctx.inputRequested.await;
 
         yield* ctx.vscode.closeNotebook(ctx.editor.notebook);
-        yield* TestClock.adjust("1 millis");
+        yield* Effect.yieldNow;
         yield* Queue.offer(ctx.inputQueue, Option.some("stale response"));
-        yield* TestClock.adjust("1 millis");
+        yield* Effect.yieldNow;
 
         expect(
           (yield* SubscriptionRef.get(ctx.executions)).some(
@@ -656,7 +661,7 @@ describe("NotebookRuntime stdin", () => {
         const runtime = yield* NotebookRuntime;
         const cellId = Option.getOrThrow(ctx.notebook.cellAt(0).id);
         yield* ctx.vscode.setActiveNotebookEditor(Option.some(ctx.editor));
-        yield* TestClock.adjust("1 millis");
+        yield* Effect.yieldNow;
 
         yield* PubSub.publish(
           ctx.operationsPubSub,
@@ -677,7 +682,7 @@ describe("NotebookRuntime stdin", () => {
         const notebook = yield* runtime.forNotebook(ctx.notebookUri);
         yield* notebook.restart;
         yield* Queue.offer(ctx.inputQueue, Option.some("stale response"));
-        yield* TestClock.adjust("1 millis");
+        yield* Effect.yieldNow;
 
         expect(
           (yield* SubscriptionRef.get(ctx.executions)).some(
@@ -717,7 +722,7 @@ describe("NotebookRuntime scratch stream", () => {
         // Extra drain: give the second scratchpad every chance to
         // (incorrectly) bypass the per-notebook lock before asserting that
         // exactly one command went out.
-        yield* TestClock.adjust("1 millis");
+        yield* Effect.yieldNow;
 
         const first_ = scratchpadCalls(
           yield* SubscriptionRef.get(ctx.executions),
@@ -784,7 +789,7 @@ describe("NotebookRuntime scratch stream", () => {
         // lifecycle subscription before its layer finishes building, so an
         // open published this early is delivered rather than dropped.
         yield* ctx.vscode.openNotebook(otherEditor.notebook);
-        yield* TestClock.adjust("1 millis");
+        yield* Effect.yieldNow;
         yield* runtime.attachController(otherNotebook.id, ctx.mockController);
         const firstNotebook = yield* runtime.forNotebook(ctx.notebookUri);
         const secondNotebook = yield* runtime.forNotebook(otherNotebook.id);
@@ -860,7 +865,7 @@ describe("NotebookRuntime scratch stream", () => {
 
         // Route cell-op notifications through processSessionOperation.
         yield* ctx.vscode.setActiveNotebookEditor(Option.some(ctx.editor));
-        yield* TestClock.adjust("1 millis");
+        yield* Effect.yieldNow;
         const notebook = yield* runtime.forNotebook(ctx.notebookUri);
 
         const streamFiber = yield* Effect.forkChild(
@@ -957,7 +962,7 @@ describe("NotebookRuntime scratch stream", () => {
         const runtime = yield* NotebookRuntime;
 
         yield* ctx.vscode.setActiveNotebookEditor(Option.some(ctx.editor));
-        yield* TestClock.adjust("1 millis");
+        yield* Effect.yieldNow;
         const notebook = yield* runtime.forNotebook(ctx.notebookUri);
 
         const streamFiber = yield* Effect.forkChild(
@@ -1008,7 +1013,7 @@ describe("NotebookRuntime scratch stream", () => {
         const runtime = yield* NotebookRuntime;
 
         yield* ctx.vscode.setActiveNotebookEditor(Option.some(ctx.editor));
-        yield* TestClock.adjust("1 millis");
+        yield* Effect.yieldNow;
         const notebook = yield* runtime.forNotebook(ctx.notebookUri);
 
         const streamFiber = yield* Effect.forkChild(
@@ -1017,7 +1022,7 @@ describe("NotebookRuntime scratch stream", () => {
 
         // Wait until the command is recorded. Do not count scheduler
         // drains. The scratchpad setup can need more than one drain, which
-        // makes a single `TestClock.adjust` flaky.
+        // makes a single scheduler yield flaky.
         const calls = yield* SubscriptionRef.changes(ctx.executions).pipe(
           Stream.filter((current) =>
             current.some((call) => call.kind === "execute-scratchpad"),
@@ -1060,14 +1065,14 @@ describe("NotebookRuntime state eviction", () => {
       yield* Effect.gen(function* () {
         yield* NotebookRuntime;
         const variables = yield* NotebookVariables;
-        yield* TestClock.adjust("1 millis");
+        yield* Effect.yieldNow;
 
         yield* PubSub.publish(ctx.operationsPubSub, {
           notebookUri: ctx.notebookUri,
           sessionId: staleSessionId,
           notification: { op: "variables", variables: [] },
         });
-        yield* TestClock.adjust("10 millis");
+        yield* Effect.yieldNow;
         expect(
           Option.isNone(yield* variables.getVariables(ctx.notebookUri)),
         ).toBe(true);
@@ -1101,7 +1106,7 @@ describe("NotebookRuntime state eviction", () => {
         // dropped since the PubSub has no replay). In production, operations
         // only flow for sessions started via this same runtime, so nothing
         // can be published before the pipeline subscribes.
-        yield* TestClock.adjust("1 millis");
+        yield* Effect.yieldNow;
 
         yield* PubSub.publish(ctx.documentAnalysisPubSub, {
           notebookUri: ctx.notebookUri,
@@ -1168,7 +1173,7 @@ describe("NotebookRuntime state eviction", () => {
             ],
           },
         });
-        yield* TestClock.adjust("10 millis");
+        yield* Effect.yieldNow;
         expect(
           Option.isSome(yield* variables.getVariables(ctx.notebookUri)),
         ).toBe(false);
@@ -1179,12 +1184,19 @@ describe("NotebookRuntime state eviction", () => {
           { notebookType: ctx.editor.notebook.notebookType },
         );
         yield* ctx.vscode.openNotebook(replacement);
-        yield* TestClock.adjust("10 millis");
-        yield* PubSub.publish(ctx.documentAnalysisPubSub, {
-          notebookUri: ctx.notebookUri,
-          analysis: { op: "variables", variables: [] },
-        });
-        yield* TestClock.adjust("10 millis");
+        yield* Effect.gen(function* () {
+          yield* PubSub.publish(ctx.documentAnalysisPubSub, {
+            notebookUri: ctx.notebookUri,
+            analysis: { op: "variables", variables: [] },
+          });
+          return yield* variables.getVariables(ctx.notebookUri);
+        }).pipe(
+          Effect.filterOrFail(
+            Option.isSome,
+            () => "replacement session not ready" as const,
+          ),
+          Effect.eventually,
+        );
         expect(
           Option.isSome(yield* variables.getVariables(ctx.notebookUri)),
         ).toBe(true);
@@ -1192,7 +1204,7 @@ describe("NotebookRuntime state eviction", () => {
         // A delayed close from the old document must not clear replacement
         // session state.
         yield* ctx.vscode.closeNotebook(ctx.editor.notebook);
-        yield* TestClock.adjust("10 millis");
+        yield* Effect.yieldNow;
         expect(
           Option.isSome(yield* variables.getVariables(ctx.notebookUri)),
         ).toBe(true);

--- a/extension/src/notebook/__tests__/NotebookEditorRegistry.test.ts
+++ b/extension/src/notebook/__tests__/NotebookEditorRegistry.test.ts
@@ -1,6 +1,5 @@
 import { expect, it } from "@effect/vitest";
 import { Effect, Fiber, Layer, Option, Stream } from "effect";
-import { TestClock } from "effect/testing";
 
 import { TestTelemetryLive } from "../../__mocks__/TestTelemetry.ts";
 import {
@@ -52,7 +51,7 @@ it.effect(
     yield* Effect.provide(
       Effect.gen(function* () {
         const registry = yield* NotebookEditorRegistry;
-        yield* TestClock.adjust("10 millis");
+        yield* Effect.yieldNow;
 
         expect(yield* registry.getActiveNotebookUri).toEqual(
           Option.some(editor.notebook.uri.toString()),
@@ -92,7 +91,7 @@ it.effect(
         yield* vscode.setActiveNotebookEditor(Option.some(mockEditor));
 
         // Tick
-        yield* TestClock.adjust("10 millis");
+        yield* Effect.yieldNow;
 
         // Verify the registry tracked the change
         const activeUri = yield* registry.getActiveNotebookUri;
@@ -112,7 +111,7 @@ it.effect(
 
         // Clear active editor
         yield* vscode.setActiveNotebookEditor(Option.none());
-        yield* TestClock.adjust("10 millis");
+        yield* Effect.yieldNow;
 
         const clearedActive = yield* registry.getActiveNotebookUri;
         expect(Option.isNone(clearedActive)).toBe(true);
@@ -159,7 +158,7 @@ it.effect(
 
         for (const change of changes) {
           yield* vscode.setActiveNotebookEditor(change);
-          yield* TestClock.adjust("10 millis");
+          yield* Effect.yieldNow;
         }
 
         const collected = yield* Fiber.join(streamResult);

--- a/extension/src/panel/variables/__tests__/NotebookVariables.test.ts
+++ b/extension/src/panel/variables/__tests__/NotebookVariables.test.ts
@@ -1,6 +1,5 @@
 import { assert, expect, it } from "@effect/vitest";
 import { Effect, Exit, Layer, Option, Ref, Scope, Stream } from "effect";
-import { TestClock } from "effect/testing";
 
 import {
   createTestNotebookDocument,
@@ -345,7 +344,7 @@ it.effect(
       );
 
       // Initial state
-      yield* TestClock.adjust("10 millis");
+      yield* Effect.yieldNow;
 
       // Make changes
       yield* service.updateVariables(
@@ -354,7 +353,7 @@ it.effect(
           { name: "x", declared_by: ["cell1"], used_by: [] },
         ]),
       );
-      yield* TestClock.adjust("10 millis");
+      yield* Effect.yieldNow;
 
       yield* service.updateVariables(
         sessionFor(notebookUri),
@@ -362,7 +361,7 @@ it.effect(
           { name: "y", declared_by: ["cell2"], used_by: [] },
         ]),
       );
-      yield* TestClock.adjust("10 millis");
+      yield* Effect.yieldNow;
 
       yield* service.updateVariables(
         sessionFor(notebookUri),
@@ -371,7 +370,7 @@ it.effect(
           { name: "z", declared_by: ["cell3"], used_by: [] },
         ]),
       );
-      yield* TestClock.adjust("10 millis");
+      yield* Effect.yieldNow;
 
       return yield* Ref.get(collected);
     }).pipe(Effect.provide(layer));
@@ -402,20 +401,20 @@ it.effect(
       );
 
       // Let stream start
-      yield* TestClock.adjust("10 millis");
+      yield* Effect.yieldNow;
 
       // Make changes
       yield* service.updateVariableValues(
         sessionFor(notebookUri),
         createMockVariableValuesOp([{ name: "x", value: 1, datatype: "int" }]),
       );
-      yield* TestClock.adjust("10 millis");
+      yield* Effect.yieldNow;
 
       yield* service.updateVariableValues(
         sessionFor(notebookUri),
         createMockVariableValuesOp([{ name: "x", value: 2, datatype: "int" }]),
       );
-      yield* TestClock.adjust("10 millis");
+      yield* Effect.yieldNow;
 
       return yield* Ref.get(collected);
     }).pipe(Effect.provide(layer));

--- a/extension/src/statusbar/__tests__/PythonEnvironmentStatusBar.test.ts
+++ b/extension/src/statusbar/__tests__/PythonEnvironmentStatusBar.test.ts
@@ -1,6 +1,5 @@
 import { expect, it } from "@effect/vitest";
 import { Effect, Layer, Option, Ref } from "effect";
-import { TestClock } from "effect/testing";
 
 import { TestPythonExtension } from "../../__mocks__/TestPythonExtension.ts";
 import { TestVsCode } from "../../__mocks__/TestVsCode.ts";
@@ -61,7 +60,7 @@ it.effect(
       yield* ctx.vscode.addNotebookDocument(marimoEditor.notebook);
       yield* ctx.vscode.setActiveNotebookEditor(Option.some(marimoEditor));
 
-      yield* TestClock.adjust("10 millis");
+      yield* Effect.yieldNow;
 
       const isVisible = yield* Ref.get(ctx.statusBarVisible);
       expect(isVisible).toBe(true);
@@ -81,7 +80,7 @@ it.effect(
       yield* ctx.vscode.addNotebookDocument(marimoEditor.notebook);
       yield* ctx.vscode.setActiveNotebookEditor(Option.some(marimoEditor));
 
-      yield* TestClock.adjust("10 millis");
+      yield* Effect.yieldNow;
       expect(yield* Ref.get(ctx.statusBarVisible)).toBe(true);
 
       // Switch to Jupyter notebook
@@ -94,7 +93,7 @@ it.effect(
       yield* ctx.vscode.addNotebookDocument(jupyterEditor.notebook);
       yield* ctx.vscode.setActiveNotebookEditor(Option.some(jupyterEditor));
 
-      yield* TestClock.adjust("10 millis");
+      yield* Effect.yieldNow;
       expect(yield* Ref.get(ctx.statusBarVisible)).toBe(false);
     }).pipe(Effect.provide(ctx.layer));
   }),
@@ -112,13 +111,13 @@ it.effect(
       yield* ctx.vscode.addNotebookDocument(marimoEditor.notebook);
       yield* ctx.vscode.setActiveNotebookEditor(Option.some(marimoEditor));
 
-      yield* TestClock.adjust("10 millis");
+      yield* Effect.yieldNow;
       expect(yield* Ref.get(ctx.statusBarVisible)).toBe(true);
 
       // Switch to no active notebook (e.g., user opens a text file)
       yield* ctx.vscode.setActiveNotebookEditor(Option.none());
 
-      yield* TestClock.adjust("10 millis");
+      yield* Effect.yieldNow;
       expect(yield* Ref.get(ctx.statusBarVisible)).toBe(false);
     }).pipe(Effect.provide(ctx.layer));
   }),
@@ -129,7 +128,7 @@ it.effect(
   Effect.fn(function* () {
     const ctx = yield* withTestCtx;
     yield* Effect.gen(function* () {
-      yield* TestClock.adjust("10 millis");
+      yield* Effect.yieldNow;
 
       const isVisible = yield* Ref.get(ctx.statusBarVisible);
       expect(isVisible).toBe(false);


### PR DESCRIPTION
Affinity recomputation only promoted matching controllers, so a sandbox or adjacent-venv preference survived after its source disappeared. These changes treat each recomputation as authoritative so every registered controller receives one final affinity, with only the current matches preferred.

Tests now yield to asynchronous subscriptions directly or wait for observable state instead of advancing virtual time. Tests for real intervals and timeouts continue to use the test clock.

Closes MO-7136