### PR TITLE
Implement local marimo discovery for VS Code

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -635,7 +635,8 @@
     ]
   },
   "activationEvents": [
-    "onStartupFinished"
+    "onStartupFinished",
+    "onUri"
   ],
   "extensionDependencies": [
     "ms-python.python"

--- a/extension/src/__mocks__/TestVsCode.ts
+++ b/extension/src/__mocks__/TestVsCode.ts
@@ -1797,6 +1797,9 @@ export class TestVsCode extends Data.TaggedClass("TestVsCode")<{
             };
           });
         },
+        registerUriHandler() {
+          return Effect.acquireRelease(Effect.void, () => Effect.void);
+        },
         getVisibleNotebookEditors: SubscriptionRef.get(visibleNotebookEditors),
         getVisibleTextEditors: SubscriptionRef.get(visibleTextEditors),
         getActiveNotebookEditor: SubscriptionRef.get(activeNotebookEditor),
@@ -1960,6 +1963,22 @@ export class TestVsCode extends Data.TaggedClass("TestVsCode")<{
           writeFile() {
             return Effect.succeed(true);
           },
+          stat(uri: vscode.Uri) {
+            const entry = options.fileSystem?.get(uri.toString());
+            if (entry === undefined || entry instanceof Error) {
+              return Effect.fail(
+                new FileSystemError({
+                  cause: entry ?? new Error(`ENOENT: ${uri.toString()}`),
+                }),
+              );
+            }
+            return Effect.succeed({
+              type: 1,
+              ctime: 0,
+              mtime: 0,
+              size: entry.byteLength,
+            });
+          },
         },
         getNotebookDocuments: Effect.map(Ref.get(notebookDocuments), (docs) =>
           Array.from(docs),
@@ -1996,6 +2015,7 @@ export class TestVsCode extends Data.TaggedClass("TestVsCode")<{
           );
         },
         notebookDocumentOpened: Stream.fromPubSub(documentOpened),
+        notebookDocumentSaved: Stream.never,
         notebookDocumentChanges: Stream.fromPubSub(documentChanges),
         notebookDocumentClosed: Stream.fromPubSub(documentClosed),
         // Mirrors the real implementation's guarantee: the subscription is
@@ -2017,6 +2037,7 @@ export class TestVsCode extends Data.TaggedClass("TestVsCode")<{
         fileRenames: Stream.never,
         fileDeletes: Stream.never,
         textDocumentChanges: Stream.never,
+        workspaceFoldersChanges: Stream.never,
         createFileSystemWatcher() {
           return Stream.never;
         },
@@ -2059,6 +2080,8 @@ export class TestVsCode extends Data.TaggedClass("TestVsCode")<{
         appRoot: "/mocks",
         appHost: "desktop",
         machineId: "mock-machine-id",
+        remoteName: undefined,
+        uriScheme: "vscode",
         createTelemetryLogger(sender, loggerOptions) {
           const withCommon = (data: Record<string, unknown> = {}) => ({
             ...data,
@@ -2080,6 +2103,9 @@ export class TestVsCode extends Data.TaggedClass("TestVsCode")<{
             },
             dispose() {},
           }));
+        },
+        asExternalUri(target) {
+          return Effect.succeed(target);
         },
         openExternal() {
           return Effect.succeed(true);

--- a/extension/src/__tests__/__utils__/TestMarimoClient.ts
+++ b/extension/src/__tests__/__utils__/TestMarimoClient.ts
@@ -181,6 +181,7 @@ export function makeTestNotebookRuntime(options: Options = {}) {
           shutdownAll: client.shutdownAllSessions({}).pipe(Effect.asVoid),
           forDocument,
           forNotebook,
+          executeSessionScratchpad: () => Stream.empty,
         };
         return runtime;
       }),

--- a/extension/src/__tests__/extension.test.ts
+++ b/extension/src/__tests__/extension.test.ts
@@ -20,7 +20,9 @@ import { makeTestMarimoClient } from "./__utils__/TestMarimoClient.ts";
 const withTestCtx = Effect.fn(function* (
   additionalLayer: Layer.Layer<never> = Layer.empty,
 ) {
-  const vscode = yield* TestVsCode.make();
+  // Keep full activation hermetic: remote extension hosts do not publish a
+  // host-machine discovery record.
+  const vscode = yield* TestVsCode.make({ env: { remoteName: "test" } });
   const layer = Layer.empty.pipe(
     Layer.merge(additionalLayer),
     Layer.provideMerge(vscode.layer),

--- a/extension/src/discovery/Api.gen.ts
+++ b/extension/src/discovery/Api.gen.ts
@@ -1,0 +1,383 @@
+// AUTO-GENERATED FILE — DO NOT EDIT.
+// Generated from marimo-desktop/schemas/local-discovery/openapi.yaml.
+// Regenerate with `cargo xtask generate-local-discovery`.
+
+import * as Schema from "effect/Schema";
+import {
+  HttpApi,
+  HttpApiEndpoint,
+  HttpApiGroup,
+  HttpApiMiddleware,
+  HttpApiSchema,
+  HttpApiSecurity,
+  OpenApi,
+} from "effect/unstable/httpapi";
+// non-recursive definitions
+export type SessionMode = "edit" | "app";
+export const SessionMode = Schema.Literals(["edit", "app"]).annotate({
+  identifier: "SessionMode",
+});
+export type SessionStatus =
+  | "starting"
+  | "running"
+  | "terminating"
+  | "terminated"
+  | "failed"
+  | "expired";
+export const SessionStatus = Schema.Literals([
+  "starting",
+  "running",
+  "terminating",
+  "terminated",
+  "failed",
+  "expired",
+]).annotate({ identifier: "SessionStatus" });
+export type ConsoleEvent = { readonly data: string };
+export const ConsoleEvent = Schema.Struct({ data: Schema.String }).annotate({
+  description: "JSON payload of a stdout or stderr SSE event.",
+  identifier: "ConsoleEvent",
+});
+export type OutputData = { readonly data: string; readonly mimetype: string };
+export const OutputData = Schema.Struct({
+  data: Schema.String,
+  mimetype: Schema.String,
+}).annotate({ identifier: "OutputData" });
+export type ErrorResponse = { readonly message: string };
+export const ErrorResponse = Schema.Struct({
+  message: Schema.String.annotate({
+    description: "Human-readable explanation; must not contain credentials.",
+  }),
+}).annotate({ identifier: "ErrorResponse" });
+export type ExecuteRequest = { readonly code: string };
+export const ExecuteRequest = Schema.Struct({ code: Schema.String }).annotate({
+  identifier: "ExecuteRequest",
+});
+export type InstanceRecord = {
+  readonly id: string;
+  readonly kind: string;
+  readonly name: string;
+  readonly pid: number;
+  readonly started_at: string;
+  readonly token: string;
+  readonly url: string;
+};
+export const InstanceRecord = Schema.Struct({
+  id: Schema.String.annotate({ format: "uuid" }),
+  kind: Schema.String.annotate({
+    description:
+      "Open application identifier; never infer capabilities from it.",
+  }),
+  name: Schema.String,
+  pid: Schema.Number.annotate({ format: "int64" })
+    .check(Schema.isInt().annotate({ expected: "an integer" }))
+    .check(
+      Schema.isGreaterThanOrEqualTo(1).annotate({
+        expected: "a value greater than or equal to 1",
+      }),
+    ),
+  started_at: Schema.String.annotate({ format: "date-time" }),
+  token: Schema.String,
+  url: Schema.String.annotate({
+    description: "HTTP API base URL using literal 127.0.0.1 or [::1].",
+  }),
+}).annotate({
+  description:
+    "Filesystem record advertising one host lifetime. Its id must match the\nfilename. Consumers verify owner-only access to the discovery directories\nand record, reject symlinks and files over 64 KiB, and ignore invalid or\nunreachable records. A PID is only a liveness hint.\n",
+  identifier: "InstanceRecord",
+});
+export type OpenNotebookResponse = { readonly uri: string };
+export const OpenNotebookResponse = Schema.Struct({
+  uri: Schema.String.annotate({
+    description: "Absolute host-defined launch URI.",
+  }),
+}).annotate({ identifier: "OpenNotebookResponse" });
+export type SessionSummary = {
+  readonly marimo_version: string | null;
+  readonly mode: SessionMode;
+  readonly session_id: string;
+  readonly started_at: string;
+  readonly status: SessionStatus;
+};
+export const SessionSummary = Schema.Struct({
+  marimo_version: Schema.Union([Schema.String, Schema.Null]),
+  mode: SessionMode,
+  session_id: Schema.String.annotate({
+    description:
+      "Opaque ID, unique within the instance and stable while listed.",
+  }),
+  started_at: Schema.String.annotate({ format: "date-time" }),
+  status: SessionStatus,
+}).annotate({ identifier: "SessionSummary" });
+export type DoneEvent = {
+  readonly output: OutputData;
+  readonly success: boolean;
+};
+export const DoneEvent = Schema.Struct({
+  output: OutputData,
+  success: Schema.Boolean,
+}).annotate({
+  description: "JSON payload of the terminal done SSE event.",
+  identifier: "DoneEvent",
+});
+export type NotebookSummary = {
+  readonly id: string;
+  readonly openable: boolean;
+  readonly path: string | null;
+  readonly sessions: ReadonlyArray<SessionSummary>;
+  readonly title: string;
+  readonly updated_at: string | null;
+};
+export const NotebookSummary = Schema.Struct({
+  id: Schema.String,
+  openable: Schema.Boolean,
+  path: Schema.Union([Schema.String, Schema.Null]).annotate({
+    description:
+      "Native path relative to the project root; null if root is null.",
+  }),
+  sessions: Schema.Array(SessionSummary),
+  title: Schema.String,
+  updated_at: Schema.Union([Schema.String, Schema.Null]).annotate({
+    description:
+      "Best-effort activity time for display, never synchronization.",
+    format: "date-time",
+  }),
+}).annotate({ identifier: "NotebookSummary" });
+export type ProjectSummary = {
+  readonly id: string;
+  readonly name: string;
+  readonly notebooks: ReadonlyArray<NotebookSummary>;
+  readonly root: string | null;
+  readonly truncated: boolean;
+};
+export const ProjectSummary = Schema.Struct({
+  id: Schema.String,
+  name: Schema.String,
+  notebooks: Schema.Array(NotebookSummary),
+  root: Schema.Union([Schema.String, Schema.Null]).annotate({
+    description:
+      "Absolute native workspace path, or null without a filesystem root.",
+  }),
+  truncated: Schema.Boolean,
+}).annotate({ identifier: "ProjectSummary" });
+export type Catalog = {
+  readonly instance_id: string;
+  readonly operations: ReadonlyArray<string>;
+  readonly projects: ReadonlyArray<ProjectSummary>;
+};
+export const Catalog = Schema.Struct({
+  instance_id: Schema.String.annotate({ format: "uuid" }),
+  operations: Schema.Array(Schema.String).annotate({
+    description:
+      "Optional operation identifiers; unknown identifiers must be accepted.",
+  }),
+  projects: Schema.Array(ProjectSummary),
+}).annotate({ identifier: "Catalog" });
+// schemas
+export type LocalDiscoveryProtocol = {
+  readonly Catalog: Catalog;
+  readonly ConsoleEvent: ConsoleEvent;
+  readonly DoneEvent: DoneEvent;
+  readonly ErrorResponse: ErrorResponse;
+  readonly ExecuteRequest: ExecuteRequest;
+  readonly InstanceRecord: InstanceRecord;
+  readonly NotebookSummary: NotebookSummary;
+  readonly OpenNotebookResponse: OpenNotebookResponse;
+  readonly OutputData: OutputData;
+  readonly ProjectSummary: ProjectSummary;
+  readonly SessionMode: SessionMode;
+  readonly SessionStatus: SessionStatus;
+  readonly SessionSummary: SessionSummary;
+};
+export const LocalDiscoveryProtocol = Schema.Struct({
+  Catalog: Catalog,
+  ConsoleEvent: ConsoleEvent,
+  DoneEvent: DoneEvent,
+  ErrorResponse: ErrorResponse,
+  ExecuteRequest: ExecuteRequest,
+  InstanceRecord: InstanceRecord,
+  NotebookSummary: NotebookSummary,
+  OpenNotebookResponse: OpenNotebookResponse,
+  OutputData: OutputData,
+  ProjectSummary: ProjectSummary,
+  SessionMode: SessionMode,
+  SessionStatus: SessionStatus,
+  SessionSummary: SessionSummary,
+});
+// schemas
+export type Catalog200 = Catalog;
+export const Catalog200 = Catalog;
+export type Catalog401 = ErrorResponse;
+export const Catalog401 = ErrorResponse;
+export type Catalog403 = ErrorResponse;
+export const Catalog403 = ErrorResponse;
+export type Catalog500 = ErrorResponse;
+export const Catalog500 = ErrorResponse;
+export type WatchCatalog200Sse = {
+  readonly data: string;
+  readonly event: "catalog.changed";
+};
+export const WatchCatalog200Sse = Schema.Struct({
+  data: Schema.String.annotate({ description: "JSON-encoded empty object." }),
+  event: Schema.Literal("catalog.changed"),
+});
+export type WatchCatalog200SseError = ErrorResponse;
+export const WatchCatalog200SseError = ErrorResponse;
+export type WatchCatalog401 = ErrorResponse;
+export const WatchCatalog401 = ErrorResponse;
+export type WatchCatalog403 = ErrorResponse;
+export const WatchCatalog403 = ErrorResponse;
+export type WatchCatalog500 = ErrorResponse;
+export const WatchCatalog500 = ErrorResponse;
+export type OpenNotebookPathParams = { readonly notebook_id: string };
+export const OpenNotebookPathParams = Schema.Struct({
+  notebook_id: Schema.String,
+});
+export type OpenNotebook200 = OpenNotebookResponse;
+export const OpenNotebook200 = OpenNotebookResponse;
+export type OpenNotebook401 = ErrorResponse;
+export const OpenNotebook401 = ErrorResponse;
+export type OpenNotebook403 = ErrorResponse;
+export const OpenNotebook403 = ErrorResponse;
+export type OpenNotebook404 = ErrorResponse;
+export const OpenNotebook404 = ErrorResponse;
+export type OpenNotebook409 = ErrorResponse;
+export const OpenNotebook409 = ErrorResponse;
+export type OpenNotebook500 = ErrorResponse;
+export const OpenNotebook500 = ErrorResponse;
+export type ExecutePathParams = { readonly session_id: string };
+export const ExecutePathParams = Schema.Struct({ session_id: Schema.String });
+export type ExecuteRequestJson = ExecuteRequest;
+export const ExecuteRequestJson = ExecuteRequest;
+export type Execute200Sse =
+  | { readonly data: string; readonly event: "stdout" | "stderr" }
+  | { readonly data: string; readonly event: "done" };
+export const Execute200Sse = Schema.Union(
+  [
+    Schema.Struct({
+      data: Schema.String.annotate({
+        description: "JSON-encoded ConsoleEvent.",
+      }),
+      event: Schema.Literals(["stdout", "stderr"]),
+    }),
+    Schema.Struct({
+      data: Schema.String.annotate({ description: "JSON-encoded DoneEvent." }),
+      event: Schema.Literal("done"),
+    }),
+  ],
+  { mode: "oneOf" },
+);
+export type Execute200SseError = ErrorResponse;
+export const Execute200SseError = ErrorResponse;
+export type Execute400 = ErrorResponse;
+export const Execute400 = ErrorResponse;
+export type Execute401 = ErrorResponse;
+export const Execute401 = ErrorResponse;
+export type Execute403 = ErrorResponse;
+export const Execute403 = ErrorResponse;
+export type Execute404 = ErrorResponse;
+export const Execute404 = ErrorResponse;
+export type Execute409 = ErrorResponse;
+export const Execute409 = ErrorResponse;
+export type Execute500 = ErrorResponse;
+export const Execute500 = ErrorResponse;
+
+export const LocalTokenSecurity = HttpApiSecurity.bearer.pipe(
+  HttpApiSecurity.annotate(
+    OpenApi.Description,
+    "The token in the validated instance record. Accept credentials only in\nAuthorization, never cookies or query parameters. Hosts reject\nnon-loopback peers and emit no CORS allow headers. Consumers must not\nfollow redirects or send this token to notebook code or launch URIs.",
+  ),
+);
+
+export class LocalTokenSecurityMiddleware extends HttpApiMiddleware.Service<LocalTokenSecurityMiddleware>()(
+  "localToken security",
+  { security: { localToken: LocalTokenSecurity } },
+) {}
+
+class DefaultGroup extends HttpApiGroup.make("default", { topLevel: true }).add(
+  HttpApiEndpoint.get("catalog", "/catalog", {
+    success: Catalog200,
+    error: [
+      Catalog401.pipe(HttpApiSchema.status(401)),
+      Catalog403.pipe(HttpApiSchema.status(403)),
+      Catalog500,
+    ],
+  })
+    .middleware(LocalTokenSecurityMiddleware)
+    .annotate(OpenApi.Identifier, "catalog")
+    .annotate(
+      OpenApi.Description,
+      "Return a complete, unpaginated snapshot of indexed resources. The\ninstance_id must match the record. A project is truncated whenever\nindexing did not enumerate it exhaustively.",
+    ),
+  HttpApiEndpoint.get("watchCatalog", "/catalog/watch", {
+    success: HttpApiSchema.StreamSse({
+      events: WatchCatalog200Sse,
+      error: WatchCatalog200SseError,
+    }),
+    error: [
+      WatchCatalog401.pipe(HttpApiSchema.status(401)),
+      WatchCatalog403.pipe(HttpApiSchema.status(403)),
+      WatchCatalog500,
+    ],
+  })
+    .middleware(LocalTokenSecurityMiddleware)
+    .annotate(OpenApi.Identifier, "watch_catalog")
+    .annotate(
+      OpenApi.Description,
+      "Requires catalog.watch. Sends event catalog.changed with JSON data {}\non connection and whenever the catalog changes. Refetch the catalog\nafter each invalidation. There are no deltas or replay cursors.\nIgnore unknown event names.",
+    ),
+  HttpApiEndpoint.post("openNotebook", "/notebooks/:notebook_id/open", {
+    params: OpenNotebookPathParams,
+    success: OpenNotebook200,
+    error: [
+      OpenNotebook401.pipe(HttpApiSchema.status(401)),
+      OpenNotebook403.pipe(HttpApiSchema.status(403)),
+      OpenNotebook404.pipe(HttpApiSchema.status(404)),
+      OpenNotebook409.pipe(HttpApiSchema.status(409)),
+      OpenNotebook500,
+    ],
+  })
+    .middleware(LocalTokenSecurityMiddleware)
+    .annotate(OpenApi.Identifier, "open_notebook")
+    .annotate(
+      OpenApi.Description,
+      "Requires notebook.open. Return the host-defined launch URI, including\napplication deep links. Consumers open it unchanged and must not attach\nthe discovery token. A notebook that is not openable returns 409.",
+    ),
+  HttpApiEndpoint.post("execute", "/sessions/:session_id/execute", {
+    params: ExecutePathParams,
+    payload: ExecuteRequestJson,
+    success: HttpApiSchema.StreamSse({
+      events: Execute200Sse,
+      error: Execute200SseError,
+    }),
+    error: [
+      Execute400.pipe(HttpApiSchema.status(400)),
+      Execute401.pipe(HttpApiSchema.status(401)),
+      Execute403.pipe(HttpApiSchema.status(403)),
+      Execute404.pipe(HttpApiSchema.status(404)),
+      Execute409.pipe(HttpApiSchema.status(409)),
+      Execute500,
+    ],
+  })
+    .middleware(LocalTokenSecurityMiddleware)
+    .annotate(OpenApi.Identifier, "execute")
+    .annotate(
+      OpenApi.Description,
+      "Requires session.execute. Only a running session accepts execution;\notherwise return 409. Send zero or more ordered stdout/stderr events\nwith ConsoleEvent payloads, followed by exactly one done event with a\nDoneEvent payload. A failed execution ends with success false.\nIgnore unknown event names. A stream ending before done has an\nindeterminate outcome and must not be retried automatically.",
+    ),
+) {}
+
+export class LocalDiscoveryApi extends HttpApi.make("LocalDiscoveryApi")
+  .annotate(OpenApi.Title, "Local marimo discovery")
+  .annotate(OpenApi.Version, "1.0.0")
+  .annotate(
+    OpenApi.Description,
+    "A local host advertises an InstanceRecord in discovery/v1 and serves this\nAPI at the record's URL. JSON does not repeat the protocol version.\nConsumers ignore unknown fields, operation identifiers, and SSE event names.\nBreaking changes require a new major version. Hosts may implement additional\noptional operations; the catalog advertises the ones currently supported.",
+  )
+  .annotate(OpenApi.Servers, [
+    {
+      description:
+        "Example only; use the URL in the validated instance record.",
+      url: "http://127.0.0.1:2718/api/marimo/v1",
+    },
+  ])
+  .add(DefaultGroup) {}

--- a/extension/src/discovery/Api.gen.ts
+++ b/extension/src/discovery/Api.gen.ts
@@ -65,9 +65,13 @@ export const InstanceRecord = Schema.Struct({
   id: Schema.String.annotate({ format: "uuid" }),
   kind: Schema.String.annotate({
     description:
-      "Open application identifier; never infer capabilities from it.",
+      "Open application identifier, such as marimo or vscode. Editors may use\ntheir URI scheme. Never infer capabilities or launch URLs from it.\n",
   }),
-  name: Schema.String,
+  name: Schema.String.annotate({
+    description:
+      "Publisher-chosen plain-text label, defaulting to a concise application\nname and optionally customized. Consumers display it verbatim; it is\nnot unique and must not be used as identity.\n",
+    examples: ["marimo"],
+  }),
   pid: Schema.Number.annotate({ format: "int64" })
     .check(Schema.isInt().annotate({ expected: "an integer" }))
     .check(
@@ -82,7 +86,7 @@ export const InstanceRecord = Schema.Struct({
   }),
 }).annotate({
   description:
-    "Filesystem record advertising one host lifetime. Its id must match the\nfilename. Consumers verify owner-only access to the discovery directories\nand record, reject symlinks and files over 64 KiB, and ignore invalid or\nunreachable records. A PID is only a liveness hint.\n",
+    "A running instance writes this record to discovery/v1. Its id must match the\nfilename. Consumers verify owner-only access to the discovery directories\nand record, reject symlinks and files over 64 KiB, and ignore invalid or\nunreachable records. On Windows, verify permissions allowing ownership\nand access only to the current user, SYSTEM, or the built-in\nAdministrators group.\n",
   identifier: "InstanceRecord",
 });
 export type OpenNotebookResponse = { readonly uri: string };
@@ -323,7 +327,7 @@ class DefaultGroup extends HttpApiGroup.make("default", { topLevel: true }).add(
     .annotate(OpenApi.Identifier, "watch_catalog")
     .annotate(
       OpenApi.Description,
-      "Requires catalog.watch. Sends event catalog.changed with JSON data {}\non connection and whenever the catalog changes. Refetch the catalog\nafter each invalidation. There are no deltas or replay cursors.\nIgnore unknown event names.",
+      "Instances offering catalog.watch send catalog.changed with JSON data {}\nwhen the stream opens and whenever the catalog changes. Publishers may combine\npending invalidations, and consumers may handle several with one catalog\nread. If another invalidation arrives during that read, read again.\nThere are no deltas or event replay. Consumers ignore unknown event names.",
     ),
   HttpApiEndpoint.post("openNotebook", "/notebooks/:notebook_id/open", {
     params: OpenNotebookPathParams,
@@ -362,7 +366,7 @@ class DefaultGroup extends HttpApiGroup.make("default", { topLevel: true }).add(
     .annotate(OpenApi.Identifier, "execute")
     .annotate(
       OpenApi.Description,
-      "Requires session.execute. Only a running session accepts execution;\notherwise return 409. Send zero or more ordered stdout/stderr events\nwith ConsoleEvent payloads, followed by exactly one done event with a\nDoneEvent payload. A failed execution ends with success false.\nIgnore unknown event names. A stream ending before done has an\nindeterminate outcome and must not be retried automatically.",
+      "Instances offering session.execute accept code for running sessions\nand return 409 otherwise. Send zero or more ordered stdout/stderr events\nwith ConsoleEvent payloads, followed by exactly one done event with a\nDoneEvent payload. Send done when the requested code and any cells it\ntriggers finish, with success false if either fails.\nPublishers should try to interrupt execution when the consumer disconnects.\nIf the stream ends before done, the consumer cannot know whether execution\ncompleted and must not retry automatically. Consumers ignore unknown event names.",
     ),
 ) {}
 

--- a/extension/src/discovery/LocalDiscoveryCatalog.ts
+++ b/extension/src/discovery/LocalDiscoveryCatalog.ts
@@ -1,0 +1,311 @@
+import * as NodePath from "node:path";
+
+import {
+  Effect,
+  Option,
+  Result,
+  Schema,
+  Stream,
+  SubscriptionRef,
+} from "effect";
+import type * as vscode from "vscode";
+
+import { LiveSessions } from "../panel/sessions/LiveSessions.ts";
+import type { SessionViewItem } from "../panel/sessions/LiveSessions.ts";
+import { VsCode } from "../platform/VsCode.ts";
+import {
+  MarimoNotebookDocument,
+  type NotebookId,
+} from "../schemas/MarimoNotebookDocument.ts";
+import type { KernelSessionId } from "../schemas/Models.gen.ts";
+import {
+  Catalog,
+  NotebookSummary,
+  ProjectSummary,
+  SessionSummary,
+} from "./Api.gen.ts";
+import { DISCOVERY_OPERATIONS, uuidV5 } from "./LocalDiscoveryProtocol.ts";
+
+interface NotebookTarget {
+  readonly uri: vscode.Uri;
+  readonly openable: boolean;
+}
+
+interface SessionTarget {
+  readonly sessionId: KernelSessionId;
+  readonly runnable: boolean;
+}
+
+interface NotebookEntry {
+  readonly notebookUri: NotebookId;
+  readonly uri: vscode.Uri;
+  readonly filename: string | null;
+  readonly sessions: ReadonlyArray<SessionViewItem>;
+}
+
+interface ProjectEntry {
+  readonly id: string;
+  readonly name: string;
+  readonly root: string | null;
+  readonly truncated: boolean;
+  readonly folder?: vscode.WorkspaceFolder;
+  readonly notebooks: NotebookEntry[];
+}
+
+function containsPath(parent: string, child: string): boolean {
+  const relative = NodePath.relative(parent, child);
+  return (
+    relative === "" ||
+    (!relative.startsWith("..") && !NodePath.isAbsolute(relative))
+  );
+}
+
+function titleFor(entry: NotebookEntry): string {
+  if (entry.filename !== null) return NodePath.basename(entry.filename);
+  if (entry.uri.scheme === "file") return NodePath.basename(entry.uri.fsPath);
+  return NodePath.basename(entry.uri.path) || "Untitled";
+}
+
+const encodeCatalog = Schema.encodeSync(Catalog);
+
+/**
+ * Projects VS Code notebook and retained-kernel state into discovery v1.
+ *
+ * Catalog data and action targets share one snapshot, so notifications and
+ * route resolution cannot observe different source projections.
+ */
+export const makeLocalDiscoveryCatalog = Effect.fn(
+  "LocalDiscoveryCatalog.make",
+)(function* () {
+  const code = yield* VsCode;
+  const liveSessions = yield* LiveSessions;
+  const instanceId = crypto.randomUUID();
+  const activity = new Map<NotebookId, Date>();
+
+  const projectCatalog = Effect.fnUntraced(function* () {
+    const [rawDocuments, sessions, maybeFolders] = yield* Effect.all([
+      code.workspace.getNotebookDocuments,
+      liveSessions.get,
+      code.workspace.getWorkspaceFolders,
+    ]);
+    const folders = Option.getOrElse(maybeFolders, () => []);
+    const entries = new Map<NotebookId, NotebookEntry>();
+
+    for (const document of rawDocuments) {
+      const notebook = MarimoNotebookDocument.tryFrom(document);
+      if (Option.isNone(notebook)) continue;
+      entries.set(notebook.value.id, {
+        notebookUri: notebook.value.id,
+        uri: notebook.value.uri,
+        filename: null,
+        sessions: [],
+      });
+    }
+    for (const session of sessions) {
+      const parsed = code.utils.parseUri(session.notebookUri);
+      if (Result.isFailure(parsed)) continue;
+      const existing = entries.get(session.notebookUri);
+      entries.set(session.notebookUri, {
+        notebookUri: session.notebookUri,
+        uri: existing?.uri ?? parsed.success,
+        filename: existing?.filename ?? session.filename,
+        sessions: [...(existing?.sessions ?? []), session],
+      });
+    }
+
+    const projects: ProjectEntry[] = folders.map((folder) => ({
+      id: uuidV5(instanceId, `project:${folder.uri.toString()}`),
+      name: folder.name,
+      root: folder.uri.scheme === "file" ? folder.uri.fsPath : null,
+      truncated: true,
+      folder,
+      notebooks: [],
+    }));
+    let loose: ProjectEntry | undefined;
+    for (const entry of entries.values()) {
+      const containing =
+        entry.uri.scheme === "file"
+          ? projects
+              .filter(
+                (project) =>
+                  project.folder?.uri.scheme === "file" &&
+                  containsPath(project.folder.uri.fsPath, entry.uri.fsPath),
+              )
+              .toSorted(
+                (left, right) =>
+                  (right.root?.length ?? 0) - (left.root?.length ?? 0),
+              )[0]
+          : undefined;
+      if (containing !== undefined) {
+        containing.notebooks.push(entry);
+        continue;
+      }
+      loose ??= {
+        id: uuidV5(instanceId, "project:loose-files"),
+        name: "Loose Files",
+        root: null,
+        truncated: false,
+        notebooks: [],
+      };
+      loose.notebooks.push(entry);
+    }
+    if (loose !== undefined) projects.push(loose);
+
+    const notebookTargets = new Map<string, NotebookTarget>();
+    const sessionTargets = new Map<string, SessionTarget>();
+    const summaries = yield* Effect.forEach(
+      projects,
+      Effect.fn(function* (project) {
+        const notebooks = yield* Effect.forEach(
+          project.notebooks,
+          Effect.fn(function* (entry) {
+            const stat =
+              entry.uri.scheme === "file"
+                ? yield* code.workspace.fs.stat(entry.uri).pipe(Effect.option)
+                : Option.none<vscode.FileStat>();
+            const openable =
+              entry.uri.scheme === "file" &&
+              Option.exists(stat, (value) => (value.type & 1) === 1);
+            let updatedAt = activity.get(entry.notebookUri);
+            if (updatedAt === undefined && Option.isSome(stat)) {
+              updatedAt = new Date(stat.value.mtime);
+              activity.set(entry.notebookUri, updatedAt);
+            }
+            const id = uuidV5(instanceId, `notebook:${entry.notebookUri}`);
+            notebookTargets.set(id, {
+              uri: entry.uri,
+              openable,
+            });
+            const visibleSessions = entry.sessions
+              .filter((session) => session.status !== "restarting")
+              .map((session) =>
+                SessionSummary.make({
+                  session_id: session.sessionId,
+                  status: "running",
+                  mode: "edit",
+                  started_at: new Date(session.startedAt * 1000).toISOString(),
+                  marimo_version: session.marimoVersion,
+                }),
+              )
+              .toSorted((left, right) =>
+                left.session_id.localeCompare(right.session_id),
+              );
+            for (const session of entry.sessions) {
+              sessionTargets.set(session.sessionId, {
+                sessionId: session.sessionId,
+                runnable: session.status !== "restarting",
+              });
+            }
+            return NotebookSummary.make({
+              id,
+              title: titleFor(entry),
+              openable,
+              path:
+                project.root !== null && entry.uri.scheme === "file"
+                  ? NodePath.relative(project.root, entry.uri.fsPath)
+                  : null,
+              updated_at: updatedAt?.toISOString() ?? null,
+              sessions: visibleSessions,
+            });
+          }),
+          { concurrency: "unbounded" },
+        );
+        return ProjectSummary.make({
+          id: project.id,
+          name: project.name,
+          root: project.root,
+          truncated: project.truncated,
+          notebooks: notebooks.toSorted((left, right) =>
+            (left.path ?? left.id).localeCompare(right.path ?? right.id),
+          ),
+        });
+      }),
+    );
+    const catalog = Catalog.make({
+      instance_id: instanceId,
+      operations: DISCOVERY_OPERATIONS,
+      projects: summaries,
+    });
+    return {
+      catalog,
+      notebooks: notebookTargets,
+      sessions: sessionTargets,
+      fingerprint: JSON.stringify(encodeCatalog(catalog)),
+    };
+  });
+
+  const initialSessions = yield* liveSessions.get;
+  const state = yield* SubscriptionRef.make(yield* projectCatalog());
+  const refresh = Effect.fn("LocalDiscoveryCatalog.refresh")(function* () {
+    yield* SubscriptionRef.updateEffect(state, () => projectCatalog());
+  });
+
+  let previousSessions: ReadonlyArray<SessionViewItem> = initialSessions;
+  const lifecycle = yield* code.workspace.subscribeNotebookLifecycle;
+  yield* Effect.forkScoped(lifecycle.pipe(Stream.runForEach(() => refresh())));
+  yield* Effect.forkScoped(
+    code.workspace.notebookDocumentSaved.pipe(
+      Stream.runForEach((document) => {
+        const notebook = MarimoNotebookDocument.tryFrom(document);
+        if (Option.isNone(notebook)) return Effect.void;
+        activity.set(notebook.value.id, new Date());
+        return refresh();
+      }),
+    ),
+  );
+  yield* Effect.forkScoped(
+    liveSessions.changes.pipe(
+      Stream.runForEach((sessions) => {
+        const prior = new Map(
+          previousSessions.map((session) => [session.sessionId, session]),
+        );
+        for (const session of sessions) {
+          if (
+            prior.get(session.sessionId)?.status === "running" &&
+            session.status === "idle"
+          ) {
+            activity.set(session.notebookUri, new Date());
+          }
+        }
+        previousSessions = sessions;
+        return refresh();
+      }),
+    ),
+  );
+  yield* Effect.forkScoped(
+    code.workspace.workspaceFoldersChanges.pipe(
+      Stream.runForEach(() => refresh()),
+    ),
+  );
+  yield* Effect.forkScoped(
+    Stream.merge(code.workspace.fileRenames, code.workspace.fileDeletes).pipe(
+      Stream.runForEach(() => refresh()),
+    ),
+  );
+
+  // Reconcile after listeners start so cached reads cannot miss a source
+  // transition during initialization.
+  yield* refresh();
+
+  return {
+    instanceId,
+    snapshot: SubscriptionRef.get(state).pipe(
+      Effect.map((value) => value.catalog),
+    ),
+    changes: SubscriptionRef.changes(state).pipe(
+      Stream.map((value) => value.fingerprint),
+      Stream.changes,
+      Stream.map(() => undefined),
+    ),
+    resolveNotebook(id: string) {
+      return SubscriptionRef.get(state).pipe(
+        Effect.map((value) => Option.fromNullishOr(value.notebooks.get(id))),
+      );
+    },
+    resolveSession(id: string) {
+      return SubscriptionRef.get(state).pipe(
+        Effect.map((value) => Option.fromNullishOr(value.sessions.get(id))),
+      );
+    },
+  } as const;
+});

--- a/extension/src/discovery/LocalDiscoveryProtocol.ts
+++ b/extension/src/discovery/LocalDiscoveryProtocol.ts
@@ -1,0 +1,25 @@
+import * as NodeCrypto from "node:crypto";
+
+export const DISCOVERY_API_PATH = "/api/marimo/v1";
+export const DISCOVERY_OPERATIONS = [
+  "catalog.watch",
+  "notebook.open",
+  "session.execute",
+] as const;
+
+/** RFC 9562 UUIDv5, used for opaque IDs stable within one publisher lifetime. */
+export function uuidV5(namespace: string, value: string): string {
+  const namespaceBytes = Buffer.from(namespace.replaceAll("-", ""), "hex");
+  if (namespaceBytes.byteLength !== 16) {
+    throw new Error("UUIDv5 namespace must be a UUID");
+  }
+  const bytes = NodeCrypto.createHash("sha1")
+    .update(namespaceBytes)
+    .update(value, "utf8")
+    .digest()
+    .subarray(0, 16);
+  bytes[6] = (bytes[6] & 0x0f) | 0x50;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const hex = bytes.toString("hex");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}

--- a/extension/src/discovery/LocalDiscoveryPublisher.ts
+++ b/extension/src/discovery/LocalDiscoveryPublisher.ts
@@ -230,14 +230,20 @@ function makeDoneEvent(
   }
 
   let data: unknown = scratchOutput.data;
+  let mimetype = scratchOutput.mimetype;
   if (typeof data === "object" && data !== null && !Array.isArray(data)) {
-    if ("text/plain" in data) data = data["text/plain"];
-    else if ("text/html" in data) data = data["text/html"];
+    if ("text/plain" in data) {
+      data = data["text/plain"];
+      mimetype = "text/plain";
+    } else if ("text/html" in data) {
+      data = data["text/html"];
+      mimetype = "text/html";
+    }
   }
   return DoneEvent.make({
     success: true,
     output: {
-      mimetype: scratchOutput.mimetype,
+      mimetype,
       data: typeof data === "string" ? data : outputDataAsString(data),
     },
   });

--- a/extension/src/discovery/LocalDiscoveryPublisher.ts
+++ b/extension/src/discovery/LocalDiscoveryPublisher.ts
@@ -58,6 +58,15 @@ const encodeDoneEvent = Schema.encodeSync(Schema.fromJsonString(DoneEvent));
 const EXTENSION_AUTHORITY = "marimo-team.vscode-marimo";
 const MAX_REQUEST_BYTES = 8 * 1024 * 1024;
 const EMPTY_OUTPUT = { mimetype: "text/plain", data: "" } as const;
+const EDITOR_DISPLAY_NAMES = new Map([
+  ["vscode", "VS Code"],
+  ["vscode-insiders", "VS Code Insiders"],
+  ["code-oss", "Code - OSS"],
+  ["cursor", "Cursor"],
+  ["vscodium", "VSCodium"],
+  ["vscodium-insiders", "VSCodium Insiders"],
+  ["positron", "Positron"],
+]);
 type CellOutput = NonNullable<CellOperationNotification["output"]>;
 
 class PublisherStartupError extends Data.TaggedError("PublisherStartupError")<{
@@ -473,7 +482,7 @@ export const makeLocalDiscoveryPublisher = Effect.fn(
   const record = InstanceRecord.make({
     id: catalog.instanceId,
     kind: code.env.uriScheme,
-    name: code.env.appName,
+    name: EDITOR_DISPLAY_NAMES.get(code.env.uriScheme) ?? code.env.appName,
     pid: process.pid,
     started_at: startedAt.toISOString(),
     url: `http://127.0.0.1:${port}${DISCOVERY_API_PATH}`,

--- a/extension/src/discovery/LocalDiscoveryPublisher.ts
+++ b/extension/src/discovery/LocalDiscoveryPublisher.ts
@@ -472,7 +472,7 @@ export const makeLocalDiscoveryPublisher = Effect.fn(
   const port = address.port;
   const record = InstanceRecord.make({
     id: catalog.instanceId,
-    kind: "vscode",
+    kind: code.env.uriScheme,
     name: code.env.appName,
     pid: process.pid,
     started_at: startedAt.toISOString(),

--- a/extension/src/discovery/LocalDiscoveryPublisher.ts
+++ b/extension/src/discovery/LocalDiscoveryPublisher.ts
@@ -1,0 +1,526 @@
+import * as NodeCrypto from "node:crypto";
+import * as NodeHttp from "node:http";
+
+import { NodeHttpServer, NodeHttpServerRequest } from "@effect/platform-node";
+import {
+  Cause,
+  Context,
+  Data,
+  Effect,
+  Exit,
+  FileSystem,
+  Layer,
+  Option,
+  Result,
+  Schema,
+  Scope,
+  Stream,
+} from "effect";
+import {
+  Headers,
+  HttpBody,
+  HttpIncomingMessage,
+  HttpRouter,
+  HttpServer,
+  HttpServerError,
+  HttpServerRequest,
+  HttpServerResponse,
+} from "effect/unstable/http";
+import { HttpApiBuilder, HttpApiError } from "effect/unstable/httpapi";
+import type * as vscode from "vscode";
+
+import openAsMarimoNotebook from "../commands/openAsMarimoNotebook.ts";
+import { SCRATCH_CELL_ID } from "../constants.ts";
+import { makeCellRunState, transitionCell } from "../kernel/CellRunReducer.ts";
+import { NotebookRuntime } from "../kernel/NotebookRuntime.ts";
+import { VsCode } from "../platform/VsCode.ts";
+import type { CellOperationNotification } from "../types.ts";
+import {
+  ConsoleEvent,
+  type Execute200Sse,
+  LocalDiscoveryApi,
+  LocalTokenSecurityMiddleware,
+  DoneEvent,
+  ErrorResponse,
+  InstanceRecord,
+  OpenNotebookResponse,
+} from "./Api.gen.ts";
+import { makeLocalDiscoveryCatalog } from "./LocalDiscoveryCatalog.ts";
+import { DISCOVERY_API_PATH } from "./LocalDiscoveryProtocol.ts";
+import { registerDiscoveryRecord } from "./LocalDiscoveryRegistry.ts";
+
+const DiscoveryApi = LocalDiscoveryApi.prefix(DISCOVERY_API_PATH);
+const encodeConsoleEvent = Schema.encodeSync(
+  Schema.fromJsonString(ConsoleEvent),
+);
+const encodeDoneEvent = Schema.encodeSync(Schema.fromJsonString(DoneEvent));
+
+const EXTENSION_AUTHORITY = "marimo-team.vscode-marimo";
+const MAX_REQUEST_BYTES = 8 * 1024 * 1024;
+const EMPTY_OUTPUT = { mimetype: "text/plain", data: "" } as const;
+type CellOutput = NonNullable<CellOperationNotification["output"]>;
+
+class PublisherStartupError extends Data.TaggedError("PublisherStartupError")<{
+  readonly cause: unknown;
+}> {}
+
+function isAuthorized(
+  authorization: string | undefined,
+  expectedToken: string,
+): boolean {
+  if (authorization === undefined) return false;
+  const separator = authorization.indexOf(" ");
+  if (separator < 0) return false;
+  const scheme = authorization.slice(0, separator);
+  const token = authorization.slice(separator + 1);
+  if (scheme.toLowerCase() !== "bearer") return false;
+  const actual = Buffer.from(token, "utf8");
+  const expected = Buffer.from(expectedToken, "utf8");
+  return (
+    actual.byteLength === expected.byteLength &&
+    NodeCrypto.timingSafeEqual(actual, expected)
+  );
+}
+
+function errorResponse(status: number, message: string) {
+  return HttpServerResponse.jsonUnsafe(ErrorResponse.make({ message }), {
+    status,
+    headers: status === 401 ? { "www-authenticate": "Bearer" } : undefined,
+  });
+}
+
+/** Enforce discovery's HTTP contract around the schema-based handlers. */
+function discoveryMiddleware(token: string) {
+  return HttpRouter.middleware(
+    (httpEffect) =>
+      Effect.gen(function* () {
+        const request = yield* HttpServerRequest.HttpServerRequest;
+        const address = Option.getOrUndefined(request.remoteAddress);
+        const response = yield* Effect.gen(function* () {
+          if (address !== "127.0.0.1" && address !== "::ffff:127.0.0.1") {
+            return errorResponse(403, "Loopback connection required");
+          }
+          // Protect unmatched routes as well as the generated API endpoints.
+          if (!isAuthorized(request.headers.authorization, token)) {
+            return errorResponse(401, "Invalid discovery token");
+          }
+          // Reject a declared oversized body before the platform reader closes
+          // its socket. MaxBodySize also bounds bodies without Content-Length.
+          if (Number(request.headers["content-length"]) > MAX_REQUEST_BYTES) {
+            return errorResponse(400, "Request body is too large");
+          }
+          // Preserve JSON sent with fetch's default string-body content type.
+          const contentType = request.headers["content-type"]?.split(";", 1)[0];
+          return yield* httpEffect.pipe(
+            Effect.provideService(
+              HttpServerRequest.HttpServerRequest,
+              contentType === "text/plain"
+                ? request.modify({
+                    headers: Headers.set(
+                      request.headers,
+                      "content-type",
+                      "application/json",
+                    ),
+                  })
+                : request,
+            ),
+          );
+        }).pipe(
+          Effect.provideService(
+            HttpIncomingMessage.MaxBodySize,
+            FileSystem.Size(MAX_REQUEST_BYTES),
+          ),
+          Effect.catchCause((cause) => {
+            if (Cause.hasInterruptsOnly(cause)) return Effect.failCause(cause);
+            const error = Cause.squash(cause);
+            if (
+              HttpApiError.HttpApiSchemaError.is(error) &&
+              error.kind === "Payload"
+            ) {
+              return Effect.succeed(
+                errorResponse(
+                  400,
+                  "Request body must contain a string 'code' field",
+                ),
+              );
+            }
+            if (HttpServerError.isHttpServerError(error)) {
+              if (error.reason._tag === "RouteNotFound") {
+                return Effect.succeed(errorResponse(404, "Not found"));
+              }
+              if (error.reason._tag === "RequestParseError") {
+                return Effect.succeed(
+                  errorResponse(400, "Invalid or oversized request body"),
+                );
+              }
+            }
+            return Effect.logWarning("Local discovery request failed").pipe(
+              Effect.annotateLogs({ cause }),
+              Effect.as(errorResponse(500, "Internal server error")),
+            );
+          }),
+        );
+        const secured = HttpServerResponse.setHeader(
+          response,
+          "cache-control",
+          "no-store",
+        );
+        if (
+          secured.body._tag !== "Stream" ||
+          !secured.body.contentType.startsWith("text/event-stream")
+        ) {
+          return secured;
+        }
+        // NodeHttpServer writes headers before consuming the body. Flush them at
+        // that point so a silent execution still lets its client connect/cancel.
+        const body = secured.body;
+        return secured.pipe(
+          HttpServerResponse.setHeaders({
+            connection: "keep-alive",
+            "x-accel-buffering": "no",
+          }),
+          HttpServerResponse.setBody(
+            HttpBody.stream(
+              Stream.suspend(() => {
+                NodeHttpServerRequest.toServerResponse(request).flushHeaders();
+                return body.stream;
+              }),
+              body.contentType,
+            ),
+          ),
+        );
+      }),
+    { global: true },
+  );
+}
+
+function outputDataAsString(data: unknown): string {
+  if (typeof data === "string") return data;
+  try {
+    return JSON.stringify(data) ?? "";
+  } catch {
+    return "";
+  }
+}
+
+/** Ignore propagated failures; the originating cell determines run success. */
+function isOnlyAncestorStopped(output: CellOutput): boolean {
+  return (
+    output.channel === "marimo-error" &&
+    Array.isArray(output.data) &&
+    output.data.length > 0 &&
+    output.data.every(
+      (error) =>
+        typeof error === "object" &&
+        error !== null &&
+        "type" in error &&
+        error.type === "ancestor-stopped",
+    )
+  );
+}
+
+function makeDoneEvent(
+  scratchOutput: CellOutput | undefined,
+  childErrored: boolean,
+) {
+  const scratchErrored = scratchOutput?.channel === "marimo-error";
+  const success = !scratchErrored && !childErrored;
+  if (!success || scratchOutput?.channel !== "output") {
+    return DoneEvent.make({ success, output: EMPTY_OUTPUT });
+  }
+
+  let data: unknown = scratchOutput.data;
+  if (typeof data === "object" && data !== null && !Array.isArray(data)) {
+    if ("text/plain" in data) data = data["text/plain"];
+    else if ("text/html" in data) data = data["text/html"];
+  }
+  return DoneEvent.make({
+    success: true,
+    output: {
+      mimetype: scratchOutput.mimetype,
+      data: typeof data === "string" ? data : outputDataAsString(data),
+    },
+  });
+}
+
+function streamExecution<E>(
+  stream: Stream.Stream<CellOperationNotification, E>,
+): Stream.Stream<Execute200Sse, ErrorResponse> {
+  return Stream.suspend(() => {
+    let scratchState = makeCellRunState().state;
+    let childErrored = false;
+    return stream.pipe(
+      Stream.map((operation) => {
+        const events: Execute200Sse[] = [];
+        if (operation.cell_id === SCRATCH_CELL_ID) {
+          scratchState = transitionCell(scratchState, operation);
+        } else if (
+          operation.output?.channel === "marimo-error" &&
+          Array.isArray(operation.output.data) &&
+          operation.output.data.length > 0 &&
+          !isOnlyAncestorStopped(operation.output)
+        ) {
+          childErrored = true;
+        }
+        const outputs = Array.isArray(operation.console)
+          ? operation.console
+          : operation.console == null
+            ? []
+            : [operation.console];
+        for (const output of outputs) {
+          if (output.channel === "stdout" || output.channel === "stderr") {
+            events.push({
+              event: output.channel,
+              data: encodeConsoleEvent({
+                data: outputDataAsString(output.data),
+              }),
+            });
+          }
+        }
+        return events;
+      }),
+      Stream.flattenIterable,
+      Stream.concat(
+        Stream.sync(
+          (): Execute200Sse => ({
+            event: "done",
+            data: encodeDoneEvent(
+              makeDoneEvent(scratchState.output ?? undefined, childErrored),
+            ),
+          }),
+        ),
+      ),
+      Stream.catchCause((cause) => {
+        if (Cause.hasInterruptsOnly(cause))
+          return Stream.fromEffect(Effect.interrupt);
+        return Stream.fromEffect(
+          Effect.logWarning("Local discovery execution failed").pipe(
+            Effect.annotateLogs({ cause }),
+            Effect.andThen(
+              Effect.fail(ErrorResponse.make({ message: "Execution failed" })),
+            ),
+          ),
+        );
+      }),
+    );
+  });
+}
+
+function discoveryHandlers(
+  code: Context.Service.Shape<typeof VsCode>,
+  catalog: Effect.Success<ReturnType<typeof makeLocalDiscoveryCatalog>>,
+  runtime: Pick<
+    Context.Service.Shape<typeof NotebookRuntime>,
+    "executeSessionScratchpad"
+  >,
+) {
+  return HttpApiBuilder.group(DiscoveryApi, "default", (handlers) =>
+    handlers
+      .handle("catalog", () => catalog.snapshot)
+      .handle("watchCatalog", () =>
+        Effect.succeed(
+          catalog.changes.pipe(
+            Stream.map(() => ({
+              event: "catalog.changed" as const,
+              data: "{}",
+            })),
+          ),
+        ),
+      )
+      .handle(
+        "openNotebook",
+        Effect.fn("LocalDiscoveryPublisher.open")(function* ({ params }) {
+          const target = yield* catalog.resolveNotebook(params.notebook_id);
+          if (Option.isNone(target))
+            return errorResponse(404, "Notebook not found");
+          if (!target.value.openable)
+            return errorResponse(409, "Notebook is not openable");
+          const query = new URLSearchParams({
+            uri: target.value.uri.toString(),
+            instance: catalog.instanceId,
+          });
+          // Resolve at request time so the link routes to this window.
+          const uri = yield* code.env.asExternalUri(
+            target.value.uri.with({
+              scheme: code.env.uriScheme,
+              authority: EXTENSION_AUTHORITY,
+              path: "/open",
+              query: query.toString(),
+              fragment: "",
+            }),
+          );
+          return OpenNotebookResponse.make({ uri: uri.toString() });
+        }),
+      )
+      .handle(
+        "execute",
+        Effect.fn("LocalDiscoveryPublisher.execute")(function* ({
+          params,
+          payload,
+        }) {
+          const target = yield* catalog.resolveSession(params.session_id);
+          if (Option.isNone(target))
+            return errorResponse(404, "Session not found");
+          if (!target.value.runnable)
+            return errorResponse(409, "Session is not running");
+          return streamExecution(
+            runtime.executeSessionScratchpad(
+              target.value.sessionId,
+              payload.code,
+            ),
+          );
+        }),
+      ),
+  );
+}
+
+function uriHandler(
+  uri: vscode.Uri,
+  instanceId: string,
+  code: Context.Service.Shape<typeof VsCode>,
+): Effect.Effect<void> {
+  return Effect.gen(function* () {
+    if (uri.path !== "/open") return;
+    const query = new URLSearchParams(uri.query);
+    const rawTarget = query.get("uri");
+    if (query.get("instance") !== instanceId || rawTarget === null) {
+      yield* Effect.logWarning("Ignored invalid local discovery deep link");
+      return;
+    }
+    const target = code.utils.parseUri(rawTarget);
+    if (Result.isFailure(target) || target.success.scheme !== "file") {
+      yield* Effect.logWarning("Ignored invalid local discovery deep link");
+      return;
+    }
+    yield* openAsMarimoNotebook
+      .invoke(target.success)
+      .pipe(Effect.provideService(VsCode, code));
+  });
+}
+
+function platformDisabledReason(
+  code: Context.Service.Shape<typeof VsCode>,
+): string | undefined {
+  if (!["darwin", "linux", "win32"].includes(process.platform)) {
+    return "unsupported platform";
+  }
+  if (code.env.remoteName !== undefined) return "remote extension host";
+  if (!code.workspace.isTrusted()) return "untrusted workspace";
+  return undefined;
+}
+
+/** Publish discovery until the enclosing scope closes. */
+export const makeLocalDiscoveryPublisher = Effect.fn(
+  "LocalDiscoveryPublisher.make",
+)(function* (
+  catalog: Effect.Success<ReturnType<typeof makeLocalDiscoveryCatalog>>,
+  runtime: Pick<
+    Context.Service.Shape<typeof NotebookRuntime>,
+    "executeSessionScratchpad"
+  >,
+  directory?: string,
+) {
+  const code = yield* VsCode;
+  const token = NodeCrypto.randomBytes(32).toString("base64url");
+  const startedAt = new Date();
+
+  // Register before publishing the record so every returned deep link has
+  // a live handler, even for a client that discovers us immediately.
+  yield* code.window.registerUriHandler((uri) =>
+    uriHandler(uri, catalog.instanceId, code),
+  );
+
+  const routes = HttpApiBuilder.layer(DiscoveryApi).pipe(
+    Layer.provide(
+      discoveryHandlers(code, catalog, runtime).pipe(
+        Layer.provide(
+          Layer.succeed(LocalTokenSecurityMiddleware, {
+            // The global middleware also protects unmatched routes.
+            localToken: (httpEffect) => httpEffect,
+          }),
+        ),
+      ),
+    ),
+    Layer.merge(discoveryMiddleware(token)),
+  );
+  const context = yield* Layer.build(
+    HttpRouter.serve(routes, {
+      disableLogger: true,
+      disableListenLog: true,
+    }).pipe(
+      Layer.provideMerge(
+        NodeHttpServer.layer(NodeHttp.createServer, {
+          host: "127.0.0.1",
+          port: 0,
+          disablePreemptiveShutdown: true,
+        }),
+      ),
+    ),
+  );
+  const { address } = Context.get(context, HttpServer.HttpServer);
+  if (address._tag !== "TcpAddress") {
+    return yield* new PublisherStartupError({
+      cause: "Discovery server did not bind a TCP port",
+    });
+  }
+  const port = address.port;
+  const record = InstanceRecord.make({
+    id: catalog.instanceId,
+    kind: "vscode",
+    name: code.env.appName,
+    pid: process.pid,
+    started_at: startedAt.toISOString(),
+    url: `http://127.0.0.1:${port}${DISCOVERY_API_PATH}`,
+    token,
+  });
+  yield* Effect.acquireRelease(
+    Effect.tryPromise({
+      try: () => registerDiscoveryRecord(record, directory),
+      catch: (cause) => new PublisherStartupError({ cause }),
+    }),
+    (registration) =>
+      Effect.promise(() => registration.deregister()).pipe(
+        Effect.catchCause((cause) =>
+          Effect.logWarning("Local discovery publisher cleanup failed").pipe(
+            Effect.annotateLogs({ cause }),
+          ),
+        ),
+      ),
+  );
+  yield* Effect.logDebug("Local discovery publisher started").pipe(
+    Effect.annotateLogs({ url: record.url }),
+  );
+  return record;
+});
+
+export const LocalDiscoveryLive = Layer.effectDiscard(
+  Effect.gen(function* () {
+    const code = yield* VsCode;
+    const disabledReason = platformDisabledReason(code);
+    if (disabledReason !== undefined) {
+      yield* Effect.logDebug("Local discovery publisher is disabled").pipe(
+        Effect.annotateLogs({ reason: disabledReason }),
+      );
+      return;
+    }
+
+    const scope = yield* Scope.fork(yield* Effect.scope);
+    yield* Effect.gen(function* () {
+      const catalog = yield* makeLocalDiscoveryCatalog();
+      const runtime = yield* NotebookRuntime;
+      yield* makeLocalDiscoveryPublisher(catalog, runtime);
+    }).pipe(
+      Effect.provideService(Scope.Scope, scope),
+      Effect.onExit((exit) =>
+        Exit.isFailure(exit) ? Scope.close(scope, exit) : Effect.void,
+      ),
+      Effect.catchCause((cause) =>
+        Cause.hasInterruptsOnly(cause)
+          ? Effect.failCause(cause)
+          : Effect.logWarning("Local discovery publisher failed to start").pipe(
+              Effect.annotateLogs({ cause }),
+            ),
+      ),
+    );
+  }),
+);

--- a/extension/src/discovery/LocalDiscoveryRegistry.ts
+++ b/extension/src/discovery/LocalDiscoveryRegistry.ts
@@ -1,0 +1,138 @@
+import * as NodeFs from "node:fs/promises";
+import * as NodeOs from "node:os";
+import * as NodePath from "node:path";
+
+import { Schema } from "effect";
+
+import { InstanceRecord } from "./Api.gen.ts";
+import { windowsPrivatePath } from "./windowsPrivatePath.ts";
+
+const PRIVATE_DIRECTORY_MODE = 0o700;
+const PRIVATE_FILE_MODE = 0o600;
+const encodeInstanceRecord = Schema.encodeSync(InstanceRecord);
+
+function discoveryDirectory(): string {
+  if (process.platform === "win32") {
+    return NodePath.join(NodeOs.homedir(), ".marimo", "discovery", "v1");
+  }
+  const stateRoot = process.env.XDG_STATE_HOME?.trim();
+  return NodePath.join(
+    stateRoot ? stateRoot : NodePath.join(NodeOs.homedir(), ".local", "state"),
+    "marimo",
+    "discovery",
+    "v1",
+  );
+}
+
+async function verifyPrivateDirectory(path: string): Promise<void> {
+  const info = await NodeFs.lstat(path);
+  if (!info.isDirectory() || info.isSymbolicLink()) {
+    throw new Error(`Discovery path is not a directory: ${path}`);
+  }
+  if (typeof process.getuid === "function" && info.uid !== process.getuid()) {
+    throw new Error(`Discovery directory has a different owner: ${path}`);
+  }
+  if ((info.mode & 0o077) !== 0) {
+    throw new Error(
+      `Discovery directory is accessible to other users: ${path}`,
+    );
+  }
+}
+
+async function verifyPrivateFile(path: string): Promise<void> {
+  const info = await NodeFs.lstat(path);
+  if (!info.isFile() || info.isSymbolicLink()) {
+    throw new Error(`Discovery record is not a regular file: ${path}`);
+  }
+  if (process.platform === "win32") {
+    await windowsPrivatePath(path);
+    return;
+  }
+  if (typeof process.getuid === "function" && info.uid !== process.getuid()) {
+    throw new Error(`Discovery record has a different owner: ${path}`);
+  }
+  if ((info.mode & 0o077) !== 0) {
+    throw new Error(`Discovery record is accessible to other users: ${path}`);
+  }
+}
+
+async function ensurePrivateDirectories(directory: string): Promise<void> {
+  const discovery = NodePath.dirname(directory);
+  const state = NodePath.dirname(discovery);
+  await NodeFs.mkdir(state, { recursive: true });
+
+  const ensure = async (path: string): Promise<void> => {
+    if (process.platform === "win32") {
+      await windowsPrivatePath(path, true);
+      return;
+    }
+    try {
+      await NodeFs.mkdir(path, { mode: PRIVATE_DIRECTORY_MODE });
+    } catch (error) {
+      if (
+        typeof error !== "object" ||
+        error === null ||
+        !("code" in error) ||
+        error.code !== "EEXIST"
+      ) {
+        throw error;
+      }
+    }
+    await verifyPrivateDirectory(path);
+  };
+  await ensure(discovery);
+  await ensure(directory);
+}
+
+/** Atomically publish one private instance record and return its cleanup. */
+export async function registerDiscoveryRecord(
+  record: typeof InstanceRecord.Type,
+  directory = discoveryDirectory(),
+) {
+  await ensurePrivateDirectories(directory);
+  const path = NodePath.join(directory, `${record.id}.json`);
+  const temporaryPath = NodePath.join(
+    directory,
+    `.${record.id}.${process.pid}.${crypto.randomUUID()}.tmp`,
+  );
+  let handle: NodeFs.FileHandle | undefined;
+  let published = false;
+
+  try {
+    handle = await NodeFs.open(temporaryPath, "wx", PRIVATE_FILE_MODE);
+    // Check inherited Windows permissions before writing the credential.
+    if (process.platform === "win32") await verifyPrivateFile(temporaryPath);
+    await handle.writeFile(JSON.stringify(encodeInstanceRecord(record)), {
+      encoding: "utf8",
+    });
+    await handle.sync();
+    await handle.close();
+    handle = undefined;
+    await NodeFs.rename(temporaryPath, path);
+    published = true;
+    await verifyPrivateFile(path);
+  } catch (error) {
+    await handle?.close().catch(() => undefined);
+    await NodeFs.unlink(temporaryPath).catch(() => undefined);
+    if (published) await NodeFs.unlink(path).catch(() => undefined);
+    throw error;
+  }
+
+  let registered = true;
+  return {
+    async deregister() {
+      if (!registered) return;
+      registered = false;
+      await NodeFs.unlink(path).catch((error: unknown) => {
+        if (
+          typeof error !== "object" ||
+          error === null ||
+          !("code" in error) ||
+          error.code !== "ENOENT"
+        ) {
+          throw error;
+        }
+      });
+    },
+  };
+}

--- a/extension/src/discovery/__tests__/LocalDiscoveryCatalog.test.ts
+++ b/extension/src/discovery/__tests__/LocalDiscoveryCatalog.test.ts
@@ -1,0 +1,313 @@
+import { describe, expect, it } from "@effect/vitest";
+import {
+  Context,
+  Deferred,
+  Effect,
+  Fiber,
+  Layer,
+  Option,
+  Schema,
+  Stream,
+  SubscriptionRef,
+} from "effect";
+
+import {
+  createTestNotebookDocument,
+  TestVsCode,
+  Uri,
+} from "../../__mocks__/TestVsCode.ts";
+import { kernelSessionId, notebookId } from "../../lib/__tests__/branded.ts";
+import {
+  LiveSessions,
+  type SessionViewItem,
+} from "../../panel/sessions/LiveSessions.ts";
+import { Catalog } from "../Api.gen.ts";
+import { makeLocalDiscoveryCatalog } from "../LocalDiscoveryCatalog.ts";
+
+const CLOSED_URI = Uri.file("/workspace/nested/closed.py");
+const CLOSED_NOTEBOOK_ID = notebookId(CLOSED_URI.toString());
+const SESSION_ID = kernelSessionId("session-1");
+
+describe("LocalDiscoveryCatalog", () => {
+  it.effect(
+    "projects open documents and retained sessions into their longest workspace root",
+    Effect.fn(function* () {
+      const openDocument = createTestNotebookDocument(
+        "/workspace/nested/open.py",
+      );
+      const untitledDocument = createTestNotebookDocument(
+        Uri.parse("untitled:Untitled-1"),
+      );
+      const vscode = yield* TestVsCode.make({
+        initialDocuments: [openDocument, untitledDocument],
+        fileSystem: new Map([
+          [openDocument.uri.toString(), new Uint8Array()],
+          [CLOSED_URI.toString(), new Uint8Array()],
+        ]),
+        workspace: {
+          getWorkspaceFolders: Effect.succeed(
+            Option.some([
+              { uri: Uri.file("/workspace"), name: "workspace", index: 0 },
+              {
+                uri: Uri.file("/workspace/nested"),
+                name: "nested",
+                index: 1,
+              },
+            ]),
+          ),
+        },
+      });
+      const initialSessions: ReadonlyArray<SessionViewItem> = [
+        {
+          sessionId: SESSION_ID,
+          notebookUri: CLOSED_NOTEBOOK_ID,
+          filename: CLOSED_URI.fsPath,
+          executable: "/usr/bin/python",
+          workingDirectory: "/workspace/nested",
+          startedAt: 1,
+          marimoVersion: "0.24.0",
+          status: "idle",
+          attached: false,
+        },
+      ];
+      const sessions = yield* SubscriptionRef.make(initialSessions);
+      const liveSessions: Context.Service.Shape<typeof LiveSessions> = {
+        get: SubscriptionRef.get(sessions),
+        changes: SubscriptionRef.changes(sessions),
+        find: (uri) =>
+          Effect.map(SubscriptionRef.get(sessions), (current) =>
+            Option.fromNullishOr(
+              current.find((session) => session.notebookUri === uri),
+            ),
+          ),
+        refresh: () => Effect.void,
+        restart: () => Effect.succeed(undefined),
+        shutdown: () => Effect.void,
+        restore: () => Effect.void,
+        shutdownAll: () => Effect.void,
+        move: () => Effect.void,
+      };
+      const dependencies = Layer.merge(
+        vscode.layer,
+        Layer.succeed(LiveSessions, liveSessions),
+      );
+
+      yield* Effect.gen(function* () {
+        const catalog = yield* makeLocalDiscoveryCatalog();
+        const value = yield* catalog.snapshot;
+        expect(value.projects.map((project) => project.root)).toEqual([
+          Uri.file("/workspace").fsPath,
+          Uri.file("/workspace/nested").fsPath,
+          null,
+        ]);
+        const nested = value.projects.find(
+          (project) => project.root === Uri.file("/workspace/nested").fsPath,
+        );
+        const retained = nested?.notebooks.find(
+          (notebook) => notebook.title === "closed.py",
+        );
+        if (retained === undefined) {
+          throw new Error("Retained notebook missing from catalog");
+        }
+        const resolvedRetained = yield* catalog.resolveNotebook(retained.id);
+        const resolvedSession = yield* catalog.resolveSession(SESSION_ID);
+        const encoded = yield* Schema.encodeEffect(Catalog)(value);
+
+        expect({
+          catalog: {
+            ...encoded,
+            instance_id: "<instance-id>",
+            projects: encoded.projects.map((project) => ({
+              ...project,
+              id: `<project:${project.name}>`,
+              // Roots above are native paths; keep the snapshot portable.
+              root: project.root === null ? null : Uri.file(project.root).path,
+              notebooks: project.notebooks.map((notebook) => ({
+                ...notebook,
+                id: `<notebook:${notebook.title}>`,
+              })),
+            })),
+          },
+          resolved: {
+            notebook: Option.match(resolvedRetained, {
+              onNone: () => null,
+              onSome: (target) => ({
+                ...target,
+                uri: target.uri.toString(),
+              }),
+            }),
+            session: Option.getOrNull(resolvedSession),
+          },
+        }).toMatchInlineSnapshot(`
+          {
+            "catalog": {
+              "instance_id": "<instance-id>",
+              "operations": [
+                "catalog.watch",
+                "notebook.open",
+                "session.execute",
+              ],
+              "projects": [
+                {
+                  "id": "<project:workspace>",
+                  "name": "workspace",
+                  "notebooks": [],
+                  "root": "/workspace",
+                  "truncated": true,
+                },
+                {
+                  "id": "<project:nested>",
+                  "name": "nested",
+                  "notebooks": [
+                    {
+                      "id": "<notebook:closed.py>",
+                      "openable": true,
+                      "path": "closed.py",
+                      "sessions": [
+                        {
+                          "marimo_version": "0.24.0",
+                          "mode": "edit",
+                          "session_id": "session-1",
+                          "started_at": "1970-01-01T00:00:01.000Z",
+                          "status": "running",
+                        },
+                      ],
+                      "title": "closed.py",
+                      "updated_at": "1970-01-01T00:00:00.000Z",
+                    },
+                    {
+                      "id": "<notebook:open.py>",
+                      "openable": true,
+                      "path": "open.py",
+                      "sessions": [],
+                      "title": "open.py",
+                      "updated_at": "1970-01-01T00:00:00.000Z",
+                    },
+                  ],
+                  "root": "/workspace/nested",
+                  "truncated": true,
+                },
+                {
+                  "id": "<project:Loose Files>",
+                  "name": "Loose Files",
+                  "notebooks": [
+                    {
+                      "id": "<notebook:Untitled-1>",
+                      "openable": false,
+                      "path": null,
+                      "sessions": [],
+                      "title": "Untitled-1",
+                      "updated_at": null,
+                    },
+                  ],
+                  "root": null,
+                  "truncated": false,
+                },
+              ],
+            },
+            "resolved": {
+              "notebook": {
+                "openable": true,
+                "uri": "file:///workspace/nested/closed.py",
+              },
+              "session": {
+                "runnable": true,
+                "sessionId": "session-1",
+              },
+            },
+          }
+        `);
+
+        const changed = yield* catalog.changes.pipe(
+          Stream.drop(1),
+          Stream.runHead,
+          Effect.forkChild,
+        );
+        yield* Effect.yieldNow;
+        yield* SubscriptionRef.set(
+          sessions,
+          initialSessions.map((session) => ({
+            ...session,
+            status: "restarting" as const,
+          })),
+        );
+        const updated = yield* catalog.snapshot.pipe(
+          Effect.filterOrFail(
+            (value) =>
+              value.projects.every((project) =>
+                project.notebooks.every(
+                  (notebook) => notebook.sessions.length === 0,
+                ),
+              ),
+            () => "catalog was not refreshed" as const,
+          ),
+          Effect.eventually,
+        );
+        const invalidation = yield* Fiber.join(changed);
+        const target = yield* catalog.resolveSession(SESSION_ID);
+
+        expect({
+          invalidated: Option.isSome(invalidation),
+          sessions: updated.projects.flatMap((project) =>
+            project.notebooks.flatMap((notebook) => notebook.sessions),
+          ),
+          target: Option.getOrNull(target),
+        }).toMatchInlineSnapshot(`
+          {
+            "invalidated": true,
+            "sessions": [],
+            "target": {
+              "runnable": false,
+              "sessionId": "session-1",
+            },
+          }
+        `);
+
+        // Keep the notebook visible while its hidden restarting session goes
+        // away. Target resolution must refresh without a watch notification.
+        const reopened = createTestNotebookDocument(CLOSED_URI);
+        yield* vscode.openNotebook(reopened);
+        const watching = yield* Deferred.make<void>();
+        const watched = yield* catalog.changes.pipe(
+          Stream.mapEffect(() => catalog.snapshot),
+          Stream.tap(() => Deferred.succeed(watching, undefined)),
+          Stream.take(2),
+          Stream.runCollect,
+          Effect.forkChild,
+        );
+        yield* Deferred.await(watching);
+        yield* SubscriptionRef.set(sessions, []);
+        yield* catalog.resolveSession(SESSION_ID).pipe(
+          Effect.filterOrFail(
+            Option.isNone,
+            () => "session target was not removed",
+          ),
+          Effect.eventually,
+        );
+        yield* Effect.yieldNow;
+        // A subsequent visible change lets us check the watch stream without
+        // waiting for a timeout to prove that no duplicate event arrived.
+        yield* vscode.closeNotebook(reopened);
+        expect(
+          (yield* Fiber.join(watched)).map((value) =>
+            value.projects.flatMap((project) =>
+              project.notebooks.map((notebook) => notebook.title),
+            ),
+          ),
+        ).toMatchInlineSnapshot(`
+          [
+            [
+              "closed.py",
+              "open.py",
+              "Untitled-1",
+            ],
+            [
+              "open.py",
+              "Untitled-1",
+            ],
+          ]
+        `);
+      }).pipe(Effect.provide(dependencies), Effect.scoped);
+    }),
+  );
+});

--- a/extension/src/discovery/__tests__/LocalDiscoveryProtocol.test.ts
+++ b/extension/src/discovery/__tests__/LocalDiscoveryProtocol.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+
+import { uuidV5 } from "../LocalDiscoveryProtocol.ts";
+
+describe("local discovery protocol", () => {
+  it("generates RFC 9562 UUIDv5 identifiers", () => {
+    expect(
+      uuidV5("6ba7b810-9dad-11d1-80b4-00c04fd430c8", "www.widgets.com"),
+    ).toMatchInlineSnapshot(`"21f7f8de-8051-5b89-8680-0195ef798b6a"`);
+  });
+});

--- a/extension/src/discovery/__tests__/LocalDiscoveryPublisher.test.ts
+++ b/extension/src/discovery/__tests__/LocalDiscoveryPublisher.test.ts
@@ -167,6 +167,7 @@ describe("local discovery publisher", { timeout: 30_000 }, () => {
     const record = await Effect.runPromise(
       Effect.gen(function* () {
         const vscode = yield* TestVsCode.make({
+          env: { uriScheme: "cursor", appName: "Cursor" },
           window: {
             registerUriHandler: () =>
               Effect.acquireRelease(
@@ -192,6 +193,10 @@ describe("local discovery publisher", { timeout: 30_000 }, () => {
           ),
         );
         expect(JSON.parse(published).url).toBe(record.url);
+        expect(JSON.parse(published)).toMatchObject({
+          kind: "cursor",
+          name: "Cursor",
+        });
         expect(handlerRegistered).toBe(true);
         return record;
       }).pipe(Effect.scoped),

--- a/extension/src/discovery/__tests__/LocalDiscoveryPublisher.test.ts
+++ b/extension/src/discovery/__tests__/LocalDiscoveryPublisher.test.ts
@@ -599,3 +599,39 @@ describe("local discovery publisher", { timeout: 30_000 }, () => {
     });
   });
 });
+
+it.each([
+  {
+    data: { "text/plain": "<literal>", "text/html": "<b>rich</b>" },
+    mimetype: "text/html",
+    expected: { mimetype: "text/plain", data: "<literal>" },
+  },
+  {
+    data: { "text/html": "<b>rich</b>" },
+    mimetype: "application/json",
+    expected: { mimetype: "text/html", data: "<b>rich</b>" },
+  },
+] as const)(
+  "labels the selected output representation consistently ($mimetype)",
+  async ({ data, mimetype, expected }) => {
+    await withServer(
+      async (baseUrl, authorized) => {
+        const response = await fetch(
+          `${baseUrl}/sessions/${SESSION_ID}/execute`,
+          {
+            method: "POST",
+            headers: { ...authorized, "Content-Type": "application/json" },
+            body: JSON.stringify({ code: "value" }),
+          },
+        );
+        expect(await readEvents(response)).toEqual([
+          { event: "done", data: { success: true, output: expected } },
+        ]);
+      },
+      runtimeFrom({
+        ...scratchResult,
+        output: { channel: "output", mimetype, data },
+      }),
+    );
+  },
+);

--- a/extension/src/discovery/__tests__/LocalDiscoveryPublisher.test.ts
+++ b/extension/src/discovery/__tests__/LocalDiscoveryPublisher.test.ts
@@ -1,0 +1,601 @@
+import * as NodeFs from "node:fs/promises";
+import * as NodeOs from "node:os";
+import * as NodePath from "node:path";
+
+import { Context, Effect, Option, Result, Schema, Stream } from "effect";
+import * as Sse from "effect/unstable/encoding/Sse";
+import {
+  FetchHttpClient,
+  HttpClient,
+  HttpClientRequest,
+} from "effect/unstable/http";
+import { HttpApiClient } from "effect/unstable/httpapi";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { TestVsCode, Uri } from "../../__mocks__/TestVsCode.ts";
+import { SCRATCH_CELL_ID } from "../../constants.ts";
+import { NotebookRuntime } from "../../kernel/NotebookRuntime.ts";
+import { cellId, kernelSessionId } from "../../lib/__tests__/branded.ts";
+import type { CellOperationNotification } from "../../types.ts";
+import {
+  Catalog,
+  LocalDiscoveryApi,
+  ExecuteRequest,
+  OpenNotebookResponse,
+} from "../Api.gen.ts";
+import { makeLocalDiscoveryCatalog } from "../LocalDiscoveryCatalog.ts";
+import { makeLocalDiscoveryPublisher } from "../LocalDiscoveryPublisher.ts";
+
+const INSTANCE_ID = "00000000-0000-4000-8000-000000000001";
+const NOTEBOOK_ID = "00000000-0000-5000-8000-000000000001";
+const SESSION_ID = kernelSessionId("session-1");
+
+const snapshot = Catalog.make({
+  instance_id: INSTANCE_ID,
+  operations: ["catalog.watch", "notebook.open", "session.execute"],
+  projects: [],
+});
+
+const catalog: Effect.Success<ReturnType<typeof makeLocalDiscoveryCatalog>> = {
+  instanceId: INSTANCE_ID,
+  snapshot: Effect.succeed(snapshot),
+  changes: Stream.make(undefined),
+  resolveNotebook: (id) =>
+    Effect.succeed(
+      id === NOTEBOOK_ID
+        ? Option.some({
+            uri: Uri.file("/workspace/notebook & #.py"),
+            openable: true,
+          })
+        : Option.none(),
+    ),
+  resolveSession: (id) =>
+    Effect.succeed(
+      id === SESSION_ID
+        ? Option.some({
+            sessionId: SESSION_ID,
+            runnable: true,
+          })
+        : Option.none(),
+    ),
+};
+
+type DiscoveryRuntime = Pick<
+  Context.Service.Shape<typeof NotebookRuntime>,
+  "executeSessionScratchpad"
+>;
+
+const scratchResult: CellOperationNotification = {
+  op: "cell-op",
+  cell_id: cellId(SCRATCH_CELL_ID),
+  output: {
+    channel: "output",
+    data: { "text/plain": "2" },
+    mimetype: "text/plain",
+  },
+};
+
+function runtimeFrom(
+  ...operations: ReadonlyArray<CellOperationNotification>
+): DiscoveryRuntime {
+  return {
+    executeSessionScratchpad: () => Stream.fromIterable(operations),
+  };
+}
+
+const runtime = runtimeFrom(
+  {
+    op: "cell-op",
+    cell_id: cellId("child"),
+    console: {
+      channel: "stdout",
+      data: "hello\n",
+      mimetype: "text/plain",
+    },
+  },
+  scratchResult,
+);
+
+const temporaryDirectories: string[] = [];
+
+async function temporaryDirectory() {
+  const root = await NodeFs.mkdtemp(
+    NodePath.join(NodeOs.tmpdir(), "marimo-publisher-test-"),
+  );
+  temporaryDirectories.push(root);
+  return NodePath.join(root, "marimo", "discovery", "v1");
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((root) => NodeFs.rm(root, { recursive: true, force: true })),
+  );
+});
+
+async function withServer<A>(
+  run: (
+    baseUrl: string,
+    authorized: { Authorization: string },
+    token: string,
+  ) => Promise<A>,
+  testRuntime: DiscoveryRuntime = runtime,
+  env: NonNullable<Parameters<typeof TestVsCode.make>[0]>["env"] = {},
+): Promise<A> {
+  const directory = await temporaryDirectory();
+  return await Effect.runPromise(
+    Effect.gen(function* () {
+      const vscode = yield* TestVsCode.make({ env });
+      const record = yield* makeLocalDiscoveryPublisher(
+        catalog,
+        testRuntime,
+        directory,
+      ).pipe(Effect.provide(vscode.layer));
+      return yield* Effect.promise(() =>
+        run(
+          record.url,
+          { Authorization: `Bearer ${record.token}` },
+          record.token,
+        ),
+      );
+    }).pipe(Effect.scoped),
+  );
+}
+
+async function readEvents(response: Response, limit = Infinity) {
+  const events: Array<{ event: string; data: unknown }> = [];
+  const parser = Sse.makeParser((event) => {
+    if (event._tag === "Event") {
+      events.push({ event: event.event, data: JSON.parse(event.data) });
+    }
+  });
+  const body = response.body;
+  if (body === null) throw new Error("Missing SSE response body");
+  for await (const text of body.pipeThrough(new TextDecoderStream())) {
+    const error = parser.feed(text);
+    if (error !== undefined) throw error;
+    if (events.length >= limit) break;
+  }
+  return events;
+}
+
+describe("local discovery publisher", { timeout: 30_000 }, () => {
+  it("removes its record, closes HTTP, and unregisters the URI handler on shutdown", async () => {
+    const directory = await temporaryDirectory();
+    let handlerRegistered = false;
+    const record = await Effect.runPromise(
+      Effect.gen(function* () {
+        const vscode = yield* TestVsCode.make({
+          window: {
+            registerUriHandler: () =>
+              Effect.acquireRelease(
+                Effect.sync(() => {
+                  handlerRegistered = true;
+                }),
+                () =>
+                  Effect.sync(() => {
+                    handlerRegistered = false;
+                  }),
+              ),
+          },
+        });
+        const record = yield* makeLocalDiscoveryPublisher(
+          catalog,
+          runtime,
+          directory,
+        ).pipe(Effect.provide(vscode.layer));
+        const published = yield* Effect.promise(() =>
+          NodeFs.readFile(
+            NodePath.join(directory, `${record.id}.json`),
+            "utf8",
+          ),
+        );
+        expect(JSON.parse(published).url).toBe(record.url);
+        expect(handlerRegistered).toBe(true);
+        return record;
+      }).pipe(Effect.scoped),
+    );
+
+    expect({
+      handlerRegistered,
+      records: await NodeFs.readdir(directory),
+    }).toEqual({ handlerRegistered: false, records: [] });
+    await expect(fetch(`${record.url}/catalog`)).rejects.toThrow();
+  });
+
+  it("releases earlier resources when registration fails", async () => {
+    const directory = await temporaryDirectory();
+    await NodeFs.mkdir(NodePath.dirname(directory), { recursive: true });
+    await NodeFs.writeFile(directory, "not a directory");
+    const handlers: string[] = [];
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const vscode = yield* TestVsCode.make({
+          window: {
+            registerUriHandler: () =>
+              Effect.acquireRelease(
+                Effect.sync(() => {
+                  handlers.push("registered");
+                }),
+                () =>
+                  Effect.sync(() => {
+                    handlers.push("disposed");
+                  }),
+              ),
+          },
+        });
+        return yield* makeLocalDiscoveryPublisher(
+          catalog,
+          runtime,
+          directory,
+        ).pipe(Effect.provide(vscode.layer));
+      }).pipe(Effect.scoped, Effect.result),
+    );
+    expect({
+      failed: Result.isFailure(result),
+      handlers,
+    }).toEqual({
+      failed: true,
+      handlers: ["registered", "disposed"],
+    });
+  });
+
+  it("interrupts execution when the HTTP client disconnects", async () => {
+    const started = Promise.withResolvers<void>();
+    const interrupted = Promise.withResolvers<void>();
+    await withServer(
+      async (baseUrl, authorized) => {
+        const response = await fetch(
+          `${baseUrl}/sessions/${SESSION_ID}/execute`,
+          {
+            method: "POST",
+            headers: authorized,
+            body: JSON.stringify({ code: "while True: pass" }),
+          },
+        );
+        await started.promise;
+        await response.body?.cancel();
+        await interrupted.promise;
+      },
+      {
+        executeSessionScratchpad: () =>
+          Stream.unwrap(
+            Effect.sync(() => {
+              started.resolve();
+              return Stream.never.pipe(
+                Stream.ensuring(Effect.sync(() => interrupted.resolve())),
+              );
+            }),
+          ),
+      },
+    );
+  });
+
+  it("interrupts a silent execution when the publisher shuts down", async () => {
+    const interrupted = Promise.withResolvers<void>();
+    const response = await withServer(
+      (baseUrl, authorized) =>
+        fetch(`${baseUrl}/sessions/${SESSION_ID}/execute`, {
+          method: "POST",
+          headers: authorized,
+          body: JSON.stringify({ code: "while True: pass" }),
+        }),
+      {
+        executeSessionScratchpad: () =>
+          Stream.never.pipe(
+            Stream.ensuring(Effect.sync(() => interrupted.resolve())),
+          ),
+      },
+    );
+    await interrupted.promise;
+    expect(await response.text()).toBe("");
+  });
+
+  it("decodes execution events and catches a sanitized stream failure with HttpApiClient", async () => {
+    const result = await withServer(
+      (baseUrl, _authorized, token) =>
+        Effect.runPromise(
+          Effect.gen(function* () {
+            const client = yield* HttpApiClient.make(LocalDiscoveryApi, {
+              baseUrl,
+              transformClient: HttpClient.mapRequest(
+                HttpClientRequest.bearerToken(token),
+              ),
+            });
+            const stream = yield* client.execute({
+              params: { session_id: SESSION_ID },
+              payload: { code: "print('hello')" },
+            });
+            return yield* stream.pipe(
+              Stream.map((event) => ({
+                ...event,
+                data: JSON.parse(event.data),
+              })),
+              Stream.catch((error) => Stream.succeed(error)),
+              Stream.runCollect,
+            );
+          }).pipe(Effect.provide(FetchHttpClient.layer), Effect.scoped),
+        ),
+      {
+        executeSessionScratchpad: () =>
+          Stream.succeed<CellOperationNotification>({
+            op: "cell-op",
+            cell_id: cellId(SCRATCH_CELL_ID),
+            console: {
+              channel: "stdout",
+              data: "hello\n",
+              mimetype: "text/plain",
+            },
+          }).pipe(
+            Stream.concat(Stream.die(new Error("private kernel details"))),
+          ),
+      },
+    );
+    expect(result).toEqual([
+      { event: "stdout", data: { data: "hello\n" } },
+      { message: "Execution failed" },
+    ]);
+  });
+
+  it("rejects oversized request bodies and keeps the server available", async () => {
+    await withServer(async (baseUrl, authorized) => {
+      const response = await fetch(
+        `${baseUrl}/sessions/${SESSION_ID}/execute`,
+        {
+          method: "POST",
+          headers: { ...authorized, "Content-Type": "application/json" },
+          body: JSON.stringify({ code: "x".repeat(8 * 1024 * 1024) }),
+        },
+      );
+      expect(response.status).toBe(400);
+      expect(await response.json()).toEqual({
+        message: "Request body is too large",
+      });
+      expect(
+        (await fetch(`${baseUrl}/catalog`, { headers: authorized })).status,
+      ).toBe(200);
+    });
+  });
+
+  it("requires a strict bearer token and returns a no-store catalog", async () => {
+    await withServer(async (baseUrl, _authorized, token) => {
+      const [missing, extra, wrongScheme, response] = await Promise.all([
+        fetch(`${baseUrl}/catalog`),
+        fetch(`${baseUrl}/catalog`, {
+          headers: { Authorization: `Bearer ${token} extra` },
+        }),
+        fetch(`${baseUrl}/catalog`, {
+          headers: { Authorization: `Basic ${token}` },
+        }),
+        fetch(`${baseUrl}/catalog`, {
+          headers: { Authorization: `bearer ${token}` },
+        }),
+      ]);
+      expect({
+        authentication: {
+          missing: missing.status,
+          extra: extra.status,
+          wrongScheme: wrongScheme.status,
+          caseInsensitiveScheme: response.status,
+          error: await missing.json(),
+        },
+        catalog: {
+          status: response.status,
+          cacheControl: response.headers.get("cache-control"),
+          accessControlAllowOrigin: response.headers.get(
+            "access-control-allow-origin",
+          ),
+          body: await response.json(),
+        },
+      }).toMatchInlineSnapshot(`
+        {
+          "authentication": {
+            "caseInsensitiveScheme": 200,
+            "error": {
+              "message": "Invalid discovery token",
+            },
+            "extra": 401,
+            "missing": 401,
+            "wrongScheme": 401,
+          },
+          "catalog": {
+            "accessControlAllowOrigin": null,
+            "body": {
+              "instance_id": "00000000-0000-4000-8000-000000000001",
+              "operations": [
+                "catalog.watch",
+                "notebook.open",
+                "session.execute",
+              ],
+              "projects": [],
+            },
+            "cacheControl": "no-store",
+            "status": 200,
+          },
+        }
+      `);
+    });
+  });
+
+  it.each(["vscode", "cursor", "vscodium"])(
+    "returns the window-resolved %s link unchanged",
+    async (uriScheme) => {
+      const resolved = "https://callback.test/opaque?window=42";
+      await withServer(
+        async (baseUrl, authorized) => {
+          const response = await fetch(
+            `${baseUrl}/notebooks/${NOTEBOOK_ID}/open`,
+            {
+              method: "POST",
+              headers: authorized,
+            },
+          );
+          expect(response.status).toBe(200);
+          expect(
+            Schema.decodeUnknownSync(OpenNotebookResponse)(
+              await response.json(),
+            ).uri,
+          ).toBe(resolved);
+        },
+        runtime,
+        {
+          uriScheme,
+          asExternalUri: (uri) => {
+            expect(uri.scheme).toBe(uriScheme);
+            expect(uri.authority).toBe("marimo-team.vscode-marimo");
+            expect(uri.path).toBe("/open");
+            expect(Object.fromEntries(new URLSearchParams(uri.query))).toEqual({
+              uri: "file:///workspace/notebook%20&%20%23.py",
+              instance: INSTANCE_ID,
+            });
+            return Effect.succeed(
+              Object.assign(Uri.parse(resolved), { toString: () => resolved }),
+            );
+          },
+        },
+      );
+    },
+  );
+
+  it("sends an immediate catalog invalidation on the watch stream", async () => {
+    await withServer(async (baseUrl, authorized) => {
+      const response = await fetch(`${baseUrl}/catalog/watch`, {
+        headers: authorized,
+      });
+      expect({
+        status: response.status,
+        events: await readEvents(response, 1),
+      }).toEqual({
+        status: 200,
+        events: [{ event: "catalog.changed", data: {} }],
+      });
+    });
+  });
+
+  it("streams stdout followed by exactly one done event", async () => {
+    await withServer(async (baseUrl, authorized) => {
+      const response = await fetch(
+        `${baseUrl}/sessions/${SESSION_ID}/execute`,
+        {
+          method: "POST",
+          headers: { ...authorized, "Content-Type": "application/json" },
+          body: JSON.stringify(ExecuteRequest.make({ code: "1 + 1" })),
+        },
+      );
+      expect({
+        status: response.status,
+        events: await readEvents(response),
+      }).toEqual({
+        status: 200,
+        events: [
+          { event: "stdout", data: { data: "hello\n" } },
+          {
+            event: "done",
+            data: {
+              success: true,
+              output: { mimetype: "text/plain", data: "2" },
+            },
+          },
+        ],
+      });
+    });
+  });
+
+  it("validates the execute request with the protocol schema", async () => {
+    await withServer(async (baseUrl, authorized) => {
+      const response = await fetch(
+        `${baseUrl}/sessions/${SESSION_ID}/execute`,
+        {
+          method: "POST",
+          headers: { ...authorized, "Content-Type": "application/json" },
+          body: JSON.stringify({ code: 42 }),
+        },
+      );
+      expect({
+        status: response.status,
+        body: await response.json(),
+      }).toMatchInlineSnapshot(`
+        {
+          "body": {
+            "message": "Request body must contain a string 'code' field",
+          },
+          "status": 400,
+        }
+      `);
+    });
+  });
+
+  it("reports child errors but ignores ancestor-stopped", async () => {
+    const execute = (testRuntime: DiscoveryRuntime) =>
+      withServer(async (baseUrl, authorized) => {
+        const response = await fetch(
+          `${baseUrl}/sessions/${SESSION_ID}/execute`,
+          {
+            method: "POST",
+            headers: { ...authorized, "Content-Type": "application/json" },
+            body: JSON.stringify(ExecuteRequest.make({ code: "1 + 1" })),
+          },
+        );
+        return readEvents(response);
+      }, testRuntime);
+
+    const error = (data: CellOperationNotification["output"]) =>
+      runtimeFrom(
+        {
+          op: "cell-op",
+          cell_id: cellId("child"),
+          output: data,
+        },
+        scratchResult,
+      );
+
+    expect({
+      childError: await execute(
+        error({
+          channel: "marimo-error",
+          mimetype: "application/vnd.marimo+error",
+          data: [
+            {
+              type: "exception",
+              msg: "ValueError: bad child",
+              exception_type: "ValueError",
+            },
+          ],
+        }),
+      ),
+      ancestorStopped: await execute(
+        error({
+          channel: "marimo-error",
+          mimetype: "application/vnd.marimo+error",
+          data: [
+            {
+              type: "ancestor-stopped",
+              msg: "Ancestor cell was stopped",
+              raising_cell: "parent",
+            },
+          ],
+        }),
+      ),
+    }).toEqual({
+      ancestorStopped: [
+        {
+          event: "done",
+          data: {
+            success: true,
+            output: { mimetype: "text/plain", data: "2" },
+          },
+        },
+      ],
+      childError: [
+        {
+          event: "done",
+          data: {
+            success: false,
+            output: { mimetype: "text/plain", data: "" },
+          },
+        },
+      ],
+    });
+  });
+});

--- a/extension/src/discovery/__tests__/LocalDiscoveryPublisher.test.ts
+++ b/extension/src/discovery/__tests__/LocalDiscoveryPublisher.test.ts
@@ -161,53 +161,60 @@ async function readEvents(response: Response, limit = Infinity) {
 }
 
 describe("local discovery publisher", { timeout: 30_000 }, () => {
-  it("removes its record, closes HTTP, and unregisters the URI handler on shutdown", async () => {
-    const directory = await temporaryDirectory();
-    let handlerRegistered = false;
-    const record = await Effect.runPromise(
-      Effect.gen(function* () {
-        const vscode = yield* TestVsCode.make({
-          env: { uriScheme: "cursor", appName: "Cursor" },
-          window: {
-            registerUriHandler: () =>
-              Effect.acquireRelease(
-                Effect.sync(() => {
-                  handlerRegistered = true;
-                }),
-                () =>
+  it.each([
+    ["vscode", "Visual Studio Code", "VS Code"],
+    ["cursor", "Cursor", "Cursor"],
+    ["custom-editor", "My editor", "My editor"],
+  ])(
+    "publishes %s identity and releases its resources on shutdown",
+    async (uriScheme, appName, name) => {
+      const directory = await temporaryDirectory();
+      let handlerRegistered = false;
+      const record = await Effect.runPromise(
+        Effect.gen(function* () {
+          const vscode = yield* TestVsCode.make({
+            env: { uriScheme, appName },
+            window: {
+              registerUriHandler: () =>
+                Effect.acquireRelease(
                   Effect.sync(() => {
-                    handlerRegistered = false;
+                    handlerRegistered = true;
                   }),
-              ),
-          },
-        });
-        const record = yield* makeLocalDiscoveryPublisher(
-          catalog,
-          runtime,
-          directory,
-        ).pipe(Effect.provide(vscode.layer));
-        const published = yield* Effect.promise(() =>
-          NodeFs.readFile(
-            NodePath.join(directory, `${record.id}.json`),
-            "utf8",
-          ),
-        );
-        expect(JSON.parse(published).url).toBe(record.url);
-        expect(JSON.parse(published)).toMatchObject({
-          kind: "cursor",
-          name: "Cursor",
-        });
-        expect(handlerRegistered).toBe(true);
-        return record;
-      }).pipe(Effect.scoped),
-    );
+                  () =>
+                    Effect.sync(() => {
+                      handlerRegistered = false;
+                    }),
+                ),
+            },
+          });
+          const record = yield* makeLocalDiscoveryPublisher(
+            catalog,
+            runtime,
+            directory,
+          ).pipe(Effect.provide(vscode.layer));
+          const published = yield* Effect.promise(() =>
+            NodeFs.readFile(
+              NodePath.join(directory, `${record.id}.json`),
+              "utf8",
+            ),
+          );
+          expect(JSON.parse(published).url).toBe(record.url);
+          expect(JSON.parse(published)).toMatchObject({
+            kind: uriScheme,
+            name,
+          });
+          expect(handlerRegistered).toBe(true);
+          return record;
+        }).pipe(Effect.scoped),
+      );
 
-    expect({
-      handlerRegistered,
-      records: await NodeFs.readdir(directory),
-    }).toEqual({ handlerRegistered: false, records: [] });
-    await expect(fetch(`${record.url}/catalog`)).rejects.toThrow();
-  });
+      expect({
+        handlerRegistered,
+        records: await NodeFs.readdir(directory),
+      }).toEqual({ handlerRegistered: false, records: [] });
+      await expect(fetch(`${record.url}/catalog`)).rejects.toThrow();
+    },
+  );
 
   it("releases earlier resources when registration fails", async () => {
     const directory = await temporaryDirectory();

--- a/extension/src/discovery/__tests__/LocalDiscoveryRegistry.test.ts
+++ b/extension/src/discovery/__tests__/LocalDiscoveryRegistry.test.ts
@@ -1,0 +1,126 @@
+import * as NodeChildProcess from "node:child_process";
+import * as NodeFs from "node:fs/promises";
+import * as NodeOs from "node:os";
+import * as NodePath from "node:path";
+import * as NodeUtil from "node:util";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { InstanceRecord } from "../Api.gen.ts";
+import { registerDiscoveryRecord } from "../LocalDiscoveryRegistry.ts";
+import { windowsPrivatePath } from "../windowsPrivatePath.ts";
+
+const temporaryDirectories: string[] = [];
+
+const record = InstanceRecord.make({
+  id: "00000000-0000-4000-8000-000000000001",
+  kind: "vscode",
+  name: "Code",
+  pid: 123,
+  started_at: "2026-09-03T12:00:00.000Z",
+  url: "http://127.0.0.1:1234/api/marimo/v1",
+  token: "secret",
+});
+
+async function temporaryDirectory(): Promise<string> {
+  const path = await NodeFs.mkdtemp(
+    NodePath.join(NodeOs.tmpdir(), "marimo-discovery-test-"),
+  );
+  temporaryDirectories.push(path);
+  return path;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((path) => NodeFs.rm(path, { recursive: true, force: true })),
+  );
+});
+
+describe("local discovery registry", { timeout: 30_000 }, () => {
+  it("publishes a private record and removes only its own record", async () => {
+    const root = await temporaryDirectory();
+    const directory = NodePath.join(root, "marimo", "discovery", "v1");
+    const recordPath = NodePath.join(directory, `${record.id}.json`);
+    const registration = await registerDiscoveryRecord(record, directory);
+    const other = InstanceRecord.make({
+      ...record,
+      id: "00000000-0000-4000-8000-000000000002",
+    });
+    await registerDiscoveryRecord(other, directory);
+
+    expect(JSON.parse(await NodeFs.readFile(recordPath, "utf8"))).toEqual(
+      record,
+    );
+
+    if (process.platform !== "win32") {
+      expect({
+        directory: (await NodeFs.stat(directory)).mode & 0o777,
+        record: (await NodeFs.stat(recordPath)).mode & 0o777,
+      }).toEqual({ directory: 0o700, record: 0o600 });
+    }
+
+    await registration.deregister();
+    expect(await NodeFs.readdir(directory)).toEqual([`${other.id}.json`]);
+  });
+
+  it.skipIf(process.platform === "win32")(
+    "refuses a pre-existing discovery directory accessible to other users",
+    async () => {
+      const root = await temporaryDirectory();
+      const directory = NodePath.join(root, "marimo", "discovery", "v1");
+      await NodeFs.mkdir(directory, { recursive: true, mode: 0o755 });
+      await NodeFs.chmod(NodePath.dirname(directory), 0o755);
+
+      await expect(registerDiscoveryRecord(record, directory)).rejects.toThrow(
+        "accessible to other users",
+      );
+    },
+  );
+
+  it.runIf(process.platform === "win32")(
+    "rejects broad Windows ACLs on existing directories and records",
+    async () => {
+      const root = await temporaryDirectory();
+      const directory = NodePath.join(root, "marimo", "discovery", "v1");
+      const registration = await registerDiscoveryRecord(record, directory);
+      const recordPath = NodePath.join(directory, `${record.id}.json`);
+      const icacls = NodePath.join(
+        process.env.SystemRoot ?? "C:\\Windows",
+        "System32",
+        "icacls.exe",
+      );
+      const run = NodeUtil.promisify(NodeChildProcess.execFile);
+
+      // Numeric SIDs keep this independent of the Windows display language.
+      await run(icacls, [recordPath, "/grant", "*S-1-1-0:R"]);
+      await expect(windowsPrivatePath(recordPath)).rejects.toThrow(
+        "accessible to other users",
+      );
+      await registration.deregister();
+      await run(icacls, [directory, "/grant", "*S-1-1-0:(OI)(CI)R"]);
+      await expect(registerDiscoveryRecord(record, directory)).rejects.toThrow(
+        "accessible to other users",
+      );
+      expect(await NodeFs.readdir(directory)).toEqual([]);
+    },
+  );
+
+  it.runIf(process.platform === "win32")(
+    "rejects a Windows junction without publishing into its target",
+    async () => {
+      const root = await temporaryDirectory();
+      const directory = NodePath.join(root, "marimo", "discovery", "v1");
+      const target = NodePath.join(root, "target");
+      await NodeFs.mkdir(target);
+      await windowsPrivatePath(NodePath.dirname(directory), true);
+      await NodeFs.symlink(target, directory, "junction");
+
+      await expect(registerDiscoveryRecord(record, directory)).rejects.toThrow(
+        "link",
+      );
+      expect(await NodeFs.readdir(target)).toEqual([]);
+    },
+  );
+});

--- a/extension/src/discovery/windowsPrivatePath.ts
+++ b/extension/src/discovery/windowsPrivatePath.ts
@@ -1,0 +1,90 @@
+import * as NodeChildProcess from "node:child_process";
+import * as NodePath from "node:path";
+import * as NodeUtil from "node:util";
+
+const run = NodeUtil.promisify(NodeChildProcess.execFile);
+
+// Match marimo's registry ACL policy without requiring a native Python host.
+// Paths are passed as data, never interpolated into PowerShell source.
+const script = String.raw`
+$ErrorActionPreference = 'Stop'
+$path = $env:MARIMO_DISCOVERY_PATH
+$user = [System.Security.Principal.WindowsIdentity]::GetCurrent().User.Value
+$trusted = @($user, 'S-1-5-18', 'S-1-5-32-544')
+
+if ($env:MARIMO_DISCOVERY_CREATE -eq '1') {
+    $security = [System.Security.AccessControl.DirectorySecurity]::new()
+    $security.SetSecurityDescriptorSddlForm(
+        ('O:{0}D:P(A;OICI;FA;;;{0})(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)' -f $user)
+    )
+    # Apply the protected DACL at creation, not after exposing a directory.
+    [void][System.IO.Directory]::CreateDirectory($path, $security)
+}
+
+$attributes = [System.IO.File]::GetAttributes($path)
+if (($attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0) {
+    throw "Discovery path is a link: $path"
+}
+$isDirectory = ($attributes -band [System.IO.FileAttributes]::Directory) -ne 0
+if ($env:MARIMO_DISCOVERY_CREATE -eq '1' -and -not $isDirectory) {
+    throw "Discovery path is not a directory: $path"
+}
+$sections = [System.Security.AccessControl.AccessControlSections]'Owner, Access'
+$acl = if ($isDirectory) {
+    [System.IO.Directory]::GetAccessControl($path, $sections)
+} else {
+    [System.IO.File]::GetAccessControl($path, $sections)
+}
+$descriptor = [System.Security.AccessControl.RawSecurityDescriptor]::new(
+    $acl.GetSecurityDescriptorBinaryForm(), 0
+)
+if ($null -eq $descriptor.Owner -or $trusted -notcontains $descriptor.Owner.Value) {
+    throw "Discovery path has an unexpected Windows owner: $path"
+}
+if ($null -eq $descriptor.DiscretionaryAcl) {
+    throw "Cannot inspect discovery ACL: $path"
+}
+foreach ($ace in $descriptor.DiscretionaryAcl) {
+    if ($ace.AceType -eq [System.Security.AccessControl.AceType]::AccessDenied) {
+        continue
+    }
+    if ($ace.AceType -ne [System.Security.AccessControl.AceType]::AccessAllowed) {
+        throw "Discovery path has an unsupported Windows ACL: $path"
+    }
+    if ($trusted -notcontains $ace.SecurityIdentifier.Value) {
+        throw "Discovery path is accessible to other users: $path"
+    }
+}
+`;
+
+/** Create or verify a path restricted to the current user and Windows admins. */
+export async function windowsPrivatePath(
+  path: string,
+  createDirectory = false,
+) {
+  await run(
+    NodePath.win32.join(
+      process.env.SystemRoot ?? "C:\\Windows",
+      "System32",
+      "WindowsPowerShell",
+      "v1.0",
+      "powershell.exe",
+    ),
+    [
+      "-NoLogo",
+      "-NoProfile",
+      "-NonInteractive",
+      "-EncodedCommand",
+      Buffer.from(script, "utf16le").toString("base64"),
+    ],
+    {
+      windowsHide: true,
+      timeout: 15_000,
+      env: {
+        ...process.env,
+        MARIMO_DISCOVERY_PATH: path,
+        MARIMO_DISCOVERY_CREATE: createDirectory ? "1" : "0",
+      },
+    },
+  );
+}

--- a/extension/src/features/Main.ts
+++ b/extension/src/features/Main.ts
@@ -3,6 +3,7 @@ import type * as vscode from "vscode";
 
 import { Config } from "../config/Config.ts";
 import { ConfigContextManagerLive } from "../config/ConfigContextManager.ts";
+import { LocalDiscoveryLive } from "../discovery/LocalDiscoveryPublisher.ts";
 import { CellExecutions } from "../kernel/CellExecutions.ts";
 import { DebugAdapter } from "../kernel/DebugAdapter.ts";
 import { NotebookControllersLive } from "../kernel/NotebookControllers.ts";
@@ -79,6 +80,7 @@ const MainLive = Layer.empty
     Layer.merge(NotebookControllersLive),
   )
   .pipe(
+    Layer.merge(LocalDiscoveryLive),
     Layer.provideMerge(Api.layer),
     Layer.provide(DebugAdapter.layer),
     Layer.provide(GitHubClient.layer),

--- a/extension/src/features/__tests__/AutoExport.test.ts
+++ b/extension/src/features/__tests__/AutoExport.test.ts
@@ -226,6 +226,7 @@ describe("AutoExport", () => {
         yield* PubSub.publish(ctx.operations, {
           notebookUri: ctx.notebook.id,
           sessionId: SESSION_ID,
+          scratchpadRunId: null,
           notification: { op: "completed-run", run_id: null },
         });
         yield* TestClock.adjust(AUTO_EXPORT_INTERVAL);
@@ -280,6 +281,7 @@ describe("AutoExport", () => {
         yield* PubSub.publish(ctx.operations, {
           notebookUri: ctx.notebook.id,
           sessionId: SESSION_ID,
+          scratchpadRunId: null,
           notification: { op: "completed-run", run_id: null },
         });
         yield* TestClock.adjust(AUTO_EXPORT_INTERVAL);

--- a/extension/src/features/__tests__/AutoExport.test.ts
+++ b/extension/src/features/__tests__/AutoExport.test.ts
@@ -103,6 +103,7 @@ const withTestCtx = Effect.fn(function* (
             next.set(uri.toString(), new TextDecoder().decode(contents));
             return next;
           }),
+        stat: () => Effect.succeed({ type: 1, ctime: 0, mtime: 0, size: 0 }),
       },
     },
   });

--- a/extension/src/kernel/NotebookRuntime.ts
+++ b/extension/src/kernel/NotebookRuntime.ts
@@ -92,6 +92,7 @@ type SessionScratchpadStream = Stream.Stream<
   | MarimoClientStartError
   | MarimoCommandError
   | NoActiveKernelError
+  | KernelSessionNotFoundError
   | Schema.SchemaError
 >;
 
@@ -156,6 +157,7 @@ export interface NotebookHandle {
     | MarimoClientStartError
     | MarimoCommandError
     | NoActiveKernelError
+    | KernelSessionNotFoundError
     | NotebookFileRootError
     | Schema.SchemaError
     | UnsavedNotebookError
@@ -414,23 +416,30 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
         sessionId: KernelSessionId,
         result: Option.Option<string>,
       ) =>
-        runInKernelSession(
-          notebookId,
-          sessionId,
-          Option.match(result, {
-            onSome: (text) =>
-              marimo.sendStdin({
-                notebookUri: notebookId,
-                kernelSessionId: sessionId,
-                text,
-              }),
-            onNone: () =>
-              marimo.interrupt({
-                notebookUri: notebookId,
-                kernelSessionId: sessionId,
-              }),
-          }),
-        );
+        Effect.gen(function* () {
+          const target = (yield* liveSessions.get).find(
+            (session) => session.sessionId === sessionId,
+          );
+          if (target === undefined)
+            return yield* new NoActiveKernelError({ notebookUri: notebookId });
+          return yield* runInKernelSession(
+            target.notebookUri,
+            sessionId,
+            Option.match(result, {
+              onSome: (text) =>
+                marimo.sendStdin({
+                  notebookUri: target.notebookUri,
+                  kernelSessionId: sessionId,
+                  text,
+                }),
+              onNone: () =>
+                marimo.interrupt({
+                  notebookUri: target.notebookUri,
+                  kernelSessionId: sessionId,
+                }),
+            }),
+          );
+        });
 
       const makeDocumentHandle = (
         session: NotebookDocumentSession,
@@ -505,12 +514,9 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
        * Only dispatch occupies the notebook FIFO; stdin and interrupts must
        * remain available while output streams. The permit serializes callers.
        */
-      const streamScratchpad = <Message extends KernelNotification, E>(
+      const streamScratchpad = <E>(
         notebookId: NotebookId,
-        notifications: PubSub.PubSub<Message>,
-        dispatch: (
-          runId: string,
-        ) => Effect.Effect<(message: Message) => boolean, E>,
+        dispatch: (runId: string) => Effect.Effect<KernelSessionId, E>,
         sessionId?: KernelSessionId,
       ) =>
         Stream.unwrap(
@@ -531,28 +537,34 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
             yield* Effect.acquireRelease(lock.take(1), () => lock.release(1), {
               interruptible: true,
             });
-            const subscription = yield* PubSub.subscribe(notifications);
+            const streamScope = yield* Effect.scope;
+            const subscription = yield* PubSub.subscribe(kernelOperations);
             const runId = crypto.randomUUID();
             const abandoned = yield* Deferred.make<void>();
 
+            let targetSessionId =
+              sessionId ?? Option.getOrUndefined(current)?.sessionId;
             yield* Effect.addFinalizer((exit) =>
               Exit.hasInterrupts(exit)
                 ? Deferred.succeed(abandoned, undefined).pipe(
                     Effect.andThen(
-                      marimo
-                        .interrupt({
-                          notebookUri: notebookId,
-                          kernelSessionId: sessionId,
+                      Effect.gen(function* () {
+                        const target = (yield* liveSessions.get).find(
+                          (session) => session.sessionId === targetSessionId,
+                        );
+                        yield* marimo.interrupt({
+                          notebookUri: target?.notebookUri ?? notebookId,
+                          kernelSessionId: targetSessionId,
                           runId,
-                        })
-                        .pipe(
-                          Effect.timeout("5 seconds"),
-                          Effect.catchCause((cause) =>
-                            Effect.logWarning(
-                              "Failed to interrupt abandoned scratchpad execution",
-                            ).pipe(Effect.annotateLogs({ cause })),
-                          ),
+                        });
+                      }).pipe(
+                        Effect.timeout("5 seconds"),
+                        Effect.catchCause((cause) =>
+                          Effect.logWarning(
+                            "Failed to interrupt abandoned scratchpad execution",
+                          ).pipe(Effect.annotateLogs({ cause })),
                         ),
+                      ),
                     ),
                   )
                 : Effect.void,
@@ -562,37 +574,64 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
               dispatch(runId),
               Deferred.await(abandoned).pipe(Effect.andThen(Effect.interrupt)),
             );
-            // Exact-session dispatch can wait for server-side admission. It
-            // must not block the notebook FIFO's stdin or interrupt commands;
-            // the server validates the requested kernel session itself.
-            const accepts = yield* send;
+            // Notebook dispatch owns a FIFO slot, so cancel inside its worker.
+            // Exact-session admission must leave the FIFO free for stdin.
+            targetSessionId = yield* sessionId === undefined
+              ? runInNotebook(notebookId, send)
+              : send;
+            const activeSessionId = targetSessionId;
 
             return Stream.fromSubscription(subscription).pipe(
               // Subscription starts before dispatch, which can wait for an
               // earlier execution. Only this server claim owns our output.
               Stream.filter(
                 (message) =>
-                  accepts(message) && message.scratchpadRunId === runId,
+                  message.sessionId === activeSessionId &&
+                  message.scratchpadRunId === runId,
               ),
               // marimo >= 0.23.3 flushes console output before cell idle.
               // The matching completed-run also includes the full cascade.
               Stream.takeUntil(isCompletedRunFor(runId)),
+              Stream.interruptWhen(
+                liveSessions.changes.pipe(
+                  Stream.filter(
+                    (sessions) =>
+                      !sessions.some(
+                        (session) => session.sessionId === activeSessionId,
+                      ),
+                  ),
+                  Stream.runHead,
+                  Effect.andThen(
+                    Effect.fail(
+                      new KernelSessionNotFoundError({
+                        sessionId: activeSessionId,
+                      }),
+                    ),
+                  ),
+                ),
+              ),
+              // Scratch and cascade prompts belong to this stream even when
+              // no editor is attached. Keep completion/cancellation readable
+              // while an input box is pending.
+              Stream.tap(({ notification, sessionId: targetSessionId }) =>
+                notification.op === "cell-op"
+                  ? handleStdinPrompt(
+                      notification,
+                      notebookId,
+                      targetSessionId,
+                      respondToStdin,
+                    ).pipe(
+                      Effect.provideService(VsCode, code),
+                      Effect.forkIn(streamScope),
+                    )
+                  : Effect.void,
+              ),
               Stream.filterMap(
                 Filter.fromPredicateOption(({ notification }) =>
                   isScratchpadOutput(notification)
                     ? Option.some(notification)
                     : Option.none(),
                 ),
-              ),
-              Stream.tap((operation) =>
-                sessionId === undefined
-                  ? Effect.void
-                  : handleStdinPrompt(
-                      operation,
-                      notebookId,
-                      sessionId,
-                      respondToStdin,
-                    ).pipe(Effect.provideService(VsCode, code)),
               ),
             );
           }),
@@ -605,17 +644,15 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
       ): SessionScratchpadStream =>
         streamScratchpad(
           notebookId,
-          kernelOperations,
           Effect.fnUntraced(function* (runId) {
+            const session = yield* findKernelSession(sessionId);
             yield* marimo.executeSessionScratchpad({
-              notebookUri: notebookId,
+              notebookUri: session.notebookUri,
               kernelSessionId: sessionId,
               code: sourceCode,
               runId,
             });
-            return (message: KernelNotification) =>
-              message.notebookUri === notebookId &&
-              message.sessionId === sessionId;
+            return sessionId;
           }),
           sessionId,
         );
@@ -627,47 +664,46 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
         id: notebookId,
         getController: Ref.get(controller),
         executeScratchpad: (sourceCode) =>
-          streamScratchpad(notebookId, kernelOperations, (runId) =>
-            runInNotebook(
-              notebookId,
-              Effect.gen(function* () {
-                const selectedController = yield* Ref.get(controller);
-                if (Option.isNone(selectedController)) {
-                  return yield* new NoActiveKernelError({
-                    notebookUri: notebookId,
-                  });
-                }
-
-                const session = documentSessions.current(notebookId);
-                if (Option.isNone(session)) {
-                  return yield* new NoActiveKernelError({
-                    notebookUri: notebookId,
-                  });
-                }
-                const notebook = yield* findOpenNotebook(notebookId);
-                const executable =
-                  yield* selectedController.value.resolveExecutable(notebook);
-                const workingDirectory = yield* resolveWorkingDirectory(
-                  notebookId,
-                  executable,
-                  notebook,
-                );
-                yield* marimo.executeScratchpad({
+          streamScratchpad(notebookId, (runId) =>
+            Effect.gen(function* () {
+              const selectedController = yield* Ref.get(controller);
+              if (Option.isNone(selectedController)) {
+                return yield* new NoActiveKernelError({
                   notebookUri: notebookId,
-                  executable,
-                  workingDirectory,
-                  code: sourceCode,
-                  runId,
                 });
-                yield* liveSessions.refresh();
-                yield* reconcileKernelSession(notebookId);
+              }
 
-                // The claim can outlive its editor document. Its envelope
-                // ID keeps results separate across close/reopen.
-                return (message: KernelNotification) =>
-                  message.notebookUri === notebookId;
-              }),
-            ),
+              const session = documentSessions.current(notebookId);
+              if (Option.isNone(session)) {
+                return yield* new NoActiveKernelError({
+                  notebookUri: notebookId,
+                });
+              }
+              const notebook = yield* findOpenNotebook(notebookId);
+              const executable =
+                yield* selectedController.value.resolveExecutable(notebook);
+              const workingDirectory = yield* resolveWorkingDirectory(
+                notebookId,
+                executable,
+                notebook,
+              );
+              yield* marimo.executeScratchpad({
+                notebookUri: notebookId,
+                executable,
+                workingDirectory,
+                code: sourceCode,
+                runId,
+              });
+              yield* liveSessions.refresh();
+              yield* reconcileKernelSession(notebookId);
+
+              const active = yield* liveSessions.find(notebookId);
+              if (Option.isNone(active))
+                return yield* new NoActiveKernelError({
+                  notebookUri: notebookId,
+                });
+              return active.value.sessionId;
+            }),
           ),
         updateUIElements: (request) =>
           runInCurrentKernelSession(notebookId, (sessionId) =>
@@ -1181,15 +1217,9 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
         ) {
           return Stream.unwrap(
             Effect.gen(function* () {
-              const session = EffectArray.findFirst(
-                yield* liveSessions.get,
-                (candidate) => candidate.sessionId === sessionId,
-              );
-              if (Option.isNone(session)) {
-                return yield* new KernelSessionNotFoundError({ sessionId });
-              }
+              const session = yield* findKernelSession(sessionId);
               return executeSessionScratchpad(
-                session.value.notebookUri,
+                session.notebookUri,
                 sessionId,
                 sourceCode,
               );
@@ -1197,6 +1227,17 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
           );
         },
       };
+
+      function findKernelSession(sessionId: KernelSessionId) {
+        return Effect.gen(function* () {
+          const session = (yield* liveSessions.get).find(
+            (candidate) => candidate.sessionId === sessionId,
+          );
+          if (session === undefined)
+            return yield* new KernelSessionNotFoundError({ sessionId });
+          return session;
+        });
+      }
 
       function findOpenNotebook(notebookId: NotebookId) {
         return Effect.gen(function* () {
@@ -1341,6 +1382,7 @@ function processOperation(
         yield* processNotebookOperation(notebookUri, operation, {
           ...options,
           kernelSessionId: sessionId,
+          scratchpadRunId: message.scratchpadRunId,
         });
         break;
       case "active-line":
@@ -1414,6 +1456,7 @@ function processNotebookOperation(
     readonly respondToStdin: RespondToStdin;
     readonly session: NotebookDocumentSession;
     readonly kernelSessionId: KernelSessionId | undefined;
+    readonly scratchpadRunId: string | null;
   },
 ) {
   return Effect.gen(function* () {
@@ -1455,6 +1498,9 @@ function processNotebookOperation(
         yield* Effect.logWarning("Cell operation has no Kernel Session ID");
         return;
       }
+      // The scratchpad stream owns prompts for its entire cascade. Normal
+      // notebook execution continues to use this document-scoped consumer.
+      if (options.scratchpadRunId !== null) return;
       yield* forkForSession(
         handleStdinPrompt(
           operation,

--- a/extension/src/kernel/NotebookRuntime.ts
+++ b/extension/src/kernel/NotebookRuntime.ts
@@ -87,6 +87,14 @@ type WithNoActiveKernel<T> =
     ? Effect.Effect<A, E | NoActiveKernelError, R>
     : never;
 
+type SessionScratchpadStream = Stream.Stream<
+  CellOperationNotification,
+  | MarimoClientStartError
+  | MarimoCommandError
+  | NoActiveKernelError
+  | Schema.SchemaError
+>;
+
 type RespondToStdin = (
   notebookId: NotebookId,
   sessionId: KernelSessionId,
@@ -115,6 +123,11 @@ export interface NotebookControllerSelection {
 export class NoActiveKernelError extends Data.TaggedError(
   "NoActiveKernelError",
 )<{ readonly notebookUri: NotebookId }> {}
+
+/** The requested kernel session is no longer live. */
+export class KernelSessionNotFoundError extends Data.TaggedError(
+  "KernelSessionNotFoundError",
+)<{ readonly sessionId: KernelSessionId }> {}
 
 /** A controller could not resolve a Python executable for the notebook. */
 export class ExecutableResolutionError extends Data.TaggedError(
@@ -184,6 +197,10 @@ export interface NotebookDocumentHandle {
 interface NotebookState {
   readonly handle: NotebookHandle;
   readonly controller: Ref.Ref<Option.Option<NotebookController>>;
+  readonly executeSessionScratchpad: (
+    sessionId: KernelSessionId,
+    code: string,
+  ) => SessionScratchpadStream;
 }
 
 type SessionNotification = KernelNotification & {
@@ -227,11 +244,18 @@ function isCompletedRunFor(runId: string) {
     message.notification.run_id === runId;
 }
 
+/**
+ * Select scratchpad results and cascade output.
+ *
+ * The scratch cell owns the result; cascade cells contribute console output
+ * and failures only.
+ */
 function isScratchpadOutput(
   notification: KernelNotification["notification"],
 ): notification is CellOperationNotification {
   if (notification.op !== "cell-op") return false;
   if (notification.cell_id === SCRATCH_CELL_ID) return true;
+  if (notification.output?.channel === "marimo-error") return true;
   if (notification.console == null) return false;
   return EffectArray.ensure(notification.console).some(
     (output) => output.channel === "stdout" || output.channel === "stderr",
@@ -267,6 +291,10 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
       const liveSessions = yield* LiveSessions;
       const documentSessions = yield* NotebookDocumentSessions;
       const operations = yield* PubSub.unbounded<SessionNotification>();
+      const kernelOperations = yield* PubSub.unbounded<KernelNotification>();
+      // Subscribe the normal notebook-operation consumer before starting the
+      // upstream fan-out so no startup notification can fall into a gap.
+      const runtimeOperations = yield* PubSub.subscribe(kernelOperations);
       const notebookStates = new Map<
         NotebookId | NotebookDocumentSession,
         NotebookState
@@ -283,8 +311,20 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
 
       yield* Effect.addFinalizer(() =>
         Effect.all(
-          [PubSub.shutdown(operations), PubSub.shutdown(controllerSelections)],
+          [
+            PubSub.shutdown(operations),
+            PubSub.shutdown(kernelOperations),
+            PubSub.shutdown(controllerSelections),
+          ],
           { discard: true },
+        ),
+      );
+
+      yield* Effect.forkScoped(
+        marimo.kernelNotifications.pipe(
+          Stream.runForEach((message) =>
+            PubSub.publish(kernelOperations, message),
+          ),
         ),
       );
 
@@ -442,6 +482,117 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
           ),
       });
 
+      /**
+       * Own one scratchpad stream from dispatch through completion.
+       *
+       * Only dispatch occupies the notebook FIFO; stdin and interrupts must
+       * remain available while output streams. The permit serializes callers.
+       */
+      const streamScratchpad = <Message extends KernelNotification, E>(
+        notebookId: NotebookId,
+        scratchpadLock: Semaphore.Semaphore,
+        notifications: PubSub.PubSub<Message>,
+        dispatch: (
+          runId: string,
+        ) => Effect.Effect<
+          (message: Message) => boolean,
+          E,
+          RuntimeWorkRequirements
+        >,
+        sessionId?: KernelSessionId,
+      ) =>
+        Stream.unwrap(
+          Effect.gen(function* () {
+            yield* Effect.acquireRelease(
+              scratchpadLock.take(1),
+              () => scratchpadLock.release(1),
+              { interruptible: true },
+            );
+            const subscription = yield* PubSub.subscribe(notifications);
+            const runId = crypto.randomUUID();
+            const abandoned = yield* Deferred.make<void>();
+
+            yield* Effect.addFinalizer((exit) =>
+              Exit.hasInterrupts(exit)
+                ? Deferred.succeed(abandoned, undefined).pipe(
+                    Effect.andThen(
+                      marimo
+                        .interrupt({
+                          notebookUri: notebookId,
+                          kernelSessionId: sessionId,
+                          runId,
+                        })
+                        .pipe(
+                          Effect.timeout("5 seconds"),
+                          Effect.catchCause((cause) =>
+                            Effect.logWarning(
+                              "Failed to interrupt abandoned scratchpad execution",
+                            ).pipe(Effect.annotateLogs({ cause })),
+                          ),
+                        ),
+                    ),
+                  )
+                : Effect.void,
+            );
+
+            const send = Effect.raceFirst(
+              dispatch(runId),
+              Deferred.await(abandoned).pipe(Effect.andThen(Effect.interrupt)),
+            );
+            const accepts = yield* sessionId === undefined
+              ? runInNotebook(notebookId, send)
+              : runInKernelSession(notebookId, sessionId, send);
+
+            return Stream.fromSubscription(subscription).pipe(
+              Stream.filter(accepts),
+              // marimo >= 0.23.3 flushes console output before cell idle.
+              // The matching completed-run also includes the full cascade.
+              Stream.takeUntil(isCompletedRunFor(runId)),
+              Stream.filterMap(
+                Filter.fromPredicateOption(({ notification }) =>
+                  isScratchpadOutput(notification)
+                    ? Option.some(notification)
+                    : Option.none(),
+                ),
+              ),
+              Stream.tap((operation) =>
+                sessionId === undefined
+                  ? Effect.void
+                  : handleStdinPrompt(
+                      operation,
+                      notebookId,
+                      sessionId,
+                      respondToStdin,
+                    ).pipe(Effect.provideService(VsCode, code)),
+              ),
+            );
+          }),
+        );
+
+      const executeSessionScratchpad = (
+        notebookId: NotebookId,
+        scratchpadLock: Semaphore.Semaphore,
+        sessionId: KernelSessionId,
+        sourceCode: string,
+      ): SessionScratchpadStream =>
+        streamScratchpad(
+          notebookId,
+          scratchpadLock,
+          kernelOperations,
+          Effect.fnUntraced(function* (runId) {
+            yield* marimo.executeSessionScratchpad({
+              notebookUri: notebookId,
+              kernelSessionId: sessionId,
+              code: sourceCode,
+              runId,
+            });
+            return (message: KernelNotification) =>
+              message.notebookUri === notebookId &&
+              message.sessionId === sessionId;
+          }),
+          sessionId,
+        );
+
       const makeHandle = (
         notebookId: NotebookId,
         controller: Ref.Ref<Option.Option<NotebookController>>,
@@ -450,99 +601,45 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
         id: notebookId,
         getController: Ref.get(controller),
         executeScratchpad: (sourceCode) =>
-          Stream.unwrap(
-            Effect.gen(function* () {
-              // Hold one permit for the lifetime of the stream's scope.
-              yield* Effect.acquireRelease(scratchpadLock.take(1), () =>
-                scratchpadLock.release(1),
-              );
-              const subscription = yield* PubSub.subscribe(operations);
-              const runId = crypto.randomUUID();
-              const abandoned = yield* Deferred.make<void>();
+          streamScratchpad(
+            notebookId,
+            scratchpadLock,
+            operations,
+            Effect.fnUntraced(function* (runId) {
+              const selectedController = yield* Ref.get(controller);
+              if (Option.isNone(selectedController)) {
+                return yield* new NoActiveKernelError({
+                  notebookUri: notebookId,
+                });
+              }
 
-              // Register cancellation in the stream scope before the command
-              // enters the notebook worker.
-              yield* Effect.addFinalizer((exit) =>
-                Exit.hasInterrupts(exit)
-                  ? Deferred.succeed(abandoned, undefined).pipe(
-                      Effect.andThen(
-                        marimo
-                          .interrupt({
-                            notebookUri: notebookId,
-                            runId,
-                          })
-                          .pipe(
-                            Effect.timeout("5 seconds"),
-                            Effect.catchCause((cause) =>
-                              Effect.logWarning(
-                                "Failed to interrupt kernel after scratchpad stream was abandoned",
-                              ).pipe(Effect.annotateLogs({ cause })),
-                            ),
-                          ),
-                      ),
-                    )
-                  : Effect.void,
-              );
-
-              return yield* runInNotebook(
+              const session = documentSessions.current(notebookId);
+              if (Option.isNone(session)) {
+                return yield* new NoActiveKernelError({
+                  notebookUri: notebookId,
+                });
+              }
+              const notebook = yield* findOpenNotebook(notebookId);
+              const executable =
+                yield* selectedController.value.resolveExecutable(notebook);
+              const workingDirectory = yield* resolveWorkingDirectory(
                 notebookId,
-                Effect.raceFirst(
-                  Effect.gen(function* () {
-                    const selectedController = yield* Ref.get(controller);
-                    if (Option.isNone(selectedController)) {
-                      return yield* new NoActiveKernelError({
-                        notebookUri: notebookId,
-                      });
-                    }
-
-                    const session = documentSessions.current(notebookId);
-                    if (Option.isNone(session)) {
-                      return yield* new NoActiveKernelError({
-                        notebookUri: notebookId,
-                      });
-                    }
-                    const notebook = yield* findOpenNotebook(notebookId);
-                    const executable =
-                      yield* selectedController.value.resolveExecutable(
-                        notebook,
-                      );
-                    const workingDirectory = yield* resolveWorkingDirectory(
-                      notebookId,
-                      executable,
-                      notebook,
-                    );
-                    yield* marimo.executeScratchpad({
-                      notebookUri: notebookId,
-                      executable,
-                      workingDirectory,
-                      code: sourceCode,
-                      runId,
-                    });
-                    yield* liveSessions.refresh();
-                    yield* reconcileKernelSession(notebookId);
-
-                    return Stream.fromSubscription(subscription).pipe(
-                      // Only output owned by the requesting document session;
-                      // a reopened notebook's operations belong to a new one.
-                      Stream.filter(
-                        (operation) => operation.session === session.value,
-                      ),
-                      Stream.takeUntil(isCompletedRunFor(runId)),
-                      Stream.filterMap(
-                        Filter.fromPredicateOption(
-                          ({ notification }: KernelNotification) =>
-                            isScratchpadOutput(notification)
-                              ? Option.some(notification)
-                              : Option.none(),
-                        ),
-                      ),
-                    );
-                  }),
-                  Deferred.await(abandoned).pipe(
-                    Effect.andThen(Effect.interrupt),
-                  ),
-                ),
+                executable,
+                notebook,
               );
+              yield* marimo.executeScratchpad({
+                notebookUri: notebookId,
+                executable,
+                workingDirectory,
+                code: sourceCode,
+                runId,
+              });
+              yield* liveSessions.refresh();
+              yield* reconcileKernelSession(notebookId);
+
+              // A reopened notebook belongs to a new document session.
+              return (message: SessionNotification) =>
+                message.session === session.value;
             }),
           ),
         updateUIElements: (request) =>
@@ -617,9 +714,17 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
         const controller = Ref.makeUnsafe<Option.Option<NotebookController>>(
           Option.none(),
         );
+        const scratchpadLock = Semaphore.makeUnsafe(1);
         return {
           controller,
-          handle: makeHandle(notebookId, controller, Semaphore.makeUnsafe(1)),
+          handle: makeHandle(notebookId, controller, scratchpadLock),
+          executeSessionScratchpad: (sessionId, sourceCode) =>
+            executeSessionScratchpad(
+              notebookId,
+              scratchpadLock,
+              sessionId,
+              sourceCode,
+            ),
         };
       };
 
@@ -694,7 +799,7 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
         ),
       );
       yield* Effect.forkScoped(
-        marimo.kernelNotifications.pipe(
+        Stream.fromSubscription(runtimeOperations).pipe(
           Stream.filterMap(
             Filter.fromPredicateOption((message: KernelNotification) => {
               return Option.map(
@@ -1052,6 +1157,24 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
           });
         },
         forNotebook,
+        executeSessionScratchpad(
+          sessionId: KernelSessionId,
+          sourceCode: string,
+        ) {
+          return Stream.unwrap(
+            Effect.gen(function* () {
+              const session = EffectArray.findFirst(
+                yield* liveSessions.get,
+                (candidate) => candidate.sessionId === sessionId,
+              );
+              if (Option.isNone(session)) {
+                return yield* new KernelSessionNotFoundError({ sessionId });
+              }
+              const state = yield* stateForNotebook(session.value.notebookUri);
+              return state.executeSessionScratchpad(sessionId, sourceCode);
+            }),
+          );
+        },
       };
 
       function findOpenNotebook(notebookId: NotebookId) {

--- a/extension/src/kernel/NotebookRuntime.ts
+++ b/extension/src/kernel/NotebookRuntime.ts
@@ -197,10 +197,6 @@ export interface NotebookDocumentHandle {
 interface NotebookState {
   readonly handle: NotebookHandle;
   readonly controller: Ref.Ref<Option.Option<NotebookController>>;
-  readonly executeSessionScratchpad: (
-    sessionId: KernelSessionId,
-    code: string,
-  ) => SessionScratchpadStream;
 }
 
 type SessionNotification = KernelNotification & {
@@ -290,7 +286,6 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
       const datasources = yield* NotebookDatasources;
       const liveSessions = yield* LiveSessions;
       const documentSessions = yield* NotebookDocumentSessions;
-      const operations = yield* PubSub.unbounded<SessionNotification>();
       const kernelOperations = yield* PubSub.unbounded<KernelNotification>();
       // Subscribe the normal notebook-operation consumer before starting the
       // upstream fan-out so no startup notification can fall into a gap.
@@ -305,6 +300,12 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
           session.sessionId,
         ]),
       );
+      // Kernel ownership survives editor document close/reopen. The notebook
+      // key covers an initial scratchpad that starts its kernel on demand.
+      const scratchpadLocks = new Map<
+        NotebookId | KernelSessionId,
+        Semaphore.Semaphore
+      >();
       const executor = yield* makeNotebookExecutor<RuntimeWorkRequirements>();
       const controllerSelections =
         yield* PubSub.unbounded<NotebookControllerSelection>();
@@ -312,7 +313,6 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
       yield* Effect.addFinalizer(() =>
         Effect.all(
           [
-            PubSub.shutdown(operations),
             PubSub.shutdown(kernelOperations),
             PubSub.shutdown(controllerSelections),
           ],
@@ -326,6 +326,7 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
             PubSub.publish(kernelOperations, message),
           ),
         ),
+        { startImmediately: true },
       );
 
       const reconcileKernelSession = Effect.fn(
@@ -337,6 +338,22 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
           ? current.value.sessionId
           : undefined;
         if (previous === next) return;
+
+        if (next !== undefined) {
+          const startingLock = scratchpadLocks.get(notebookId);
+          if (startingLock !== undefined) {
+            scratchpadLocks.set(next, startingLock);
+            scratchpadLocks.delete(notebookId);
+          }
+        }
+        if (
+          previous !== undefined &&
+          !(yield* liveSessions.get).some(
+            (session) => session.sessionId === previous,
+          )
+        ) {
+          scratchpadLocks.delete(previous);
+        }
 
         if (next === undefined) kernelSessions.delete(notebookId);
         else kernelSessions.set(notebookId, next);
@@ -490,24 +507,30 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
        */
       const streamScratchpad = <Message extends KernelNotification, E>(
         notebookId: NotebookId,
-        scratchpadLock: Semaphore.Semaphore,
         notifications: PubSub.PubSub<Message>,
         dispatch: (
           runId: string,
-        ) => Effect.Effect<
-          (message: Message) => boolean,
-          E,
-          RuntimeWorkRequirements
-        >,
+        ) => Effect.Effect<(message: Message) => boolean, E>,
         sessionId?: KernelSessionId,
       ) =>
         Stream.unwrap(
           Effect.gen(function* () {
-            yield* Effect.acquireRelease(
-              scratchpadLock.take(1),
-              () => scratchpadLock.release(1),
-              { interruptible: true },
-            );
+            const current = yield* liveSessions.find(notebookId);
+            const lockId =
+              sessionId ??
+              Option.getOrUndefined(current)?.sessionId ??
+              notebookId;
+            let scratchpadLock =
+              scratchpadLocks.get(lockId) ?? scratchpadLocks.get(notebookId);
+            if (scratchpadLock === undefined) {
+              scratchpadLock = Semaphore.makeUnsafe(1);
+            }
+            scratchpadLocks.set(lockId, scratchpadLock);
+            if (lockId !== notebookId) scratchpadLocks.delete(notebookId);
+            const lock = scratchpadLock;
+            yield* Effect.acquireRelease(lock.take(1), () => lock.release(1), {
+              interruptible: true,
+            });
             const subscription = yield* PubSub.subscribe(notifications);
             const runId = crypto.randomUUID();
             const abandoned = yield* Deferred.make<void>();
@@ -539,12 +562,18 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
               dispatch(runId),
               Deferred.await(abandoned).pipe(Effect.andThen(Effect.interrupt)),
             );
-            const accepts = yield* sessionId === undefined
-              ? runInNotebook(notebookId, send)
-              : runInKernelSession(notebookId, sessionId, send);
+            // Exact-session dispatch can wait for server-side admission. It
+            // must not block the notebook FIFO's stdin or interrupt commands;
+            // the server validates the requested kernel session itself.
+            const accepts = yield* send;
 
             return Stream.fromSubscription(subscription).pipe(
-              Stream.filter(accepts),
+              // Subscription starts before dispatch, which can wait for an
+              // earlier execution. Only this server claim owns our output.
+              Stream.filter(
+                (message) =>
+                  accepts(message) && message.scratchpadRunId === runId,
+              ),
               // marimo >= 0.23.3 flushes console output before cell idle.
               // The matching completed-run also includes the full cascade.
               Stream.takeUntil(isCompletedRunFor(runId)),
@@ -571,13 +600,11 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
 
       const executeSessionScratchpad = (
         notebookId: NotebookId,
-        scratchpadLock: Semaphore.Semaphore,
         sessionId: KernelSessionId,
         sourceCode: string,
       ): SessionScratchpadStream =>
         streamScratchpad(
           notebookId,
-          scratchpadLock,
           kernelOperations,
           Effect.fnUntraced(function* (runId) {
             yield* marimo.executeSessionScratchpad({
@@ -596,51 +623,51 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
       const makeHandle = (
         notebookId: NotebookId,
         controller: Ref.Ref<Option.Option<NotebookController>>,
-        scratchpadLock: Semaphore.Semaphore,
       ): NotebookHandle => ({
         id: notebookId,
         getController: Ref.get(controller),
         executeScratchpad: (sourceCode) =>
-          streamScratchpad(
-            notebookId,
-            scratchpadLock,
-            operations,
-            Effect.fnUntraced(function* (runId) {
-              const selectedController = yield* Ref.get(controller);
-              if (Option.isNone(selectedController)) {
-                return yield* new NoActiveKernelError({
-                  notebookUri: notebookId,
-                });
-              }
+          streamScratchpad(notebookId, kernelOperations, (runId) =>
+            runInNotebook(
+              notebookId,
+              Effect.gen(function* () {
+                const selectedController = yield* Ref.get(controller);
+                if (Option.isNone(selectedController)) {
+                  return yield* new NoActiveKernelError({
+                    notebookUri: notebookId,
+                  });
+                }
 
-              const session = documentSessions.current(notebookId);
-              if (Option.isNone(session)) {
-                return yield* new NoActiveKernelError({
+                const session = documentSessions.current(notebookId);
+                if (Option.isNone(session)) {
+                  return yield* new NoActiveKernelError({
+                    notebookUri: notebookId,
+                  });
+                }
+                const notebook = yield* findOpenNotebook(notebookId);
+                const executable =
+                  yield* selectedController.value.resolveExecutable(notebook);
+                const workingDirectory = yield* resolveWorkingDirectory(
+                  notebookId,
+                  executable,
+                  notebook,
+                );
+                yield* marimo.executeScratchpad({
                   notebookUri: notebookId,
+                  executable,
+                  workingDirectory,
+                  code: sourceCode,
+                  runId,
                 });
-              }
-              const notebook = yield* findOpenNotebook(notebookId);
-              const executable =
-                yield* selectedController.value.resolveExecutable(notebook);
-              const workingDirectory = yield* resolveWorkingDirectory(
-                notebookId,
-                executable,
-                notebook,
-              );
-              yield* marimo.executeScratchpad({
-                notebookUri: notebookId,
-                executable,
-                workingDirectory,
-                code: sourceCode,
-                runId,
-              });
-              yield* liveSessions.refresh();
-              yield* reconcileKernelSession(notebookId);
+                yield* liveSessions.refresh();
+                yield* reconcileKernelSession(notebookId);
 
-              // A reopened notebook belongs to a new document session.
-              return (message: SessionNotification) =>
-                message.session === session.value;
-            }),
+                // The claim can outlive its editor document. Its envelope
+                // ID keeps results separate across close/reopen.
+                return (message: KernelNotification) =>
+                  message.notebookUri === notebookId;
+              }),
+            ),
           ),
         updateUIElements: (request) =>
           runInCurrentKernelSession(notebookId, (sessionId) =>
@@ -714,17 +741,9 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
         const controller = Ref.makeUnsafe<Option.Option<NotebookController>>(
           Option.none(),
         );
-        const scratchpadLock = Semaphore.makeUnsafe(1);
         return {
           controller,
-          handle: makeHandle(notebookId, controller, scratchpadLock),
-          executeSessionScratchpad: (sessionId, sourceCode) =>
-            executeSessionScratchpad(
-              notebookId,
-              scratchpadLock,
-              sessionId,
-              sourceCode,
-            ),
+          handle: makeHandle(notebookId, controller),
         };
       };
 
@@ -840,7 +859,6 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
                   return;
                 }
 
-                yield* PubSub.publish(operations, message);
                 yield* Effect.annotateCurrentSpan(
                   "notification.type",
                   message.notification.op,
@@ -1170,8 +1188,11 @@ export class NotebookRuntime extends Context.Service<NotebookRuntime>()(
               if (Option.isNone(session)) {
                 return yield* new KernelSessionNotFoundError({ sessionId });
               }
-              const state = yield* stateForNotebook(session.value.notebookUri);
-              return state.executeSessionScratchpad(sessionId, sourceCode);
+              return executeSessionScratchpad(
+                session.value.notebookUri,
+                sessionId,
+                sourceCode,
+              );
             }),
           );
         },

--- a/extension/src/kernel/__tests__/NotebookRuntime.test.ts
+++ b/extension/src/kernel/__tests__/NotebookRuntime.test.ts
@@ -50,6 +50,7 @@ const makeTestLayer = Effect.fn(function* (
       executable: string;
       workingDirectory: string;
       startedAt: number;
+      marimoVersion: string | null;
       status: "idle";
       attached: boolean;
     }
@@ -74,6 +75,7 @@ const makeTestLayer = Effect.fn(function* (
               executable: request.executable,
               workingDirectory: request.workingDirectory,
               startedAt: 1,
+              marimoVersion: "0.24.0",
               status: "idle",
               attached: true,
             });
@@ -669,6 +671,7 @@ it.effect(
         executable: string;
         workingDirectory: string;
         startedAt: number;
+        marimoVersion: string | null;
         status: "idle";
         attached: boolean;
       }>;
@@ -692,6 +695,7 @@ it.effect(
             executable: "/usr/bin/python",
             workingDirectory: "/test",
             startedAt: 1,
+            marimoVersion: "0.24.0",
             status: "idle",
             attached: true,
           },

--- a/extension/src/kernel/__tests__/NotebookRuntimeOperations.test.ts
+++ b/extension/src/kernel/__tests__/NotebookRuntimeOperations.test.ts
@@ -80,6 +80,7 @@ const withTestCtx = Effect.fn(function* (
   workspace: {
     readonly applyEdit?: () => Effect.Effect<boolean>;
   } = {},
+  scratchpadDispatch: Effect.Effect<void> = Effect.void,
 ) {
   // Controllable showInputBox via Queue
   const inputQueue = yield* Queue.unbounded<Option.Option<string>>();
@@ -198,7 +199,8 @@ const withTestCtx = Effect.fn(function* (
             ) {
               const id = notebookId(request.notebookUri);
               serverSessions.set(id, {
-                sessionId: activeSessionId,
+                sessionId:
+                  id === notebookUri ? activeSessionId : REPLACEMENT_SESSION_ID,
                 notebookUri: id,
                 filename: NodePath.basename(request.notebookUri),
                 executable: request.executable,
@@ -209,6 +211,11 @@ const withTestCtx = Effect.fn(function* (
                 attached: true,
               });
             }
+            if (
+              request.kind === "execute-scratchpad" ||
+              request.kind === "execute-session-scratchpad"
+            )
+              yield* scratchpadDispatch;
             if (request.kind === "restart-session") {
               const id = notebookId(request.notebookUri);
               const current = serverSessions.get(id);
@@ -261,10 +268,12 @@ function makeIdleCellOperation(
   notebookUri: NotebookId,
   cid: string,
   overrides: Partial<CellOperationNotification> = {},
+  scratchpadRunId: string | null = null,
 ): KernelNotification {
   return {
     notebookUri,
     sessionId: ACTIVE_SESSION_ID,
+    scratchpadRunId,
     notification: {
       op: "cell-op" as const,
       cell_id: cellId(cid),
@@ -412,6 +421,7 @@ describe("NotebookRuntime operation processing", () => {
         yield* PubSub.publish(ctx.operationsPubSub, {
           notebookUri: ctx.notebookUri,
           sessionId: ACTIVE_SESSION_ID,
+          scratchpadRunId: null,
           notification: {
             op: "notebook-document-transaction",
             transaction: {
@@ -854,6 +864,7 @@ describe("NotebookRuntime scratch stream", () => {
         yield* PubSub.publish(ctx.operationsPubSub, {
           notebookUri: ctx.notebookUri,
           sessionId: ACTIVE_SESSION_ID,
+          scratchpadRunId: firstCommand.runId,
           notification: {
             op: "completed-run",
             run_id: firstCommand.runId,
@@ -879,6 +890,7 @@ describe("NotebookRuntime scratch stream", () => {
         yield* PubSub.publish(ctx.operationsPubSub, {
           notebookUri: ctx.notebookUri,
           sessionId: ACTIVE_SESSION_ID,
+          scratchpadRunId: secondCommand.runId,
           notification: {
             op: "completed-run",
             run_id: secondCommand.runId,
@@ -959,7 +971,11 @@ describe("NotebookRuntime scratch stream", () => {
         for (const command of commands) {
           yield* PubSub.publish(ctx.operationsPubSub, {
             notebookUri: command.notebookUri,
-            sessionId: ACTIVE_SESSION_ID,
+            sessionId:
+              command.notebookUri === ctx.notebookUri
+                ? ACTIVE_SESSION_ID
+                : REPLACEMENT_SESSION_ID,
+            scratchpadRunId: command.runId,
             notification: {
               op: "completed-run",
               run_id: command.runId,
@@ -1011,51 +1027,66 @@ describe("NotebookRuntime scratch stream", () => {
         const realCellId = Option.getOrThrow(cell.id);
 
         // The scratch cell's op carries the run's output. marimo leaves its
-        // run_id null (only the completed-run echoes ours), so we key on the
-        // SCRATCH_CELL_ID, not the run_id.
+        // run_id null. The envelope carries the server claim independently.
         yield* PubSub.publish(
           ctx.operationsPubSub,
-          makeIdleCellOperation(ctx.notebookUri, SCRATCH_CELL_ID, {
-            status: "running",
-            console: [
-              {
-                channel: "stdout",
-                data: "hi",
-                mimetype: "text/plain",
-                timestamp: 0,
-              },
-            ],
-          }),
+          makeIdleCellOperation(
+            ctx.notebookUri,
+            SCRATCH_CELL_ID,
+            {
+              status: "running",
+              console: [
+                {
+                  channel: "stdout",
+                  data: "hi",
+                  mimetype: "text/plain",
+                  timestamp: 0,
+                },
+              ],
+            },
+            runId,
+          ),
         );
 
         // Console from a cascade cell (one code mode ran) also streams.
         yield* PubSub.publish(
           ctx.operationsPubSub,
-          makeIdleCellOperation(ctx.notebookUri, realCellId, {
-            status: "running",
-            console: [
-              {
-                channel: "stdout",
-                data: "from cascade",
-                mimetype: "text/plain",
-                timestamp: 0,
-              },
-            ],
-          }),
+          makeIdleCellOperation(
+            ctx.notebookUri,
+            realCellId,
+            {
+              status: "running",
+              console: [
+                {
+                  channel: "stdout",
+                  data: "from cascade",
+                  mimetype: "text/plain",
+                  timestamp: 0,
+                },
+              ],
+            },
+            runId,
+          ),
         );
 
         // A status-only cascade op (no console) is not streamed.
         yield* PubSub.publish(
           ctx.operationsPubSub,
-          makeIdleCellOperation(ctx.notebookUri, realCellId, {
-            status: "idle",
-          }),
+          makeIdleCellOperation(
+            ctx.notebookUri,
+            realCellId,
+            {
+              status: "idle",
+            },
+            runId,
+          ),
         );
 
         // Our completed-run ends the stream (inclusive; filtered back out).
         yield* PubSub.publish(ctx.operationsPubSub, {
           notebookUri: ctx.notebookUri,
           sessionId: ACTIVE_SESSION_ID,
+          scratchpadRunId: runId ?? null,
           notification: {
             op: "completed-run",
             run_id: runId,
@@ -1156,20 +1187,26 @@ describe("NotebookRuntime scratch stream", () => {
 
         yield* PubSub.publish(
           ctx.operationsPubSub,
-          makeIdleCellOperation(ctx.notebookUri, SCRATCH_CELL_ID, {
-            console: [
-              {
-                channel: "stdout",
-                data: "retained\n",
-                mimetype: "text/plain",
-                timestamp: 0,
-              },
-            ],
-          }),
+          makeIdleCellOperation(
+            ctx.notebookUri,
+            SCRATCH_CELL_ID,
+            {
+              console: [
+                {
+                  channel: "stdout",
+                  data: "retained\n",
+                  mimetype: "text/plain",
+                  timestamp: 0,
+                },
+              ],
+            },
+            executeCmd.runId,
+          ),
         );
         yield* PubSub.publish(ctx.operationsPubSub, {
           notebookUri: ctx.notebookUri,
           sessionId: ACTIVE_SESSION_ID,
+          scratchpadRunId: executeCmd.runId ?? null,
           notification: {
             op: "completed-run",
             run_id: executeCmd.runId,
@@ -1178,16 +1215,21 @@ describe("NotebookRuntime scratch stream", () => {
         // Output after completion does not belong to this request.
         yield* PubSub.publish(
           ctx.operationsPubSub,
-          makeIdleCellOperation(ctx.notebookUri, SCRATCH_CELL_ID, {
-            console: [
-              {
-                channel: "stdout",
-                data: "trailing\n",
-                mimetype: "text/plain",
-                timestamp: 1,
-              },
-            ],
-          }),
+          makeIdleCellOperation(
+            ctx.notebookUri,
+            SCRATCH_CELL_ID,
+            {
+              console: [
+                {
+                  channel: "stdout",
+                  data: "trailing\n",
+                  mimetype: "text/plain",
+                  timestamp: 1,
+                },
+              ],
+            },
+            executeCmd.runId,
+          ),
         );
 
         const operations = yield* Fiber.join(streamFiber);
@@ -1241,17 +1283,22 @@ describe("NotebookRuntime scratch stream", () => {
 
         yield* PubSub.publish(
           ctx.operationsPubSub,
-          makeIdleCellOperation(ctx.notebookUri, SCRATCH_CELL_ID, {
-            status: "running",
-            console: [
-              {
-                channel: "stdin",
-                data: "Enter name: ",
-                mimetype: "text/plain",
-                timestamp: 0,
-              },
-            ],
-          }),
+          makeIdleCellOperation(
+            ctx.notebookUri,
+            SCRATCH_CELL_ID,
+            {
+              status: "running",
+              console: [
+                {
+                  channel: "stdin",
+                  data: "Enter name: ",
+                  mimetype: "text/plain",
+                  timestamp: 0,
+                },
+              ],
+            },
+            executeCmd.runId,
+          ),
         );
         yield* Queue.offer(ctx.inputQueue, Option.some("foo"));
         const responses = yield* SubscriptionRef.changes(ctx.executions).pipe(
@@ -1284,6 +1331,7 @@ describe("NotebookRuntime scratch stream", () => {
         yield* PubSub.publish(ctx.operationsPubSub, {
           notebookUri: ctx.notebookUri,
           sessionId: ACTIVE_SESSION_ID,
+          scratchpadRunId: executeCmd.runId ?? null,
           notification: {
             op: "completed-run",
             run_id: executeCmd.runId,
@@ -1333,6 +1381,218 @@ describe("NotebookRuntime scratch stream", () => {
       }).pipe(Effect.provide(ctx.layer));
     }),
   );
+  it.effect.each([
+    { reopen: false, caller: "discovery" },
+    { reopen: true, caller: "discovery" },
+    { reopen: false, caller: "notebook" },
+    { reopen: true, caller: "notebook" },
+  ])(
+    "preserves $caller scratchpad serialization after closing (reopen=$reopen)",
+    Effect.fn(function* ({ reopen, caller }) {
+      const ctx = yield* withTestCtx();
+      yield* Effect.gen(function* () {
+        const runtime = yield* NotebookRuntime;
+        const first = yield* Effect.forkChild(
+          Effect.gen(function* () {
+            if (caller === "notebook") {
+              const notebook = yield* runtime.forNotebook(ctx.notebookUri);
+              yield* notebook.executeScratchpad("first").pipe(Stream.runDrain);
+            } else {
+              yield* runtime
+                .executeSessionScratchpad(ACTIVE_SESSION_ID, "first")
+                .pipe(Stream.runDrain);
+            }
+          }),
+        );
+        const calls = yield* settle(
+          SubscriptionRef.get(ctx.executions),
+          (calls) =>
+            calls.some(
+              (c) =>
+                c.kind === "execute-session-scratchpad" ||
+                c.kind === "execute-scratchpad",
+            ),
+          "first dispatch",
+        );
+        const firstCommand = calls.find(
+          (c) =>
+            c.kind === "execute-session-scratchpad" ||
+            c.kind === "execute-scratchpad",
+        );
+        assert(firstCommand !== undefined);
+        yield* ctx.vscode.closeNotebook(ctx.editor.notebook);
+        if (reopen) yield* ctx.vscode.openNotebook(ctx.editor.notebook);
+        const second = yield* Effect.forkChild(
+          runtime
+            .executeSessionScratchpad(ACTIVE_SESSION_ID, "second")
+            .pipe(Stream.runDrain),
+          { startImmediately: true },
+        );
+        for (let i = 0; i < 30; i++) yield* Effect.yieldNow;
+        expect(
+          (yield* SubscriptionRef.get(ctx.executions)).filter(
+            (c) =>
+              c.kind === "execute-session-scratchpad" ||
+              c.kind === "execute-scratchpad",
+          ),
+        ).toHaveLength(1);
+        yield* PubSub.publish(ctx.operationsPubSub, {
+          notebookUri: ctx.notebookUri,
+          sessionId: ACTIVE_SESSION_ID,
+          scratchpadRunId: firstCommand.runId ?? null,
+          notification: { op: "completed-run", run_id: firstCommand.runId },
+        });
+        yield* Fiber.join(first);
+        yield* settle(
+          SubscriptionRef.get(ctx.executions),
+          (calls) =>
+            calls.filter(
+              (c) =>
+                c.kind === "execute-session-scratchpad" ||
+                c.kind === "execute-scratchpad",
+            ).length === 2,
+          "second dispatch after completion",
+        );
+        yield* Fiber.interrupt(second);
+      }).pipe(Effect.provide(ctx.layer));
+    }),
+  );
+
+  it.effect(
+    "excludes earlier output buffered while dispatch waits for an idle kernel",
+    Effect.fn(function* () {
+      const dispatch = yield* Latch.make();
+      const ctx = yield* withTestCtx(ACTIVE_SESSION_ID, {}, dispatch.await);
+      yield* Effect.gen(function* () {
+        const runtime = yield* NotebookRuntime;
+        const execution = yield* Effect.forkChild(
+          runtime
+            .executeSessionScratchpad(ACTIVE_SESSION_ID, "42")
+            .pipe(Stream.runCollect),
+        );
+        const calls = yield* settle(
+          SubscriptionRef.get(ctx.executions),
+          (calls) => calls.some((c) => c.kind === "execute-session-scratchpad"),
+          "dispatch waiting for idle",
+        );
+        const command = calls.find(
+          (c) => c.kind === "execute-session-scratchpad",
+        );
+        assert(command !== undefined);
+        yield* PubSub.publish(
+          ctx.operationsPubSub,
+          makeIdleCellOperation(ctx.notebookUri, "cell-1", {
+            console: [
+              {
+                channel: "stdout",
+                data: "previous execution",
+                mimetype: "text/plain",
+              },
+            ],
+            output: {
+              channel: "marimo-error",
+              mimetype: "application/vnd.marimo+error",
+              data: [
+                {
+                  type: "exception",
+                  exception_type: "ValueError",
+                  msg: "previous failure",
+                },
+              ],
+            },
+          }),
+        );
+        // A request waiting for admission must leave notebook controls free.
+        const notebook = yield* runtime.forNotebook(ctx.notebookUri);
+        yield* notebook.interrupt;
+        expect((yield* SubscriptionRef.get(ctx.executions)).at(-1)?.kind).toBe(
+          "interrupt",
+        );
+        yield* dispatch.open;
+        const ownOutput = makeIdleCellOperation(
+          ctx.notebookUri,
+          SCRATCH_CELL_ID,
+          { output: { channel: "output", mimetype: "text/plain", data: "42" } },
+          command.runId,
+        );
+        yield* PubSub.publish(ctx.operationsPubSub, ownOutput);
+        yield* PubSub.publish(ctx.operationsPubSub, {
+          notebookUri: ctx.notebookUri,
+          sessionId: ACTIVE_SESSION_ID,
+          scratchpadRunId: command.runId ?? null,
+          notification: { op: "completed-run", run_id: command.runId },
+        });
+        expect(yield* Fiber.join(execution)).toEqual([ownOutput.notification]);
+      }).pipe(Effect.provide(ctx.layer));
+    }),
+  );
+
+  it.effect(
+    "excludes the cancelled run's trailing output from the next request",
+    Effect.fn(function* () {
+      const ctx = yield* withTestCtx();
+      yield* Effect.gen(function* () {
+        const runtime = yield* NotebookRuntime;
+        const first = yield* Effect.forkChild(
+          runtime
+            .executeSessionScratchpad(ACTIVE_SESSION_ID, "first")
+            .pipe(Stream.runCollect),
+        );
+        const firstCalls = yield* settle(
+          SubscriptionRef.get(ctx.executions),
+          (calls) => calls.some((c) => c.kind === "execute-session-scratchpad"),
+          "first dispatch",
+        );
+        const firstCommand = firstCalls.find(
+          (c) => c.kind === "execute-session-scratchpad",
+        );
+        assert(firstCommand !== undefined);
+        yield* Fiber.interrupt(first);
+        const second = yield* Effect.forkChild(
+          runtime
+            .executeSessionScratchpad(ACTIVE_SESSION_ID, "second")
+            .pipe(Stream.runCollect),
+        );
+        const calls = yield* settle(
+          SubscriptionRef.get(ctx.executions),
+          (calls) =>
+            calls.filter((c) => c.kind === "execute-session-scratchpad")
+              .length === 2,
+          "second dispatch",
+        );
+        const secondCommand = calls.filter(
+          (c) => c.kind === "execute-session-scratchpad",
+        )[1];
+        assert(secondCommand !== undefined);
+        yield* PubSub.publish(
+          ctx.operationsPubSub,
+          makeIdleCellOperation(
+            ctx.notebookUri,
+            SCRATCH_CELL_ID,
+            {
+              console: [
+                {
+                  channel: "stderr",
+                  data: "interrupted previous run",
+                  mimetype: "text/plain",
+                },
+              ],
+            },
+            firstCommand.runId,
+          ),
+        );
+        for (const command of [firstCommand, secondCommand]) {
+          yield* PubSub.publish(ctx.operationsPubSub, {
+            notebookUri: ctx.notebookUri,
+            sessionId: ACTIVE_SESSION_ID,
+            scratchpadRunId: command.runId ?? null,
+            notification: { op: "completed-run", run_id: command.runId },
+          });
+        }
+        expect(yield* Fiber.join(second)).toEqual([]);
+      }).pipe(Effect.provide(ctx.layer));
+    }),
+  );
 });
 
 describe("NotebookRuntime state eviction", () => {
@@ -1353,6 +1613,7 @@ describe("NotebookRuntime state eviction", () => {
         yield* PubSub.publish(ctx.operationsPubSub, {
           notebookUri: ctx.notebookUri,
           sessionId: staleSessionId,
+          scratchpadRunId: null,
           notification: { op: "variables", variables: [] },
         });
         yield* Effect.yieldNow;
@@ -1363,6 +1624,7 @@ describe("NotebookRuntime state eviction", () => {
         yield* PubSub.publish(ctx.operationsPubSub, {
           notebookUri: ctx.notebookUri,
           sessionId: activeSessionId,
+          scratchpadRunId: null,
           notification: { op: "variables", variables: [] },
         });
         yield* variables.getVariables(ctx.notebookUri).pipe(
@@ -1407,6 +1669,7 @@ describe("NotebookRuntime state eviction", () => {
         yield* PubSub.publish(ctx.operationsPubSub, {
           notebookUri: ctx.notebookUri,
           sessionId: ACTIVE_SESSION_ID,
+          scratchpadRunId: null,
           notification: { op: "datasets", tables: [] },
         });
         yield* Effect.all([

--- a/extension/src/kernel/__tests__/NotebookRuntimeOperations.test.ts
+++ b/extension/src/kernel/__tests__/NotebookRuntimeOperations.test.ts
@@ -29,7 +29,10 @@ import {
 import { NOTEBOOK_TYPE, SCRATCH_CELL_ID } from "../../constants.ts";
 import { CellOutputProjections } from "../../kernel/CellOutputProjections.ts";
 import { makeNotebookExecutor } from "../../kernel/NotebookExecutor.ts";
-import { NotebookRuntime } from "../../kernel/NotebookRuntime.ts";
+import {
+  KernelSessionNotFoundError,
+  NotebookRuntime,
+} from "../../kernel/NotebookRuntime.ts";
 import { PythonController } from "../../kernel/PythonController.ts";
 import { VsCodeCellDrive } from "../../kernel/VsCodeCellDrive.ts";
 import {
@@ -85,6 +88,7 @@ const withTestCtx = Effect.fn(function* (
   // Controllable showInputBox via Queue
   const inputQueue = yield* Queue.unbounded<Option.Option<string>>();
   const inputRequested = yield* Latch.make();
+  const inputPrompts = yield* Ref.make(0);
 
   // Capture executeCommand calls
   const executions = yield* SubscriptionRef.make<ReadonlyArray<TestCommand>>(
@@ -141,7 +145,10 @@ const withTestCtx = Effect.fn(function* (
     workspace,
     window: {
       showInputBox: () =>
-        inputRequested.open.pipe(Effect.andThen(Queue.take(inputQueue))),
+        Ref.update(inputPrompts, (count) => count + 1).pipe(
+          Effect.andThen(inputRequested.open),
+          Effect.andThen(Queue.take(inputQueue)),
+        ),
       showErrorMessage: (message) =>
         Ref.update(errorMessages, (messages) => [...messages, message]).pipe(
           Effect.as(Option.none()),
@@ -216,6 +223,20 @@ const withTestCtx = Effect.fn(function* (
               request.kind === "execute-session-scratchpad"
             )
               yield* scratchpadDispatch;
+            if (request.kind === "move-session") {
+              const current = serverSessions.get(
+                notebookId(request.notebookUri),
+              );
+              if (current !== undefined) {
+                serverSessions.delete(notebookId(request.notebookUri));
+                serverSessions.set(notebookId(request.newNotebookUri), {
+                  ...current,
+                  notebookUri: notebookId(request.newNotebookUri),
+                });
+              }
+            }
+            if (request.kind === "close-session")
+              serverSessions.delete(notebookId(request.notebookUri));
             if (request.kind === "restart-session") {
               const id = notebookId(request.notebookUri);
               const current = serverSessions.get(id);
@@ -259,6 +280,7 @@ const withTestCtx = Effect.fn(function* (
     errorMessages,
     inputQueue,
     inputRequested,
+    inputPrompts,
     operationsPubSub,
     documentAnalysisPubSub,
   };
@@ -772,6 +794,69 @@ describe("NotebookRuntime stdin", () => {
 
 describe("NotebookRuntime scratch stream", () => {
   it.effect(
+    "releases the notebook queue when dispatch is cancelled",
+    Effect.fn(function* () {
+      const pending = yield* Latch.make();
+      const ctx = yield* withTestCtx(ACTIVE_SESSION_ID, {}, pending.await);
+      yield* Effect.gen(function* () {
+        const runtime = yield* NotebookRuntime;
+        const notebook = yield* runtime.forNotebook(ctx.notebookUri);
+        const execution = yield* Effect.forkChild(
+          notebook.executeScratchpad("42").pipe(Stream.runDrain),
+        );
+        yield* settle(
+          SubscriptionRef.get(ctx.executions),
+          (calls) => calls.some((c) => c.kind === "execute-scratchpad"),
+          "dispatch",
+        );
+        yield* Fiber.interrupt(execution);
+        const interrupted = yield* Ref.make(false);
+        yield* Effect.forkChild(
+          notebook.interrupt.pipe(Effect.andThen(Ref.set(interrupted, true))),
+        );
+        yield* settle(
+          Ref.get(interrupted),
+          Boolean,
+          "interrupt blocked by cancelled dispatch",
+        );
+      }).pipe(Effect.provide(ctx.layer));
+    }),
+  );
+
+  it.effect.each(["close", "restart"] as const)(
+    "fails an active execution on kernel %s",
+    Effect.fn(function* (action) {
+      const ctx = yield* withTestCtx();
+      yield* Effect.gen(function* () {
+        const runtime = yield* NotebookRuntime;
+        const notebook = yield* runtime.forNotebook(ctx.notebookUri);
+        const failure = yield* Deferred.make<unknown>();
+        yield* Effect.forkChild(
+          runtime.executeSessionScratchpad(ACTIVE_SESSION_ID, "42").pipe(
+            Stream.runDrain,
+            Effect.flip,
+            Effect.flatMap((error) => Deferred.succeed(failure, error)),
+          ),
+        );
+        yield* settle(
+          SubscriptionRef.get(ctx.executions),
+          (calls) => calls.some((c) => c.kind === "execute-session-scratchpad"),
+          "dispatch",
+        );
+        yield* notebook[action];
+        yield* settle(
+          Deferred.isDone(failure),
+          Boolean,
+          "stream outlived its kernel",
+        );
+        expect(yield* Deferred.await(failure)).toEqual(
+          new KernelSessionNotFoundError({ sessionId: ACTIVE_SESSION_ID }),
+        );
+      }).pipe(Effect.provide(ctx.layer));
+    }),
+  );
+
+  it.effect(
     "rejects a replaced session without dispatching scratchpad code",
     Effect.fn(function* () {
       const ctx = yield* withTestCtx();
@@ -1159,110 +1244,12 @@ describe("NotebookRuntime scratch stream", () => {
   );
 
   it.effect(
-    "streams an exact retained session after its notebook document closes",
+    "keeps stdin and interrupts available after renaming a retained notebook",
     Effect.fn(function* () {
       const ctx = yield* withTestCtx();
 
       yield* Effect.gen(function* () {
         const runtime = yield* NotebookRuntime;
-        yield* ctx.vscode.closeNotebook(ctx.editor.notebook);
-        yield* Effect.yieldNow;
-
-        const streamFiber = yield* Effect.forkChild(
-          runtime
-            .executeSessionScratchpad(ACTIVE_SESSION_ID, "print('retained')")
-            .pipe(Stream.runCollect),
-        );
-        const calls = yield* SubscriptionRef.changes(ctx.executions).pipe(
-          Stream.filter((current) =>
-            current.some((call) => call.kind === "execute-session-scratchpad"),
-          ),
-          Stream.runHead,
-          Effect.map(Option.getOrThrow),
-        );
-        const executeCmd = calls.find(
-          (call) => call.kind === "execute-session-scratchpad",
-        );
-        assert(executeCmd !== undefined);
-
-        yield* PubSub.publish(
-          ctx.operationsPubSub,
-          makeIdleCellOperation(
-            ctx.notebookUri,
-            SCRATCH_CELL_ID,
-            {
-              console: [
-                {
-                  channel: "stdout",
-                  data: "retained\n",
-                  mimetype: "text/plain",
-                  timestamp: 0,
-                },
-              ],
-            },
-            executeCmd.runId,
-          ),
-        );
-        yield* PubSub.publish(ctx.operationsPubSub, {
-          notebookUri: ctx.notebookUri,
-          sessionId: ACTIVE_SESSION_ID,
-          scratchpadRunId: executeCmd.runId ?? null,
-          notification: {
-            op: "completed-run",
-            run_id: executeCmd.runId,
-          },
-        });
-        // Output after completion does not belong to this request.
-        yield* PubSub.publish(
-          ctx.operationsPubSub,
-          makeIdleCellOperation(
-            ctx.notebookUri,
-            SCRATCH_CELL_ID,
-            {
-              console: [
-                {
-                  channel: "stdout",
-                  data: "trailing\n",
-                  mimetype: "text/plain",
-                  timestamp: 1,
-                },
-              ],
-            },
-            executeCmd.runId,
-          ),
-        );
-
-        const operations = yield* Fiber.join(streamFiber);
-        expect(
-          operations.flatMap((operation) => {
-            const console = Array.isArray(operation.console)
-              ? operation.console
-              : operation.console == null
-                ? []
-                : [operation.console];
-            return console.map(({ channel, data }) => ({ channel, data }));
-          }),
-        ).toMatchInlineSnapshot(`
-          [
-            {
-              "channel": "stdout",
-              "data": "retained
-          ",
-            },
-          ]
-        `);
-      }).pipe(Effect.provide(ctx.layer));
-    }),
-  );
-
-  it.effect(
-    "keeps stdin and interrupts available during retained execution",
-    Effect.fn(function* () {
-      const ctx = yield* withTestCtx();
-
-      yield* Effect.gen(function* () {
-        const runtime = yield* NotebookRuntime;
-        const notebook = yield* runtime.forNotebook(ctx.notebookUri);
         const streamFiber = yield* Effect.forkChild(
           runtime
             .executeSessionScratchpad(ACTIVE_SESSION_ID, "input()")
@@ -1300,6 +1287,10 @@ describe("NotebookRuntime scratch stream", () => {
             executeCmd.runId,
           ),
         );
+        yield* ctx.inputRequested.await;
+        const renamed = notebookId("file:///workspace/renamed.py");
+        yield* runtime.moveSession(ctx.notebookUri, renamed);
+        const notebook = yield* runtime.forNotebook(renamed);
         yield* Queue.offer(ctx.inputQueue, Option.some("foo"));
         const responses = yield* SubscriptionRef.changes(ctx.executions).pipe(
           Stream.filter((calls) =>
@@ -1311,7 +1302,7 @@ describe("NotebookRuntime scratch stream", () => {
         expect(
           responses.find((call) => call.kind === "send-stdin"),
         ).toMatchObject({
-          notebookUri: ctx.notebookUri,
+          notebookUri: renamed,
           kernelSessionId: ACTIVE_SESSION_ID,
           text: "foo",
         });
@@ -1324,12 +1315,12 @@ describe("NotebookRuntime scratch stream", () => {
           (yield* SubscriptionRef.get(ctx.executions)).at(-1),
         ).toMatchObject({
           kind: "interrupt",
-          notebookUri: ctx.notebookUri,
+          notebookUri: renamed,
           kernelSessionId: ACTIVE_SESSION_ID,
         });
 
         yield* PubSub.publish(ctx.operationsPubSub, {
-          notebookUri: ctx.notebookUri,
+          notebookUri: renamed,
           sessionId: ACTIVE_SESSION_ID,
           scratchpadRunId: executeCmd.runId ?? null,
           notification: {
@@ -1343,7 +1334,7 @@ describe("NotebookRuntime scratch stream", () => {
   );
 
   it.effect(
-    "interrupts the exact retained run when its stream disconnects",
+    "interrupts the exact retained run after rename when its stream disconnects",
     Effect.fn(function* () {
       const ctx = yield* withTestCtx();
 
@@ -1366,6 +1357,8 @@ describe("NotebookRuntime scratch stream", () => {
         );
         assert(executeCmd !== undefined);
 
+        const renamed = notebookId("file:///workspace/renamed.py");
+        yield* runtime.moveSession(ctx.notebookUri, renamed);
         yield* Fiber.interrupt(streamFiber);
 
         expect(
@@ -1374,7 +1367,7 @@ describe("NotebookRuntime scratch stream", () => {
           ),
         ).toMatchObject({
           kind: "interrupt",
-          notebookUri: ctx.notebookUri,
+          notebookUri: renamed,
           kernelSessionId: ACTIVE_SESSION_ID,
           runId: executeCmd.runId,
         });
@@ -1382,13 +1375,13 @@ describe("NotebookRuntime scratch stream", () => {
     }),
   );
   it.effect.each([
-    { reopen: false, caller: "discovery" },
+    { reopen: false, caller: "discovery", rename: true },
     { reopen: true, caller: "discovery" },
-    { reopen: false, caller: "notebook" },
+    { reopen: false, caller: "notebook", rename: true },
     { reopen: true, caller: "notebook" },
   ])(
-    "preserves $caller scratchpad serialization after closing (reopen=$reopen)",
-    Effect.fn(function* ({ reopen, caller }) {
+    "preserves $caller scratchpad serialization across lifecycle changes (reopen=$reopen)",
+    Effect.fn(function* ({ reopen, caller, rename }) {
       const ctx = yield* withTestCtx();
       yield* Effect.gen(function* () {
         const runtime = yield* NotebookRuntime;
@@ -1422,6 +1415,10 @@ describe("NotebookRuntime scratch stream", () => {
         assert(firstCommand !== undefined);
         yield* ctx.vscode.closeNotebook(ctx.editor.notebook);
         if (reopen) yield* ctx.vscode.openNotebook(ctx.editor.notebook);
+        const target = rename
+          ? notebookId("file:///workspace/renamed.py")
+          : ctx.notebookUri;
+        if (rename) yield* runtime.moveSession(ctx.notebookUri, target);
         const second = yield* Effect.forkChild(
           runtime
             .executeSessionScratchpad(ACTIVE_SESSION_ID, "second")
@@ -1437,7 +1434,7 @@ describe("NotebookRuntime scratch stream", () => {
           ),
         ).toHaveLength(1);
         yield* PubSub.publish(ctx.operationsPubSub, {
-          notebookUri: ctx.notebookUri,
+          notebookUri: target,
           sessionId: ACTIVE_SESSION_ID,
           scratchpadRunId: firstCommand.runId ?? null,
           notification: { op: "completed-run", run_id: firstCommand.runId },
@@ -1459,12 +1456,13 @@ describe("NotebookRuntime scratch stream", () => {
   );
 
   it.effect(
-    "excludes earlier output buffered while dispatch waits for an idle kernel",
+    "streams only the retained run through completion after its editor closes",
     Effect.fn(function* () {
       const dispatch = yield* Latch.make();
       const ctx = yield* withTestCtx(ACTIVE_SESSION_ID, {}, dispatch.await);
       yield* Effect.gen(function* () {
         const runtime = yield* NotebookRuntime;
+        yield* ctx.vscode.closeNotebook(ctx.editor.notebook);
         const execution = yield* Effect.forkChild(
           runtime
             .executeSessionScratchpad(ACTIVE_SESSION_ID, "42")
@@ -1522,6 +1520,8 @@ describe("NotebookRuntime scratch stream", () => {
           scratchpadRunId: command.runId ?? null,
           notification: { op: "completed-run", run_id: command.runId },
         });
+        // Even a notification with the same claim is excluded after completion.
+        yield* PubSub.publish(ctx.operationsPubSub, ownOutput);
         expect(yield* Fiber.join(execution)).toEqual([ownOutput.notification]);
       }).pipe(Effect.provide(ctx.layer));
     }),
@@ -1590,6 +1590,144 @@ describe("NotebookRuntime scratch stream", () => {
           });
         }
         expect(yield* Fiber.join(second)).toEqual([]);
+      }).pipe(Effect.provide(ctx.layer));
+    }),
+  );
+  it.effect.each([
+    { caller: "detached", cell: "cell-1" },
+    { caller: "attached", cell: "cell-1" },
+    { caller: "notebook", cell: "cell-1" },
+    { caller: "notebook", cell: SCRATCH_CELL_ID },
+  ])(
+    "answers exactly one stdin prompt for $caller execution in $cell",
+    Effect.fn(function* ({ caller, cell }) {
+      const ctx = yield* withTestCtx();
+      yield* Effect.gen(function* () {
+        const runtime = yield* NotebookRuntime;
+        if (caller === "detached")
+          yield* ctx.vscode.closeNotebook(ctx.editor.notebook);
+        const execution = yield* Effect.forkChild(
+          Effect.gen(function* () {
+            if (caller === "notebook") {
+              const notebook = yield* runtime.forNotebook(ctx.notebookUri);
+              yield* notebook
+                .executeScratchpad("input()")
+                .pipe(Stream.runDrain);
+            } else {
+              yield* runtime
+                .executeSessionScratchpad(ACTIVE_SESSION_ID, "input()")
+                .pipe(Stream.runDrain);
+            }
+          }),
+        );
+        const calls = yield* settle(
+          SubscriptionRef.get(ctx.executions),
+          (calls) =>
+            calls.some(
+              (c) =>
+                c.kind === "execute-session-scratchpad" ||
+                c.kind === "execute-scratchpad",
+            ),
+          "scratchpad dispatch",
+        );
+        const command = calls.find(
+          (c) =>
+            c.kind === "execute-session-scratchpad" ||
+            c.kind === "execute-scratchpad",
+        );
+        assert(command !== undefined);
+        yield* PubSub.publish(
+          ctx.operationsPubSub,
+          makeIdleCellOperation(
+            ctx.notebookUri,
+            cell,
+            {
+              console: [
+                { channel: "stdin", data: "Name?", mimetype: "text/plain" },
+              ],
+            },
+            command.runId,
+          ),
+        );
+        yield* ctx.inputRequested.await;
+        yield* Queue.offer(ctx.inputQueue, Option.some("answer"));
+        yield* settle(
+          SubscriptionRef.get(ctx.executions),
+          (calls) => calls.some((c) => c.kind === "send-stdin"),
+          "stdin response",
+        );
+        yield* PubSub.publish(ctx.operationsPubSub, {
+          notebookUri: ctx.notebookUri,
+          sessionId: ACTIVE_SESSION_ID,
+          scratchpadRunId: command.runId ?? null,
+          notification: { op: "completed-run", run_id: command.runId },
+        });
+        yield* Fiber.join(execution);
+        expect(yield* Ref.get(ctx.inputPrompts)).toBe(1);
+        expect(
+          (yield* SubscriptionRef.get(ctx.executions)).filter(
+            (c) => c.kind === "send-stdin",
+          ),
+        ).toEqual([
+          {
+            kind: "send-stdin",
+            notebookUri: ctx.notebookUri,
+            kernelSessionId: ACTIVE_SESSION_ID,
+            text: "answer",
+          },
+        ]);
+      }).pipe(Effect.provide(ctx.layer));
+    }),
+  );
+
+  it.effect(
+    "finishes a scratchpad stream while its stdin prompt is still pending",
+    Effect.fn(function* () {
+      const ctx = yield* withTestCtx();
+      yield* Effect.gen(function* () {
+        const runtime = yield* NotebookRuntime;
+        const execution = yield* Effect.forkChild(
+          runtime
+            .executeSessionScratchpad(ACTIVE_SESSION_ID, "input()")
+            .pipe(Stream.runDrain),
+        );
+        const calls = yield* settle(
+          SubscriptionRef.get(ctx.executions),
+          (calls) => calls.some((c) => c.kind === "execute-session-scratchpad"),
+          "scratchpad dispatch",
+        );
+        const command = calls.find(
+          (c) => c.kind === "execute-session-scratchpad",
+        );
+        assert(command !== undefined);
+        yield* PubSub.publish(
+          ctx.operationsPubSub,
+          makeIdleCellOperation(
+            ctx.notebookUri,
+            SCRATCH_CELL_ID,
+            {
+              console: [
+                { channel: "stdin", data: "Name?", mimetype: "text/plain" },
+              ],
+            },
+            command.runId,
+          ),
+        );
+        yield* ctx.inputRequested.await;
+        // An interrupt from another caller can finish the run before the user answers.
+        yield* PubSub.publish(ctx.operationsPubSub, {
+          notebookUri: ctx.notebookUri,
+          sessionId: ACTIVE_SESSION_ID,
+          scratchpadRunId: command.runId ?? null,
+          notification: { op: "completed-run", run_id: command.runId },
+        });
+        yield* Fiber.join(execution);
+        yield* Queue.offer(ctx.inputQueue, Option.some("late answer"));
+        expect(
+          (yield* SubscriptionRef.get(ctx.executions)).filter(
+            (c) => c.kind === "send-stdin",
+          ),
+        ).toEqual([]);
       }).pipe(Effect.provide(ctx.layer));
     }),
   );

--- a/extension/src/kernel/__tests__/NotebookRuntimeOperations.test.ts
+++ b/extension/src/kernel/__tests__/NotebookRuntimeOperations.test.ts
@@ -762,7 +762,41 @@ describe("NotebookRuntime stdin", () => {
 
 describe("NotebookRuntime scratch stream", () => {
   it.effect(
-    "runs one scratchpad at a time within a notebook",
+    "rejects a replaced session without dispatching scratchpad code",
+    Effect.fn(function* () {
+      const ctx = yield* withTestCtx();
+
+      yield* Effect.gen(function* () {
+        const runtime = yield* NotebookRuntime;
+        const notebook = yield* runtime.forNotebook(ctx.notebookUri);
+        const stream = runtime.executeSessionScratchpad(
+          ACTIVE_SESSION_ID,
+          "42",
+        );
+
+        yield* notebook.restart;
+
+        const error = yield* stream.pipe(Stream.runDrain, Effect.flip);
+        expect({
+          error: { ...error },
+          dispatched: (yield* SubscriptionRef.get(ctx.executions)).filter(
+            (call) => call.kind === "execute-session-scratchpad",
+          ),
+        }).toMatchInlineSnapshot(`
+          {
+            "dispatched": [],
+            "error": {
+              "_tag": "KernelSessionNotFoundError",
+              "sessionId": "00000000-0000-4000-8000-000000000001",
+            },
+          }
+        `);
+      }).pipe(Effect.provide(ctx.layer));
+    }),
+  );
+
+  it.effect(
+    "serializes scratchpad callers and cancels waiting requests",
     Effect.fn(function* () {
       const ctx = yield* withTestCtx();
 
@@ -773,11 +807,17 @@ describe("NotebookRuntime scratch stream", () => {
           notebook.executeScratchpad("print('first')").pipe(Stream.runDrain),
         );
         const second = yield* Effect.forkChild(
-          notebook.executeScratchpad("print('second')").pipe(Stream.runDrain),
+          runtime
+            .executeSessionScratchpad(ACTIVE_SESSION_ID, "print('second')")
+            .pipe(Stream.runDrain),
         );
 
         const scratchpadCalls = (calls: ReadonlyArray<TestCommand>) =>
-          calls.filter((call) => call.kind === "execute-scratchpad");
+          calls.filter(
+            (call) =>
+              call.kind === "execute-scratchpad" ||
+              call.kind === "execute-session-scratchpad",
+          );
 
         // Wait until the first command is recorded. Do not count scheduler
         // drains. The scratchpad setup can need more than one drain.
@@ -785,6 +825,18 @@ describe("NotebookRuntime scratch stream", () => {
           Stream.filter((calls) => scratchpadCalls(calls).length >= 1),
           Stream.runHead,
         );
+        const cancelled = yield* Effect.forkChild(
+          notebook
+            .executeScratchpad("print('cancelled')")
+            .pipe(Stream.runDrain),
+          { startImmediately: true },
+        );
+        yield* Fiber.interrupt(cancelled);
+        expect(
+          (yield* SubscriptionRef.get(ctx.executions)).some(
+            (call) => call.kind === "interrupt",
+          ),
+        ).toBe(false);
         // Extra drain: give the second scratchpad every chance to
         // (incorrectly) bypass the per-notebook lock before asserting that
         // exactly one command went out.
@@ -1011,10 +1063,15 @@ describe("NotebookRuntime scratch stream", () => {
         });
 
         const ops = yield* Fiber.join(streamFiber);
-        const cellIds = ops.map((op) => op.cell_id);
-        expect(ops).toHaveLength(2);
-        expect(cellIds).toContain(SCRATCH_CELL_ID);
-        expect(cellIds).toContain(realCellId);
+        expect({
+          cellIds: ops.map((op) => op.cell_id),
+          interrupted: (yield* SubscriptionRef.get(ctx.executions)).some(
+            (call) => call.kind === "interrupt",
+          ),
+        }).toEqual({
+          cellIds: [SCRATCH_CELL_ID, realCellId],
+          interrupted: false,
+        });
       }).pipe(Effect.provide(ctx.layer));
     }),
   );
@@ -1071,48 +1128,208 @@ describe("NotebookRuntime scratch stream", () => {
   );
 
   it.effect(
-    "does not interrupt the kernel after a normal completed-run",
+    "streams an exact retained session after its notebook document closes",
     Effect.fn(function* () {
       const ctx = yield* withTestCtx();
 
       yield* Effect.gen(function* () {
         const runtime = yield* NotebookRuntime;
-
-        yield* ctx.vscode.setActiveNotebookEditor(Option.some(ctx.editor));
+        yield* ctx.vscode.closeNotebook(ctx.editor.notebook);
         yield* Effect.yieldNow;
-        const notebook = yield* runtime.forNotebook(ctx.notebookUri);
 
         const streamFiber = yield* Effect.forkChild(
-          notebook.executeScratchpad("print('hi')").pipe(Stream.runCollect),
+          runtime
+            .executeSessionScratchpad(ACTIVE_SESSION_ID, "print('retained')")
+            .pipe(Stream.runCollect),
         );
-
-        // Wait until the command is recorded. Do not count scheduler
-        // drains. The scratchpad setup can need more than one drain, which
-        // makes a single scheduler yield flaky.
         const calls = yield* SubscriptionRef.changes(ctx.executions).pipe(
           Stream.filter((current) =>
-            current.some((call) => call.kind === "execute-scratchpad"),
+            current.some((call) => call.kind === "execute-session-scratchpad"),
           ),
           Stream.runHead,
           Effect.map(Option.getOrThrow),
         );
-        const executeCmd = calls.find((c) => c.kind === "execute-scratchpad");
+        const executeCmd = calls.find(
+          (call) => call.kind === "execute-session-scratchpad",
+        );
         assert(executeCmd !== undefined);
-        const { runId } = executeCmd;
 
-        // Our completed-run ends the stream normally.
+        yield* PubSub.publish(
+          ctx.operationsPubSub,
+          makeIdleCellOperation(ctx.notebookUri, SCRATCH_CELL_ID, {
+            console: [
+              {
+                channel: "stdout",
+                data: "retained\n",
+                mimetype: "text/plain",
+                timestamp: 0,
+              },
+            ],
+          }),
+        );
         yield* PubSub.publish(ctx.operationsPubSub, {
           notebookUri: ctx.notebookUri,
           sessionId: ACTIVE_SESSION_ID,
-          notification: { op: "completed-run", run_id: runId },
+          notification: {
+            op: "completed-run",
+            run_id: executeCmd.runId,
+          },
+        });
+        // Output after completion does not belong to this request.
+        yield* PubSub.publish(
+          ctx.operationsPubSub,
+          makeIdleCellOperation(ctx.notebookUri, SCRATCH_CELL_ID, {
+            console: [
+              {
+                channel: "stdout",
+                data: "trailing\n",
+                mimetype: "text/plain",
+                timestamp: 1,
+              },
+            ],
+          }),
+        );
+
+        const operations = yield* Fiber.join(streamFiber);
+        expect(
+          operations.flatMap((operation) => {
+            const console = Array.isArray(operation.console)
+              ? operation.console
+              : operation.console == null
+                ? []
+                : [operation.console];
+            return console.map(({ channel, data }) => ({ channel, data }));
+          }),
+        ).toMatchInlineSnapshot(`
+          [
+            {
+              "channel": "stdout",
+              "data": "retained
+          ",
+            },
+          ]
+        `);
+      }).pipe(Effect.provide(ctx.layer));
+    }),
+  );
+
+  it.effect(
+    "keeps stdin and interrupts available during retained execution",
+    Effect.fn(function* () {
+      const ctx = yield* withTestCtx();
+
+      yield* Effect.gen(function* () {
+        const runtime = yield* NotebookRuntime;
+        const notebook = yield* runtime.forNotebook(ctx.notebookUri);
+        const streamFiber = yield* Effect.forkChild(
+          runtime
+            .executeSessionScratchpad(ACTIVE_SESSION_ID, "input()")
+            .pipe(Stream.runDrain),
+          { startImmediately: true },
+        );
+        const calls = yield* SubscriptionRef.changes(ctx.executions).pipe(
+          Stream.filter((current) =>
+            current.some((call) => call.kind === "execute-session-scratchpad"),
+          ),
+          Stream.runHead,
+          Effect.map(Option.getOrThrow),
+        );
+        const executeCmd = calls.find(
+          (call) => call.kind === "execute-session-scratchpad",
+        );
+        assert(executeCmd !== undefined);
+
+        yield* PubSub.publish(
+          ctx.operationsPubSub,
+          makeIdleCellOperation(ctx.notebookUri, SCRATCH_CELL_ID, {
+            status: "running",
+            console: [
+              {
+                channel: "stdin",
+                data: "Enter name: ",
+                mimetype: "text/plain",
+                timestamp: 0,
+              },
+            ],
+          }),
+        );
+        yield* Queue.offer(ctx.inputQueue, Option.some("foo"));
+        const responses = yield* SubscriptionRef.changes(ctx.executions).pipe(
+          Stream.filter((calls) =>
+            calls.some((call) => call.kind === "send-stdin"),
+          ),
+          Stream.runHead,
+          Effect.map(Option.getOrThrow),
+        );
+        expect(
+          responses.find((call) => call.kind === "send-stdin"),
+        ).toMatchObject({
+          notebookUri: ctx.notebookUri,
+          kernelSessionId: ACTIVE_SESSION_ID,
+          text: "foo",
         });
 
-        yield* Fiber.join(streamFiber);
+        const interruptFiber = yield* Effect.forkChild(notebook.interrupt, {
+          startImmediately: true,
+        });
+        yield* Fiber.join(interruptFiber);
+        expect(
+          (yield* SubscriptionRef.get(ctx.executions)).at(-1),
+        ).toMatchObject({
+          kind: "interrupt",
+          notebookUri: ctx.notebookUri,
+          kernelSessionId: ACTIVE_SESSION_ID,
+        });
 
-        const interruptCmd = (yield* SubscriptionRef.get(ctx.executions)).find(
-          (c) => c.kind === "interrupt",
+        yield* PubSub.publish(ctx.operationsPubSub, {
+          notebookUri: ctx.notebookUri,
+          sessionId: ACTIVE_SESSION_ID,
+          notification: {
+            op: "completed-run",
+            run_id: executeCmd.runId,
+          },
+        });
+        yield* Fiber.join(streamFiber);
+      }).pipe(Effect.provide(ctx.layer));
+    }),
+  );
+
+  it.effect(
+    "interrupts the exact retained run when its stream disconnects",
+    Effect.fn(function* () {
+      const ctx = yield* withTestCtx();
+
+      yield* Effect.gen(function* () {
+        const runtime = yield* NotebookRuntime;
+        const streamFiber = yield* Effect.forkChild(
+          runtime
+            .executeSessionScratchpad(ACTIVE_SESSION_ID, "print('disconnect')")
+            .pipe(Stream.runCollect),
         );
-        expect(interruptCmd).toBeUndefined();
+        const calls = yield* SubscriptionRef.changes(ctx.executions).pipe(
+          Stream.filter((current) =>
+            current.some((call) => call.kind === "execute-session-scratchpad"),
+          ),
+          Stream.runHead,
+          Effect.map(Option.getOrThrow),
+        );
+        const executeCmd = calls.find(
+          (call) => call.kind === "execute-session-scratchpad",
+        );
+        assert(executeCmd !== undefined);
+
+        yield* Fiber.interrupt(streamFiber);
+
+        expect(
+          (yield* SubscriptionRef.get(ctx.executions)).find(
+            (call) => call.kind === "interrupt",
+          ),
+        ).toMatchObject({
+          kind: "interrupt",
+          notebookUri: ctx.notebookUri,
+          kernelSessionId: ACTIVE_SESSION_ID,
+          runId: executeCmd.runId,
+        });
       }).pipe(Effect.provide(ctx.layer));
     }),
   );

--- a/extension/src/kernel/__tests__/NotebookRuntimeOperations.test.ts
+++ b/extension/src/kernel/__tests__/NotebookRuntimeOperations.test.ts
@@ -128,6 +128,7 @@ const withTestCtx = Effect.fn(function* (
         executable: "/usr/bin/python3",
         workingDirectory: process.cwd(),
         startedAt: 1,
+        marimoVersion: "0.24.0",
         status: "idle",
         attached: true,
       },
@@ -203,6 +204,7 @@ const withTestCtx = Effect.fn(function* (
                 executable: request.executable,
                 workingDirectory: request.workingDirectory,
                 startedAt: 1,
+                marimoVersion: "0.24.0",
                 status: "idle",
                 attached: true,
               });

--- a/extension/src/lsp/__tests__/MarimoClient.test.ts
+++ b/extension/src/lsp/__tests__/MarimoClient.test.ts
@@ -415,6 +415,7 @@ it.effect(
     const message = {
       notebookUri: notebook,
       sessionId: kernelSessionId("00000000-0000-4000-8000-000000000001"),
+      scratchpadRunId: null,
       notification: { op: "completed-run", run_id: null },
     } as const;
     const [first, second] = yield* Effect.all(
@@ -494,6 +495,7 @@ it.effect(
     const kernelSnapshot: KernelNotification = {
       notebookUri: notebook,
       sessionId: kernelSessionId("00000000-0000-4000-8000-000000000001"),
+      scratchpadRunId: null,
       notification: { op: "variables", variables: [] },
     };
 

--- a/extension/src/panel/sessions/__tests__/LiveSessions.test.ts
+++ b/extension/src/panel/sessions/__tests__/LiveSessions.test.ts
@@ -19,6 +19,7 @@ const SNAPSHOT = {
       executable: "/venv/bin/python",
       workingDirectory: "/workspace",
       startedAt: 42,
+      marimoVersion: "0.24.0",
       status: "idle",
       attached: false,
     },

--- a/extension/src/platform/VsCode.ts
+++ b/extension/src/platform/VsCode.ts
@@ -204,6 +204,28 @@ export class Window extends Context.Service<Window>()("Window", {
           api.createOutputChannel(name, { log: true }),
         );
       },
+      registerUriHandler(
+        handler: (uri: vscode.Uri) => Effect.Effect<void>,
+      ): Effect.Effect<void, never, Scope.Scope> {
+        return Effect.gen(function* () {
+          const runFork = Effect.runForkWith(yield* Effect.context());
+          yield* acquireDisposable(() =>
+            api.registerUriHandler({
+              handleUri(uri) {
+                runFork(
+                  handler(uri).pipe(
+                    Effect.catchCause((cause) =>
+                      Effect.logWarning("Failed to handle extension URI").pipe(
+                        Effect.annotateLogs({ cause }),
+                      ),
+                    ),
+                  ),
+                );
+              },
+            }),
+          );
+        });
+      },
       getActiveNotebookEditor: Effect.sync(() =>
         Option.fromNullishOr(api.activeNotebookEditor),
       ),
@@ -549,6 +571,12 @@ export class Workspace extends Context.Service<Workspace>()("Workspace", {
             catch: (cause) => new FileSystemError({ cause }),
           });
         },
+        stat(uri: vscode.Uri) {
+          return Effect.tryPromise({
+            try: () => api.fs.stat(uri),
+            catch: (cause) => new FileSystemError({ cause }),
+          });
+        },
       },
       getNotebookDocuments: Effect.sync(() => api.notebookDocuments),
       getTextDocuments: Effect.sync(() => api.textDocuments),
@@ -585,6 +613,13 @@ export class Workspace extends Context.Service<Workspace>()("Workspace", {
               Queue.offerUnsafe(queue, event),
             ),
           ),
+      ),
+      notebookDocumentSaved: Stream.callback<vscode.NotebookDocument>((queue) =>
+        acquireDisposable(() =>
+          api.onDidSaveNotebookDocument((document) =>
+            Queue.offerUnsafe(queue, document),
+          ),
+        ),
       ),
       // Everything here — both listener registrations and the snapshot of
       // already-open documents — runs before the effect completes, within one
@@ -626,6 +661,14 @@ export class Workspace extends Context.Service<Workspace>()("Workspace", {
             ),
           ),
       ),
+      workspaceFoldersChanges:
+        Stream.callback<vscode.WorkspaceFoldersChangeEvent>((queue) =>
+          acquireDisposable(() =>
+            api.onDidChangeWorkspaceFolders((event) =>
+              Queue.offerUnsafe(queue, event),
+            ),
+          ),
+        ),
       applyEdit(edit: vscode.WorkspaceEdit) {
         return Effect.promise(() => api.applyEdit(edit));
       },
@@ -677,6 +720,8 @@ export class Env extends Context.Service<Env>()("Env", {
       appRoot: api.appRoot,
       appHost: api.appHost,
       machineId: api.machineId,
+      remoteName: api.remoteName,
+      uriScheme: api.uriScheme,
       createTelemetryLogger(
         sender: vscode.TelemetrySender,
         options?: vscode.TelemetryLoggerOptions,
@@ -684,6 +729,9 @@ export class Env extends Context.Service<Env>()("Env", {
         return acquireDisposable(() =>
           api.createTelemetryLogger(sender, options),
         );
+      },
+      asExternalUri(target: vscode.Uri): Effect.Effect<vscode.Uri> {
+        return Effect.promise(() => api.asExternalUri(target));
       },
       openExternal(target: vscode.Uri): Effect.Effect<boolean> {
         return Effect.promise(() => api.openExternal(target));

--- a/extension/src/schemas/Models.gen.ts
+++ b/extension/src/schemas/Models.gen.ts
@@ -637,6 +637,9 @@ export const KernelNotification = Schema.Struct({
   notebookUri: NotebookIdFromString,
   sessionId: KernelSessionIdFromString,
   notification: MarimoNotification,
+  scratchpadRunId: Schema.NullOr(Schema.String).pipe(
+    Schema.withDecodingDefault(Effect.sync(() => null)),
+  ),
 }).annotate({ identifier: "KernelNotification" });
 export type KernelNotification = typeof KernelNotification.Type;
 

--- a/extension/src/schemas/Models.gen.ts
+++ b/extension/src/schemas/Models.gen.ts
@@ -338,6 +338,23 @@ export const ExecuteScratchpad = Schema.Struct({
 export type ExecuteScratchpad = typeof ExecuteScratchpad.Type;
 
 /**
+ * Execute transient code in one exact retained kernel session.
+ */
+export const ExecuteSessionScratchpad = Schema.Struct({
+  kind: Schema.Literal("execute-session-scratchpad"),
+  notebookUri: NotebookUriFromString,
+  kernelSessionId: KernelSessionIdFromString,
+  code: Schema.String,
+  runId: Schema.NullOr(Schema.String).pipe(
+    Schema.withDecodingDefault(Effect.sync(() => null)),
+  ),
+}).annotate({
+  identifier: "ExecuteSessionScratchpad",
+  parseOptions: { onExcessProperty: "error" },
+});
+export type ExecuteSessionScratchpad = typeof ExecuteSessionScratchpad.Type;
+
+/**
  * A concrete environment identified by its Python executable.
  */
 export const VenvSource = Schema.Struct({
@@ -598,6 +615,7 @@ export const Command = Schema.Union([
   ListSessions,
   ShutdownAllSessions,
   ExecuteScratchpad,
+  ExecuteSessionScratchpad,
   ListPackages,
   GetDependencyTree,
   PrintNotebook,
@@ -858,6 +876,7 @@ export const SessionInfo = Schema.Struct({
   executable: Schema.String,
   workingDirectory: Schema.String,
   startedAt: Schema.Number,
+  marimoVersion: Schema.NullOr(Schema.String),
   status: Schema.Literals(["idle", "running"]),
   attached: Schema.Boolean,
 }).annotate({ identifier: "SessionInfo" });
@@ -1682,6 +1701,15 @@ export const makeCommandClient = <E, R>(send: CommandTransport<E, R>) => ({
       kind: "execute-scratchpad",
       ...params,
     } satisfies typeof ExecuteScratchpad.Encoded;
+    return dispatch(send, command, Schema.Null);
+  },
+  executeSessionScratchpad: (
+    params: Omit<typeof ExecuteSessionScratchpad.Encoded, "kind">,
+  ) => {
+    const command = {
+      kind: "execute-session-scratchpad",
+      ...params,
+    } satisfies typeof ExecuteSessionScratchpad.Encoded;
     return dispatch(send, command, Schema.Null);
   },
   listPackages: (params: Omit<typeof ListPackages.Encoded, "kind">) => {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,12 @@ ignore = [
 [tool.typos.default.extend-words]
 somes = "somes"
 
+[tool.typos.type.windows-discovery]
+extend-glob = ["windowsPrivatePath.ts"]
+
+[tool.typos.type.windows-discovery.extend-identifiers]
+BA = "BA" # Windows SDDL alias for Built-in Administrators.
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 

--- a/src/marimo_lsp/api.py
+++ b/src/marimo_lsp/api.py
@@ -45,7 +45,11 @@ from pygls.uris import to_fs_path
 from typing_extensions import TypeForm
 
 from marimo_lsp import notebook_source, protocol
-from marimo_lsp.app_file_manager import find_notebook_document, snapshot_for_scratchpad
+from marimo_lsp.app_file_manager import (
+    find_notebook_document,
+    snapshot_for_scratchpad,
+    snapshot_retained_scratchpad,
+)
 from marimo_lsp.loggers import get_logger
 from marimo_lsp.models import (
     DeleteCellRequest,
@@ -64,6 +68,7 @@ from marimo_lsp.models import (
 from marimo_lsp.package_manager import LspPackageManager
 
 if TYPE_CHECKING:
+    from lsprotocol.types import NotebookDocument
     from marimo._config.config import (
         DisplayConfig,
         PartialMarimoConfig,
@@ -463,19 +468,71 @@ async def shutdown_all_sessions(
     ctx.sessions.close_all()
 
 
+async def _dispatch_scratchpad(
+    ctx: ApiContext,
+    session: Session,
+    args: protocol.ExecuteScratchpad | protocol.ExecuteSessionScratchpad,
+    notebook: NotebookDocument | None,
+) -> None:
+    """Claim a session and dispatch through marimo's scratchpad path.
+
+    Exact-session requests forward operations even when the notebook is detached.
+    """
+    notebook_uri = str(args.notebook_uri)
+    exact_session = isinstance(args, protocol.ExecuteSessionScratchpad)
+    run_id = args.run_id
+    while True:
+        if not await session.wait_until_idle():
+            if exact_session:
+                raise SessionNotFoundError(notebook_uri)
+            logger.info(f"Skipping scratchpad run {run_id}; session closed")
+            return
+        if run_id is not None and ctx.sessions.take_scratchpad_cancellation(
+            notebook_uri, run_id
+        ):
+            logger.info(f"Skipping scratchpad run {run_id} cancelled before dispatch")
+            return
+        if session.try_start_scratchpad(run_id, forward_operations=exact_session):
+            break
+
+    try:
+        session.instantiate(
+            InstantiateNotebookRequest(auto_run=False, object_ids=[], values=[]),
+            http_request=None,
+        )
+        if notebook is None:
+            notebook_cells, cell_outputs = snapshot_retained_scratchpad(session)
+        else:
+            notebook_cells, cell_outputs = snapshot_for_scratchpad(
+                ctx.ls.workspace, session, notebook
+            )
+        session.put_control_request(
+            ExecuteScratchpadCommand(
+                code=args.code,
+                run_id=run_id,
+                notebook_cells=notebook_cells,
+                cell_outputs=cell_outputs,
+            ),
+            from_consumer_id=None,
+        )
+    except BaseException:
+        session.release_scratchpad(run_id)
+        raise
+    if exact_session:
+        logger.info(f"Retained scratchpad execution sent for {notebook_uri}")
+    else:
+        logger.info(f"Scratchpad execution request sent for {notebook_uri}")
+
+
 @command(protocol.ExecuteScratchpad)
 async def execute_scratch(
     ctx: ApiContext,
     args: protocol.ExecuteScratchpad,
 ) -> None:
-    """Execute code in the scratchpad (isolated from dependency graph).
+    """Execute isolated scratchpad code against the notebook's active session.
 
-    Populates the document + output snapshot on the command so that
-    ``marimo._code_mode.get_context()`` can bind inside the kernel. Cells come
-    from the LSP notebook document (id-aligned with VS Code);
-    outputs come from the session view.
-
-    Creates the session on demand when none exists, like :func:`run`.
+    The open LSP document supplies cells; the session view supplies outputs.
+    Start a session on demand, as ordinary notebook execution does.
     """
     logger.info(f"execute_scratch for {args.notebook_uri}")
     run_id = args.run_id
@@ -497,43 +554,37 @@ async def execute_scratch(
     session = await ctx.sessions.start(
         args.notebook_uri, args.executable, args.working_directory
     )
-    while True:
-        if not await session.wait_until_idle():
-            logger.info(f"Skipping scratchpad run {run_id}; session closed")
-            return
-        if run_id is not None and ctx.sessions.take_scratchpad_cancellation(
-            args.notebook_uri, run_id
-        ):
-            logger.info(f"Skipping scratchpad run {run_id} cancelled before dispatch")
-            return
-        if session.try_start_scratchpad(run_id):
-            break
+    await _dispatch_scratchpad(
+        ctx,
+        session,
+        args,
+        notebook,
+    )
 
-    try:
-        session.instantiate(
-            InstantiateNotebookRequest(auto_run=False, object_ids=[], values=[]),
-            http_request=None,
-        )
 
-        notebook_cells, cell_outputs = snapshot_for_scratchpad(
-            workspace=ctx.ls.workspace,
-            session=session,
-            notebook=notebook,
-        )
+@command(protocol.ExecuteSessionScratchpad)
+async def execute_session_scratch(
+    ctx: ApiContext,
+    args: protocol.ExecuteSessionScratchpad,
+) -> None:
+    """Execute a scratchpad against one exact retained session."""
+    notebook_uri = str(args.notebook_uri)
+    run_id = args.run_id
+    if run_id is not None and ctx.sessions.take_scratchpad_cancellation(
+        notebook_uri, run_id
+    ):
+        logger.info(f"Skipping cancelled retained scratchpad run {run_id}")
+        return
 
-        session.put_control_request(
-            ExecuteScratchpadCommand(
-                code=args.code,
-                run_id=args.run_id,
-                notebook_cells=notebook_cells,
-                cell_outputs=cell_outputs,
-            ),
-            from_consumer_id=None,
-        )
-    except BaseException:
-        session.release_scratchpad(run_id)
-        raise
-    logger.info(f"Scratchpad execution request sent for {args.notebook_uri}")
+    session = _require_kernel_session(
+        ctx, notebook_uri, SessionId(str(args.kernel_session_id))
+    )
+    await _dispatch_scratchpad(
+        ctx,
+        session,
+        args,
+        None,
+    )
 
 
 @command(protocol.ListPackages)

--- a/src/marimo_lsp/api.py
+++ b/src/marimo_lsp/api.py
@@ -476,7 +476,7 @@ async def _dispatch_scratchpad(
 ) -> None:
     """Claim a session and dispatch through marimo's scratchpad path.
 
-    Exact-session requests forward operations even when the notebook is detached.
+    Correlated streams retain their output even when the notebook is detached.
     """
     notebook_uri = str(args.notebook_uri)
     exact_session = isinstance(args, protocol.ExecuteSessionScratchpad)
@@ -492,7 +492,9 @@ async def _dispatch_scratchpad(
         ):
             logger.info(f"Skipping scratchpad run {run_id} cancelled before dispatch")
             return
-        if session.try_start_scratchpad(run_id, forward_operations=exact_session):
+        if session.try_start_scratchpad(
+            run_id, forward_operations=exact_session or run_id is not None
+        ):
             break
 
     try:

--- a/src/marimo_lsp/app_file_manager.py
+++ b/src/marimo_lsp/app_file_manager.py
@@ -176,16 +176,46 @@ def _snapshot_notebook_cells(
     )
 
 
+def _with_session_outputs(
+    session: Session, cells: tuple[NotebookCell, ...]
+) -> tuple[tuple[NotebookCell, ...], CellOutputs]:
+    cell_ids = [cell.id for cell in cells]
+    return cells, CellOutputs(
+        output=session.session_view.get_cell_outputs(cell_ids),
+        console_outputs=session.session_view.get_cell_console_outputs(cell_ids),
+    )
+
+
 def snapshot_for_scratchpad(
     workspace: Workspace,
     session: Session,
     notebook: NotebookDocument,
 ) -> tuple[tuple[NotebookCell, ...], CellOutputs]:
-    """Snapshot the LSP notebook document's cells for code mode."""
-    cells = _snapshot_notebook_cells(workspace, notebook)
-    ids = [cell.id for cell in cells]
-    cell_outputs = CellOutputs(
-        output=session.session_view.get_cell_outputs(ids),
-        console_outputs=session.session_view.get_cell_console_outputs(ids),
+    """Snapshot an open notebook for scratchpad execution.
+
+    The LSP document is authoritative; a session's app may lag unsaved edits.
+    Outputs still come from the matching live session.
+    """
+    return _with_session_outputs(session, _snapshot_notebook_cells(workspace, notebook))
+
+
+def snapshot_retained_scratchpad(
+    session: Session,
+) -> tuple[tuple[NotebookCell, ...], CellOutputs]:
+    """Snapshot the session's synchronized source cells and outputs.
+
+    LSP open/change/save events refresh the cell manager. A detached session
+    retains the source from its last synchronization.
+    """
+    manager = session.app.cell_manager
+    cells = tuple(
+        NotebookCell(id=cell_id, code=code, name=name, config=config)
+        for cell_id, code, name, config in zip(
+            manager.cell_ids(),
+            manager.codes(),
+            manager.names(),
+            manager.configs(),
+            strict=True,
+        )
     )
-    return cells, cell_outputs
+    return _with_session_outputs(session, cells)

--- a/src/marimo_lsp/models.py
+++ b/src/marimo_lsp/models.py
@@ -31,12 +31,14 @@ from marimo_lsp.protocol import AppOptions, NotebookCellConfig, NotebookMetadata
 DEFAULT_SQL_ENGINE = "__marimo_duckdb"
 
 
-class KernelNotification(msgspec.Struct, rename="camel"):
+class KernelNotification(msgspec.Struct, rename="camel", omit_defaults=True):
     """A notification emitted by one exact live kernel."""
 
     notebook_uri: str
     session_id: SessionId
     notification: NotificationMessage
+    scratchpad_run_id: str | None = None
+    """The server's scratchpad claim, separate from each cell's kernel run ID."""
 
 
 class DocumentAnalysis(msgspec.Struct, rename="camel"):

--- a/src/marimo_lsp/models.py
+++ b/src/marimo_lsp/models.py
@@ -174,6 +174,7 @@ class SessionInfo(msgspec.Struct, rename="camel", frozen=True):
     executable: str
     working_directory: str
     started_at: float
+    marimo_version: str | None
     status: typing.Literal["idle", "running"]
     attached: bool
 

--- a/src/marimo_lsp/protocol.py
+++ b/src/marimo_lsp/protocol.py
@@ -423,6 +423,21 @@ class ExecuteScratchpad(
     run_id: str | None = None
 
 
+class ExecuteSessionScratchpad(
+    msgspec.Struct,
+    tag="execute-session-scratchpad",
+    tag_field="kind",
+    rename="camel",
+    forbid_unknown_fields=True,
+):
+    """Execute transient code in one exact retained kernel session."""
+
+    notebook_uri: typing.Annotated[NotebookUri, _brand("NotebookUri")]
+    kernel_session_id: typing.Annotated[KernelSessionId, _brand("KernelSessionId")]
+    code: str
+    run_id: str | None = None
+
+
 class ListPackages(
     msgspec.Struct,
     tag="list-packages",
@@ -579,6 +594,7 @@ type Command = (
     | ListSessions
     | ShutdownAllSessions
     | ExecuteScratchpad
+    | ExecuteSessionScratchpad
     | ListPackages
     | GetDependencyTree
     | PrintNotebook

--- a/src/marimo_lsp/sessions.py
+++ b/src/marimo_lsp/sessions.py
@@ -144,8 +144,8 @@ class _OperationSink:
         """Route future operations to a renamed notebook."""
         self._notebook_uri = notebook_uri
 
-    def notify(self, message: KernelMessage) -> None:
-        if not self._attached:
+    def notify(self, message: KernelMessage, *, force: bool = False) -> None:
+        if not self._attached and not force:
             return
 
         try:
@@ -215,6 +215,7 @@ class Session:
         self._idle.set()
         self._scratchpad_running = False
         self._scratchpad_run_id: str | None = None
+        self._scratchpad_forward_operations = False
         self._on_change = on_change or (lambda: None)
         self._on_kernel_failure: typing.Callable[[Session, str], None] = (
             lambda _session, _error: None
@@ -345,9 +346,13 @@ class Session:
         """Record and forward an operation received from the kernel."""
         if self._closed:
             return
+        with self._state_lock:
+            # Capture before completion clears the claim so detached clients
+            # receive the terminal notification too.
+            force_forward = self._scratchpad_forward_operations
         self.session_view.add_raw_notification(message)
         kernel_error = self._update_status(message)
-        self._operation_sink.notify(message)
+        self._operation_sink.notify(message, force=force_forward)
         if kernel_error is not None:
             self._on_kernel_failure(self, kernel_error)
 
@@ -386,6 +391,7 @@ class Session:
                     return
                 self._scratchpad_running = False
                 self._scratchpad_run_id = None
+                self._scratchpad_forward_operations = False
             if self._status == "idle":
                 return
             self._status = "idle"
@@ -402,13 +408,19 @@ class Session:
         with self._state_lock:
             return not self._closed
 
-    def try_start_scratchpad(self, run_id: str | None) -> bool:
+    def try_start_scratchpad(
+        self,
+        run_id: str | None,
+        *,
+        forward_operations: bool = False,
+    ) -> bool:
         """Claim an idle session for one scratchpad run without yielding."""
         with self._state_lock:
             if self._closed or self._status != "idle":
                 return False
             self._scratchpad_running = True
             self._scratchpad_run_id = run_id
+            self._scratchpad_forward_operations = forward_operations
             self._status = "running"
             self._idle.clear()
         self._on_change()
@@ -433,6 +445,7 @@ class Session:
                 executable=self.executable,
                 working_directory=self.working_directory,
                 started_at=self.started_at,
+                marimo_version=self._kernel.marimo_version,
                 status=self._status,
                 attached=self.attached,
             )

--- a/src/marimo_lsp/sessions.py
+++ b/src/marimo_lsp/sessions.py
@@ -105,7 +105,7 @@ class _OperationSink:
         self._session_id = session_id
         self._attached = True
         self._activated = activated
-        self._pending: list[NotificationMessage] = []
+        self._pending: list[tuple[NotificationMessage, str | None]] = []
 
     @property
     def attached(self) -> bool:
@@ -130,11 +130,11 @@ class _OperationSink:
             return
         pending = self._pending
         self._pending = []
-        for operation in pending:
+        for operation, scratchpad_run_id in pending:
             # Match notify(): one undeliverable notification must not fail
             # the start or restart that is releasing the backlog.
             try:
-                self._forward(operation)
+                self._forward(operation, scratchpad_run_id)
             except Exception:
                 logger.exception(
                     "Dropped pending kernel notification (op=%s)", operation.name
@@ -144,16 +144,22 @@ class _OperationSink:
         """Route future operations to a renamed notebook."""
         self._notebook_uri = notebook_uri
 
-    def notify(self, message: KernelMessage, *, force: bool = False) -> None:
+    def notify(
+        self,
+        message: KernelMessage,
+        *,
+        force: bool = False,
+        scratchpad_run_id: str | None = None,
+    ) -> None:
         if not self._attached and not force:
             return
 
         try:
             notification = deserialize_kernel_message(message)
             if not self._activated:
-                self._pending.append(notification)
+                self._pending.append((notification, scratchpad_run_id))
                 return
-            self._forward(notification)
+            self._forward(notification, scratchpad_run_id)
         except Exception:
             # A dropped message is invisible to the client; name the op so a
             # kernel emitting notifications this build cannot decode (e.g. a
@@ -163,7 +169,9 @@ class _OperationSink:
                 _notification_name(message),
             )
 
-    def _forward(self, notification: NotificationMessage) -> None:
+    def _forward(
+        self, notification: NotificationMessage, scratchpad_run_id: str | None
+    ) -> None:
         self._server.protocol.notify(
             "marimo/kernelNotification",
             asdict(
@@ -171,6 +179,7 @@ class _OperationSink:
                     notebook_uri=self._notebook_uri,
                     session_id=self._session_id,
                     notification=notification,
+                    scratchpad_run_id=scratchpad_run_id,
                 )
             ),
         )
@@ -350,9 +359,12 @@ class Session:
             # Capture before completion clears the claim so detached clients
             # receive the terminal notification too.
             force_forward = self._scratchpad_forward_operations
+            scratchpad_run_id = self._scratchpad_run_id
         self.session_view.add_raw_notification(message)
         kernel_error = self._update_status(message)
-        self._operation_sink.notify(message, force=force_forward)
+        self._operation_sink.notify(
+            message, force=force_forward, scratchpad_run_id=scratchpad_run_id
+        )
         if kernel_error is not None:
             self._on_kernel_failure(self, kernel_error)
 

--- a/tests/fixtures/command_protocol.json
+++ b/tests/fixtures/command_protocol.json
@@ -102,6 +102,13 @@
       "runId": null
     },
     {
+      "kind": "execute-session-scratchpad",
+      "notebookUri": "file:///notebook.py",
+      "kernelSessionId": "kernel-1",
+      "code": "answer + 1",
+      "runId": "run-1"
+    },
+    {
       "kind": "list-packages",
       "notebookUri": "file:///notebook.py",
       "source": { "kind": "venv", "executable": "/venv/bin/python" }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -6,12 +6,15 @@ from pathlib import Path
 from typing import TYPE_CHECKING, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import lsprotocol.types as lsp
 import msgspec
 import pytest
 from inline_snapshot import snapshot
 from marimo._config.config import DEFAULT_CONFIG
 from marimo._convert.converters import MarimoConvert
-from marimo._types.ids import RequestId, SessionId
+from marimo._messaging.cell_output import CellChannel, CellOutput
+from marimo._messaging.notification import CellNotification
+from marimo._types.ids import CellId_t, RequestId, SessionId
 
 from marimo_lsp import protocol
 from marimo_lsp.api import (
@@ -21,6 +24,7 @@ from marimo_lsp.api import (
     KernelSessionRequiredError,
     delete_cell,
     execute_scratch,
+    execute_session_scratch,
     export_as_markdown,
     function_call_request,
     get_configuration,
@@ -35,12 +39,14 @@ from marimo_lsp.api import (
     set_ui_element_value,
     update_configuration,
 )
+from marimo_lsp.app_file_manager import LspAppFileManager
 from marimo_lsp.app_options import app_options_from_source, merge_app_options
 from marimo_lsp.models import (
     ListSQLSchemasRequest,
     ListSQLTablesRequest,
 )
 from marimo_lsp.notebook_source import _restore_unknown_app_options
+from marimo_lsp.sessions import Session
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
@@ -123,6 +129,128 @@ async def test_execute_scratch_claims_idle_session_before_dispatch() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("caller", ["notebook", "session", "detached-session"])
+async def test_scratchpad_dispatch_captures_unsaved_edits_and_outputs(
+    caller: str,
+) -> None:
+    session_id = SessionId("00000000-0000-4000-8000-000000000001")
+    cell_uri = f"{NOTEBOOK_URI}#cell-1"
+    cell = lsp.NotebookCell(
+        kind=lsp.NotebookCellKind.Code,
+        document=cell_uri,
+        metadata=cast("lsp.LSPObject", {"marimoRuntime": {"stableId": "cell-1"}}),
+    )
+    server = MagicMock()
+    server.workspace.notebook_documents = {
+        NOTEBOOK_URI: lsp.NotebookDocument(
+            uri=NOTEBOOK_URI, notebook_type="marimo-notebook", version=1, cells=[cell]
+        )
+    }
+    source = MagicMock(source="answer = 0", language_id="python")
+    server.workspace.text_documents = {cell_uri: source}
+    kernel = MagicMock()
+    config_manager = MagicMock()
+    config_manager.get_config.return_value = DEFAULT_CONFIG
+    session = Session(
+        session_id=session_id,
+        notebook_uri=NOTEBOOK_URI,
+        server=server,
+        kernel=kernel,
+        app_file_manager=LspAppFileManager(server=server, notebook_uri=NOTEBOOK_URI),
+        config_manager=config_manager,
+    )
+    # An unsaved source and metadata edit reaches the session through the
+    # same sync method used by notebookDocument/didChange.
+    source.source = "answer = 42"
+    cell.metadata = cast(
+        "lsp.LSPObject",
+        {
+            "marimoRuntime": {"stableId": "cell-1"},
+            "marimo": {"name": "answer", "options": {"disabled": True}},
+        },
+    )
+    session.sync(server.workspace)
+    session.session_view.add_notification(
+        CellNotification(
+            cell_id=CellId_t("cell-1"),
+            status="idle",
+            output=CellOutput(
+                channel=CellChannel.OUTPUT,
+                mimetype="text/plain",
+                data="previous output",
+                timestamp=0,
+            ),
+        )
+    )
+    if caller == "detached-session":
+        session.detach()
+        server.workspace.notebook_documents.clear()
+        server.workspace.text_documents.clear()
+    sessions = MagicMock()
+    sessions.start = AsyncMock(return_value=session)
+    sessions.get.return_value = session
+    sessions.take_scratchpad_cancellation.return_value = False
+
+    context = ApiContext(ls=server, sessions=sessions)
+    if caller == "notebook":
+        await execute_scratch(
+            context,
+            protocol.ExecuteScratchpad(
+                notebook_uri=protocol.NotebookUri(NOTEBOOK_URI),
+                executable="/usr/bin/python",
+                working_directory="/workspace",
+                code="print('retained')",
+                run_id="run-1",
+            ),
+        )
+    else:
+        await execute_session_scratch(
+            context,
+            protocol.ExecuteSessionScratchpad(
+                notebook_uri=protocol.NotebookUri(NOTEBOOK_URI),
+                kernel_session_id=protocol.KernelSessionId(str(session_id)),
+                code="print('retained')",
+                run_id="run-1",
+            ),
+        )
+
+    command = kernel.send.call_args.args[0]
+    assert sessions.start.called is (caller == "notebook")
+    assert msgspec.to_builtins(command) == snapshot(
+        {
+            "type": "execute-scratchpad",
+            "code": "print('retained')",
+            "request": None,
+            "notebookCells": (
+                {
+                    "id": "cell-1",
+                    "code": "answer = 42",
+                    "name": "answer",
+                    "config": {
+                        "column": None,
+                        "disabled": True,
+                        "hide_code": False,
+                    },
+                    "version": 0,
+                },
+            ),
+            "cellOutputs": {
+                "output": {
+                    "cell-1": {
+                        "channel": "output",
+                        "mimetype": "text/plain",
+                        "data": "previous output",
+                        "timestamp": 0,
+                    },
+                },
+                "console_outputs": {},
+            },
+            "runId": "run-1",
+        }
+    )
+
+
+@pytest.mark.asyncio
 async def test_run_correlated_interrupt_records_scratchpad_cancellation() -> None:
     sessions = MagicMock()
 
@@ -186,6 +314,15 @@ LIVE_SESSION_ID = SessionId("00000000-0000-4000-8000-000000000002")
 @pytest.mark.parametrize(
     ("handler", "command"),
     [
+        (
+            execute_session_scratch,
+            protocol.ExecuteSessionScratchpad(
+                notebook_uri=protocol.NotebookUri(NOTEBOOK_URI),
+                kernel_session_id=protocol.KernelSessionId(str(STALE_SESSION_ID)),
+                code="print('stale')",
+                run_id="run-1",
+            ),
+        ),
         (
             set_ui_element_value,
             protocol.UpdateUiElement(
@@ -254,6 +391,7 @@ async def test_kernel_commands_reject_a_replaced_kernel_session(
     session = MagicMock(session_id=LIVE_SESSION_ID)
     sessions = MagicMock()
     sessions.get.return_value = session
+    sessions.take_scratchpad_cancellation.return_value = False
 
     with pytest.raises(KernelSessionMismatchError):
         await handler(

--- a/tests/test_app_file_manager.py
+++ b/tests/test_app_file_manager.py
@@ -11,7 +11,10 @@ import lsprotocol.types as lsp
 import msgspec
 import pytest
 
-from marimo_lsp.app_file_manager import find_notebook_document, sync_app_with_workspace
+from marimo_lsp.app_file_manager import (
+    find_notebook_document,
+    sync_app_with_workspace,
+)
 
 
 def _lsp_object(d: dict[str, object] | None) -> lsp.LSPObject | None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1880,6 +1880,7 @@ y\
             {
                 "notebookUri": "file:///scratch_test.py",
                 "sessionId": IsUUID(4),
+                "scratchpadRunId": "scratch-output",
                 "notification": {
                     "op": "cell-op",
                     "cell_id": "__scratch__",
@@ -1894,6 +1895,7 @@ y\
             {
                 "notebookUri": "file:///scratch_test.py",
                 "sessionId": IsUUID(4),
+                "scratchpadRunId": "scratch-output",
                 "notification": {
                     "op": "cell-op",
                     "cell_id": "__scratch__",
@@ -1908,6 +1910,7 @@ y\
             {
                 "notebookUri": "file:///scratch_test.py",
                 "sessionId": IsUUID(4),
+                "scratchpadRunId": "scratch-output",
                 "notification": {
                     "op": "cell-op",
                     "cell_id": "__scratch__",
@@ -1927,6 +1930,7 @@ y\
             {
                 "notebookUri": "file:///scratch_test.py",
                 "sessionId": IsUUID(4),
+                "scratchpadRunId": "scratch-output",
                 "notification": {
                     "op": "cell-op",
                     "cell_id": "__scratch__",
@@ -1946,6 +1950,7 @@ y\
             {
                 "notebookUri": "file:///scratch_test.py",
                 "sessionId": IsUUID(4),
+                "scratchpadRunId": "scratch-output",
                 "notification": {
                     "op": "cell-op",
                     "cell_id": "__scratch__",

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1758,8 +1758,9 @@ async def test_cell_addition(client: LanguageClient) -> None:
     )
 
 
-async def test_scratchpad_execution(client: LanguageClient) -> None:
-    """Test that scratchpad executes code outside the dependency graph."""
+@pytest.mark.parametrize("retained", [False, True])
+async def test_scratchpad_execution(client: LanguageClient, *, retained: bool) -> None:
+    """Scratchpad output arrives before completion, including after detaching."""
     # First, open a notebook with a cell (required to have a session)
     notebook_code = "x = 10"
     client.notebook_document_did_open(
@@ -1791,27 +1792,32 @@ async def test_scratchpad_execution(client: LanguageClient) -> None:
     scratch_messages: list[dict] = []
     scratch_completion_event = asyncio.Event()
     waiting_for_scratch = False
+    session_id: str | None = None
+    run_id = "scratch-output"
 
     @client.feature("marimo/kernelNotification")
-    async def on_marimo_operation(params: Any) -> None:  # noqa: ANN401
-        nonlocal waiting_for_scratch
+    def on_marimo_operation(params: Any) -> None:  # noqa: ANN401
+        nonlocal session_id
         msg = asdict(params)
         op = msg.get("notification", {})
 
         # Handle cell completion (kernel startup)
         if op.get("op") == "completed-run" and not waiting_for_scratch:
-            # `completed-run` fires before trailing notifications drain.
-            await asyncio.sleep(0.1)
+            session_id = msg["sessionId"]
             cell_completion_event.set()
             return
 
+        if op.get("op") == "completed-run" and op.get("run_id") == run_id:
+            scratch_completion_event.set()
+            return
+
         # Handle scratchpad operations
-        if op.get("op") == "cell-op" and op.get("cell_id") == "__scratch__":
+        if (
+            op.get("op") == "cell-op"
+            and op.get("cell_id") == "__scratch__"
+            and not scratch_completion_event.is_set()
+        ):
             scratch_messages.append(msg)
-            # Scratchpad completes when status is "idle"
-            if op.get("status") == "idle":
-                await asyncio.sleep(0.1)
-                scratch_completion_event.set()
 
     # Execute a cell to start the kernel session
     await send_command(
@@ -1837,16 +1843,35 @@ y = 42
 print("scratchpad output")
 y\
 """
-    await send_command(
-        client,
-        {
+    command: dict[str, object]
+    if retained:
+        client.notebook_document_did_close(
+            lsp.DidCloseNotebookDocumentParams(
+                notebook_document=lsp.NotebookDocumentIdentifier(
+                    uri="file:///scratch_test.py"
+                ),
+                cell_text_documents=[
+                    lsp.TextDocumentIdentifier(uri="file:///scratch_test.py#cell1")
+                ],
+            ),
+        )
+        command = {
+            "kind": "execute-session-scratchpad",
+            "notebookUri": "file:///scratch_test.py",
+            "kernelSessionId": session_id,
+            "code": scratchpad_code,
+            "runId": run_id,
+        }
+    else:
+        command = {
             "kind": "execute-scratchpad",
             "notebookUri": "file:///scratch_test.py",
             "executable": sys.executable,
             "workingDirectory": str(Path.cwd()),
             "code": scratchpad_code,
-        },
-    )
+            "runId": run_id,
+        }
+    await send_command(client, command)
 
     await asyncio.wait_for(scratch_completion_event.wait(), timeout=5.0)
     assert_one_kernel_session(scratch_messages)

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, cast
 from unittest.mock import ANY, AsyncMock, Mock
 
 import pytest
+from inline_snapshot import snapshot
 from marimo._config.config import DEFAULT_CONFIG, MarimoConfig, RuntimeConfig
 from marimo._messaging.cell_output import CellChannel, CellOutput
 from marimo._messaging.notification import CellNotification
@@ -52,6 +53,7 @@ def _make_session() -> tuple[Session, Mock]:
     session._idle.set()
     session._scratchpad_running = False
     session._scratchpad_run_id = None
+    session._scratchpad_forward_operations = False
     session._closed = False
     session._state_lock = threading.RLock()
     return session, ipc_queue_manager
@@ -405,6 +407,67 @@ def test_scratchpad_ignores_unrelated_completed_runs() -> None:
     assert not session.is_scratchpad_running("scratch-1")
 
 
+def test_retained_scratchpad_forwards_through_matching_completion() -> None:
+    session, _ = _make_session()
+    server = Mock()
+    session._operation_sink = _OperationSink(server, "file:///test.py", SESSION_ID)
+    session._operation_sink.detach()
+
+    started = session.try_start_scratchpad("scratch-1", forward_operations=True)
+    completed = KernelMessage(b'{"op": "completed-run", "run_id": "scratch-1"}')
+    unrelated = KernelMessage(b'{"op": "completed-run", "run_id": "other"}')
+    session.accept_kernel_message(unrelated)
+    session.accept_kernel_message(completed)
+    session.accept_kernel_message(unrelated)
+
+    assert {
+        "started": started,
+        "forwarded": [call.args for call in server.protocol.notify.call_args_list],
+    } == snapshot(
+        {
+            "started": True,
+            "forwarded": [
+                (
+                    "marimo/kernelNotification",
+                    {
+                        "notebookUri": "file:///test.py",
+                        "sessionId": "00000000-0000-4000-8000-000000000001",
+                        "notification": {"op": "completed-run", "run_id": "other"},
+                    },
+                ),
+                (
+                    "marimo/kernelNotification",
+                    {
+                        "notebookUri": "file:///test.py",
+                        "sessionId": "00000000-0000-4000-8000-000000000001",
+                        "notification": {"op": "completed-run", "run_id": "scratch-1"},
+                    },
+                ),
+            ],
+        }
+    )
+
+
+def test_failed_retained_scratchpad_dispatch_does_not_leave_forwarding_open() -> None:
+    session, _ = _make_session()
+    server = Mock()
+    session._operation_sink = _OperationSink(server, "file:///test.py", SESSION_ID)
+    session._operation_sink.detach()
+
+    started = session.try_start_scratchpad("scratch-1", forward_operations=True)
+    session.release_scratchpad("scratch-1")
+    session.accept_kernel_message(
+        KernelMessage(b'{"op": "completed-run", "run_id": "scratch-1"}')
+    )
+    reclaimed = session.try_start_scratchpad("scratch-2", forward_operations=True)
+
+    assert {
+        "started": started,
+        "reclaimed": reclaimed,
+        "forwarded": server.protocol.notify.call_count,
+    } == snapshot({"started": True, "reclaimed": True, "forwarded": 0})
+
+
 def test_terminal_kernel_error_removes_live_session() -> None:
     server = Mock()
     sessions = Sessions(server, kernels=Mock())
@@ -429,7 +492,7 @@ def test_terminal_kernel_operation_invokes_failure_callback() -> None:
     session.accept_kernel_message(message)
 
     session._on_kernel_failure.assert_called_once_with(session, "bridge exited")
-    session._operation_sink.notify.assert_called_once_with(message)
+    assert session._operation_sink.notify.call_count == 1
 
 
 def test_pending_scratchpad_cancellation_does_not_interrupt_other_work() -> None:
@@ -469,6 +532,7 @@ def test_sessions_changed_notification_contains_public_snapshot() -> None:
         executable="/usr/bin/python",
         working_directory="/workspace",
         started_at=42,
+        marimo_version="0.24.0",
         status="idle",
         attached=False,
     )
@@ -487,6 +551,7 @@ def test_sessions_changed_notification_contains_public_snapshot() -> None:
                     "executable": "/usr/bin/python",
                     "workingDirectory": "/workspace",
                     "startedAt": 42,
+                    "marimoVersion": "0.24.0",
                     "status": "idle",
                     "attached": False,
                 }

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -432,6 +432,7 @@ def test_retained_scratchpad_forwards_through_matching_completion() -> None:
                     {
                         "notebookUri": "file:///test.py",
                         "sessionId": "00000000-0000-4000-8000-000000000001",
+                        "scratchpadRunId": "scratch-1",
                         "notification": {"op": "completed-run", "run_id": "other"},
                     },
                 ),
@@ -440,6 +441,7 @@ def test_retained_scratchpad_forwards_through_matching_completion() -> None:
                     {
                         "notebookUri": "file:///test.py",
                         "sessionId": "00000000-0000-4000-8000-000000000001",
+                        "scratchpadRunId": "scratch-1",
                         "notification": {"op": "completed-run", "run_id": "scratch-1"},
                     },
                 ),
@@ -492,7 +494,9 @@ def test_terminal_kernel_operation_invokes_failure_callback() -> None:
     session.accept_kernel_message(message)
 
     session._on_kernel_failure.assert_called_once_with(session, "bridge exited")
-    assert session._operation_sink.notify.call_count == 1
+    session._operation_sink.notify.assert_called_once_with(
+        message, force=False, scratchpad_run_id=None
+    )
 
 
 def test_pending_scratchpad_cancellation_does_not_interrupt_other_work() -> None:
@@ -916,3 +920,40 @@ def test_close_all_clears_collection_and_notifies_once() -> None:
     first.close.assert_called_once_with()
     second.close.assert_called_once_with()
     sessions._notify_changed.assert_called_once_with()
+
+
+@pytest.mark.parametrize("attached", [False, True])
+def test_scratchpad_claim_correlates_output_and_completion(*, attached: bool) -> None:
+    session, _ = _make_session()
+    server = Mock()
+    session._operation_sink = _OperationSink(server, "file:///test.py", SESSION_ID)
+    if not attached:
+        session._operation_sink.detach()
+    output = KernelMessage(
+        b'{"op":"cell-op","cell_id":"child","run_id":"cell-run",'
+        b'"console":[{"channel":"stdout","mimetype":"text/plain","data":"hello"}]}'
+    )
+
+    session.accept_kernel_message(output)
+    assert session.try_start_scratchpad("scratch-1", forward_operations=True)
+    session.accept_kernel_message(output)
+    session.accept_kernel_message(
+        KernelMessage(b'{"op":"completed-run","run_id":"scratch-1"}')
+    )
+    session.accept_kernel_message(output)
+    assert session.try_start_scratchpad("scratch-2", forward_operations=True)
+    session.accept_kernel_message(output)
+    session.release_scratchpad("scratch-2")
+    session.accept_kernel_message(output)
+
+    messages = [call.args[1] for call in server.protocol.notify.call_args_list]
+    assert [message.get("scratchpadRunId") for message in messages] == (
+        [None, "scratch-1", "scratch-1", None, "scratch-2", None]
+        if attached
+        else ["scratch-1", "scratch-1", "scratch-2"]
+    )
+    assert all(
+        message["notification"]["run_id"] == "cell-run"
+        for message in messages
+        if message["notification"]["op"] == "cell-op"
+    )


### PR DESCRIPTION
Implements the marimo local discovery protocol for the VS Code extension. Clients that support the protocol can discover its notebooks and kernel sessions, watch catalog changes, open notebooks in VS Code, and execute code with streamed output.

Each extension host publishes an instance record. Workspace folders map to projects, notebook URIs to notebooks, and retained kernels to sessions. Execution targets an exact session, including after its editor document closes:

```ts
runtime.executeSessionScratchpad(sessionId, code);
```

The shared contract in marimo-desktop generates `Api.gen.ts` with the Effect `HttpApi` and models. This PR implements its handlers using the extension's catalog and notebook runtime, with token-authenticated loopback HTTP and SSE.
