### PR TITLE
Keep rendered outputs alive across updates and re-runs

### DIFF
--- a/extension/src/kernel/CellOutputOperation.ts
+++ b/extension/src/kernel/CellOutputOperation.ts
@@ -1,0 +1,24 @@
+import { Data, Effect } from "effect";
+
+export type CellOutputOperation =
+  | "appendOutput"
+  | "clearOutput"
+  | "replaceOutput"
+  | "replaceOutputItems"
+  | "synchronize";
+
+export class CellOutputOperationError extends Data.TaggedError(
+  "CellOutputOperationError",
+)<{
+  readonly operation: CellOutputOperation;
+  readonly cause: unknown;
+}> {}
+
+export const tryCellOutputOperation = <A>(
+  operation: CellOutputOperation,
+  run: () => PromiseLike<A>,
+): Effect.Effect<A, CellOutputOperationError> =>
+  Effect.tryPromise({
+    try: run,
+    catch: (cause) => new CellOutputOperationError({ operation, cause }),
+  });

--- a/extension/src/kernel/CellOutputProjection.ts
+++ b/extension/src/kernel/CellOutputProjection.ts
@@ -1,5 +1,10 @@
-import { Effect } from "effect";
+import { Effect, Semaphore } from "effect";
 import type * as vscode from "vscode";
+
+import {
+  CellOutputOperationError,
+  tryCellOutputOperation,
+} from "./CellOutputOperation.ts";
 
 /** A cell output tagged with the stable key of its logical slot. */
 export interface KeyedCellOutput {
@@ -33,54 +38,112 @@ interface Slot {
 export class CellOutputProjection {
   // Slots in on-screen (insertion) order; index i is `cell.outputs[i]`.
   #slots: Slot[] = [];
+  readonly #ordering = Semaphore.makeUnsafe(1);
 
   /** Apply a live, incremental update toward `keyed`. */
-  project = Effect.fn(
+  project = Effect.fn("CellOutputProjection.project")(
     { self: this },
     function* (
+      this: CellOutputProjection,
       execution: OutputExecution,
       keyed: ReadonlyArray<KeyedCellOutput>,
-    ): Effect.fn.Return<void> {
+    ) {
+      yield* this.#ordering.withPermit(this.#project(execution, keyed));
+    },
+  );
+
+  /** Finish the run with exactly `keyed` and measure newly appended slots. */
+  commit = Effect.fn("CellOutputProjection.commit")(
+    { self: this },
+    function* (
+      this: CellOutputProjection,
+      execution: OutputExecution,
+      keyed: ReadonlyArray<KeyedCellOutput>,
+    ) {
+      yield* this.#ordering.withPermit(this.#commit(execution, keyed));
+    },
+  );
+
+  /** Adopt outputs installed by replay without replacing them. */
+  restore = Effect.fn("CellOutputProjection.restore")(
+    { self: this },
+    function* (
+      this: CellOutputProjection,
+      displayed: ReadonlyArray<vscode.NotebookCellOutput>,
+      keyed: ReadonlyArray<KeyedCellOutput>,
+    ) {
+      return yield* this.#ordering.withPermit(
+        Effect.sync(() => {
+          if (
+            displayed.length !== keyed.length ||
+            !displayed.every(
+              (output, index) =>
+                channelOf(output) === channelOf(keyed[index].output),
+            )
+          ) {
+            return false;
+          }
+          this.#slots = keyed.map(({ key }, index) => ({
+            key,
+            channel: channelOf(displayed[index]),
+            measured: true,
+          }));
+          return true;
+        }),
+      );
+    },
+  );
+
+  #project(execution: OutputExecution, keyed: ReadonlyArray<KeyedCellOutput>) {
+    return Effect.gen({ self: this }, function* () {
       // Nothing to show yet: keep whatever is on screen (typically the previous
       // run's output) rather than flashing empty while the run is in flight.
-      if (keyed.length === 0) {
-        return;
-      }
+      if (keyed.length === 0) return;
 
       if (!this.#inSync(execution)) {
         yield* this.#rebuild(execution, keyed);
         return;
       }
-      yield* this.#edit(execution, keyed);
-      yield* this.#append(execution, keyed);
-    },
-  );
+      if (!(yield* this.#edit(execution, keyed))) {
+        yield* this.#rebuild(execution, keyed);
+        return;
+      }
+      if (!(yield* this.#append(execution, keyed))) {
+        yield* this.#rebuild(execution, keyed);
+      }
+    });
+  }
 
-  /** Finish the run with exactly `keyed` and measure newly appended slots. */
-  commit = Effect.fn(
-    { self: this },
-    function* (
-      execution: OutputExecution,
-      keyed: ReadonlyArray<KeyedCellOutput>,
-    ): Effect.fn.Return<void> {
+  #commit(execution: OutputExecution, keyed: ReadonlyArray<KeyedCellOutput>) {
+    return Effect.gen({ self: this }, function* () {
       if (keyed.length === 0) {
         // A run that produced no output must end with none.
         if (execution.cell.outputs.length > 0) {
           yield* this.#clear(execution);
+        } else {
+          this.#slots = [];
         }
-        return;
+        return undefined;
       }
       if (this.#inSync(execution) && this.#sameKeys(keyed)) {
-        yield* this.#edit(execution, keyed);
+        if (!(yield* this.#edit(execution, keyed))) {
+          yield* this.#rebuild(execution, keyed);
+        }
       } else {
         // Marimo can deliver cell-ops out of order (e.g. the error before the
         // stdout that preceded it), or the run dropped a slot the last run had.
         // Rebuild from a clean slate; clearing first avoids a phantom slot.
         yield* this.#rebuild(execution, keyed);
       }
-      yield* this.#measure(execution);
-    },
-  );
+      if (!(yield* this.#measure(execution))) {
+        yield* this.#rebuild(execution, keyed);
+        if (!(yield* this.#measure(execution))) {
+          return yield* synchronizationFailed();
+        }
+      }
+      return undefined;
+    });
+  }
 
   /** Whether the live outputs still match the tracked slot positions. */
   #inSync(execution: OutputExecution): boolean {
@@ -98,87 +161,98 @@ export class CellOutputProjection {
     );
   }
 
-  #clear = Effect.fn(
-    { self: this },
-    function* (execution: OutputExecution): Effect.fn.Return<void> {
-      yield* Effect.promise(() => execution.clearOutput());
+  #clear(execution: OutputExecution) {
+    return Effect.gen({ self: this }, function* () {
+      yield* tryCellOutputOperation("clearOutput", () =>
+        execution.clearOutput(),
+      );
       this.#slots = [];
-    },
-  );
+    });
+  }
 
-  #rebuild = Effect.fn(
-    { self: this },
-    function* (
-      execution: OutputExecution,
-      keyed: ReadonlyArray<KeyedCellOutput>,
-    ): Effect.fn.Return<void> {
-      if (execution.cell.outputs.length > 0) {
-        yield* Effect.promise(() => execution.clearOutput());
+  #rebuild(execution: OutputExecution, keyed: ReadonlyArray<KeyedCellOutput>) {
+    return Effect.gen({ self: this }, function* () {
+      for (let attempt = 0; attempt < 2; attempt++) {
+        if (execution.cell.outputs.length > 0) {
+          yield* tryCellOutputOperation("clearOutput", () =>
+            execution.clearOutput(),
+          );
+        }
+        this.#slots = [];
+        if (yield* this.#append(execution, keyed)) return undefined;
       }
-      this.#slots = [];
-      yield* this.#append(execution, keyed);
-    },
-  );
+      return yield* synchronizationFailed();
+    });
+  }
 
   /** Edit changed slot items in place; output metadata remains unchanged. */
-  #edit = Effect.fn(
-    { self: this },
-    function* (
-      execution: OutputExecution,
-      keyed: ReadonlyArray<KeyedCellOutput>,
-    ): Effect.fn.Return<void> {
+  #edit(execution: OutputExecution, keyed: ReadonlyArray<KeyedCellOutput>) {
+    return Effect.gen({ self: this }, function* () {
       for (const k of keyed) {
         const index = this.#slots.findIndex((slot) => slot.key === k.key);
         if (index === -1) continue;
+        if (!this.#inSync(execution)) return false;
         const current = execution.cell.outputs[index];
+        if (current === undefined) return false;
         if (outputItemsEqual(current.items, k.output.items)) {
           continue;
         }
-        yield* Effect.promise(() =>
+        yield* tryCellOutputOperation("replaceOutputItems", () =>
           execution.replaceOutputItems(k.output.items, current),
         );
+        if (!this.#inSync(execution)) return false;
         this.#slots[index].measured = true;
       }
-    },
-  );
+      return true;
+    });
+  }
 
   /** Append new slots sequentially to preserve their display order. */
-  #append = Effect.fn(
-    { self: this },
-    function* (
-      execution: OutputExecution,
-      keyed: ReadonlyArray<KeyedCellOutput>,
-    ): Effect.fn.Return<void> {
+  #append(execution: OutputExecution, keyed: ReadonlyArray<KeyedCellOutput>) {
+    return Effect.gen({ self: this }, function* () {
       for (const k of keyed) {
         if (this.#slots.some((slot) => slot.key === k.key)) continue;
+        if (!this.#inSync(execution)) return false;
         // oxlint-disable-next-line eslint/no-await-in-loop -- ordered appends
-        yield* Effect.promise(() => execution.appendOutput(k.output));
+        yield* tryCellOutputOperation("appendOutput", () =>
+          execution.appendOutput(k.output),
+        );
         this.#slots.push({
           key: k.key,
           channel: channelOf(k.output),
           measured: false,
         });
+        if (!this.#inSync(execution)) return false;
       }
-    },
-  );
+      return true;
+    });
+  }
 
   /** Re-set unmeasured slots' items in place to force the webview to measure. */
-  #measure = Effect.fn(
-    { self: this },
-    function* (execution: OutputExecution): Effect.fn.Return<void> {
+  #measure(execution: OutputExecution) {
+    return Effect.gen({ self: this }, function* () {
       for (const [index, slot] of this.#slots.entries()) {
         if (slot.measured) continue;
+        if (!this.#inSync(execution)) return false;
         const current = execution.cell.outputs[index];
-        // Not mirrored back yet: leave it; the next sync check will rebuild.
-        if (current === undefined) {
-          continue;
-        }
-        yield* Effect.promise(() =>
+        if (current === undefined) return false;
+        yield* tryCellOutputOperation("replaceOutputItems", () =>
           execution.replaceOutputItems(current.items, current),
         );
+        if (!this.#inSync(execution)) return false;
         slot.measured = true;
       }
-    },
+      return true;
+    });
+  }
+}
+
+function synchronizationFailed() {
+  return Effect.fail(
+    new CellOutputOperationError({
+      operation: "synchronize",
+      cause: new Error("Cell outputs changed during reconciliation"),
+    }),
   );
 }
 

--- a/extension/src/kernel/CellOutputProjection.ts
+++ b/extension/src/kernel/CellOutputProjection.ts
@@ -1,168 +1,189 @@
+import { Effect } from "effect";
 import type * as vscode from "vscode";
 
-/**
- * A cell output tagged with the stable key of the logical slot it fills.
- *
- * The key is stable across a run's cell-ops, which is what lets the projection
- * edit slots in place instead of rebuilding the list each op. There's one key
- * per console channel and per traceback, plus a `"main"` slot shared by the
- * cell's result, error, or suppressing traceback.
- */
+/** A cell output tagged with the stable key of its logical slot. */
 export interface KeyedCellOutput {
   readonly key: string;
   readonly output: vscode.NotebookCellOutput;
 }
 
-/**
- * The slice of `vscode.NotebookCellExecution` the projection drives.
- *
- * Narrowed to a port so the projection can be tested against a recording fake;
- * a real `NotebookCellExecution` satisfies it structurally.
- */
-export type OutputExecution = Pick<
+/** The output operations used by {@link CellOutputProjection}. */
+type OutputExecution = Pick<
   vscode.NotebookCellExecution,
   "clearOutput" | "appendOutput" | "replaceOutputItems"
 > & {
   readonly cell: Pick<vscode.NotebookCell, "outputs">;
 };
 
-/**
- * A slot the projection has emitted and is tracking: the `NotebookCellOutput`
- * VS Code now owns (its identity is what `replaceOutputItems` targets) and the
- * items we last gave it (to skip no-op edits that would re-measure it).
- */
-interface TrackedOutput {
-  readonly output: vscode.NotebookCellOutput;
-  items: readonly vscode.NotebookCellOutputItem[];
+/** A logical slot tracked by position; live outputs are read from the cell. */
+interface Slot {
+  readonly key: string;
+  /** `metadata.channel` of the output appended for this slot. */
+  readonly channel: unknown;
+  /** Whether VS Code has measured this slot since it was appended. */
+  measured: boolean;
 }
 
 /**
- * Drives one cell run's outputs onto a `NotebookCellExecution`.
+ * Reconciles a cell's logical output slots across executions.
  *
- * Outputs are reconciled incrementally — cleared once on the run's first output,
- * then appended and edited in place as more arrive — the way Jupyter does it,
- * rather than rebuilt from scratch on every cell-op. The stable `"main"` key
- * (see {@link KeyedCellOutput}) turns the common "error box, then traceback
- * supersedes it" transition into an in-place edit.
- *
- * One instance backs one run and holds that run's reconcile state; the next run
- * gets a fresh one.
+ * Stable slots are updated in place. If their keys or order change, `commit`
+ * rebuilds the output list because VS Code cannot remove a single output.
  */
 export class CellOutputProjection {
-  readonly #execution: OutputExecution;
-  // Tracked slots, in on-screen (insertion) order.
-  readonly #tracked = new Map<string, TrackedOutput>();
-  // Whether we've cleared the *previous* run's outputs and begun this run's
-  // fresh output list. Deferred until the first output arrives.
-  #cleared = false;
-
-  constructor(execution: OutputExecution) {
-    this.#execution = execution;
-  }
+  // Slots in on-screen (insertion) order; index i is `cell.outputs[i]`.
+  #slots: Slot[] = [];
 
   /** Apply a live, incremental update toward `keyed`. */
-  async project(keyed: ReadonlyArray<KeyedCellOutput>): Promise<void> {
-    await this.#applyIncremental(keyed);
-  }
-
-  /**
-   * Finish the run: leave the cell showing exactly `keyed`, every output
-   * measured.
-   *
-   * A bare `appendOutput` renders at zero height until something touches it
-   * again, so `commit` re-sets each slot's items to force a final measurement.
-   * It avoids a full `replaceOutput`, which re-collapses tall outputs and can
-   * leave a phantom empty slot when the output set shrank.
-   */
-  async commit(keyed: ReadonlyArray<KeyedCellOutput>): Promise<void> {
-    if (keyed.length === 0) {
-      // A run that produced no output must end with none.
-      if (this.#execution.cell.outputs.length > 0) await this.#clear();
-      return;
-    }
-    await this.#applyIncremental(keyed);
-    await this.#finalize(keyed);
-  }
-
-  async #clear(): Promise<void> {
-    await this.#execution.clearOutput();
-    this.#tracked.clear();
-    this.#cleared = true;
-  }
-
-  async #applyIncremental(
-    keyed: ReadonlyArray<KeyedCellOutput>,
-  ): Promise<void> {
-    const execution = this.#execution;
-
-    if (keyed.length === 0) {
-      // Nothing to show yet. If the previous run left outputs, clear them once;
-      // otherwise wait for the first output.
-      if (!this.#cleared && execution.cell.outputs.length > 0) {
-        await this.#clear();
+  project = Effect.fn(
+    { self: this },
+    function* (
+      execution: OutputExecution,
+      keyed: ReadonlyArray<KeyedCellOutput>,
+    ): Effect.fn.Return<void> {
+      // Nothing to show yet: keep whatever is on screen (typically the previous
+      // run's output) rather than flashing empty while the run is in flight.
+      if (keyed.length === 0) {
+        return;
       }
-      return;
-    }
 
-    // First output of this run: clear the prior run's outputs so this run's are
-    // appended fresh rather than morphed onto stale ones.
-    if (!this.#cleared) {
-      await this.#clear();
-    }
-
-    // A slot we were tracking is gone — VS Code can't remove a single output,
-    // so re-clear and re-append from scratch. Uncommon within a single run.
-    const desiredKeys = new Set(keyed.map((k) => k.key));
-    if ([...this.#tracked.keys()].some((k) => !desiredKeys.has(k))) {
-      await this.#clear();
-    }
-
-    // Edit tracked slots in place, only when their items actually changed, so
-    // unchanged outputs (the traceback) are never re-measured.
-    for (const k of keyed) {
-      const slot = this.#tracked.get(k.key);
-      if (slot && !outputItemsEqual(slot.items, k.output.items)) {
-        // oxlint-disable-next-line eslint/no-await-in-loop -- ordered edits
-        await execution.replaceOutputItems(k.output.items, slot.output);
-        slot.items = k.output.items;
+      if (!this.#inSync(execution)) {
+        yield* this.#rebuild(execution, keyed);
+        return;
       }
-    }
+      yield* this.#edit(execution, keyed);
+      yield* this.#append(execution, keyed);
+    },
+  );
 
-    // Append genuinely-new slots at the end, in arrival order. Sequential by
-    // design — `appendOutput` appends at the tail, so await order is on-screen
-    // order.
-    for (const k of keyed) {
-      if (this.#tracked.has(k.key)) continue;
-      // oxlint-disable-next-line eslint/no-await-in-loop -- ordered appends
-      await execution.appendOutput(k.output);
-      this.#tracked.set(k.key, { output: k.output, items: k.output.items });
-    }
+  /** Finish the run with exactly `keyed` and measure newly appended slots. */
+  commit = Effect.fn(
+    { self: this },
+    function* (
+      execution: OutputExecution,
+      keyed: ReadonlyArray<KeyedCellOutput>,
+    ): Effect.fn.Return<void> {
+      if (keyed.length === 0) {
+        // A run that produced no output must end with none.
+        if (execution.cell.outputs.length > 0) {
+          yield* this.#clear(execution);
+        }
+        return;
+      }
+      if (this.#inSync(execution) && this.#sameKeys(keyed)) {
+        yield* this.#edit(execution, keyed);
+      } else {
+        // Marimo can deliver cell-ops out of order (e.g. the error before the
+        // stdout that preceded it), or the run dropped a slot the last run had.
+        // Rebuild from a clean slate; clearing first avoids a phantom slot.
+        yield* this.#rebuild(execution, keyed);
+      }
+      yield* this.#measure(execution);
+    },
+  );
+
+  /** Whether the live outputs still match the tracked slot positions. */
+  #inSync(execution: OutputExecution): boolean {
+    const outputs = execution.cell.outputs;
+    if (outputs.length !== this.#slots.length) return false;
+    return this.#slots.every(
+      (slot, i) => channelOf(outputs[i]) === slot.channel,
+    );
   }
 
-  async #finalize(keyed: ReadonlyArray<KeyedCellOutput>): Promise<void> {
-    const execution = this.#execution;
-    const canonicalOrder =
-      [...this.#tracked.keys()].join(" ") === keyed.map((k) => k.key).join(" ");
+  #sameKeys(keyed: ReadonlyArray<KeyedCellOutput>): boolean {
+    return (
+      this.#slots.length === keyed.length &&
+      this.#slots.every((slot, i) => slot.key === keyed[i].key)
+    );
+  }
 
-    if (!canonicalOrder) {
-      // Marimo can deliver cell-ops out of order (e.g. the error before the
-      // stdout that preceded it), so the appended order may not match. Rebuild
-      // from a clean slate; clearing first avoids a phantom leftover slot.
-      await execution.clearOutput();
-      this.#tracked.clear();
+  #clear = Effect.fn(
+    { self: this },
+    function* (execution: OutputExecution): Effect.fn.Return<void> {
+      yield* Effect.promise(() => execution.clearOutput());
+      this.#slots = [];
+    },
+  );
+
+  #rebuild = Effect.fn(
+    { self: this },
+    function* (
+      execution: OutputExecution,
+      keyed: ReadonlyArray<KeyedCellOutput>,
+    ): Effect.fn.Return<void> {
+      if (execution.cell.outputs.length > 0) {
+        yield* Effect.promise(() => execution.clearOutput());
+      }
+      this.#slots = [];
+      yield* this.#append(execution, keyed);
+    },
+  );
+
+  /** Edit changed slot items in place; output metadata remains unchanged. */
+  #edit = Effect.fn(
+    { self: this },
+    function* (
+      execution: OutputExecution,
+      keyed: ReadonlyArray<KeyedCellOutput>,
+    ): Effect.fn.Return<void> {
       for (const k of keyed) {
-        // oxlint-disable-next-line eslint/no-await-in-loop -- ordered re-append
-        await execution.appendOutput(k.output);
-        this.#tracked.set(k.key, { output: k.output, items: k.output.items });
+        const index = this.#slots.findIndex((slot) => slot.key === k.key);
+        if (index === -1) continue;
+        const current = execution.cell.outputs[index];
+        if (outputItemsEqual(current.items, k.output.items)) {
+          continue;
+        }
+        yield* Effect.promise(() =>
+          execution.replaceOutputItems(k.output.items, current),
+        );
+        this.#slots[index].measured = true;
       }
-    }
+    },
+  );
 
-    // Re-set each slot's items in place to force the webview to (re)measure it.
-    for (const [, slot] of this.#tracked) {
-      // oxlint-disable-next-line eslint/no-await-in-loop -- ordered re-measure
-      await execution.replaceOutputItems(slot.items, slot.output);
-    }
-  }
+  /** Append new slots sequentially to preserve their display order. */
+  #append = Effect.fn(
+    { self: this },
+    function* (
+      execution: OutputExecution,
+      keyed: ReadonlyArray<KeyedCellOutput>,
+    ): Effect.fn.Return<void> {
+      for (const k of keyed) {
+        if (this.#slots.some((slot) => slot.key === k.key)) continue;
+        // oxlint-disable-next-line eslint/no-await-in-loop -- ordered appends
+        yield* Effect.promise(() => execution.appendOutput(k.output));
+        this.#slots.push({
+          key: k.key,
+          channel: channelOf(k.output),
+          measured: false,
+        });
+      }
+    },
+  );
+
+  /** Re-set unmeasured slots' items in place to force the webview to measure. */
+  #measure = Effect.fn(
+    { self: this },
+    function* (execution: OutputExecution): Effect.fn.Return<void> {
+      for (const [index, slot] of this.#slots.entries()) {
+        if (slot.measured) continue;
+        const current = execution.cell.outputs[index];
+        // Not mirrored back yet: leave it; the next sync check will rebuild.
+        if (current === undefined) {
+          continue;
+        }
+        yield* Effect.promise(() =>
+          execution.replaceOutputItems(current.items, current),
+        );
+        slot.measured = true;
+      }
+    },
+  );
+}
+
+function channelOf(output: vscode.NotebookCellOutput): unknown {
+  return output.metadata?.channel;
 }
 
 /** Structural equality for two output-item lists (mime + raw bytes). */

--- a/extension/src/kernel/CellOutputProjections.ts
+++ b/extension/src/kernel/CellOutputProjections.ts
@@ -1,0 +1,90 @@
+import { Context, Effect, Layer, Option, Stream } from "effect";
+import type * as vscode from "vscode";
+
+import { VsCode } from "../platform/VsCode.ts";
+import {
+  MarimoNotebookCell,
+  type NotebookCellId,
+} from "../schemas/MarimoNotebookDocument.ts";
+import {
+  CellOutputProjection,
+  type KeyedCellOutput,
+} from "./CellOutputProjection.ts";
+
+/** Shares output identity state between replay and live execution. */
+export class CellOutputProjections extends Context.Service<CellOutputProjections>()(
+  "CellOutputProjections",
+  {
+    make: Effect.gen(function* () {
+      const code = yield* VsCode;
+      const notebooks = new WeakMap<
+        vscode.NotebookDocument,
+        Map<NotebookCellId, CellOutputProjection>
+      >();
+
+      const forCell = (
+        notebook: vscode.NotebookDocument,
+        cellId: NotebookCellId,
+      ): CellOutputProjection => {
+        let cells = notebooks.get(notebook);
+        if (cells === undefined) {
+          cells = new Map();
+          notebooks.set(notebook, cells);
+        }
+        let projection = cells.get(cellId);
+        if (projection === undefined) {
+          projection = new CellOutputProjection();
+          cells.set(cellId, projection);
+        }
+        return projection;
+      };
+
+      yield* code.workspace.notebookDocumentChanges.pipe(
+        Stream.runForEach((event) =>
+          Effect.sync(() => {
+            const cells = notebooks.get(event.notebook);
+            if (cells === undefined) return;
+            const retained = new Set(
+              event.contentChanges.flatMap((change) =>
+                change.addedCells.flatMap((rawCell) => {
+                  const cell = MarimoNotebookCell.from(rawCell);
+                  return Option.isSome(cell.id) ? [cell.id.value] : [];
+                }),
+              ),
+            );
+            for (const change of event.contentChanges) {
+              for (const rawCell of change.removedCells) {
+                const cell = MarimoNotebookCell.from(rawCell);
+                if (Option.isSome(cell.id) && !retained.has(cell.id.value)) {
+                  cells.delete(cell.id.value);
+                }
+              }
+            }
+            if (cells.size === 0) notebooks.delete(event.notebook);
+          }),
+        ),
+        Effect.forkScoped({ startImmediately: true }),
+      );
+      yield* code.workspace.notebookDocumentClosed.pipe(
+        Stream.runForEach((notebook) =>
+          Effect.sync(() => notebooks.delete(notebook)),
+        ),
+        Effect.forkScoped({ startImmediately: true }),
+      );
+
+      return {
+        forCell,
+        restore(
+          notebook: vscode.NotebookDocument,
+          cellId: NotebookCellId,
+          displayed: ReadonlyArray<vscode.NotebookCellOutput>,
+          keyed: ReadonlyArray<KeyedCellOutput>,
+        ) {
+          return forCell(notebook, cellId).restore(displayed, keyed);
+        },
+      } as const;
+    }),
+  },
+) {
+  static readonly layer = Layer.effect(this, this.make);
+}

--- a/extension/src/kernel/NotebookControllers.ts
+++ b/extension/src/kernel/NotebookControllers.ts
@@ -26,6 +26,7 @@ import { findVenvPath } from "../python/findVenvPath.ts";
 import { PythonExtension } from "../python/PythonExtension.ts";
 import { Uv } from "../python/Uv.ts";
 import { MarimoNotebookDocument } from "../schemas/MarimoNotebookDocument.ts";
+import { CellOutputProjections } from "./CellOutputProjections.ts";
 import {
   type NotebookController as RuntimeNotebookController,
   NotebookRuntime,
@@ -49,6 +50,11 @@ export interface NotebookController extends RuntimeNotebookController {
     affinity: vscode.NotebookControllerAffinity,
   ) => Effect.Effect<void>;
 }
+
+const outputPresentationLive = Layer.merge(
+  VsCodeCellDrive.layer,
+  VsCodeNotebookOutputPresenter.layer,
+).pipe(Layer.provide(CellOutputProjections.layer));
 
 interface NotebookControllerHandle {
   readonly controller: PythonController;
@@ -158,8 +164,7 @@ export const NotebookControllersLive = Layer.effectDiscard(
     );
   }),
 ).pipe(
-  Layer.provide(VsCodeCellDrive.layer),
-  Layer.provide(VsCodeNotebookOutputPresenter.layer),
+  Layer.provide(outputPresentationLive),
   Layer.provide(Uv.layer),
   Layer.provide(OutputChannel.layer),
   Layer.provide(Config.layer),

--- a/extension/src/kernel/VsCodeCellDrive.ts
+++ b/extension/src/kernel/VsCodeCellDrive.ts
@@ -11,7 +11,7 @@ import {
 } from "../schemas/MarimoNotebookDocument.ts";
 import type { CellRuntimeState } from "../types.ts";
 import type { CellRef, Drive } from "./CellExecutions.ts";
-import { CellOutputProjection } from "./CellOutputProjection.ts";
+import { CellOutputProjections } from "./CellOutputProjections.ts";
 import { CellCommand, type RunId } from "./CellRunReducer.ts";
 import {
   buildKeyedCellOutputs,
@@ -43,8 +43,6 @@ interface PresentedRun {
 
 const resourceKey = (cell: CellRef, runId: RunId): string =>
   JSON.stringify([cell.notebookId, cell.cellId, runId]);
-const cellKey = (cell: CellRef): string =>
-  JSON.stringify([cell.notebookId, cell.cellId]);
 
 /** Owns VS Code's live execution handles behind the {@link Drive} seam. */
 export class VsCodeCellDrive extends Context.Service<VsCodeCellDrive>()(
@@ -52,9 +50,8 @@ export class VsCodeCellDrive extends Context.Service<VsCodeCellDrive>()(
   {
     make: Effect.gen(function* () {
       const code = yield* VsCode;
+      const projections = yield* CellOutputProjections;
       const resources = new Map<string, PresentedRun>();
-      // Retained per cell so outputs can be updated in place across runs.
-      const projections = new Map<string, CellOutputProjection>();
       const errorDiagnostics = yield* acquireDisposable(() =>
         code.languages.createDiagnosticCollection("marimo-runtime"),
       );
@@ -69,7 +66,6 @@ export class VsCodeCellDrive extends Context.Service<VsCodeCellDrive>()(
             }
           }
           resources.clear();
-          projections.clear();
         }),
       );
 
@@ -85,17 +81,6 @@ export class VsCodeCellDrive extends Context.Service<VsCodeCellDrive>()(
               Effect.annotateLogs({ ...cell, runId }),
             )
           : apply(resource);
-      };
-
-      /** The projection that owns a cell's on-screen outputs. */
-      const projectionFor = (cell: CellRef): CellOutputProjection => {
-        const key = cellKey(cell);
-        let projection = projections.get(key);
-        if (projection === undefined) {
-          projection = new CellOutputProjection();
-          projections.set(key, projection);
-        }
-        return projection;
       };
 
       /** Resolves a cell within the notebook bound to this drive. */
@@ -137,7 +122,7 @@ export class VsCodeCellDrive extends Context.Service<VsCodeCellDrive>()(
             code,
             notebook,
           );
-          const projection = projectionFor(cell);
+          const projection = projections.forCell(notebook, cell.cellId);
           return (
             final
               ? projection.commit(execution, outputs)
@@ -205,7 +190,8 @@ export class VsCodeCellDrive extends Context.Service<VsCodeCellDrive>()(
               code,
               binding.notebook.rawNotebookDocument,
             );
-            yield* projectionFor(cell)
+            yield* projections
+              .forCell(binding.notebook.rawNotebookDocument, cell.cellId)
               .commit(execution, outputs)
               .pipe(
                 Effect.catchCause((cause) =>

--- a/extension/src/kernel/VsCodeCellDrive.ts
+++ b/extension/src/kernel/VsCodeCellDrive.ts
@@ -37,13 +37,14 @@ class InvalidCellError extends Data.TaggedError("InvalidCellError")<{
 
 interface PresentedRun {
   readonly execution: vscode.NotebookCellExecution;
-  readonly projection: CellOutputProjection;
   readonly notebook: vscode.NotebookDocument;
   started: boolean;
 }
 
 const resourceKey = (cell: CellRef, runId: RunId): string =>
   JSON.stringify([cell.notebookId, cell.cellId, runId]);
+const cellKey = (cell: CellRef): string =>
+  JSON.stringify([cell.notebookId, cell.cellId]);
 
 /** Owns VS Code's live execution handles behind the {@link Drive} seam. */
 export class VsCodeCellDrive extends Context.Service<VsCodeCellDrive>()(
@@ -52,6 +53,8 @@ export class VsCodeCellDrive extends Context.Service<VsCodeCellDrive>()(
     make: Effect.gen(function* () {
       const code = yield* VsCode;
       const resources = new Map<string, PresentedRun>();
+      // Retained per cell so outputs can be updated in place across runs.
+      const projections = new Map<string, CellOutputProjection>();
       const errorDiagnostics = yield* acquireDisposable(() =>
         code.languages.createDiagnosticCollection("marimo-runtime"),
       );
@@ -66,6 +69,7 @@ export class VsCodeCellDrive extends Context.Service<VsCodeCellDrive>()(
             }
           }
           resources.clear();
+          projections.clear();
         }),
       );
 
@@ -81,6 +85,17 @@ export class VsCodeCellDrive extends Context.Service<VsCodeCellDrive>()(
               Effect.annotateLogs({ ...cell, runId }),
             )
           : apply(resource);
+      };
+
+      /** The projection that owns a cell's on-screen outputs. */
+      const projectionFor = (cell: CellRef): CellOutputProjection => {
+        const key = cellKey(cell);
+        let projection = projections.get(key);
+        if (projection === undefined) {
+          projection = new CellOutputProjection();
+          projections.set(key, projection);
+        }
+        return projection;
       };
 
       /** Resolves a cell within the notebook bound to this drive. */
@@ -114,7 +129,7 @@ export class VsCodeCellDrive extends Context.Service<VsCodeCellDrive>()(
         state: CellRuntimeState,
         final: boolean,
       ) =>
-        withResource(cell, runId, ({ notebook, projection, started }) => {
+        withResource(cell, runId, ({ execution, notebook, started }) => {
           if (!started) return Effect.void;
           const outputs = buildKeyedCellOutputs(
             cell.cellId,
@@ -122,8 +137,11 @@ export class VsCodeCellDrive extends Context.Service<VsCodeCellDrive>()(
             code,
             notebook,
           );
-          return Effect.tryPromise(() =>
-            final ? projection.commit(outputs) : projection.project(outputs),
+          const projection = projectionFor(cell);
+          return (
+            final
+              ? projection.commit(execution, outputs)
+              : projection.project(execution, outputs)
           ).pipe(
             Effect.catchCause((cause) =>
               Effect.logWarning("Failed to update cell output").pipe(
@@ -187,15 +205,15 @@ export class VsCodeCellDrive extends Context.Service<VsCodeCellDrive>()(
               code,
               binding.notebook.rawNotebookDocument,
             );
-            yield* Effect.tryPromise(() =>
-              new CellOutputProjection(execution).commit(outputs),
-            ).pipe(
-              Effect.catchCause((cause) =>
-                Effect.logWarning("Failed to update cell output").pipe(
-                  Effect.annotateLogs({ cause, ...cell }),
+            yield* projectionFor(cell)
+              .commit(execution, outputs)
+              .pipe(
+                Effect.catchCause((cause) =>
+                  Effect.logWarning("Failed to update cell output").pipe(
+                    Effect.annotateLogs({ cause, ...cell }),
+                  ),
                 ),
-              ),
-            );
+              );
             if (applyDiagnostic) {
               yield* setDiagnostic(cell, binding, Option.some(state));
             }
@@ -218,7 +236,6 @@ export class VsCodeCellDrive extends Context.Service<VsCodeCellDrive>()(
               const execution = yield* createExecution(cell, binding);
               resources.set(resourceKey(cell, runId), {
                 execution,
-                projection: new CellOutputProjection(execution),
                 notebook: binding.notebook.rawNotebookDocument,
                 started: false,
               });

--- a/extension/src/kernel/VsCodeNotebookOutputPresenter.ts
+++ b/extension/src/kernel/VsCodeNotebookOutputPresenter.ts
@@ -9,8 +9,10 @@ import {
   NotebookCellId,
 } from "../schemas/MarimoNotebookDocument.ts";
 import type { CellOutputReplay } from "../schemas/Models.gen.ts";
+import { tryCellOutputOperation } from "./CellOutputOperation.ts";
+import { CellOutputProjections } from "./CellOutputProjections.ts";
 import { transitionCell } from "./CellRunReducer.ts";
-import { buildCellOutputs } from "./VsCodeCellOutputs.ts";
+import { buildKeyedCellOutputs } from "./VsCodeCellOutputs.ts";
 
 interface CellController {
   readonly createNotebookCellExecution: (
@@ -24,6 +26,7 @@ export class VsCodeNotebookOutputPresenter extends Context.Service<VsCodeNoteboo
   {
     make: Effect.gen(function* () {
       const code = yield* VsCode;
+      const projections = yield* CellOutputProjections;
 
       const present = Effect.fn("VsCodeNotebookOutputPresenter.present")(
         function* (
@@ -38,19 +41,30 @@ export class VsCodeNotebookOutputPresenter extends Context.Service<VsCodeNoteboo
                 const { notification } = replay;
                 const cellId = NotebookCellId(notification.cell_id);
                 const cell = yield* findNotebookCell(notebook, cellId);
-                if (cell.outputs.length > 0) return;
 
                 const state = transitionCell(
                   createCellRuntimeState(),
                   notification,
                 );
-                const outputs = buildCellOutputs(
+                const keyed = buildKeyedCellOutputs(
                   cellId,
                   state,
                   code,
                   notebook.rawNotebookDocument,
                 );
-                if (outputs.length === 0) return;
+                if (keyed.length === 0) return;
+
+                if (cell.outputs.length > 0) {
+                  yield* projections.restore(
+                    notebook.rawNotebookDocument,
+                    cellId,
+                    cell.outputs,
+                    keyed,
+                  );
+                  return;
+                }
+
+                const outputs = keyed.map(({ output }) => output);
 
                 const execution = yield* Effect.try(() =>
                   controller.createNotebookCellExecution(cell.rawNotebookCell),
@@ -60,7 +74,17 @@ export class VsCodeNotebookOutputPresenter extends Context.Service<VsCodeNoteboo
                   (current) =>
                     Effect.sync(() => current.start(Date.now())).pipe(
                       Effect.andThen(
-                        Effect.tryPromise(() => current.replaceOutput(outputs)),
+                        tryCellOutputOperation("replaceOutput", () =>
+                          current.replaceOutput(outputs),
+                        ),
+                      ),
+                      Effect.andThen(
+                        projections.restore(
+                          notebook.rawNotebookDocument,
+                          cellId,
+                          outputs,
+                          keyed,
+                        ),
                       ),
                     ),
                   (current) => Effect.sync(() => current.end(undefined)),

--- a/extension/src/kernel/__tests__/CellOutputProjection.test.ts
+++ b/extension/src/kernel/__tests__/CellOutputProjection.test.ts
@@ -7,39 +7,61 @@ import { VsCode } from "../../platform/VsCode.ts";
 import {
   CellOutputProjection,
   type KeyedCellOutput,
-  type OutputExecution,
 } from "../CellOutputProjection.ts";
 
+type OutputExecution = Parameters<CellOutputProjection["project"]>[0];
+
 const decoder = new TextDecoder();
-const decode = (o: vscode.NotebookCellOutput) =>
-  o.items.map((i) => decoder.decode(i.data)).join("|");
+const decodeItems = (items: ReadonlyArray<vscode.NotebookCellOutputItem>) =>
+  items.map((i) => decoder.decode(i.data)).join("|");
+const decode = (o: vscode.NotebookCellOutput) => decodeItems(o.items);
+
+/** The cell's outputs, shared by every execution of that cell. */
+class FakeCell {
+  readonly outputs: vscode.NotebookCellOutput[] = [];
+  readonly log: string[] = [];
+
+  constructor(initial: ReadonlyArray<vscode.NotebookCellOutput> = []) {
+    this.outputs.push(...initial);
+  }
+
+  /** What's on screen, by slot. */
+  get shown(): string[] {
+    return this.outputs.map(decode);
+  }
+
+  /** Drain the recorded calls. */
+  take(): string[] {
+    return this.log.splice(0);
+  }
+}
 
 /** Records the projection's calls; mirrors `cell.outputs` like VS Code does. */
 class FakeExecution implements OutputExecution {
-  readonly #outputs: vscode.NotebookCellOutput[] = [];
-  readonly log: string[] = [];
-  readonly cell = { outputs: this.#outputs };
+  readonly cell: FakeCell;
 
-  constructor(initial: ReadonlyArray<vscode.NotebookCellOutput> = []) {
-    this.#outputs.push(...initial);
+  constructor(cell: FakeCell) {
+    this.cell = cell;
   }
   clearOutput(): Thenable<void> {
-    this.log.push("clear");
-    this.#outputs.length = 0;
+    this.cell.log.push("clear");
+    this.cell.outputs.length = 0;
     return Promise.resolve();
   }
   appendOutput(output: vscode.NotebookCellOutput): Thenable<void> {
-    this.log.push(`append(${decode(output)})`);
-    this.#outputs.push(output);
+    this.cell.log.push(`append(${decode(output)})`);
+    this.cell.outputs.push(output);
     return Promise.resolve();
   }
   replaceOutputItems(
     items: ReadonlyArray<vscode.NotebookCellOutputItem>,
-    _output: vscode.NotebookCellOutput,
+    output: vscode.NotebookCellOutput,
   ): Thenable<void> {
-    this.log.push(
-      `replace(${items.map((i) => decoder.decode(i.data)).join("|")})`,
-    );
+    const index = this.cell.outputs.indexOf(output);
+    expect(index, "replaceOutputItems must target a live output").not.toBe(-1);
+    this.cell.log.push(`replace(${decodeItems(items)})`);
+    // VS Code hands back a fresh object for the edited output.
+    this.cell.outputs[index] = { items: [...items], metadata: output.metadata };
     return Promise.resolve();
   }
 }
@@ -48,9 +70,10 @@ class FakeExecution implements OutputExecution {
 const builders = (code: Context.Service.Shape<typeof VsCode>) => ({
   stdout: (text: string): KeyedCellOutput => ({
     key: "stdout",
-    output: new code.NotebookCellOutput([
-      code.NotebookCellOutputItem.stdout(text),
-    ]),
+    output: new code.NotebookCellOutput(
+      [code.NotebookCellOutputItem.stdout(text)],
+      { channel: "stdout" },
+    ),
   }),
   main: (text: string): KeyedCellOutput => ({
     key: "main",
@@ -60,94 +83,200 @@ const builders = (code: Context.Service.Shape<typeof VsCode>) => ({
   }),
 });
 
+const withBuilders = (
+  body: (b: ReturnType<typeof builders>) => Effect.Effect<void>,
+) =>
+  Effect.gen(function* () {
+    const vscode = yield* TestVsCode.make({});
+    yield* Effect.gen(function* () {
+      yield* body(builders(yield* VsCode));
+    }).pipe(Effect.provide(vscode.layer));
+  });
+
 describe("CellOutputProjection", () => {
   it.effect(
-    "clears once on first output, then appends; commit re-measures each slot",
+    "appends as outputs arrive; commit measures each appended slot",
     Effect.fn(function* () {
-      const vscode = yield* TestVsCode.make({});
-      yield* Effect.gen(function* () {
-        const { stdout, main } = builders(yield* VsCode);
-        const exec = new FakeExecution();
-        const p = new CellOutputProjection(exec);
+      yield* withBuilders(({ stdout, main }) =>
+        Effect.gen(function* () {
+          const cell = new FakeCell();
+          const exec = new FakeExecution(cell);
+          const p = new CellOutputProjection();
 
-        yield* Effect.promise(() => p.project([stdout("10")]));
-        yield* Effect.promise(() => p.project([stdout("10"), main("trace")]));
-        yield* Effect.promise(() => p.commit([stdout("10"), main("trace")]));
+          yield* p.project(exec, [stdout("10")]);
+          yield* p.project(exec, [stdout("10"), main("trace")]);
+          yield* p.commit(exec, [stdout("10"), main("trace")]);
 
-        expect(exec.log).toEqual([
-          "clear",
-          "append(10)",
-          // stdout unchanged → skipped; only the new slot appends
-          "append(trace)",
-          // commit touches every slot to force a height measurement
-          "replace(10)",
-          "replace(trace)",
-        ]);
-      }).pipe(Effect.provide(vscode.layer));
+          expect(cell.take()).toEqual([
+            "append(10)",
+            // stdout unchanged → skipped; only the new slot appends
+            "append(trace)",
+            // commit touches each bare slot to force a height measurement
+            "replace(10)",
+            "replace(trace)",
+          ]);
+          expect(cell.shown).toEqual(["10", "trace"]);
+        }),
+      );
     }),
   );
 
   it.effect(
-    "clears a previous run's outputs on this run's first output",
+    "only re-emits a slot whose items changed, and does not re-measure it",
     Effect.fn(function* () {
-      const vscode = yield* TestVsCode.make({});
-      yield* Effect.gen(function* () {
-        const { stdout } = builders(yield* VsCode);
-        const exec = new FakeExecution([stdout("stale").output]);
-        const p = new CellOutputProjection(exec);
+      yield* withBuilders(({ stdout }) =>
+        Effect.gen(function* () {
+          const cell = new FakeCell();
+          const exec = new FakeExecution(cell);
+          const p = new CellOutputProjection();
 
-        yield* Effect.promise(() => p.project([stdout("10")]));
+          yield* p.project(exec, [stdout("10")]);
+          yield* p.project(exec, [stdout("10")]); // no-op
+          yield* p.project(exec, [stdout("10\n20")]);
+          yield* p.commit(exec, [stdout("10\n20")]);
 
-        expect(exec.log).toEqual(["clear", "append(10)"]);
-      }).pipe(Effect.provide(vscode.layer));
-    }),
-  );
-
-  it.effect(
-    "only re-emits a slot whose items changed",
-    Effect.fn(function* () {
-      const vscode = yield* TestVsCode.make({});
-      yield* Effect.gen(function* () {
-        const { stdout } = builders(yield* VsCode);
-        const exec = new FakeExecution();
-        const p = new CellOutputProjection(exec);
-
-        yield* Effect.promise(() => p.project([stdout("10")]));
-        yield* Effect.promise(() => p.project([stdout("10")])); // no-op
-        yield* Effect.promise(() => p.project([stdout("10\n20")]));
-
-        expect(exec.log).toEqual(["clear", "append(10)", "replace(10\n20)"]);
-      }).pipe(Effect.provide(vscode.layer));
+          // The in-place edit already measured the slot; commit adds nothing.
+          expect(cell.take()).toEqual(["append(10)", "replace(10\n20)"]);
+        }),
+      );
     }),
   );
 
   it.effect(
     "rebuilds from a clean slate when commit order differs (no phantom)",
     Effect.fn(function* () {
-      const vscode = yield* TestVsCode.make({});
-      yield* Effect.gen(function* () {
-        const { stdout, main } = builders(yield* VsCode);
-        const exec = new FakeExecution();
-        const p = new CellOutputProjection(exec);
+      yield* withBuilders(({ stdout, main }) =>
+        Effect.gen(function* () {
+          const cell = new FakeCell();
+          const exec = new FakeExecution(cell);
+          const p = new CellOutputProjection();
 
-        // Arrival order put the error first, then stdout.
-        yield* Effect.promise(() => p.project([main("trace")]));
-        yield* Effect.promise(() => p.project([main("trace"), stdout("10")]));
-        // Canonical order is stdout-first: commit re-clears and re-appends.
-        yield* Effect.promise(() => p.commit([stdout("10"), main("trace")]));
+          // Arrival order put the error first, then stdout.
+          yield* p.project(exec, [main("trace")]);
+          yield* p.project(exec, [main("trace"), stdout("10")]);
+          // Canonical order is stdout-first: commit re-clears and re-appends.
+          yield* p.commit(exec, [stdout("10"), main("trace")]);
 
-        expect(exec.log).toEqual([
-          "clear",
-          "append(trace)",
-          "append(10)",
-          // order mismatch → clean rebuild, then measure
-          "clear",
-          "append(10)",
-          "append(trace)",
-          "replace(10)",
-          "replace(trace)",
-        ]);
-      }).pipe(Effect.provide(vscode.layer));
+          expect(cell.take()).toEqual([
+            "append(trace)",
+            "append(10)",
+            // order mismatch → clean rebuild, then measure
+            "clear",
+            "append(10)",
+            "append(trace)",
+            "replace(10)",
+            "replace(trace)",
+          ]);
+          expect(cell.shown).toEqual(["10", "trace"]);
+        }),
+      );
+    }),
+  );
+
+  it.effect(
+    "a re-run edits the previous run's outputs in place",
+    Effect.fn(function* () {
+      yield* withBuilders(({ stdout, main }) =>
+        Effect.gen(function* () {
+          const cell = new FakeCell();
+          const p = new CellOutputProjection();
+
+          const first = new FakeExecution(cell);
+          yield* p.project(first, [stdout("10"), main("v1")]);
+          yield* p.commit(first, [stdout("10"), main("v1")]);
+          cell.take();
+
+          // The next run gets its own execution but the same cell projection.
+          const second = new FakeExecution(cell);
+          // Queued/running with nothing new yet: the previous output stays.
+          yield* p.project(second, []);
+          expect(cell.take()).toEqual([]);
+          expect(cell.shown).toEqual(["10", "v1"]);
+
+          yield* p.project(second, [stdout("10"), main("v2")]);
+          yield* p.commit(second, [stdout("10"), main("v2")]);
+
+          // No clear, no append: the on-screen outputs keep their identity.
+          expect(cell.take()).toEqual(["replace(v2)"]);
+          expect(cell.shown).toEqual(["10", "v2"]);
+        }),
+      );
+    }),
+  );
+
+  it.effect(
+    "a re-run that drops a slot rebuilds only at commit",
+    Effect.fn(function* () {
+      yield* withBuilders(({ stdout, main }) =>
+        Effect.gen(function* () {
+          const cell = new FakeCell();
+          const p = new CellOutputProjection();
+
+          const first = new FakeExecution(cell);
+          yield* p.commit(first, [stdout("10"), main("v1")]);
+          cell.take();
+
+          // This run never prints. Its result lands in place while the stale
+          // stdout lingers; VS Code can't drop one output, so commit rebuilds.
+          const second = new FakeExecution(cell);
+          yield* p.project(second, [main("v2")]);
+          expect(cell.take()).toEqual(["replace(v2)"]);
+          expect(cell.shown).toEqual(["10", "v2"]);
+
+          yield* p.commit(second, [main("v2")]);
+          expect(cell.take()).toEqual(["clear", "append(v2)", "replace(v2)"]);
+          expect(cell.shown).toEqual(["v2"]);
+        }),
+      );
+    }),
+  );
+
+  it.effect(
+    "rebuilds when something else rewrote the cell's outputs",
+    Effect.fn(function* () {
+      yield* withBuilders(({ stdout, main }) =>
+        Effect.gen(function* () {
+          const cell = new FakeCell();
+          const p = new CellOutputProjection();
+          yield* p.commit(new FakeExecution(cell), [main("v1")]);
+          cell.take();
+
+          // "Clear All Outputs" emptied the cell behind our back.
+          cell.outputs.length = 0;
+          yield* p.project(new FakeExecution(cell), [main("v2")]);
+          expect(cell.take()).toEqual(["append(v2)"]);
+
+          // Same count, but not the slot we appended.
+          cell.outputs[0] = stdout("other").output;
+          yield* p.project(new FakeExecution(cell), [main("v3")]);
+          expect(cell.take()).toEqual(["clear", "append(v3)"]);
+          expect(cell.shown).toEqual(["v3"]);
+        }),
+      );
+    }),
+  );
+
+  it.effect(
+    "a run with no output ends with none",
+    Effect.fn(function* () {
+      yield* withBuilders(({ main }) =>
+        Effect.gen(function* () {
+          const cell = new FakeCell();
+          const p = new CellOutputProjection();
+          yield* p.commit(new FakeExecution(cell), [main("v1")]);
+          cell.take();
+
+          const second = new FakeExecution(cell);
+          yield* p.project(second, []);
+          yield* p.commit(second, []);
+          expect(cell.take()).toEqual(["clear"]);
+          expect(cell.shown).toEqual([]);
+
+          // And a later empty commit on an empty cell is a no-op.
+          yield* p.commit(new FakeExecution(cell), []);
+          expect(cell.take()).toEqual([]);
+        }),
+      );
     }),
   );
 });

--- a/extension/src/kernel/__tests__/CellOutputProjection.test.ts
+++ b/extension/src/kernel/__tests__/CellOutputProjection.test.ts
@@ -4,6 +4,7 @@ import type * as vscode from "vscode";
 
 import { TestVsCode } from "../../__mocks__/TestVsCode.ts";
 import { VsCode } from "../../platform/VsCode.ts";
+import { CellOutputOperationError } from "../CellOutputOperation.ts";
 import {
   CellOutputProjection,
   type KeyedCellOutput,
@@ -83,13 +84,13 @@ const builders = (code: Context.Service.Shape<typeof VsCode>) => ({
   }),
 });
 
-const withBuilders = (
-  body: (b: ReturnType<typeof builders>) => Effect.Effect<void>,
+const withBuilders = <A, E>(
+  body: (b: ReturnType<typeof builders>) => Effect.Effect<A, E>,
 ) =>
   Effect.gen(function* () {
     const vscode = yield* TestVsCode.make({});
-    yield* Effect.gen(function* () {
-      yield* body(builders(yield* VsCode));
+    return yield* Effect.gen(function* () {
+      return yield* body(builders(yield* VsCode));
     }).pipe(Effect.provide(vscode.layer));
   });
 
@@ -139,6 +140,66 @@ describe("CellOutputProjection", () => {
           expect(cell.take()).toEqual(["append(10)", "replace(10\n20)"]);
         }),
       );
+    }),
+  );
+
+  it.effect(
+    "recovers when the live output list changes during an edit",
+    Effect.fn(function* () {
+      yield* withBuilders(({ stdout, main }) =>
+        Effect.gen(function* () {
+          const cell = new FakeCell();
+          const p = new CellOutputProjection();
+          yield* p.commit(new FakeExecution(cell), [stdout("10"), main("v1")]);
+          cell.take();
+
+          class DriftingExecution extends FakeExecution {
+            #first = true;
+            override replaceOutputItems(
+              items: readonly vscode.NotebookCellOutputItem[],
+              output: vscode.NotebookCellOutput,
+            ): Thenable<void> {
+              const result = super.replaceOutputItems(items, output);
+              if (this.#first) {
+                this.#first = false;
+                cell.outputs.pop();
+              }
+              return result;
+            }
+          }
+
+          yield* p.project(new DriftingExecution(cell), [
+            stdout("20"),
+            main("v2"),
+          ]);
+
+          expect(cell.take()).toEqual([
+            "replace(20)",
+            "clear",
+            "append(20)",
+            "append(v2)",
+          ]);
+          expect(cell.shown).toEqual(["20", "v2"]);
+        }),
+      );
+    }),
+  );
+
+  it.effect(
+    "reports rejected VS Code output operations",
+    Effect.fn(function* () {
+      const failure = yield* withBuilders(({ stdout }) => {
+        const cause = new Error("append rejected");
+        const execution = new FakeExecution(new FakeCell());
+        execution.appendOutput = () => Promise.reject(cause);
+        return new CellOutputProjection()
+          .project(execution, [stdout("10")])
+          .pipe(Effect.flip);
+      });
+
+      expect(failure).toBeInstanceOf(CellOutputOperationError);
+      expect(failure.operation).toBe("appendOutput");
+      expect(failure.cause).toEqual(new Error("append rejected"));
     }),
   );
 

--- a/extension/src/kernel/__tests__/NotebookRuntimeOperations.test.ts
+++ b/extension/src/kernel/__tests__/NotebookRuntimeOperations.test.ts
@@ -27,6 +27,7 @@ import {
   type TestCommand,
 } from "../../__tests__/__utils__/TestMarimoClient.ts";
 import { NOTEBOOK_TYPE, SCRATCH_CELL_ID } from "../../constants.ts";
+import { CellOutputProjections } from "../../kernel/CellOutputProjections.ts";
 import { makeNotebookExecutor } from "../../kernel/NotebookExecutor.ts";
 import { NotebookRuntime } from "../../kernel/NotebookRuntime.ts";
 import { PythonController } from "../../kernel/PythonController.ts";
@@ -145,8 +146,12 @@ const withTestCtx = Effect.fn(function* (
         ),
     },
   });
+  const projections = yield* CellOutputProjections.make.pipe(
+    Effect.provide(vscode.layer),
+  );
   const cellDrive = yield* VsCodeCellDrive.make.pipe(
     Effect.provide(vscode.layer),
+    Effect.provideService(CellOutputProjections, projections),
   );
 
   const mockController = yield* Effect.gen(function* () {

--- a/extension/src/kernel/__tests__/VsCodeCellDrive.test.ts
+++ b/extension/src/kernel/__tests__/VsCodeCellDrive.test.ts
@@ -57,8 +57,13 @@ describe("VsCodeCellDrive", () => {
       const cellId = Option.getOrThrow(notebook.cellAt(0).id);
       const runId = Option.getOrThrow(runIdFromWire("run-1"));
       const events: string[] = [];
+      const outputs: vscode.NotebookCellOutput[] = [
+        ...editor.notebook.cellAt(0).outputs,
+      ];
       const execution: vscode.NotebookCellExecution = {
-        cell: editor.notebook.cellAt(0),
+        cell: Object.create(editor.notebook.cellAt(0), {
+          outputs: { get: () => outputs },
+        }),
         executionOrder: undefined,
         token: {
           isCancellationRequested: false,
@@ -68,9 +73,11 @@ describe("VsCodeCellDrive", () => {
         end: () => {},
         clearOutput: async () => {
           events.push("clear");
+          outputs.length = 0;
         },
-        appendOutput: async () => {
+        appendOutput: async (out) => {
           events.push("append");
+          outputs.push(...(Array.isArray(out) ? out : [out]));
         },
         replaceOutput: async () => {},
         appendOutputItems: async () => {},
@@ -131,8 +138,13 @@ describe("VsCodeCellDrive", () => {
       const notebook = MarimoNotebookDocument.from(editor.notebook);
       const cellId = Option.getOrThrow(notebook.cellAt(0).id);
       const events: string[] = [];
+      const outputs: vscode.NotebookCellOutput[] = [
+        ...editor.notebook.cellAt(0).outputs,
+      ];
       const execution: vscode.NotebookCellExecution = {
-        cell: editor.notebook.cellAt(0),
+        cell: Object.create(editor.notebook.cellAt(0), {
+          outputs: { get: () => outputs },
+        }),
         executionOrder: undefined,
         token: {
           isCancellationRequested: false,
@@ -142,14 +154,21 @@ describe("VsCodeCellDrive", () => {
         end: (success) => events.push(`end:${success}`),
         clearOutput: async () => {
           events.push("clear");
+          outputs.length = 0;
         },
-        appendOutput: async () => {
+        appendOutput: async (out) => {
           events.push("append");
+          outputs.push(...(Array.isArray(out) ? out : [out]));
         },
         replaceOutput: async () => {},
         appendOutputItems: async () => {},
-        replaceOutputItems: async () => {
+        replaceOutputItems: async (items, out) => {
           events.push("finalize");
+          const index = outputs.indexOf(out);
+          outputs[index] = {
+            items: Array.isArray(items) ? [...items] : [items],
+            metadata: out.metadata,
+          };
         },
       };
       const cellDrive = yield* VsCodeCellDrive.make.pipe(
@@ -167,13 +186,8 @@ describe("VsCodeCellDrive", () => {
         }),
       );
 
-      expect(events).toEqual([
-        "start",
-        "clear",
-        "append",
-        "finalize",
-        "end:false",
-      ]);
+      // The cell had no outputs, so there is nothing to clear first.
+      expect(events).toEqual(["start", "append", "finalize", "end:false"]);
     }),
   );
 });

--- a/extension/src/kernel/__tests__/VsCodeCellDrive.test.ts
+++ b/extension/src/kernel/__tests__/VsCodeCellDrive.test.ts
@@ -9,6 +9,7 @@ import {
   MarimoNotebookDocument,
 } from "../../schemas/MarimoNotebookDocument.ts";
 import type { CellRuntimeState } from "../../types.ts";
+import { CellOutputProjections } from "../CellOutputProjections.ts";
 import { CellCommand, runIdFromWire } from "../CellRunReducer.ts";
 import { VsCodeCellDrive } from "../VsCodeCellDrive.ts";
 
@@ -33,16 +34,6 @@ describe("VsCodeCellDrive", () => {
               kind: 1,
               value: "x = 1",
               languageId: "python",
-              outputs: [
-                {
-                  items: [
-                    {
-                      mime: "text/plain",
-                      data: new TextEncoder().encode("saved"),
-                    },
-                  ],
-                },
-              ],
               metadata: MarimoNotebookCell.createMetadata({
                 marimoRuntime: { stableId: "cell-1" },
               }),
@@ -53,6 +44,9 @@ describe("VsCodeCellDrive", () => {
       const code = yield* TestVsCode.make({
         initialDocuments: [editor.notebook],
       });
+      const projections = yield* CellOutputProjections.make.pipe(
+        Effect.provide(code.layer),
+      );
       const notebook = MarimoNotebookDocument.from(editor.notebook);
       const cellId = Option.getOrThrow(notebook.cellAt(0).id);
       const runId = Option.getOrThrow(runIdFromWire("run-1"));
@@ -85,6 +79,7 @@ describe("VsCodeCellDrive", () => {
       };
       const drive = (yield* VsCodeCellDrive.make.pipe(
         Effect.provide(code.layer),
+        Effect.provideService(CellOutputProjections, projections),
       )).bind({
         notebook,
         controller: { createNotebookCellExecution: () => execution },
@@ -111,7 +106,7 @@ describe("VsCodeCellDrive", () => {
           final: false,
         }),
       );
-      expect(events).toEqual(["start", "clear", "append"]);
+      expect(events).toEqual(["start", "append"]);
     }),
   );
 
@@ -135,6 +130,9 @@ describe("VsCodeCellDrive", () => {
       const code = yield* TestVsCode.make({
         initialDocuments: [editor.notebook],
       });
+      const projections = yield* CellOutputProjections.make.pipe(
+        Effect.provide(code.layer),
+      );
       const notebook = MarimoNotebookDocument.from(editor.notebook);
       const cellId = Option.getOrThrow(notebook.cellAt(0).id);
       const events: string[] = [];
@@ -173,6 +171,7 @@ describe("VsCodeCellDrive", () => {
       };
       const cellDrive = yield* VsCodeCellDrive.make.pipe(
         Effect.provide(code.layer),
+        Effect.provideService(CellOutputProjections, projections),
       );
 
       yield* cellDrive.bind({

--- a/extension/src/kernel/__tests__/VsCodeNotebookOutputPresenter.test.ts
+++ b/extension/src/kernel/__tests__/VsCodeNotebookOutputPresenter.test.ts
@@ -3,12 +3,14 @@ import { Effect } from "effect";
 import type * as vscode from "vscode";
 
 import { TestVsCode } from "../../__mocks__/TestVsCode.ts";
+import { VsCode } from "../../platform/VsCode.ts";
 import {
   MarimoNotebookCell,
   MarimoNotebookDocument,
   NotebookCellId,
 } from "../../schemas/MarimoNotebookDocument.ts";
 import type { CellOutputReplay } from "../../schemas/Models.gen.ts";
+import { CellOutputProjections } from "../CellOutputProjections.ts";
 import { VsCodeNotebookOutputPresenter } from "../VsCodeNotebookOutputPresenter.ts";
 
 const savedReplay: CellOutputReplay = {
@@ -50,6 +52,9 @@ it.effect(
     const code = yield* TestVsCode.make({
       initialDocuments: [notebookEditor.notebook],
     });
+    const projections = yield* CellOutputProjections.make.pipe(
+      Effect.provide(code.layer),
+    );
     const events: string[] = [];
     const rendered: vscode.NotebookCellOutput[][] = [];
     const execution: vscode.NotebookCellExecution = {
@@ -72,6 +77,7 @@ it.effect(
     };
     const presenter = yield* VsCodeNotebookOutputPresenter.make.pipe(
       Effect.provide(code.layer),
+      Effect.provideService(CellOutputProjections, projections),
     );
 
     yield* presenter.present(
@@ -93,9 +99,9 @@ it.effect(
 );
 
 it.effect(
-  "does not overwrite output already owned by the notebook",
+  "adopts output already owned by the notebook",
   Effect.fn(function* () {
-    const notebookEditor = editor([
+    const displayed: vscode.NotebookCellOutput[] = [
       {
         items: [
           {
@@ -104,12 +110,17 @@ it.effect(
           },
         ],
       },
-    ]);
+    ];
+    const notebookEditor = editor(displayed);
     const code = yield* TestVsCode.make({
       initialDocuments: [notebookEditor.notebook],
     });
+    const projections = yield* CellOutputProjections.make.pipe(
+      Effect.provide(code.layer),
+    );
     const presenter = yield* VsCodeNotebookOutputPresenter.make.pipe(
       Effect.provide(code.layer),
+      Effect.provideService(CellOutputProjections, projections),
     );
     let executions = 0;
 
@@ -125,5 +136,51 @@ it.effect(
     );
 
     expect(executions).toBe(0);
+
+    const api = yield* VsCode.pipe(Effect.provide(code.layer));
+    const events: string[] = [];
+    const execution: vscode.NotebookCellExecution = {
+      cell: notebookEditor.notebook.cellAt(0),
+      executionOrder: undefined,
+      token: {
+        isCancellationRequested: false,
+        onCancellationRequested: () => ({ dispose() {} }),
+      },
+      start: () => {},
+      end: () => {},
+      clearOutput: async () => {
+        events.push("clear");
+        displayed.length = 0;
+      },
+      appendOutput: async (output) => {
+        events.push("append");
+        displayed.push(...(Array.isArray(output) ? output : [output]));
+      },
+      replaceOutput: async () => {},
+      appendOutputItems: async () => {},
+      replaceOutputItems: async (items, output) => {
+        events.push("replace");
+        const index = displayed.indexOf(output);
+        displayed[index] = new api.NotebookCellOutput(
+          Array.isArray(items) ? [...items] : [items],
+          output.metadata,
+        );
+      },
+    };
+    const updated = {
+      key: "main",
+      output: new api.NotebookCellOutput([
+        api.NotebookCellOutputItem.text("updated"),
+      ]),
+    };
+
+    yield* projections
+      .forCell(notebookEditor.notebook, NotebookCellId("cell-1"))
+      .project(execution, [updated]);
+
+    expect(events).toEqual(["replace"]);
+    expect(new TextDecoder().decode(displayed[0].items[0].data)).toBe(
+      "updated",
+    );
   }),
 );

--- a/extension/src/renderer/__tests__/outputRoots.test.ts
+++ b/extension/src/renderer/__tests__/outputRoots.test.ts
@@ -1,0 +1,84 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { act } from "react";
+import * as React from "react";
+import { afterEach, describe, expect, it } from "vite-plus/test";
+
+import { OutputRoots } from "../outputRoots.ts";
+
+declare global {
+  var IS_REACT_ACT_ENVIRONMENT: boolean | undefined;
+}
+
+// Required by React 19's `act` to confirm it runs in a test environment.
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+function Probe({ label }: { label: string }) {
+  return React.createElement("span", { "data-probe": true }, label);
+}
+
+let roots: OutputRoots;
+
+afterEach(() => {
+  act(() => roots.dispose());
+});
+
+describe("OutputRoots", () => {
+  it("re-renders into the same root and keeps DOM nodes across updates", () => {
+    roots = new OutputRoots();
+    const element = document.createElement("div");
+
+    const first = roots.acquire("out-1", element);
+    act(() => first.render(React.createElement(Probe, { label: "a" })));
+    const node = element.querySelector("span");
+    expect(node?.textContent).toBe("a");
+
+    // Simulates VS Code re-invoking `renderOutputItem` for an updated item.
+    const second = roots.acquire("out-1", element);
+    expect(second).toBe(first);
+    act(() => second.render(React.createElement(Probe, { label: "b" })));
+
+    // Same node, new content: React reconciled instead of remounting.
+    expect(element.querySelector("span")).toBe(node);
+    expect(node?.textContent).toBe("b");
+    expect(roots.size).toBe(1);
+  });
+
+  it("replaces the root when the same id arrives on a new element", () => {
+    roots = new OutputRoots();
+    const stale = document.createElement("div");
+    const fresh = document.createElement("div");
+
+    const first = roots.acquire("out-1", stale);
+    act(() => first.render(React.createElement(Probe, { label: "a" })));
+
+    const second = roots.acquire("out-1", fresh);
+    expect(second).not.toBe(first);
+    act(() => second.render(React.createElement(Probe, { label: "b" })));
+
+    // The stale element's tree was unmounted, not left dangling.
+    expect(stale.querySelector("span")).toBeNull();
+    expect(fresh.querySelector("span")?.textContent).toBe("b");
+    expect(roots.size).toBe(1);
+  });
+
+  it("disposes one id or every id", () => {
+    roots = new OutputRoots();
+    const a = document.createElement("div");
+    const b = document.createElement("div");
+    act(() => {
+      roots.acquire("a", a).render(React.createElement(Probe, { label: "a" }));
+      roots.acquire("b", b).render(React.createElement(Probe, { label: "b" }));
+    });
+
+    act(() => roots.dispose("a"));
+    expect(a.querySelector("span")).toBeNull();
+    expect(b.querySelector("span")?.textContent).toBe("b");
+    expect(roots.size).toBe(1);
+
+    act(() => roots.dispose());
+    expect(b.querySelector("span")).toBeNull();
+    expect(roots.size).toBe(0);
+  });
+});

--- a/extension/src/renderer/__tests__/outputRoots.test.ts
+++ b/extension/src/renderer/__tests__/outputRoots.test.ts
@@ -36,13 +36,11 @@ describe("OutputRoots", () => {
 
     // Simulates VS Code re-invoking `renderOutputItem` for an updated item.
     const second = roots.acquire("out-1", element);
-    expect(second).toBe(first);
     act(() => second.render(React.createElement(Probe, { label: "b" })));
 
     // Same node, new content: React reconciled instead of remounting.
     expect(element.querySelector("span")).toBe(node);
     expect(node?.textContent).toBe("b");
-    expect(roots.size).toBe(1);
   });
 
   it("replaces the root when the same id arrives on a new element", () => {
@@ -54,13 +52,11 @@ describe("OutputRoots", () => {
     act(() => first.render(React.createElement(Probe, { label: "a" })));
 
     const second = roots.acquire("out-1", fresh);
-    expect(second).not.toBe(first);
     act(() => second.render(React.createElement(Probe, { label: "b" })));
 
     // The stale element's tree was unmounted, not left dangling.
     expect(stale.querySelector("span")).toBeNull();
     expect(fresh.querySelector("span")?.textContent).toBe("b");
-    expect(roots.size).toBe(1);
   });
 
   it("disposes one id or every id", () => {
@@ -75,10 +71,8 @@ describe("OutputRoots", () => {
     act(() => roots.dispose("a"));
     expect(a.querySelector("span")).toBeNull();
     expect(b.querySelector("span")?.textContent).toBe("b");
-    expect(roots.size).toBe(1);
 
     act(() => roots.dispose());
     expect(b.querySelector("span")).toBeNull();
-    expect(roots.size).toBe(0);
   });
 });

--- a/extension/src/renderer/outputRoots.ts
+++ b/extension/src/renderer/outputRoots.ts
@@ -6,18 +6,10 @@ interface OutputRoot {
 }
 
 /**
- * React roots for rendered output items, keyed by output item id.
+ * Owns React roots by VS Code output ID.
  *
- * VS Code calls `renderOutputItem` again on the *same* element every time an
- * output's items change, and aborts the previous call's signal first. That
- * abort means "the previous render was cancelled", not "the output is gone" —
- * treating it as disposal unmounted the whole React tree on every update, so
- * marimo UI elements lost their DOM nodes (and any in-progress pointer
- * interaction) each time a cell re-rendered (#826).
- *
- * Reusing the root per output id lets React reconcile in place. Roots are
- * released only from `disposeOutputItem`, which VS Code calls when the
- * output is actually removed.
+ * Render cancellation does not imply disposal; roots remain alive until
+ * `disposeOutputItem` is called.
  */
 export class OutputRoots {
   readonly #roots = new Map<string, OutputRoot>();
@@ -48,10 +40,5 @@ export class OutputRoots {
     if (!existing) return;
     existing.root.unmount();
     this.#roots.delete(id);
-  }
-
-  /** Number of live roots; exposed for tests. */
-  get size(): number {
-    return this.#roots.size;
   }
 }

--- a/extension/src/renderer/outputRoots.ts
+++ b/extension/src/renderer/outputRoots.ts
@@ -1,0 +1,57 @@
+import * as ReactDOM from "react-dom/client";
+
+interface OutputRoot {
+  readonly element: HTMLElement;
+  readonly root: ReactDOM.Root;
+}
+
+/**
+ * React roots for rendered output items, keyed by output item id.
+ *
+ * VS Code calls `renderOutputItem` again on the *same* element every time an
+ * output's items change, and aborts the previous call's signal first. That
+ * abort means "the previous render was cancelled", not "the output is gone" —
+ * treating it as disposal unmounted the whole React tree on every update, so
+ * marimo UI elements lost their DOM nodes (and any in-progress pointer
+ * interaction) each time a cell re-rendered (#826).
+ *
+ * Reusing the root per output id lets React reconcile in place. Roots are
+ * released only from `disposeOutputItem`, which VS Code calls when the
+ * output is actually removed.
+ */
+export class OutputRoots {
+  readonly #roots = new Map<string, OutputRoot>();
+
+  /**
+   * Returns the root mounted on `element` for `id`, creating one if needed.
+   *
+   * If VS Code hands us a different element for an id we already know, the
+   * old root is unmounted first: the previous node is gone.
+   */
+  acquire(id: string, element: HTMLElement): ReactDOM.Root {
+    const existing = this.#roots.get(id);
+    if (existing?.element === element) return existing.root;
+    existing?.root.unmount();
+    const root = ReactDOM.createRoot(element);
+    this.#roots.set(id, { element, root });
+    return root;
+  }
+
+  /** Unmounts the root for `id`, or every root when `id` is `undefined`. */
+  dispose(id?: string): void {
+    if (id === undefined) {
+      for (const { root } of this.#roots.values()) root.unmount();
+      this.#roots.clear();
+      return;
+    }
+    const existing = this.#roots.get(id);
+    if (!existing) return;
+    existing.root.unmount();
+    this.#roots.delete(id);
+  }
+
+  /** Number of live roots; exposed for tests. */
+  get size(): number {
+    return this.#roots.size;
+  }
+}

--- a/extension/src/renderer/renderer.tsx
+++ b/extension/src/renderer/renderer.tsx
@@ -115,9 +115,7 @@ export const activate: vscode.ActivationFunction = (context) => {
 
   return {
     renderOutputItem(data, element) {
-      // Reuse the root per output id so an updated item reconciles in place.
-      // VS Code aborts the previous call's `signal` before every re-render, so
-      // it must not be treated as disposal; see `OutputRoots` (#826).
+      // Render cancellation is not disposal; retain roots until explicitly released.
       const root = roots.acquire(data.id, element);
       const { cellId, state }: { cellId: CellId; state: CellRuntimeState } =
         data.json();

--- a/extension/src/renderer/renderer.tsx
+++ b/extension/src/renderer/renderer.tsx
@@ -2,7 +2,6 @@
 
 import "./styles.css";
 import { flushSync } from "react-dom";
-import * as ReactDOM from "react-dom/client";
 import styleText from "virtual:stylesheet";
 import type * as vscode from "vscode-notebook-renderer";
 
@@ -22,6 +21,7 @@ import {
   handleSendUiElementMessage,
   initialize,
 } from "./marimo-frontend.ts";
+import { OutputRoots } from "./outputRoots.ts";
 import { createRequestClient, isTypedRequestContext } from "./utils.ts";
 
 const TABLE_EXPORT_LIMIT_MB = 50;
@@ -111,11 +111,14 @@ export const activate: vscode.ActivationFunction = (context) => {
     document.head.appendChild(style);
   }
 
-  const registry = new Map<HTMLElement, ReactDOM.Root>();
+  const roots = new OutputRoots();
 
   return {
-    renderOutputItem(data, element, signal) {
-      const root = registry.get(element) ?? ReactDOM.createRoot(element);
+    renderOutputItem(data, element) {
+      // Reuse the root per output id so an updated item reconciles in place.
+      // VS Code aborts the previous call's `signal` before every re-render, so
+      // it must not be treated as disposal; see `OutputRoots` (#826).
+      const root = roots.acquire(data.id, element);
       const { cellId, state }: { cellId: CellId; state: CellRuntimeState } =
         data.json();
       // Render synchronously so the output's real height is in the DOM before
@@ -126,11 +129,9 @@ export const activate: vscode.ActivationFunction = (context) => {
       flushSync(() => {
         root.render(<CellOutput cellId={cellId} state={state} />);
       });
-      registry.set(element, root);
-      signal.addEventListener("abort", () => {
-        root.unmount();
-        registry.delete(element);
-      });
+    },
+    disposeOutputItem(id) {
+      roots.dispose(id);
     },
   };
 };

--- a/extension/tests/output-reconcile.test.cjs
+++ b/extension/tests/output-reconcile.test.cjs
@@ -75,6 +75,11 @@ function cellOutputText(cell) {
     .join("");
 }
 
+/** @param {vscode.NotebookCell} cell */
+function outputIds(cell) {
+  return cell.outputs.map((output) => Reflect.get(output, "id"));
+}
+
 // The canonical acceptance repro from the goal: stdout followed by an
 // uncaught exception. Running it any number of times must leave exactly the
 // same well-formed output set.
@@ -87,8 +92,8 @@ suite("output reconcile on re-run", function () {
     const nb = await ctx.writeAndOpenNotebook(makeSource([ERROR_REPRO]));
     await selectKernel(nb);
 
-    /** @type {number | undefined} */
-    let baselineCount;
+    /** @type {unknown[] | undefined} */
+    let baselineIds;
 
     for (let run = 1; run <= 3; run++) {
       const cell = nb.cellAt(0);
@@ -130,18 +135,22 @@ suite("output reconcile on re-run", function () {
         )}`,
       );
 
-      // Re-running reconciles in place — the output count never grows.
-      if (baselineCount === undefined) {
-        baselineCount = cell.outputs.length;
+      // Re-running reconciles in place, preserving each output's identity.
+      const ids = outputIds(cell);
+      if (baselineIds === undefined) {
+        baselineIds = ids;
         NodeAssert.ok(
-          baselineCount >= 2,
-          `expected at least stdout + traceback outputs, got ${baselineCount}`,
+          ids.length >= 2 &&
+            ids.every((id) => typeof id === "string" && id.length > 0),
+          `expected identifiable stdout + traceback outputs, got ${JSON.stringify(
+            ids,
+          )}`,
         );
       } else {
-        NodeAssert.strictEqual(
-          cell.outputs.length,
-          baselineCount,
-          `run ${run}: output count changed across re-runs (stacking?)`,
+        NodeAssert.deepStrictEqual(
+          ids,
+          baselineIds,
+          `run ${run}: output identities changed across re-runs`,
         );
       }
     }

--- a/extension/tests/output-reconcile.test.cjs
+++ b/extension/tests/output-reconcile.test.cjs
@@ -80,10 +80,13 @@ function outputIds(cell) {
   return cell.outputs.map((output) => Reflect.get(output, "id"));
 }
 
-// The canonical acceptance repro from the goal: stdout followed by an
-// uncaught exception. Running it any number of times must leave exactly the
-// same well-formed output set.
-const ERROR_REPRO = "print(10)\nraise ValueError()";
+// Multiple output slots must remain well-formed across repeated runs.
+const ERROR_REPRO = `
+import time
+_run_marker = time.time_ns()
+print(f"stdout-marker:{_run_marker}")
+raise ValueError(f"error-marker:{_run_marker}")
+`.trim();
 
 suite("output reconcile on re-run", function () {
   test("repeated runs keep stdout + traceback without stacking", async function () {
@@ -94,6 +97,8 @@ suite("output reconcile on re-run", function () {
 
     /** @type {unknown[] | undefined} */
     let baselineIds;
+    /** @type {string | undefined} */
+    let previousMarker;
 
     for (let run = 1; run <= 3; run++) {
       const cell = nb.cellAt(0);
@@ -123,8 +128,25 @@ suite("output reconcile on re-run", function () {
         )}`,
       );
 
-      // ...and the printed value is still visible.
-      NodeAssert.match(cellOutputText(cell), /10/);
+      // ...and every identity now carries this run's content.
+      const text = cellOutputText(cell);
+      const stdoutMarker = /stdout-marker:(\d+)/.exec(text)?.[1];
+      const errorMarker = /error-marker:(\d+)/.exec(text)?.[1];
+      NodeAssert.ok(
+        stdoutMarker,
+        `run ${run}: missing stdout marker in ${text}`,
+      );
+      NodeAssert.strictEqual(
+        errorMarker,
+        stdoutMarker,
+        `run ${run}: stdout and error came from different runs`,
+      );
+      NodeAssert.notStrictEqual(
+        stdoutMarker,
+        previousMarker,
+        `run ${run}: output items did not update`,
+      );
+      previousMarker = stdoutMarker;
 
       // ...in arrival order: stdout precedes the traceback (Jupyter-like),
       // not result-first.


### PR DESCRIPTION
A slider displayed inside another cell's output re-runs that cell on every tick of its drag, and each tick rebuilt the output's DOM under the pointer. The renderer treated VS Code's pre-re-render abort as disposal and remounted its React root on every item update, and `CellOutputProjection` was per run and cleared outputs before appending the new run's, giving them a new identity each time. Roots now live per output item id until `disposeOutputItem`, and one projection per cell edits the previous run's outputs in place, keeping them on screen until the new run produces its own.

Fixes #826.
